### PR TITLE
fix(commander): handle tmux pane exhaustion gracefully (#209)

### DIFF
--- a/src/claude_mpm/commander/api/errors.py
+++ b/src/claude_mpm/commander/api/errors.py
@@ -110,3 +110,24 @@ class InvalidRuntimeError(CommanderAPIError):
             f"Invalid runtime: {runtime}",
             400,
         )
+
+
+class TmuxNoSpaceError(CommanderAPIError):
+    """Raised when tmux has no space for a new pane."""
+
+    def __init__(self, message: str | None = None):
+        """Initialize tmux no space error.
+
+        Args:
+            message: Custom error message (optional)
+        """
+        default_msg = (
+            "Unable to create session: tmux has no space for new pane. "
+            "Try closing some sessions or resize your terminal window. "
+            "You can also create a new tmux window with `tmux new-window`."
+        )
+        super().__init__(
+            "TMUX_NO_SPACE",
+            message or default_msg,
+            409,
+        )

--- a/tests/commander/api/test_tmux_error_handling.py
+++ b/tests/commander/api/test_tmux_error_handling.py
@@ -1,0 +1,194 @@
+"""Tests for tmux error handling in Commander API."""
+
+import subprocess
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_mpm.commander.api.errors import TmuxNoSpaceError
+from claude_mpm.commander.models import Project
+
+
+class TestTmuxNoSpaceError:
+    """Tests for TmuxNoSpaceError."""
+
+    def test_default_message(self):
+        """Test default error message contains helpful guidance."""
+        error = TmuxNoSpaceError()
+        assert "no space for new pane" in error.detail["error"]["message"].lower()
+        assert "tmux new-window" in error.detail["error"]["message"]
+        assert error.status_code == 409
+
+    def test_custom_message(self):
+        """Test custom error message is used when provided."""
+        error = TmuxNoSpaceError("Custom error message")
+        assert error.detail["error"]["message"] == "Custom error message"
+        assert error.status_code == 409
+
+    def test_error_code(self):
+        """Test error code is set correctly."""
+        error = TmuxNoSpaceError()
+        assert error.detail["error"]["code"] == "TMUX_NO_SPACE"
+
+
+class TestSessionCreatePaneErrorHandling:
+    """Tests for pane creation error handling in session creation."""
+
+    @pytest.fixture
+    def mock_registry(self):
+        """Mock registry with a test project."""
+        registry = MagicMock()
+        project = Project(
+            id="test-proj-123",
+            name="test-project",
+            path="/fake/path",
+            sessions={},
+        )
+        registry.get.return_value = project
+        registry.add_session = MagicMock()
+        return registry
+
+    @pytest.fixture
+    def mock_tmux(self):
+        """Mock tmux orchestrator."""
+        tmux = MagicMock()
+        return tmux
+
+    def test_no_space_error_raises_tmux_no_space_error(self, mock_registry, mock_tmux):
+        """Test that subprocess error with 'no space' raises TmuxNoSpaceError."""
+        from claude_mpm.commander.api.routes.sessions import create_session
+        from claude_mpm.commander.api.schemas import CreateSessionRequest
+
+        # Mock subprocess error with "no space for new pane" in stderr
+        error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["tmux", "split-window"],
+            stderr=b"tmux: no space for new pane",
+        )
+        mock_tmux.create_pane.side_effect = error
+
+        # Patch app globals
+        with patch(
+            "claude_mpm.commander.api.routes.sessions._get_registry",
+            return_value=mock_registry,
+        ):
+            with patch(
+                "claude_mpm.commander.api.routes.sessions._get_tmux",
+                return_value=mock_tmux,
+            ):
+                # Create session request
+                request = CreateSessionRequest(runtime="claude-code")
+
+                # Should raise TmuxNoSpaceError
+                with pytest.raises(TmuxNoSpaceError) as exc_info:
+                    import asyncio
+
+                    asyncio.run(create_session("test-proj-123", request))
+
+                # Verify error details
+                assert exc_info.value.status_code == 409
+                assert (
+                    "no space for new pane"
+                    in exc_info.value.detail["error"]["message"].lower()
+                )
+
+    def test_other_subprocess_errors_are_reraised(self, mock_registry, mock_tmux):
+        """Test that other subprocess errors are re-raised unchanged."""
+        from claude_mpm.commander.api.routes.sessions import create_session
+        from claude_mpm.commander.api.schemas import CreateSessionRequest
+
+        # Mock subprocess error without "no space" message
+        error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["tmux", "split-window"],
+            stderr=b"tmux: session not found",
+        )
+        mock_tmux.create_pane.side_effect = error
+
+        # Patch app globals
+        with patch(
+            "claude_mpm.commander.api.routes.sessions._get_registry",
+            return_value=mock_registry,
+        ):
+            with patch(
+                "claude_mpm.commander.api.routes.sessions._get_tmux",
+                return_value=mock_tmux,
+            ):
+                # Create session request
+                request = CreateSessionRequest(runtime="claude-code")
+
+                # Should re-raise original CalledProcessError
+                with pytest.raises(subprocess.CalledProcessError) as exc_info:
+                    import asyncio
+
+                    asyncio.run(create_session("test-proj-123", request))
+
+                # Verify it's the original error
+                assert exc_info.value.returncode == 1
+                assert b"session not found" in exc_info.value.stderr
+
+    def test_successful_pane_creation(self, mock_registry, mock_tmux):
+        """Test successful pane creation without errors."""
+        from claude_mpm.commander.api.routes.sessions import create_session
+        from claude_mpm.commander.api.schemas import CreateSessionRequest
+
+        # Mock successful pane creation
+        mock_tmux.create_pane.return_value = "%1"
+
+        # Patch app globals
+        with patch(
+            "claude_mpm.commander.api.routes.sessions._get_registry",
+            return_value=mock_registry,
+        ):
+            with patch(
+                "claude_mpm.commander.api.routes.sessions._get_tmux",
+                return_value=mock_tmux,
+            ):
+                # Create session request
+                request = CreateSessionRequest(runtime="claude-code")
+
+                # Should succeed
+                import asyncio
+
+                response = asyncio.run(create_session("test-proj-123", request))
+
+                # Verify response
+                assert response.project_id == "test-proj-123"
+                assert response.runtime == "claude-code"
+                assert response.tmux_target == "%1"
+                assert response.status == "initializing"
+
+                # Verify session was added to registry
+                mock_registry.add_session.assert_called_once()
+
+    def test_no_space_error_case_insensitive(self, mock_registry, mock_tmux):
+        """Test that 'no space' detection is case-insensitive."""
+        from claude_mpm.commander.api.routes.sessions import create_session
+        from claude_mpm.commander.api.schemas import CreateSessionRequest
+
+        # Mock subprocess error with mixed-case message
+        error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["tmux", "split-window"],
+            stderr=b"tmux: No Space For New Pane",
+        )
+        mock_tmux.create_pane.side_effect = error
+
+        # Patch app globals
+        with patch(
+            "claude_mpm.commander.api.routes.sessions._get_registry",
+            return_value=mock_registry,
+        ):
+            with patch(
+                "claude_mpm.commander.api.routes.sessions._get_tmux",
+                return_value=mock_tmux,
+            ):
+                # Create session request
+                request = CreateSessionRequest(runtime="claude-code")
+
+                # Should raise TmuxNoSpaceError
+                with pytest.raises(TmuxNoSpaceError):
+                    import asyncio
+
+                    asyncio.run(create_session("test-proj-123", request))


### PR DESCRIPTION
## Summary
- Add `TmuxNoSpaceError` exception class with HTTP 409 status
- Wrap `create_pane()` call in try/except with helpful error message
- Guide users to close sessions, resize terminal, or create new tmux window

## Before
Generic HTTP 500 "Internal Server Error" when tmux runs out of pane space

## After
HTTP 409 with actionable error message:
```json
{
  "error": {
    "code": "TMUX_NO_SPACE",
    "message": "Unable to create session: tmux has no space for new pane. Try closing some sessions or resize your terminal window."
  }
}
```

## Test Plan
- [x] Unit tests for TmuxNoSpaceError class
- [x] Tests for error handling in create_session()
- [x] 7 tests passing

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)