### PR TITLE
fix: preserve CLAUDE_CODE_USE_BEDROCK env var when config loaded from defaults

### DIFF
--- a/src/claude_mpm/config/api_provider.py
+++ b/src/claude_mpm/config/api_provider.py
@@ -72,6 +72,7 @@ class APIProviderConfig:
     bedrock: BedrockConfig = field(default_factory=BedrockConfig)
     anthropic: AnthropicConfig = field(default_factory=AnthropicConfig)
     disable_prompt_caching: bool = False
+    _loaded_from_file: bool = field(default=False, repr=False)
 
     @classmethod
     def load(cls, config_path: Path | None = None) -> "APIProviderConfig":
@@ -85,7 +86,9 @@ class APIProviderConfig:
             APIProviderConfig instance with loaded or default values.
         """
         if config_path is None:
-            config_path = Path.cwd() / ".claude-mpm" / "configuration.yaml"
+            user_pwd = os.environ.get("CLAUDE_MPM_USER_PWD")
+            base_dir = Path(user_pwd) if user_pwd else Path.cwd()
+            config_path = base_dir / ".claude-mpm" / "configuration.yaml"
 
         config = cls()
 
@@ -134,6 +137,7 @@ class APIProviderConfig:
                     api_provider["disable_prompt_caching"]
                 )
 
+            config._loaded_from_file = True
             config._apply_env_overrides()
 
             logger.debug(f"Loaded API provider config: backend={config.backend.value}")
@@ -186,8 +190,11 @@ class APIProviderConfig:
             )
 
         elif self.backend == APIBackend.ANTHROPIC:
-            # Disable Bedrock mode
-            if "CLAUDE_CODE_USE_BEDROCK" in os.environ:
+            # Only remove CLAUDE_CODE_USE_BEDROCK if this config was explicitly
+            # loaded from a file. When no config file exists and defaults are
+            # used, we must NOT delete env vars that the user set in their shell
+            # (e.g. CLAUDE_CODE_USE_BEDROCK=1 for Bedrock access).
+            if self._loaded_from_file and "CLAUDE_CODE_USE_BEDROCK" in os.environ:
                 del os.environ["CLAUDE_CODE_USE_BEDROCK"]
                 changes["CLAUDE_CODE_USE_BEDROCK"] = "(unset)"
 
@@ -239,7 +246,9 @@ class APIProviderConfig:
                         .claude-mpm/configuration.yaml in current directory.
         """
         if config_path is None:
-            config_path = Path.cwd() / ".claude-mpm" / "configuration.yaml"
+            user_pwd = os.environ.get("CLAUDE_MPM_USER_PWD")
+            base_dir = Path(user_pwd) if user_pwd else Path.cwd()
+            config_path = base_dir / ".claude-mpm" / "configuration.yaml"
 
         # Ensure directory exists
         config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/config/test_api_provider.py
+++ b/tests/unit/config/test_api_provider.py
@@ -135,19 +135,42 @@ class TestAPIProviderConfig:
         for var in ["CLAUDE_CODE_USE_BEDROCK", "ANTHROPIC_MODEL", "AWS_REGION"]:
             os.environ.pop(var, None)
 
-    def test_apply_environment_anthropic(self):
-        """Test applying environment for Anthropic backend."""
+    def test_apply_environment_anthropic_from_file(self):
+        """Test applying environment for Anthropic backend loaded from file.
+
+        When config is loaded from a file, CLAUDE_CODE_USE_BEDROCK should be
+        removed to honor the explicit file-based configuration.
+        """
         # Set bedrock var to test it gets removed
         os.environ["CLAUDE_CODE_USE_BEDROCK"] = "1"
         os.environ.pop("ANTHROPIC_MODEL", None)
 
-        config = APIProviderConfig(backend=APIBackend.ANTHROPIC)
+        config = APIProviderConfig(backend=APIBackend.ANTHROPIC, _loaded_from_file=True)
         changes = config.apply_environment()
 
         assert "CLAUDE_CODE_USE_BEDROCK" not in os.environ
         # ANTHROPIC_MODEL is not set when model is empty (default)
         assert "ANTHROPIC_MODEL" not in os.environ
         assert changes.get("CLAUDE_CODE_USE_BEDROCK") == "(unset)"
+
+    def test_apply_environment_anthropic_from_defaults_preserves_bedrock(self):
+        """Test that default config does NOT delete user's CLAUDE_CODE_USE_BEDROCK.
+
+        When no config file exists and defaults are used (_loaded_from_file=False),
+        the user's shell env vars must be preserved.
+        """
+        os.environ["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        os.environ.pop("ANTHROPIC_MODEL", None)
+
+        config = APIProviderConfig(backend=APIBackend.ANTHROPIC)
+        changes = config.apply_environment()
+
+        # Should NOT have deleted the user's env var
+        assert os.environ.get("CLAUDE_CODE_USE_BEDROCK") == "1"
+        assert "CLAUDE_CODE_USE_BEDROCK" not in changes
+
+        # Cleanup
+        os.environ.pop("CLAUDE_CODE_USE_BEDROCK", None)
 
     def test_apply_environment_anthropic_with_model(self):
         """Test applying environment for Anthropic backend with explicit model."""


### PR DESCRIPTION
## Summary

Two bugs cause `CLAUDE_CODE_USE_BEDROCK` to not be passed through to Claude Code:

- **Bug 1**: `APIProviderConfig.load()` uses `Path.cwd()` for config path, which resolves incorrectly when installed via `uv tool`. Fixed by using `CLAUDE_MPM_USER_PWD` env var.
- **Bug 2**: `apply_environment()` actively deletes `CLAUDE_CODE_USE_BEDROCK` from `os.environ` when backend defaults to ANTHROPIC (because config file wasn't found). Fixed by tracking whether config was loaded from an actual file vs defaults.

## Files Changed

- `src/claude_mpm/config/api_provider.py`
- `tests/unit/config/test_api_provider.py`

## Test plan

- [x] Existing tests updated to reflect new behavior
- [x] New test added for the defaults case (config not found)
- [x] All 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)