### PR TITLE
fix: centralize DISABLE_TELEMETRY to respect user overrides

### DIFF
--- a/scripts/claude-mpm
+++ b/scripts/claude-mpm
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Claude MPM executable wrapper with venv support
 
-# Disable telemetry by default
-export DISABLE_TELEMETRY=1
+# Disable telemetry by default, but respect any value already set in the shell
+export DISABLE_TELEMETRY="${DISABLE_TELEMETRY:-1}"
 
 # Get the directory where this script is located, following symlinks
 SOURCE="${BASH_SOURCE[0]}"

--- a/scripts/utilities/mcp_server.py
+++ b/scripts/utilities/mcp_server.py
@@ -17,8 +17,8 @@ import os
 import sys
 from pathlib import Path
 
-# Disable telemetry by default
-os.environ["DISABLE_TELEMETRY"] = "1"
+# Disable telemetry by default, but respect any value already set in the shell
+os.environ.setdefault("DISABLE_TELEMETRY", "1")
 
 # Add the project root to Python path
 project_root = Path(__file__).parent.parent

--- a/scripts/utilities/mcp_wrapper.py
+++ b/scripts/utilities/mcp_wrapper.py
@@ -16,8 +16,8 @@ to make debugging easier when things go wrong.
 import os
 import sys
 
-# Disable telemetry by default (set as early as possible)
-os.environ["DISABLE_TELEMETRY"] = "1"
+# Disable telemetry by default, but respect any value already set in the shell
+os.environ.setdefault("DISABLE_TELEMETRY", "1")
 
 import atexit
 import json

--- a/src/claude_mpm/__main__.py
+++ b/src/claude_mpm/__main__.py
@@ -13,8 +13,8 @@ keeping this file minimal and focused on its single responsibility.
 import os
 import sys
 
-# Disable telemetry by default
-os.environ["DISABLE_TELEMETRY"] = "1"
+# Disable telemetry by default, but respect any value already set in the shell
+os.environ.setdefault("DISABLE_TELEMETRY", "1")
 
 # Add parent directory to path to ensure proper imports
 sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/claude_mpm/cli/__main__.py
+++ b/src/claude_mpm/cli/__main__.py
@@ -23,8 +23,8 @@ proper Python module context and import resolution.
 import os
 import sys
 
-# Disable telemetry by default
-os.environ["DISABLE_TELEMETRY"] = "1"
+# Disable telemetry by default, but respect any value already set in the shell
+os.environ.setdefault("DISABLE_TELEMETRY", "1")
 
 from . import main
 

--- a/src/claude_mpm/core/constants.py
+++ b/src/claude_mpm/core/constants.py
@@ -276,6 +276,9 @@ class Defaults:
     TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
     LOG_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+    # Telemetry defaults
+    DISABLE_TELEMETRY_DEFAULT = "1"  # Telemetry disabled by default
+
 
 class PerformanceConfig:
     """Performance optimization settings."""
@@ -447,6 +450,25 @@ class ProjectPaths:
     def get_claude_dir(cls) -> Path:
         """Get the Claude directory."""
         return Path.cwd() / cls.CLAUDE_DIR
+
+
+def get_telemetry_env_value() -> str:
+    """Get the DISABLE_TELEMETRY value, respecting the shell environment.
+
+    If DISABLE_TELEMETRY is already set in the environment (e.g. by the user
+    before launching claude-mpm), that value is returned unchanged.  Otherwise
+    the default of ``"1"`` (telemetry disabled) is used.
+
+    This function is intended for use when building subprocess environment
+    dictionaries so that a user-supplied ``DISABLE_TELEMETRY=0`` propagates
+    into every child process rather than being silently overwritten.
+
+    Returns:
+        The string value of DISABLE_TELEMETRY (``"0"`` or ``"1"``, or
+        whatever the user set).  Defaults to ``Defaults.DISABLE_TELEMETRY_DEFAULT``
+        (``"1"``) when the variable is absent from the environment.
+    """
+    return os.environ.get("DISABLE_TELEMETRY", Defaults.DISABLE_TELEMETRY_DEFAULT)
 
 
 def skip_permissions_disabled() -> bool:

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+from claude_mpm.core.constants import get_telemetry_env_value
 from claude_mpm.core.logger import get_logger
 
 # Protocol imports for type checking without circular dependencies
@@ -379,8 +380,8 @@ class HeadlessSession:
         """Prepare the execution environment."""
         env = os.environ.copy()
 
