### PR TITLE
fix: clean stale claude-mpm hook entries from ~/.claude/settings.json on startup

### DIFF
--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -189,46 +189,209 @@ def quiet_startup_context(headless: bool = False):
 
 
 def cleanup_user_level_hooks() -> bool:
-    """Remove stale user-level hooks directory.
+    """Remove stale user-level hooks directory and settings.json entries.
 
     WHY: claude-mpm previously deployed hooks to ~/.claude/hooks/claude-mpm/
     (user-level). This is now deprecated in favor of project-level hooks
     configured in .claude/settings.local.json. Stale user-level hooks can
-    cause conflicts and confusion.
+    cause conflicts and confusion, and stale entries in ~/.claude/settings.json
+    (the user-level settings) cause "SessionStart:startup hook error" on every
+    Claude Code session when the referenced script no longer exists on disk.
 
     DESIGN DECISION: Runs early in startup, before project hook sync.
     Non-blocking - failures are logged at debug level but don't prevent startup.
 
     Returns:
-        bool: True if hooks were cleaned up, False if none found or cleanup failed
+        bool: True if any cleanup was performed, False if nothing found or
+              cleanup failed
     """
     import shutil
 
+    cleaned = False
+
+    # Step 1: Remove stale user-level hooks directory
     user_hooks_dir = Path.home() / ".claude" / "hooks" / "claude-mpm"
 
-    if not user_hooks_dir.exists():
+    if user_hooks_dir.exists():
+        try:
+            from ..core.logger import get_logger
+
+            logger = get_logger("startup")
+            logger.debug(f"Removing stale user-level hooks directory: {user_hooks_dir}")
+
+            shutil.rmtree(user_hooks_dir)
+
+            logger.debug("User-level hooks directory cleanup complete")
+            cleaned = True
+        except Exception as e:
+            # Non-critical - log but don't fail startup
+            try:
+                from ..core.logger import get_logger
+
+                logger = get_logger("startup")
+                logger.debug(
+                    f"Failed to cleanup user-level hooks directory (non-fatal): {e}"
+                )
+            except Exception:  # nosec B110
+                pass  # Avoid any errors in error handling
+
+    # Step 2: Remove stale claude-mpm hook entries from ~/.claude/settings.json
+    stale_removed = _cleanup_stale_settings_json_hooks()
+    if stale_removed > 0:
+        cleaned = True
+
+    return cleaned
+
+
+def _is_stale_hook_command(command: str) -> bool:
+    """Return True if a hook command string belongs to claude-mpm and the
+    referenced script no longer exists on disk.
+
+    Stale entries are those where:
+    - The command contains "claude-mpm" or "claude-hook" (belongs to us), AND
+    - The command is an absolute path that does not exist on disk.
+
+    Entry-point style commands like "claude-hook" that are resolved via PATH
+    at runtime are NOT considered stale even if the package is not currently
+    installed, because their existence depends on PATH at execution time.
+
+    Args:
+        command: The command string from a hook entry.
+
+    Returns:
+        bool: True if this is a stale claude-mpm absolute-path hook command.
+    """
+    if not command:
         return False
+
+    is_ours = "claude-mpm" in command or "claude-hook" in command
+
+    if not is_ours:
+        return False
+
+    # Entry-point commands (no path separator) are PATH-resolved at runtime —
+    # don't remove them based on current filesystem state.
+    if not command.startswith("/"):
+        return False
+
+    # Absolute path that belongs to claude-mpm: check if it exists.
+    return not Path(command).exists()
+
+
+def _cleanup_stale_settings_json_hooks() -> int:
+    """Remove stale claude-mpm hook entries from ~/.claude/settings.json.
+
+    Reads the user-level settings file, removes hook entries where:
+    - The command path contains "claude-mpm" or "claude-hook", AND
+    - The referenced script file does not exist on disk.
+
+    Valid hook entries from other tools and entries with resolvable commands
+    are preserved. The file is only written if changes were actually made
+    (idempotent).
+
+    Returns:
+        int: Number of stale hook command entries removed.
+    """
+    user_settings = Path.home() / ".claude" / "settings.json"
+
+    if not user_settings.exists():
+        return 0
 
     try:
         from ..core.logger import get_logger
 
         logger = get_logger("startup")
-        logger.debug(f"Removing stale user-level hooks directory: {user_hooks_dir}")
+    except Exception:
+        logger = None
 
-        shutil.rmtree(user_hooks_dir)
+    def _log_debug(msg: str) -> None:
+        if logger:
+            logger.debug(msg)
 
-        logger.debug("User-level hooks cleanup complete")
-        return True
+    try:
+        with user_settings.open() as f:
+            settings = json.load(f)
     except Exception as e:
-        # Non-critical - log but don't fail startup
-        try:
-            from ..core.logger import get_logger
+        _log_debug(
+            f"Could not read {user_settings} for stale hook cleanup (non-fatal): {e}"
+        )
+        return 0
 
-            logger = get_logger("startup")
-            logger.debug(f"Failed to cleanup user-level hooks (non-fatal): {e}")
-        except Exception:  # nosec B110
-            pass  # Avoid any errors in error handling
-        return False
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return 0
+
+    total_removed = 0
+    events_to_delete: list[str] = []
+
+    for event_type, hook_list in hooks.items():
+        if not isinstance(hook_list, list):
+            continue
+
+        entries_to_delete: list[int] = []
+
+        for entry_idx, entry in enumerate(hook_list):
+            if not isinstance(entry, dict):
+                continue
+
+            inner_hooks = entry.get("hooks", [])
+            if not isinstance(inner_hooks, list):
+                continue
+
+            cmds_to_delete: list[int] = []
+            for cmd_idx, cmd_entry in enumerate(inner_hooks):
+                if not isinstance(cmd_entry, dict):
+                    continue
+                command = cmd_entry.get("command", "")
+                if _is_stale_hook_command(command):
+                    cmds_to_delete.append(cmd_idx)
+                    _log_debug(
+                        f"Marking stale hook for removal: {event_type} "
+                        f"entry[{entry_idx}] command '{command}'"
+                    )
+
+            if cmds_to_delete:
+                total_removed += len(cmds_to_delete)
+                # Remove stale commands in reverse order to preserve indices
+                for cmd_idx in reversed(cmds_to_delete):
+                    inner_hooks.pop(cmd_idx)
+
+            # If all commands in this entry are now gone, mark the whole entry
+            # for removal so we don't leave behind an empty hooks wrapper.
+            if not inner_hooks:
+                entries_to_delete.append(entry_idx)
+
+        if entries_to_delete:
+            # Remove entries in reverse order to preserve indices
+            for entry_idx in reversed(entries_to_delete):
+                hook_list.pop(entry_idx)
+
+        # If all entries for an event type are gone, schedule event removal
+        if not hook_list:
+            events_to_delete.append(event_type)
+
+    for event_type in events_to_delete:
+        del hooks[event_type]
+
+    if total_removed == 0:
+        # Nothing changed — don't touch the file (idempotent)
+        return 0
+
+    # Write the cleaned settings back, preserving all other keys
+    try:
+        with user_settings.open("w") as f:
+            json.dump(settings, f, indent=2)
+        _log_debug(
+            f"Removed {total_removed} stale claude-mpm hook command(s) "
+            f"from {user_settings}"
+        )
+    except Exception as e:
+        _log_debug(
+            f"Could not write cleaned settings to {user_settings} (non-fatal): {e}"
+        )
+        return 0
+
+    return total_removed
 
 
 def sync_hooks_on_startup(quiet: bool = False) -> bool:

--- a/tests/cli/test_cleanup_stale_settings_hooks.py
+++ b/tests/cli/test_cleanup_stale_settings_hooks.py
@@ -1,0 +1,445 @@
+"""Tests for stale hook entry cleanup from ~/.claude/settings.json.
+
+Covers:
+- Stale entries are removed (path contains claude-mpm/claude-hook and file
+  doesn't exist on disk)
+- Valid entries from other tools are preserved
+- No-op when no stale entries exist (file not modified)
+- Handles missing ~/.claude/settings.json gracefully
+- Handles settings.json with no hooks key gracefully
+- cleanup_user_level_hooks() integrates both directory and settings cleanup
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hook_entry(command: str, with_matcher: bool = False) -> dict:
+    """Build a minimal hook entry dict as written by HookInstaller."""
+    cmd_obj = {"type": "command", "command": command}
+    entry: dict = {"hooks": [cmd_obj]}
+    if with_matcher:
+        entry["matcher"] = "*"
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# _is_stale_hook_command unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsStaleHookCommand:
+    """Unit tests for the _is_stale_hook_command predicate."""
+
+    def _call(self, command: str) -> bool:
+        from claude_mpm.cli.startup import _is_stale_hook_command
+
+        return _is_stale_hook_command(command)
+
+    def test_empty_command_is_not_stale(self):
+        assert self._call("") is False
+
+    def test_unrelated_command_is_not_stale(self):
+        assert self._call("/usr/local/bin/some-other-tool") is False
+
+    def test_entry_point_claude_hook_is_not_stale(self):
+        """'claude-hook' (no path) is resolved via PATH at runtime — not stale."""
+        assert self._call("claude-hook") is False
+
+    def test_relative_path_with_claude_hook_is_not_stale(self):
+        """Relative paths are not absolute-path validated."""
+        assert self._call("bin/claude-hook") is False
+
+    def test_absolute_path_containing_claude_mpm_nonexistent_is_stale(self, tmp_path):
+        stale_path = str(tmp_path / "claude-mpm" / "scripts" / "hook.sh")
+        # File does NOT exist at stale_path
+        assert self._call(stale_path) is True
+
+    def test_absolute_path_containing_claude_hook_nonexistent_is_stale(self, tmp_path):
+        stale_path = str(tmp_path / "bin" / "claude-hook-fast.sh")
+        assert self._call(stale_path) is True
+
+    def test_absolute_path_claude_mpm_existing_is_not_stale(self, tmp_path):
+        """An absolute path that actually exists is not stale."""
+        existing = tmp_path / "claude-mpm" / "scripts" / "hook.sh"
+        existing.parent.mkdir(parents=True)
+        existing.touch()
+        assert self._call(str(existing)) is False
+
+    def test_absolute_path_claude_hook_existing_is_not_stale(self, tmp_path):
+        existing = tmp_path / "claude-hook-fast.sh"
+        existing.touch()
+        assert self._call(str(existing)) is False
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_stale_settings_json_hooks unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupStaleSettingsJsonHooks:
+    """Unit tests for _cleanup_stale_settings_json_hooks."""
+
+    def _call(self) -> int:
+        from claude_mpm.cli.startup import _cleanup_stale_settings_json_hooks
+
+        return _cleanup_stale_settings_json_hooks()
+
+    def test_missing_settings_file_returns_zero(self, tmp_path):
+        """When ~/.claude/settings.json does not exist, return 0."""
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 0
+
+    def test_settings_without_hooks_key_returns_zero(self, tmp_path):
+        """When settings.json has no 'hooks' key, return 0."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 0
+
+    def test_no_stale_entries_returns_zero_and_file_unchanged(self, tmp_path):
+        """When all hook entries reference existing files, nothing is removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        # Create a real script file so the path "exists"
+        script = tmp_path / "claude-hook-fast.sh"
+        script.touch()
+
+        original_data = {
+            "hooks": {
+                "SessionStart": [
+                    _make_hook_entry(str(script), with_matcher=True)
+                ]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(original_data, indent=2))
+        original_mtime = settings_file.stat().st_mtime
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 0
+        # File must not have been rewritten
+        assert settings_file.stat().st_mtime == original_mtime
+
+    def test_stale_entry_is_removed(self, tmp_path):
+        """A hook entry pointing to a non-existent claude-mpm script is removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale_path = str(tmp_path / "pipx" / "venvs" / "claude-mpm" / "scripts" / "claude-hook-fast.sh")
+        # stale_path does NOT exist on disk
+
+        data = {
+            "hooks": {
+                "SessionStart": [
+                    _make_hook_entry(stale_path, with_matcher=True)
+                ]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 1  # one command removed
+        cleaned = json.loads(settings_file.read_text())
+        # Event key should be gone since entry is empty
+        assert "SessionStart" not in cleaned.get("hooks", {})
+
+    def test_entries_from_other_tools_are_preserved(self, tmp_path):
+        """Hook entries not belonging to claude-mpm are never removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale_path = str(tmp_path / "claude-mpm" / "nonexistent.sh")
+
+        other_tool_entry = _make_hook_entry("/usr/local/bin/some-other-hook")
+        stale_entry = _make_hook_entry(stale_path)
+
+        data = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {"type": "command", "command": "/usr/local/bin/some-other-hook"},
+                            {"type": "command", "command": stale_path},
+                        ],
+                    }
+                ]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 1  # only the stale command removed
+        cleaned = json.loads(settings_file.read_text())
+        session_hooks = cleaned["hooks"]["SessionStart"]
+        assert len(session_hooks) == 1
+        remaining_cmds = session_hooks[0]["hooks"]
+        assert len(remaining_cmds) == 1
+        assert remaining_cmds[0]["command"] == "/usr/local/bin/some-other-hook"
+
+    def test_multiple_stale_entries_across_events_all_removed(self, tmp_path):
+        """Multiple stale entries across different event types are all removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale1 = str(tmp_path / "claude-mpm" / "scripts" / "hook.sh")
+        stale2 = str(tmp_path / "claude-hook-handler.sh")
+
+        data = {
+            "hooks": {
+                "SessionStart": [_make_hook_entry(stale1, with_matcher=True)],
+                "Stop": [_make_hook_entry(stale2)],
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 2
+        cleaned = json.loads(settings_file.read_text())
+        assert cleaned.get("hooks", {}) == {}
+
+    def test_non_hooks_settings_are_preserved(self, tmp_path):
+        """Non-hook settings keys (permissions, mcpServers, etc.) survive cleanup."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale_path = str(tmp_path / "claude-mpm" / "hook.sh")
+
+        data = {
+            "permissions": {"allow": ["Bash"]},
+            "enableAllProjectMcpServers": True,
+            "outputStyle": "claude_mpm",
+            "hooks": {
+                "Stop": [_make_hook_entry(stale_path)]
+            },
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 1
+        cleaned = json.loads(settings_file.read_text())
+        assert cleaned["permissions"] == {"allow": ["Bash"]}
+        assert cleaned["enableAllProjectMcpServers"] is True
+        assert cleaned["outputStyle"] == "claude_mpm"
+
+    def test_entry_point_command_not_removed(self, tmp_path):
+        """The 'claude-hook' entry-point command is PATH-resolved — never removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        data = {
+            "hooks": {
+                "Stop": [_make_hook_entry("claude-hook")]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 0
+
+    def test_invalid_json_returns_zero(self, tmp_path):
+        """Corrupted settings.json is handled gracefully."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text("{not valid json")
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 0
+
+    def test_empty_hooks_section_after_cleanup(self, tmp_path):
+        """When all hook entries are removed, the hooks key becomes empty dict."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale = str(tmp_path / "claude-mpm" / "scripts" / "fast-hook.sh")
+
+        data = {
+            "hooks": {
+                "SessionStart": [_make_hook_entry(stale, with_matcher=True)],
+                "PreToolUse": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {"type": "command", "command": stale},
+                        ],
+                    }
+                ],
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 2
+        cleaned = json.loads(settings_file.read_text())
+        # Hooks dict should be empty (all events removed)
+        assert cleaned["hooks"] == {}
+
+    def test_mixed_valid_and_stale_same_entry(self, tmp_path):
+        """When one entry has both a valid and stale command, only stale is removed."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        # Valid script (actually exists)
+        valid_script = tmp_path / "claude-hook-fast.sh"
+        valid_script.touch()
+
+        stale_path = str(tmp_path / "pipx" / "claude-mpm" / "hook.sh")
+
+        data = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {"type": "command", "command": str(valid_script)},
+                            {"type": "command", "command": stale_path},
+                        ],
+                    }
+                ]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result == 1
+        cleaned = json.loads(settings_file.read_text())
+        session_hooks = cleaned["hooks"]["SessionStart"]
+        assert len(session_hooks) == 1
+        remaining = session_hooks[0]["hooks"]
+        assert len(remaining) == 1
+        assert remaining[0]["command"] == str(valid_script)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_user_level_hooks integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupUserLevelHooksIntegration:
+    """Integration tests for cleanup_user_level_hooks() combining both steps."""
+
+    def _call(self) -> bool:
+        from claude_mpm.cli.startup import cleanup_user_level_hooks
+
+        return cleanup_user_level_hooks()
+
+    def test_nothing_to_clean_returns_false(self, tmp_path):
+        """When neither the directory nor stale entries exist, return False."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result is False
+
+    def test_directory_cleanup_returns_true(self, tmp_path):
+        """When the stale hooks directory exists, cleanup returns True."""
+        hooks_dir = tmp_path / ".claude" / "hooks" / "claude-mpm"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "hook.sh").touch()
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result is True
+        assert not hooks_dir.exists()
+
+    def test_stale_settings_cleanup_returns_true(self, tmp_path):
+        """When stale settings.json entries exist, cleanup returns True."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+
+        stale_path = str(tmp_path / "claude-mpm" / "hook.sh")
+        data = {
+            "hooks": {
+                "SessionStart": [_make_hook_entry(stale_path, with_matcher=True)]
+            }
+        }
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result is True
+        cleaned = json.loads(settings_file.read_text())
+        assert cleaned.get("hooks", {}) == {}
+
+    def test_both_cleanups_run(self, tmp_path):
+        """Both directory and settings cleanup run in the same call."""
+        # Stale directory
+        hooks_dir = tmp_path / ".claude" / "hooks" / "claude-mpm"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "hook.sh").touch()
+
+        # Stale settings entry
+        stale_path = str(tmp_path / "claude-mpm" / "hook.sh")
+        data = {
+            "hooks": {
+                "Stop": [_make_hook_entry(stale_path)]
+            }
+        }
+        settings_file = tmp_path / ".claude" / "settings.json"
+        settings_file.write_text(json.dumps(data))
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result is True
+        assert not hooks_dir.exists()
+        cleaned = json.loads(settings_file.read_text())
+        assert cleaned.get("hooks", {}) == {}
+
+    def test_no_settings_file_is_graceful(self, tmp_path):
+        """Missing ~/.claude/settings.json does not raise an exception."""
+        # No .claude directory at all
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = self._call()
+
+        assert result is False


