### PR TITLE
feat: add --no-dangerously-skip-permissions to make claude-mpm safe for DevOps/SRE environments

### DIFF
--- a/scripts/claude-mpm
+++ b/scripts/claude-mpm
@@ -118,7 +118,7 @@ fi
 
 # Check if it's a claude-mpm specific flag (with or without prefix)
 # Note: --resume is handled by MPM and passed to Claude CLI; --mpm-resume is MPM's own session resume
-MPM_FLAGS=("--resume" "--mpm-resume" "--logging" "--log-dir" "--framework-path" "--agents-dir" "--no-hooks" "--no-tickets" "--subprocess" "--interactive-subprocess" "--todo-hijack" "-i" "--input" "--non-interactive" "--no-native-agents" "-d" "--debug" "--launch-method" "--monitor" "--websocket-port")
+MPM_FLAGS=("--resume" "--mpm-resume" "--logging" "--log-dir" "--framework-path" "--agents-dir" "--no-hooks" "--no-tickets" "--subprocess" "--interactive-subprocess" "--todo-hijack" "-i" "--input" "--non-interactive" "--no-native-agents" "-d" "--debug" "--launch-method" "--monitor" "--websocket-port" "--no-dangerously-skip-permissions")
 for flag in "${MPM_FLAGS[@]}"; do
     if [[ " $* " =~ " $flag " ]] || [[ " $* " =~ " --mpm:${flag#--} " ]] || [[ " $* " =~ " -mpm:${flag#-} " ]]; then
         IS_MPM_COMMAND=true
@@ -152,5 +152,9 @@ if [[ "$IS_MPM_COMMAND" == true ]]; then
     exec python -m claude_mpm "${ARGS[@]}"
 else
     # Pass through to claude CLI
-    exec claude --dangerously-skip-permissions "$@"
+    if [[ "${CLAUDE_MPM_NO_SKIP_PERMISSIONS}" == "1" ]]; then
+        exec claude "$@"
+    else
+        exec claude --dangerously-skip-permissions "$@"
+    fi
 fi

