### PR TITLE
fix(autoconf): resolve three interconnected recommender bugs (#2)

### DIFF
--- a/src/claude_mpm/cli/commands/auto_configure.py
+++ b/src/claude_mpm/cli/commands/auto_configure.py
@@ -198,7 +198,7 @@ class AutoConfigureCommand(BaseCommand):
             min_confidence = (
                 args.min_confidence
                 if hasattr(args, "min_confidence") and args.min_confidence
-                else 0.8
+                else 0.5
             )
             dry_run = getattr(args, "preview", False)
             skip_confirmation = args.yes if hasattr(args, "yes") and args.yes else False

--- a/src/claude_mpm/cli/parsers/auto_configure_parser.py
+++ b/src/claude_mpm/cli/parsers/auto_configure_parser.py
@@ -105,9 +105,9 @@ Examples:
     auto_configure_parser.add_argument(
         "--min-confidence",
         type=float,
-        default=0.8,
+        default=0.5,
         metavar="FLOAT",
-        help="Minimum confidence threshold for recommendations (0.0-1.0, default: 0.8)",
+        help="Minimum confidence threshold for recommendations (0.0-1.0, default: 0.5)",
     )
 
     auto_configure_parser.add_argument(

--- a/src/claude_mpm/cli/parsers/config_parser.py
+++ b/src/claude_mpm/cli/parsers/config_parser.py
@@ -106,9 +106,9 @@ The command provides safety features including:
     auto_parser.add_argument(
         "--min-confidence",
         type=float,
-        default=0.8,
+        default=0.5,
         metavar="FLOAT",
-        help="Minimum confidence threshold for recommendations (0.0-1.0, default: 0.8)",
+        help="Minimum confidence threshold for recommendations (0.0-1.0, default: 0.5)",
     )
 
     auto_parser.add_argument(

--- a/src/claude_mpm/services/agents/auto_config_manager.py
+++ b/src/claude_mpm/services/agents/auto_config_manager.py
@@ -51,7 +51,7 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
     7. Configuration persistence for future reference
 
     Safety Features:
-    - Minimum confidence threshold (default 0.8)
+    - Minimum confidence threshold (default 0.5)
     - Dry-run mode for preview without changes
     - Validation gates to block invalid configurations
     - Rollback capability for failed deployments
@@ -97,8 +97,8 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
         self._agent_registry = agent_registry
         self._agent_deployment = agent_deployment
 
-        # Configuration settings
-        self._min_confidence_default = 0.8
+        # Configuration settings - use YAML-configured threshold (default 0.5)
+        self._min_confidence_default = 0.5
         self._max_rollback_attempts = 3
         self._deployment_timeout_seconds = 300  # 5 minutes
         self._config_file_name = "auto-config.yaml"
@@ -137,7 +137,7 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
         project_path: Path,
         confirmation_required: bool = True,
         dry_run: bool = False,
-        min_confidence: float = 0.8,
+        min_confidence: float = 0.5,
         observer: Optional[IDeploymentObserver] = None,
     ) -> ConfigurationResult:
         """
@@ -501,7 +501,7 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
         )
 
     def preview_configuration(
-        self, project_path: Path, min_confidence: float = 0.8
+        self, project_path: Path, min_confidence: float = 0.5
     ) -> ConfigurationPreview:
         """
         Preview what would be configured without applying changes.

--- a/tests/services/agents/test_recommender.py
+++ b/tests/services/agents/test_recommender.py
@@ -342,8 +342,9 @@ def test_match_score_language_only(
 
     score = recommender_service.match_score("test_python_engineer", toolchain)
 
-    # Should have decent score from language match (50% weight * 0.9 confidence)
-    assert 0.4 < score < 0.6
+    # Should have decent score from language match (language_only_boost + blended confidence)
+    # With fix: base_score = 0.5 + 0.15 = 0.65, final = 0.65 * (0.5 + 0.45) = ~0.617
+    assert 0.5 < score < 0.7
 
 
 def test_match_score_framework_priority(
@@ -916,12 +917,12 @@ def test_default_configuration_priority_ordering(tmp_path: Path):
 
     recommendations = recommender.recommend_agents(toolchain)
 
-    # Check priority ordering
+    # Check priority ordering (matches agent_capabilities.yaml default_configuration)
     assert recommendations[0].agent_id == "engineer"  # priority 1
     assert recommendations[1].agent_id == "research"  # priority 2
     assert recommendations[2].agent_id == "qa"  # priority 3
-    assert recommendations[3].agent_id == "ops"  # priority 4
-    assert recommendations[4].agent_id == "documentation"  # priority 5
+    assert recommendations[3].agent_id == "documentation"  # priority 4
+    assert recommendations[4].agent_id == "ops"  # priority 5
 
     # Verify priorities are correct
     assert recommendations[0].deployment_priority == 1


### PR DESCRIPTION
This fixes several interconnected issues which caused auto-configure to not detect agents/skills for python/nodejs projects. 

Based on: https://github.com/MacPhobos/claude-mpm/issues/2

Fix PEP 621 dependency parsing, scoring math thresholds, and Node.js language name mismatch that caused the recommender to always return generic defaults instead of project-specific agent recommendations.

Bug 1 - PEP 621 Parsing: Add _parse_pep621_dependencies(), _extract_toml_array(), and _extract_pep621_packages() methods to handle modern Python pyproject.toml format alongside existing Poetry parsing.

Bug 2 - Scoring Math: Add language_only_boost (+0.15) for language-only matches, change confidence_weight to blended formula, and lower all hardcoded 0.8 thresholds to 0.5 across 7 locations to match YAML config.

Bug 3 - Node.js Language: Add LANGUAGE_ALIASES mapping and _resolve_language_aliases() so "Node.js" correctly matches agents that support "javascript"/"typescript".

Closes #2