-        # Disable telemetry for Claude Code
-        env["DISABLE_TELEMETRY"] = "1"
+        # Propagate the user's DISABLE_TELEMETRY preference to the child process.
+        env["DISABLE_TELEMETRY"] = get_telemetry_env_value()
 
         # Ensure no interactive prompts
         env["CI"] = "true"

--- a/src/claude_mpm/core/interactive_session.py
+++ b/src/claude_mpm/core/interactive_session.py
@@ -17,6 +17,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
+from claude_mpm.core.constants import get_telemetry_env_value
 from claude_mpm.core.enums import ServiceState
 from claude_mpm.core.logger import get_logger
 
@@ -561,9 +562,8 @@ class InteractiveSession:
         for var in claude_vars_to_remove:
             clean_env.pop(var, None)
 
-        # Disable telemetry for Claude Code
-        # This ensures Claude Code doesn't send telemetry data during runtime
-        clean_env["DISABLE_TELEMETRY"] = "1"
+        # Propagate the user's DISABLE_TELEMETRY preference to the child process.
+        clean_env["DISABLE_TELEMETRY"] = get_telemetry_env_value()
 
         return clean_env
 

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
+from claude_mpm.core.constants import get_telemetry_env_value
 from claude_mpm.core.enums import OperationResult, ServiceState
 from claude_mpm.core.logger import get_logger
 
@@ -318,9 +319,8 @@ class OneshotSession:
         """Prepare the execution environment."""
         env = os.environ.copy()
 
-        # Disable telemetry for Claude Code
-        # This ensures Claude Code doesn't send telemetry data during runtime
-        env["DISABLE_TELEMETRY"] = "1"
+        # Propagate the user's DISABLE_TELEMETRY preference to the child process.
+        env["DISABLE_TELEMETRY"] = get_telemetry_env_value()
 
         return env
 

--- a/src/claude_mpm/mcp/subprocess_wrapper.py
+++ b/src/claude_mpm/mcp/subprocess_wrapper.py
@@ -11,6 +11,7 @@ import uuid
 from pathlib import Path
 from typing import Any, AsyncIterator
 
+from claude_mpm.core.constants import get_telemetry_env_value
 from claude_mpm.mcp.errors import SessionError
 from claude_mpm.mcp.models import SessionResult
 from claude_mpm.mcp.ndjson_parser import (
@@ -42,7 +43,7 @@ class ClaudeMPMSubprocess:
         overrides: dict[str, str] | None = None,
     ) -> dict[str, str]:
         env = os.environ.copy()
-        env["DISABLE_TELEMETRY"] = "1"
+        env["DISABLE_TELEMETRY"] = get_telemetry_env_value()
         env["CI"] = "true"
         env["CLAUDE_MPM_USER_PWD"] = self.working_directory
         env["CLAUDE_MPM_IS_SUBPROCESS"] = "1"

--- a/src/claude_mpm/services/subprocess_launcher_service.py
+++ b/src/claude_mpm/services/subprocess_launcher_service.py
@@ -22,6 +22,7 @@ import tty
 from typing import Any, Dict, List, Optional
 
 from claude_mpm.core.base_service import BaseService
+from claude_mpm.core.constants import get_telemetry_env_value
 from claude_mpm.core.enums import OperationResult, ServiceState
 from claude_mpm.services.core.interfaces import SubprocessLauncherInterface
 
@@ -315,8 +316,9 @@ class SubprocessLauncherService(BaseService, SubprocessLauncherInterface):
         if base_env:
             env.update(base_env)
 
-        # Disable telemetry for Claude Code subprocesses
-        # This ensures Claude Code doesn't send telemetry data during runtime
-        env["DISABLE_TELEMETRY"] = "1"
+        # Propagate the user's DISABLE_TELEMETRY preference to child processes.
+        # get_telemetry_env_value() returns the current env value (defaulting to
+        # "1") so a user-supplied DISABLE_TELEMETRY=0 is honoured here.
+        env["DISABLE_TELEMETRY"] = get_telemetry_env_value()
 
         return env

--- a/tests/cli/test_headless.py
+++ b/tests/cli/test_headless.py
@@ -17,6 +17,7 @@ The actual os.execvpe() execution is mocked since it replaces the process.
 
 import io
 import json
+import os
 import subprocess
 import sys
 from argparse import Namespace
@@ -477,7 +478,7 @@ class TestHeadlessIntegration:
                 assert exit_code == 126  # Standard "permission denied" exit code
 
     def test_environment_sets_disable_telemetry(self, mock_runner):