--- a/src/claude_mpm/cli/commands/run.py
+++ b/src/claude_mpm/cli/commands/run.py
@@ -13,6 +13,7 @@ DESIGN DECISIONS:
 - Support multiple output formats (json, yaml, table, text)
 """
 
+import os
 import subprocess  # nosec B404 - required for process management
 import sys
 from datetime import datetime, timezone
@@ -70,6 +71,7 @@ def filter_claude_mpm_args(claude_args):
         "--mpm-resume",
         "--reload-agents",  # New flag to force rebuild system agents
         "--slack",  # Start Slack bot instead of Claude session
+        "--no-dangerously-skip-permissions",
         # Dependency checking flags (MPM-specific)
         "--no-check-dependencies",
         "--force-check-dependencies",
@@ -733,6 +735,10 @@ def _run_headless_session(args) -> int:
     if getattr(args, "fork_session", False):
         claude_args.append("--fork-session")
 
+    # Propagate --no-dangerously-skip-permissions to env var for session layers
+    if getattr(args, "no_dangerously_skip_permissions", False):
+        os.environ["CLAUDE_MPM_NO_SKIP_PERMISSIONS"] = "1"
+
     # Use ClaudeRunner (not MinimalRunner) to ensure _create_system_prompt is available
     # This is required for PM system prompt injection in headless mode
     try:
@@ -1161,6 +1167,10 @@ def run_session_legacy(args):
                     args._browser_opened_by_cli = False
             else:
                 print(f"✓ Socket.IO ready (port: {websocket_port})")
+
+    # Propagate --no-dangerously-skip-permissions to env var for session layers
+    if getattr(args, "no_dangerously_skip_permissions", False):
+        os.environ["CLAUDE_MPM_NO_SKIP_PERMISSIONS"] = "1"
 
     runner = ClaudeRunner(
         enable_tickets=enable_tickets,

--- a/src/claude_mpm/cli/parsers/base_parser.py
+++ b/src/claude_mpm/cli/parsers/base_parser.py
@@ -328,6 +328,17 @@ def add_top_level_run_arguments(parser: argparse.ArgumentParser) -> None:
         metavar="SERVICES",
         help="Comma-separated list of MCP services to enable for this session (e.g., --mcp kuzu-memory,mcp-ticketer,gworkspace-mcp). Use 'claude-mpm mcp list' to see available services.",
     )
+    run_group.add_argument(
+        "--no-dangerously-skip-permissions",
+        action="store_true",
+        dest="no_dangerously_skip_permissions",
+        default=False,
+        help=(
+            "Do not pass --dangerously-skip-permissions to Claude Code. "
+            "By default claude-mpm adds this flag automatically. "
+            "Alternatively set CLAUDE_MPM_NO_SKIP_PERMISSIONS=1."
+        ),
+    )
 
     # Dependency checking options (for backward compatibility at top level)
     dep_group_top = parser.add_argument_group(

--- a/src/claude_mpm/cli/parsers/run_parser.py
+++ b/src/claude_mpm/cli/parsers/run_parser.py
@@ -165,6 +165,13 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         help="Skip permission prompts (passed to Claude Code)",
     )
     passthrough_group.add_argument(
+        "--no-dangerously-skip-permissions",
+        action="store_true",
+        dest="no_dangerously_skip_permissions",
+        default=False,
+        help="Suppress the automatic --dangerously-skip-permissions flag passed to Claude Code.",
+    )
+    passthrough_group.add_argument(
         "--output-format",
         type=str,
         metavar="FORMAT",

--- a/src/claude_mpm/core/constants.py
+++ b/src/claude_mpm/core/constants.py
@@ -403,3 +403,12 @@ class ProjectPaths:
     def get_claude_dir(cls) -> Path:
         """Get the Claude directory."""
         return Path.cwd() / cls.CLAUDE_DIR
+
+
+import os
+
+
+def skip_permissions_disabled() -> bool:
+    """Return True if --dangerously-skip-permissions should be suppressed.
+    Checks CLAUDE_MPM_NO_SKIP_PERMISSIONS=1 environment variable."""
+    return os.environ.get("CLAUDE_MPM_NO_SKIP_PERMISSIONS", "0") == "1"

--- a/src/claude_mpm/core/interactive_session.py
+++ b/src/claude_mpm/core/interactive_session.py
@@ -416,7 +416,8 @@ class InteractiveSession:
 
             return cmd
         # Normal mode - full command with all claude-mpm enhancements
-        cmd = ["claude", "--dangerously-skip-permissions"]
+        from claude_mpm.core.constants import skip_permissions_disabled
+        cmd = ["claude"] if skip_permissions_disabled() else ["claude", "--dangerously-skip-permissions"]
 
         # Add custom arguments
         if self.runner.claude_args:

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -326,7 +326,8 @@ class OneshotSession:
 
     def _build_command(self) -> list:
         """Build the base Claude command."""
-        cmd = ["claude", "--dangerously-skip-permissions"]
+        from claude_mpm.core.constants import skip_permissions_disabled
+        cmd = ["claude"] if skip_permissions_disabled() else ["claude", "--dangerously-skip-permissions"]
 
         # Add custom arguments
         if self.runner.claude_args:


### PR DESCRIPTION
# 🚨 Security: claude-mpm is currently unsafe for DevOps/SRE use

## Problem

**claude-mpm unconditionally passes `--dangerously-skip-permissions` to every Claude Code subprocess it spawns.** This flag bypasses all of Claude Code's built-in permission prompts — meaning Claude can execute arbitrary shell commands, read/write any file on disk, and interact with external services **without ever asking for confirmation**.

This is not an opt-in behaviour. It cannot be disabled. It is hard-coded in:

- `src/claude_mpm/core/oneshot_session.py:329`
- `src/claude_mpm/core/interactive_session.py:419`
- `scripts/claude-mpm:155` (the shell wrapper pass-through)

### Why this matters for DevOps and SRE teams

In a typical CI/CD or infrastructure automation context, claude-mpm would run with access to:

- Cloud provider credentials (`AWS_ACCESS_KEY_ID`, `GCP_APPLICATION_CREDENTIALS`, etc.)
- Kubernetes configs and cluster access (`~/.kube/config`)
- Secrets managers, Vault tokens, and database connection strings
- Terraform state and infrastructure-as-code
- SSH keys and deploy credentials

With `--dangerously-skip-permissions` always on, **any prompt that causes the AI agent to take an unexpected action will execute immediately and silently** — no confirmation gate, no audit trail, no human in the loop.

This is not a theoretical risk. Common failure modes include:

- An agent misinterpreting a task and deleting files or dropping database tables
- Prompt injection via a malicious file in the repo causing unintended shell execution
- A runaway sub-agent executing `rm -rf`, `kubectl delete`, or `terraform destroy` without review
- Credentials being exfiltrated by a compromised tool or injected instruction

**In production or staging environments, this is a single-prompt-away from a serious incident.**

### Current status

claude-mpm is effectively **unusable in any security-conscious DevOps or SRE environment** in its current form. Teams that want to integrate AI-assisted automation into their pipelines cannot do so responsibly when bypass mode is always active and cannot be disabled.

---

## Solution

This PR adds two ways to opt out of bypass permissions mode:

### 1. CLI flag

```bash
claude-mpm --no-dangerously-skip-permissions
```

### 2. Environment variable (for CI/CD `.env` files, Docker, Kubernetes secrets)

```bash
CLAUDE_MPM_NO_SKIP_PERMISSIONS=1 claude-mpm
```

**Default behaviour is unchanged** — bypass mode remains on by default for backward compatibility. This is an opt-out, not an opt-in.

---

## Files Changed

| File | Change |
|------|--------|
| `src/claude_mpm/core/constants.py` | Add `skip_permissions_disabled()` helper reading `CLAUDE_MPM_NO_SKIP_PERMISSIONS` env var |
| `src/claude_mpm/cli/parsers/base_parser.py` | Add `--no-dangerously-skip-permissions` as a top-level flag |
| `src/claude_mpm/cli/parsers/run_parser.py` | Mirror flag in the `run` subcommand |
| `src/claude_mpm/cli/commands/run.py` | Bridge parsed flag to env var before session init; add to `mpm_flags` filter |
| `src/claude_mpm/core/oneshot_session.py` | Guard hard-coded flag via `skip_permissions_disabled()` |
| `src/claude_mpm/core/interactive_session.py` | Same guard in normal-mode `_build_command()` |
| `scripts/claude-mpm` | Guard shell wrapper pass-through with env var check |

---

## Future consideration

A follow-up PR could **flip the default** — making bypass permissions opt-in rather than opt-out — which would be the correct posture for a tool targeting DevOps and SRE workflows. This PR intentionally avoids that breaking change to keep the diff minimal and reviewable.
