### PR TITLE
Test instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,15 +67,15 @@ make release-publish
 ```
 
 ## Running Testcases Workflow
-**CRITICAL**: Preferably use `-n auto` pytest argument to leverage all available CPU cores for faster test execution when running the full suite.
+**CRITICAL**: Preferably use `-n auto` pytest argument to leverage all available CPU cores for faster test execution when running the full test suite.
 Use `-p no:xdist` pytest argument when debugging flaky or order-dependent tests, as parallelization can obscure root causes.
 Tests are run via `uv run pytest`, to ensure correct virtual environment activation.
 
 ### Run All Tests
-This uses uv run pytest with xdist parallelization under the hood, so tests run concurrently across multiple workers.
+This uses uv run pytest with xdist parallelization causing tests to run concurrently.
 ```bash
 make test
-```
+``
 
 **DO NOT**:
 - Manually edit version files


### PR DESCRIPTION
Parallelize testing when claude executes test cases to verify changes. This is a huge velocity improvement when verifying features, debugging etc in claude-mpm codebase. 

'make test' is the preferable full suite entry point. It already uses '-n auto' to detect number of cores. I'm thinking it should really be something like "auto" * 1.5 or 2.0. Observing the cpu/io loads when 'make test' is ran shows that there is room for more agressive parallelization. 