-        """Headless run should set DISABLE_TELEMETRY=1."""
+        """Headless run should default DISABLE_TELEMETRY to '1' when not set."""
         mock_runner.claude_args = []
 
         with patch.object(
@@ -485,9 +486,25 @@ class TestHeadlessIntegration:
         ):
             session = HeadlessSession(mock_runner)
 
-        env = session._prepare_environment()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DISABLE_TELEMETRY", None)
+            env = session._prepare_environment()
 
         assert env.get("DISABLE_TELEMETRY") == "1"
+
+    def test_environment_propagates_telemetry_override(self, mock_runner):
+        """Headless run should propagate a user-supplied DISABLE_TELEMETRY=0."""
+        mock_runner.claude_args = []
+
+        with patch.object(
+            HeadlessSession, "_get_working_directory", return_value=Path("/test")
+        ):
+            session = HeadlessSession(mock_runner)
+
+        with patch.dict(os.environ, {"DISABLE_TELEMETRY": "0"}):
+            env = session._prepare_environment()
+
+        assert env.get("DISABLE_TELEMETRY") == "0"
 
     def test_environment_sets_ci_true(self, mock_runner):
         """Headless run should set CI=true."""

--- a/tests/core/test_oneshot_session.py
+++ b/tests/core/test_oneshot_session.py
@@ -528,10 +528,19 @@ class TestOneshotSession:
             assert oneshot_session.runner.websocket_server is None
 
     def test_prepare_environment(self, oneshot_session):
-        """Test environment preparation."""
+        """Test environment preparation defaults DISABLE_TELEMETRY to '1'."""
         with patch("os.environ.copy", return_value={"TEST": "value"}):
-            result = oneshot_session._prepare_environment()
-            assert result == {"TEST": "value", "DISABLE_TELEMETRY": "1"}
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("DISABLE_TELEMETRY", None)
+                result = oneshot_session._prepare_environment()
+        assert result == {"TEST": "value", "DISABLE_TELEMETRY": "1"}
+
+    def test_prepare_environment_respects_override(self, oneshot_session):
+        """Test that a user-supplied DISABLE_TELEMETRY value is propagated."""
+        with patch("os.environ.copy", return_value={"TEST": "value"}):
+            with patch.dict(os.environ, {"DISABLE_TELEMETRY": "0"}):
+                result = oneshot_session._prepare_environment()
+        assert result["DISABLE_TELEMETRY"] == "0"
 
     def test_build_command_basic(self, oneshot_session):
         """Test basic command building."""

--- a/tests/mcp/test_subprocess_wrapper.py
+++ b/tests/mcp/test_subprocess_wrapper.py
@@ -56,13 +56,24 @@ class TestPrepareEnvironment:
         # Should have environment variables from os.environ
         assert "PATH" in env or len(env) > 0
 
-    def test_sets_disable_telemetry(self):
-        """Should set DISABLE_TELEMETRY=1."""
+    def test_sets_disable_telemetry_default(self):
+        """Should default DISABLE_TELEMETRY to '1' when not set in the environment."""
         wrapper = ClaudeMPMSubprocess()
 
-        env = wrapper._prepare_environment()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DISABLE_TELEMETRY", None)
+            env = wrapper._prepare_environment()
 
         assert env["DISABLE_TELEMETRY"] == "1"
+
+    def test_propagates_user_disable_telemetry_override(self):
+        """Should propagate a user-supplied DISABLE_TELEMETRY value to child env."""
+        wrapper = ClaudeMPMSubprocess()
+
+        with patch.dict(os.environ, {"DISABLE_TELEMETRY": "0"}):
+            env = wrapper._prepare_environment()
+
+        assert env["DISABLE_TELEMETRY"] == "0"
 
     def test_sets_ci_mode(self):
         """Should set CI=true for non-interactive mode."""

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """
-Test script to verify that DISABLE_TELEMETRY is set correctly.
+Test script to verify that DISABLE_TELEMETRY is handled correctly.
+
+The expected behaviour after centralisation:
+- When DISABLE_TELEMETRY is *not* set in the environment, entry points default
+  it to "1" (telemetry disabled).
+- When DISABLE_TELEMETRY is *already* set (e.g. DISABLE_TELEMETRY=0 by the
+  user), entry points preserve that value instead of overwriting it.
 """
 
 import os
@@ -11,28 +17,55 @@ from pathlib import Path
 import pytest
 
 
