### PR TITLE
fix(skills): Sync full skill directories including scripts and references

### DIFF
--- a/src/claude_mpm/services/skills/git_skill_source_manager.py
+++ b/src/claude_mpm/services/skills/git_skill_source_manager.py
@@ -533,15 +533,29 @@ class GitSkillSourceManager:
             f"Discovered {len(all_files)} files in {owner_repo}/{source.branch} via Tree API"
         )
 
-        # Step 2: Filter to only download relevant files (markdown, JSON metadata)
+        # Step 2: Filter to download relevant files
+        # Include full skill directory structure: SKILL.md, scripts/, references/
+        # Supported extensions:
+        #   - Documentation: .md, .json, .yaml, .yml, .txt
+        #   - Scripts: .sh, .py, .js, .ts, .mjs, .cjs
+        #   - Assets: .png, .jpg, .jpeg, .gif, .svg, .webp
+        #   - Config: .gitignore, .env.example
+        relevant_extensions = (
+            # Documentation
+            ".md", ".json", ".yaml", ".yml", ".txt",
+            # Scripts
+            ".sh", ".py", ".js", ".ts", ".mjs", ".cjs",
+            # Assets
+            ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp",
+        )
         relevant_files = [
             f
             for f in all_files
-            if f.endswith(".md") or f.endswith(".json") or f == ".gitignore"
+            if f.endswith(relevant_extensions) or f in (".gitignore", ".env.example")
         ]
 
         self.logger.info(
-            f"Filtered to {len(relevant_files)} relevant files (.md, .json, .gitignore)"
+            f"Filtered to {len(relevant_files)} relevant files (docs, scripts, assets)"
         )
 
         # Step 3: Download files to cache with ETag caching (parallel)


### PR DESCRIPTION
## Summary

The current skill sync implementation only downloads `.md` and `.json` files, which causes skills with helper scripts and reference documentation (like `vercel-labs/agent-skills`) to be incomplete.

This PR expands the file filter to include the full skill directory structure:

**Before:** Only `.md`, `.json`, `.gitignore` files synced
**After:** Full skill directories synced including:
- Documentation: `.md`, `.json`, `.yaml`, `.yml`, `.txt`
- Scripts: `.sh`, `.py`, `.js`, `.ts`, `.mjs`, `.cjs`
- Assets: `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`
- Config: `.gitignore`, `.env.example`

## Motivation

Many skill repositories (e.g., [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills)) include:
- `scripts/` - Helper automation scripts
- `references/` - Supporting documentation
- Assets like images and diagrams

Without this fix, these supporting files are silently dropped during sync, making skills incomplete.

## Test Plan

- [x] Verified syncing `vercel-labs/agent-skills` now includes all 138 files (vs previously ~10 markdown files)
- [x] Confirmed all 5 Vercel skills are discovered and have their full content

🤖 Generated with [Claude Code](https://claude.ai/code)