### PR TITLE
fix: add --dangerously-skip-permissions to resume command path (#326)

### DIFF
--- a/src/claude_mpm/core/interactive_session.py
+++ b/src/claude_mpm/core/interactive_session.py
@@ -402,21 +402,18 @@ class InteractiveSession:
         # Check if --resume flag is present
         has_resume = self.runner.claude_args and "--resume" in self.runner.claude_args
 
+        cmd = ["claude", "--dangerously-skip-permissions"]
+
         if has_resume:
             # When resuming, use minimal command to avoid interfering with conversation selection
             self.logger.info(
                 "🔄 Resume mode detected - using minimal Claude command to preserve conversation selection"
             )
-            cmd = ["claude"]
-
-            # Add only the claude_args (which includes --resume)
-            if self.runner.claude_args:
-                cmd.extend(self.runner.claude_args)
-                self.logger.info(f"Resume command: {cmd}")
-
+            # has_resume guarantees claude_args is non-empty and contains --resume
+            cmd.extend(self.runner.claude_args)
+            self.logger.info(f"Resume command: {cmd}")
             return cmd
         # Normal mode - full command with all claude-mpm enhancements
-        cmd = ["claude", "--dangerously-skip-permissions"]
 
         # Add custom arguments
         if self.runner.claude_args:

--- a/tests/test_resume_command_build.py
+++ b/tests/test_resume_command_build.py
@@ -13,11 +13,6 @@ import pytest
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-pytestmark = pytest.mark.skip(
-    reason="References removed _ensure_run_attributes - tests need rewrite"
-)
-
-
 def test_interactive_session_command():
     """Test that InteractiveSession builds the command with --resume."""
     print("Testing InteractiveSession command building...")
@@ -50,6 +45,7 @@ def test_interactive_session_command():
     print("✅ InteractiveSession test passed!\n")
 
 
+@pytest.mark.skip(reason="References removed _ensure_run_attributes - needs rewrite")
 def test_run_command_with_resume():
     """Test the full run command flow with --resume."""
     print("Testing full run command flow...")


### PR DESCRIPTION
## Summary

Fixes #326

When using `claude-mpm --resume`, the \"bypass permissions\" option was missing from the TUI shift-tab menu because `--dangerously-skip-permissions` was never passed to Claude in resume mode.

## Changes

- **`src/claude_mpm/core/interactive_session.py`** — moved `cmd = [\"claude\", \"--dangerously-skip-permissions\"]` to a single assignment before the `if has_resume` branch so both resume and normal paths share the base command; removed redundant inner `claude_args` guard in resume branch
- **`tests/test_resume_command_build.py`** — removed blanket module-level `pytestmark` skip; re-enabled two valid tests; added targeted `@pytest.mark.skip` only to the one test that legitimately references a removed API

## Test Results

\`\`\`
tests/test_resume_command_build.py::test_interactive_session_command  PASSED
tests/test_resume_command_build.py::test_run_command_with_resume      SKIPPED (references removed _ensure_run_attributes)
tests/test_resume_command_build.py::test_actual_command_execution     PASSED

2 passed, 1 skipped
\`\`\`

## Root Cause

The `_build_claude_command()` method had two independent code paths. The resume path early-returned with only `[\"claude\"]`, never reaching the normal path where `--dangerously-skip-permissions` was hardcoded. The fix unifies the base command into a single assignment shared by both paths.