-def test_python_module():
-    """Test if DISABLE_TELEMETRY is set when running as Python module."""
-    try:
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                "import os; os.environ.setdefault('DISABLE_TELEMETRY', '0'); "
-                "import sys; sys.path.insert(0, 'src'); "
-                "from claude_mpm import __main__; "
-                "print(os.environ.get('DISABLE_TELEMETRY', 'not set'))",
-            ],
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            check=False,
-        )
-        output = result.stdout.strip()
-        return output == "1"
-    except Exception as e:
-        print(f"  Error: {e}")
-        return False
+def _run_python_snippet(snippet: str, env: dict | None = None) -> str:
+    """Run a one-liner Python snippet in a subprocess and return its stdout."""
+    run_env = os.environ.copy()
+    if env is not None:
+        run_env.update(env)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; sys.path.insert(0, 'src'); {snippet}",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parent.parent,
+        check=False,
+        env=run_env,
+    )
+    return result.stdout.strip()
+
+
+def test_python_module_default():
+    """Entry point defaults DISABLE_TELEMETRY to '1' when not pre-set."""
+    # Strip DISABLE_TELEMETRY from the child environment so we test the true
+    # default path.
+    child_env = {k: v for k, v in os.environ.items() if k != "DISABLE_TELEMETRY"}
+    output = _run_python_snippet(
+        "import os; "
+        "from claude_mpm import __main__; "
+        "print(os.environ.get('DISABLE_TELEMETRY', 'not set'))",
+        env=child_env,
+    )
+    assert output == "1", (
+        f"Expected DISABLE_TELEMETRY='1' when not pre-set, got {output!r}"
+    )
+
+
+def test_python_module_preserves_override():
+    """Entry point preserves DISABLE_TELEMETRY='0' when pre-set by the user."""
+    child_env = dict(os.environ)
+    child_env["DISABLE_TELEMETRY"] = "0"
+    output = _run_python_snippet(
+        "import os; "
+        "from claude_mpm import __main__; "
+        "print(os.environ.get('DISABLE_TELEMETRY', 'not set'))",
+        env=child_env,
+    )
+    assert output == "0", (
+        f"Expected DISABLE_TELEMETRY='0' to be preserved, got {output!r}"
+    )
 
 
 @pytest.mark.skip(
@@ -64,9 +97,9 @@ def test_bash_script(script_path):
     "Not a standalone pytest test — 'script_path' is not a registered pytest fixture."
 )
 def test_python_script(script_path):
-    """Test if a Python script sets DISABLE_TELEMETRY."""
+    """Test if a Python script sets DISABLE_TELEMETRY (via setdefault pattern)."""
     try:
