### PR TITLE
fix: graceful fallback for unknown AgentType in agent parser

### DIFF
--- a/src/claude_mpm/services/agents/management/agent_management_service.py
+++ b/src/claude_mpm/services/agents/management/agent_management_service.py
@@ -432,6 +432,15 @@ class AgentManager:
 
         return None
 
+    @staticmethod
+    def _safe_parse_agent_type(type_str: str) -> AgentType:
+        """Parse agent type string with graceful fallback to CUSTOM."""
+        try:
+            return AgentType(type_str)
+        except ValueError:
+            logger.debug(f"Unknown agent type '{type_str}', defaulting to CUSTOM")
+            return AgentType.CUSTOM
+
     def _parse_agent_markdown(
         self, content: str, name: str, file_path: str
     ) -> AgentDefinition:
@@ -441,7 +450,7 @@ class AgentManager:
 
         # Extract metadata
         metadata = AgentMetadata(
-            type=AgentType(post.metadata.get("type", "core")),
+            type=self._safe_parse_agent_type(post.metadata.get("type", "core")),
             model_preference=post.metadata.get("model_preference", "claude-3-sonnet"),
             version=post.metadata.get("version", "1.0.0"),
             last_updated=post.metadata.get("last_updated"),


### PR DESCRIPTION
Summary

  - Fix dashboard showing 2/48 deployed agents due to strict AgentType enum validation silently dropping agents with non-standard type values (e.g., "engineer", "ops", "qa") in frontmatter

*NOTE* this is a quick fix to work around a larger issues of AgentType enum being defined in 3 different places, none of which acurately handle the agent type present in the agent md frontmatter. A separate issue spec to follow. 


Details

  Added graceful fallback in AgentManager._parse_agent_markdown() so unrecognized agent type strings default to AgentType.CUSTOM instead of raising ValueError — which was silently caught by read_agent(), causing 46 of 48 agents to be skipped from the listing.

Test plan

  - Existing test suite passes (1865 passed)
  - Verify dashboard Config tab shows all 48 agents after fix