### PR DESCRIPTION
# PR: Fix stale hook cleanup on startup

## Title

```
fix: clean stale claude-mpm hook entries from ~/.claude/settings.json on startup
```

## Description

### Motivation

Users migrating from a pipx-based installation to UV tools (`uv tool install claude-mpm`) are greeted with persistent hook errors on every Claude Code session:

```
SessionStart:startup hook error
UserPromptSubmit hook error
```

These errors erode trust in the tool and cannot be self-resolved without manually editing `~/.claude/settings.json` — a file most users don't know about.

### Problem

The existing `cleanup_user_level_hooks()` function in `startup.py` removes the deprecated hooks **directory** (`~/.claude/hooks/claude-mpm/`) but does not touch the hooks **configuration entries** in `~/.claude/settings.json`. After a pipx-to-UV migration, all six event types (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`) still reference absolute paths to scripts inside the old pipx virtualenv — paths that no longer exist on disk. Claude Code attempts to execute these missing scripts and surfaces the errors.

### Changes

**`src/claude_mpm/cli/startup.py`** — Extended startup cleanup with two new helpers:

| Function | Purpose |
|----------|---------|
| `_is_stale_hook_command(command)` | Predicate that identifies our stale commands: absolute paths containing `claude-mpm` or `claude-hook` that don't exist on disk. Entry-point style commands (e.g., `claude-hook` without a path) are left alone since they resolve via `PATH` at runtime. |
| `_cleanup_stale_settings_json_hooks()` | Reads `~/.claude/settings.json`, removes stale command entries in-place, prunes empty wrapper objects and empty event types, writes back only if something changed. Returns count of entries removed. |
| `cleanup_user_level_hooks()` | Now runs both the existing directory cleanup and the new settings.json cleanup. |

**`tests/cli/test_cleanup_stale_settings_hooks.py`** (new) — 24 tests across three classes:

- `TestIsStaleHookCommand` (8 tests) — predicate edge cases
- `TestCleanupStaleSettingsJsonHooks` (11 tests) — file I/O, stale removal, preservation of other tools' entries, invalid JSON, idempotency
- `TestCleanupUserLevelHooksIntegration` (5 tests) — end-to-end behavior of the combined function

### Reviewer Notes

- **Safety**: Only entries matching `claude-mpm` or `claude-hook` in the command string with non-existent absolute paths are removed. Entries from other tools are never touched.
- **Idempotency**: If no stale entries are found, the file is not written.
- **Non-blocking**: All failures are caught and logged at debug level — startup is never interrupted.
- **No regressions**: Full test suite (8,429 tests) passes; the 13 pre-existing failures and 56 errors (missing optional `claude-agent-sdk` dependency, timing-sensitive daemon tests) are unchanged.