-        # Check if the script contains the environment setting
+        # Accept both the old hard-override pattern and the new setdefault pattern
         with script_path.open() as f:
             content = f.read()
         return (
@@ -102,12 +135,12 @@ def main():
         script_path = project_root / script
         if script_path.exists():
             if test_bash_script(script_path):
-                print(f"  ✅ {description}: DISABLE_TELEMETRY=1 is set")
+                print(f"  OK {description}: DISABLE_TELEMETRY=1 is set")
             else:
-                print(f"  ❌ {description}: DISABLE_TELEMETRY not properly set")
+                print(f"  FAIL {description}: DISABLE_TELEMETRY not properly set")
                 bash_passed = False
         else:
-            print(f"  ⚠️  {description}: Script not found at {script_path}")
+            print(f"  SKIP {description}: Script not found at {script_path}")
 
     # Test Python entry points
     print("\n2. Testing Python Entry Points:")
@@ -128,12 +161,12 @@ def main():
         script_path = project_root / script
         if script_path.exists():
             if test_python_script(script_path):
-                print(f"  ✅ {description}: Sets DISABLE_TELEMETRY=1")
+                print(f"  OK {description}: Sets DISABLE_TELEMETRY=1")
             else:
-                print(f"  ❌ {description}: Does not set DISABLE_TELEMETRY")
+                print(f"  FAIL {description}: Does not set DISABLE_TELEMETRY")
                 python_passed = False
         else:
-            print(f"  ⚠️  {description}: Script not found at {script_path}")
+            print(f"  SKIP {description}: Script not found at {script_path}")
 
     # Test Node.js scripts
     print("\n3. Testing Node.js Entry Points:")
@@ -149,29 +182,35 @@ def main():
             with script_path.open() as f:
                 content = f.read()
             if "process.env.DISABLE_TELEMETRY = '1'" in content:
-                print(f"  ✅ {description}: Sets DISABLE_TELEMETRY=1")
+                print(f"  OK {description}: Sets DISABLE_TELEMETRY=1")
             else:
-                print(f"  ❌ {description}: Does not set DISABLE_TELEMETRY")
+                print(f"  FAIL {description}: Does not set DISABLE_TELEMETRY")
                 node_passed = False
         else:
-            print(f"  ⚠️  {description}: Script not found at {script_path}")
+            print(f"  SKIP {description}: Script not found at {script_path}")
 
     # Test the actual Python module import
     print("\n4. Testing Runtime Behavior:")
-    if test_python_module():
-        print("  ✅ Python module sets DISABLE_TELEMETRY=1 on import")
-        module_passed = True
+    child_env = {k: v for k, v in os.environ.items() if k != "DISABLE_TELEMETRY"}
+    output = _run_python_snippet(
+        "import os; "
+        "from claude_mpm import __main__; "
+        "print(os.environ.get('DISABLE_TELEMETRY', 'not set'))",
+        env=child_env,
+    )
+    module_passed = output == "1"
+    if module_passed:
+        print("  OK Python module defaults DISABLE_TELEMETRY=1")
     else:
-        print("  ❌ Python module does not set DISABLE_TELEMETRY properly")
-        module_passed = False
+        print(f"  FAIL Python module produced unexpected value: {output!r}")
 
     print("\n" + "=" * 60)
     all_passed = bash_passed and python_passed and node_passed and module_passed
     if all_passed:
-        print("✅ SUCCESS: All entry points properly set DISABLE_TELEMETRY=1")
+        print("SUCCESS: All entry points properly set DISABLE_TELEMETRY=1")
         print("Telemetry is disabled by default in claude-mpm")
     else:
-        print("⚠️  WARNING: Some entry points may not disable telemetry")
+        print("WARNING: Some entry points may not disable telemetry")
         print("Please review the failed tests above")
     print("=" * 60)
 


### PR DESCRIPTION
## Summary

Alternative approach to #338. Rather than simply removing `DISABLE_TELEMETRY=1`, this PR **centralizes** the handling so that:

- Telemetry is still **disabled by default** (`DISABLE_TELEMETRY=1`)
- Users who **need** telemetry can set `export DISABLE_TELEMETRY=0` and have that value respected throughout the entire process tree (entry points + all subprocesses)

### What changed

- **`core/constants.py`**: Added `Defaults.DISABLE_TELEMETRY_DEFAULT` and `get_telemetry_env_value()` as single source of truth
- **Entry points** (5 files): Changed from `os.environ["DISABLE_TELEMETRY"] = "1"` (which overwrites user preference) to `os.environ.setdefault(...)` (which respects it)
- **Subprocess env prep** (5 files): Changed from hardcoded `"1"` to `get_telemetry_env_value()` so child processes inherit the user's choice
- **Bash wrapper**: `export DISABLE_TELEMETRY=1` → `export DISABLE_TELEMETRY="${DISABLE_TELEMETRY:-1}"`
- **Tests** (4 files): Added override propagation tests alongside existing default-behavior tests

### Why this instead of #338

PR #338 removes `DISABLE_TELEMETRY=1` entirely, which changes the default behavior for all users. This PR preserves the safe default (telemetry off) while fixing the actual bug: user-set `DISABLE_TELEMETRY=0` was being silently overwritten in 10+ locations.

### 15 files changed, 0 files created

| Category | Files |
|----------|-------|
| Core | `constants.py` |
| Entry points | `__main__.py` ×2, `scripts/claude-mpm`, `mcp_server.py`, `mcp_wrapper.py` |
| Subprocess env | `subprocess_wrapper.py`, `subprocess_launcher_service.py`, `headless_session.py`, `interactive_session.py`, `oneshot_session.py` |
| Tests | `test_telemetry_disabled.py`, `test_subprocess_wrapper.py`, `test_oneshot_session.py`, `test_headless.py` |

## Test plan

- [x] 142 tests pass, 2 skipped (pre-existing helper stubs)
- [x] Zero hardcoded `environ["DISABLE_TELEMETRY"] = "1"` overrides remain in source
- [x] New tests verify: default → `"1"`, pre-set `"0"` → preserved through subprocesses
- [ ] Manual: `export DISABLE_TELEMETRY=0 && claude-mpm --help` should propagate `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)