### PR TITLE
feat: add non-destructive startup cleanup for agent/skill overlap

### DIFF
--- a/src/claude_mpm/migrations/cleanup_overlap.py
+++ b/src/claude_mpm/migrations/cleanup_overlap.py
@@ -1,0 +1,414 @@
+"""Non-destructive cleanup of agent/skill overlap between user-level and project-level.
+
+WHY: After the 6.1.0 and 6.2.0 migrations that split CORE agents/skills into
+user-level storage, some projects may still have stale copies at the project
+level.  Additionally, early versions of claude-mpm deployed agents with a
+redundant "-agent" suffix (e.g. "research-agent" instead of "research") which
+should be cleaned up at the user level.
+
+WHAT THIS MODULE DOES:
+1. cleanup_agent_overlap: Archives project-level copies of USER_LEVEL_AGENTS
+   when the user-level copy already exists.
+2. cleanup_skill_overlap: Same for USER_LEVEL_SKILLS (directories, not files).
+3. cleanup_stale_agent_names: Archives user-level agents that have a redundant
+   "-agent" suffix when the correct (non-suffixed) name already exists.
+
+All operations are non-destructive: files are archived before removal, and a
+manifest is written to each archive directory documenting what happened.
+
+IDEMPOTENCY: Running this multiple times is safe -- if the archive already
+contains the file, the item is skipped.
+"""
+
+import json
+import logging
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Lazy imports to avoid circular dependencies at module load time.
+
+
+def _get_user_level_agents() -> frozenset[str]:
+    """Return USER_LEVEL_AGENTS, importing lazily to avoid circular imports."""
+    from claude_mpm.services.agents.deployment.agent_deployment import (
+        USER_LEVEL_AGENTS,
+    )
+
+    return USER_LEVEL_AGENTS
+
+
+def _get_user_level_skills() -> frozenset[str]:
+    """Return USER_LEVEL_SKILLS, importing lazily to avoid circular imports."""
+    from claude_mpm.services.skills.selective_skill_deployer import (
+        USER_LEVEL_SKILLS,
+    )
+
+    return USER_LEVEL_SKILLS
+
+
+# Stale agent names that had a redundant "-agent" suffix in early versions.
+STALE_AGENT_NAMES: frozenset[str] = frozenset(
+    {
+        "documentation-agent",
+        "javascript-engineer-agent",
+        "local-ops-agent",
+        "memory-manager-agent",
+        "qa-agent",
+        "research-agent",
+        "security-agent",
+    }
+)
+
+
+def _write_manifest(
+    archive_dir: Path,
+    reason: str,
+    source_level: str,
+    superseded_by: str,
+    files: list[str],
+) -> None:
+    """Write a cleanup manifest to the archive directory.
+
+    Args:
+        archive_dir: Directory where archived files live.
+        reason: Human-readable reason for the cleanup.
+        source_level: Where the originals came from (e.g. "project" or "user").
+        superseded_by: What replaced the archived files.
+        files: List of archived filenames.
+    """
+    manifest = {
+        "cleanup_date": datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S"),
+        "reason": reason,
+        "source_level": source_level,
+        "superseded_by": superseded_by,
+        "archived_files": files,
+    }
+    manifest_path = archive_dir / "_cleanup_manifest.json"
+    try:
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        logger.debug("Wrote manifest to %s", manifest_path)
+    except OSError as exc:
+        logger.warning("Failed to write manifest at %s: %s", manifest_path, exc)
+
+
+def cleanup_agent_overlap(
+    project_dir: Path,
+    dry_run: bool = False,
+) -> dict:
+    """Archive and remove project-level copies of USER_LEVEL_AGENTS.
+
+    For each agent in USER_LEVEL_AGENTS, if both the user-level copy
+    (~/.claude/agents/{name}.md) and the project-level copy
+    ({project_dir}/.claude/agents/{name}.md) exist, the project copy is
+    archived and removed.
+
+    Args:
+        project_dir: Root of the project to clean up.
+        dry_run: If True, log what would happen without modifying files.
+
+    Returns:
+        Dict with keys "archived", "skipped", "errors" (lists of agent names).
+    """
+    user_level_agents = _get_user_level_agents()
+    user_agents_base = Path.home() / ".claude" / "agents"
+    project_agents_base = project_dir / ".claude" / "agents"
+
+    date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    archive_dir = project_agents_base / "archived" / f"{date_str}_overlap_cleanup"
+
+    result: dict[str, list[str]] = {"archived": [], "skipped": [], "errors": []}
+
+    if not project_agents_base.exists():
+        logger.debug("No project agents directory at %s", project_agents_base)
+        return result
+
+    archived_files: list[str] = []
+
+    for agent_name in sorted(user_level_agents):
+        user_file = user_agents_base / f"{agent_name}.md"
+        project_file = project_agents_base / f"{agent_name}.md"
+
+        # Both must exist to be considered overlap
+        if not project_file.exists():
+            logger.debug("No project copy of agent %s, skipping", agent_name)
+            result["skipped"].append(agent_name)
+            continue
+
+        if not user_file.exists():
+            logger.debug(
+                "No user-level copy of agent %s, skipping (not overlap)", agent_name
+            )
+            result["skipped"].append(agent_name)
+            continue
+
+        # Check if already archived (idempotent)
+        archived_dest = archive_dir / f"{agent_name}.md"
+        if archived_dest.exists():
+            logger.debug("Already archived: %s", agent_name)
+            result["skipped"].append(agent_name)
+            continue
+
+        if dry_run:
+            logger.info(
+                "[DRY RUN] Would archive project agent %s to %s",
+                agent_name,
+                archive_dir,
+            )
+            result["archived"].append(agent_name)
+            continue
+
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(project_file, archived_dest)
+            project_file.unlink()
+            archived_files.append(f"{agent_name}.md")
+            result["archived"].append(agent_name)
+            logger.info(
+                "Archived project agent %s (user copy at %s)",
+                agent_name,
+                user_file,
+            )
+        except OSError as exc:
+            logger.error("Failed to archive agent %s: %s", agent_name, exc)
+            result["errors"].append(agent_name)
+
+    # Write manifest if we archived anything
+    if archived_files:
+        _write_manifest(
+            archive_dir=archive_dir,
+            reason="Project-level agent duplicates user-level agent",
+            source_level="project",
+            superseded_by="~/.claude/agents/",
+            files=archived_files,
+        )
+
+    return result
+
+
+def cleanup_skill_overlap(
+    project_dir: Path,
+    dry_run: bool = False,
+) -> dict:
+    """Archive and remove project-level copies of USER_LEVEL_SKILLS.
+
+    Skills are directories (not single files), so this uses shutil.copytree
+    for archiving and shutil.rmtree for removal.
+
+    Args:
+        project_dir: Root of the project to clean up.
+        dry_run: If True, log what would happen without modifying files.
+
+    Returns:
+        Dict with keys "archived", "skipped", "errors" (lists of skill names).
+    """
+    user_level_skills = _get_user_level_skills()
+    user_skills_base = Path.home() / ".claude" / "skills"
+    project_skills_base = project_dir / ".claude" / "skills"
+
+    date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    archive_dir = project_skills_base / "archived" / f"{date_str}_overlap_cleanup"
+
+    result: dict[str, list[str]] = {"archived": [], "skipped": [], "errors": []}
+
+    if not project_skills_base.exists():
+        logger.debug("No project skills directory at %s", project_skills_base)
+        return result
+
+    archived_files: list[str] = []
+
+    for skill_name in sorted(user_level_skills):
+        user_skill_dir = user_skills_base / skill_name
+        project_skill_dir = project_skills_base / skill_name
+
+        # Both must exist to be considered overlap
+        if not project_skill_dir.exists():
+            logger.debug("No project copy of skill %s, skipping", skill_name)
+            result["skipped"].append(skill_name)
+            continue
+
+        if not (user_skill_dir / "SKILL.md").exists():
+            logger.debug(
+                "No user-level copy of skill %s, skipping (not overlap)", skill_name
+            )
+            result["skipped"].append(skill_name)
+            continue
+
+        # Check if already archived (idempotent)
+        archived_dest = archive_dir / skill_name
+        if archived_dest.exists():
+            logger.debug("Already archived: %s", skill_name)
+            result["skipped"].append(skill_name)
+            continue
+
+        if dry_run:
+            logger.info(
+                "[DRY RUN] Would archive project skill %s to %s",
+                skill_name,
+                archive_dir,
+            )
+            result["archived"].append(skill_name)
+            continue
+
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(project_skill_dir, archived_dest)
+            shutil.rmtree(project_skill_dir)
+            archived_files.append(skill_name)
+            result["archived"].append(skill_name)
+            logger.info(
+                "Archived project skill %s (user copy at %s)",
+                skill_name,
+                user_skill_dir,
+            )
+        except OSError as exc:
+            logger.error("Failed to archive skill %s: %s", skill_name, exc)
+            result["errors"].append(skill_name)
+
+    # Write manifest if we archived anything
+    if archived_files:
+        _write_manifest(
+            archive_dir=archive_dir,
+            reason="Project-level skill duplicates user-level skill",
+            source_level="project",
+            superseded_by="~/.claude/skills/",
+            files=archived_files,
+        )
+
+    return result
+
+
+def cleanup_stale_agent_names(dry_run: bool = False) -> dict:
+    """Archive user-level agents with stale '-agent' suffix.
+
+    For each name in STALE_AGENT_NAMES (e.g. "research-agent"), if BOTH the
+    stale file (~/.claude/agents/research-agent.md) AND the correct file
+    (~/.claude/agents/research.md) exist, the stale file is archived.
+
+    Args:
+        dry_run: If True, log what would happen without modifying files.
+
+    Returns:
+        Dict with keys "archived", "skipped", "errors" (lists of stale names).
+    """
+    user_agents_base = Path.home() / ".claude" / "agents"
+
+    date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    archive_dir = user_agents_base / "archived" / f"{date_str}_stale_naming"
+
+    result: dict[str, list[str]] = {"archived": [], "skipped": [], "errors": []}
+
+    archived_files: list[str] = []
+
+    for stale_name in sorted(STALE_AGENT_NAMES):
+        # Derive the correct name by removing "-agent" suffix
+        correct_name = stale_name.removesuffix("-agent")
+
+        stale_file = user_agents_base / f"{stale_name}.md"
+        correct_file = user_agents_base / f"{correct_name}.md"
+
+        if not stale_file.exists():
+            logger.debug("No stale file for %s, skipping", stale_name)
+            result["skipped"].append(stale_name)
+            continue
+
+        if not correct_file.exists():
+            logger.debug(
+                "No correct replacement for %s (%s.md missing), skipping",
+                stale_name,
+                correct_name,
+            )
+            result["skipped"].append(stale_name)
+            continue
+
+        # Check if already archived (idempotent)
+        archived_dest = archive_dir / f"{stale_name}.md"
+        if archived_dest.exists():
+            logger.debug("Already archived: %s", stale_name)
+            result["skipped"].append(stale_name)
+            continue
+
+        if dry_run:
+            logger.info(
+                "[DRY RUN] Would archive stale agent %s (replaced by %s)",
+                stale_name,
+                correct_name,
+            )
+            result["archived"].append(stale_name)
+            continue
+
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(stale_file, archived_dest)
+            stale_file.unlink()
+            archived_files.append(f"{stale_name}.md")
+            result["archived"].append(stale_name)
+            logger.info(
+                "Archived stale agent %s (replaced by %s)",
+                stale_name,
+                correct_name,
+            )
+        except OSError as exc:
+            logger.error("Failed to archive stale agent %s: %s", stale_name, exc)
+            result["errors"].append(stale_name)
+
+    # Write manifest if we archived anything
+    if archived_files:
+        _write_manifest(
+            archive_dir=archive_dir,
+            reason="Agent with stale '-agent' suffix replaced by canonical name",
+            source_level="user",
+            superseded_by="~/.claude/agents/ (canonical names without -agent suffix)",
+            files=archived_files,
+        )
+
+    return result
+
+
+def run_overlap_cleanup(
+    project_dir: Path,
+    dry_run: bool = False,
+) -> dict:
+    """Orchestrator: run all overlap cleanup operations.
+
+    Args:
+        project_dir: Root of the project to clean up.
+        dry_run: If True, log what would happen without modifying files.
+
+    Returns:
+        Combined results dict with keys "agents", "skills", "stale_agents",
+        each containing {"archived": [...], "skipped": [...], "errors": [...]}.
+    """
+    logger.info(
+        "Starting overlap cleanup for project %s (dry_run=%s)", project_dir, dry_run
+    )
+
+    agents_result = cleanup_agent_overlap(project_dir, dry_run=dry_run)
+    skills_result = cleanup_skill_overlap(project_dir, dry_run=dry_run)
+    stale_result = cleanup_stale_agent_names(dry_run=dry_run)
+
+    total_archived = (
+        len(agents_result["archived"])
+        + len(skills_result["archived"])
+        + len(stale_result["archived"])
+    )
+    total_errors = (
+        len(agents_result["errors"])
+        + len(skills_result["errors"])
+        + len(stale_result["errors"])
+    )
+
+    logger.info(
+        "Overlap cleanup complete: archived=%d, errors=%d",
+        total_archived,
+        total_errors,
+    )
+
+    return {
+        "agents": agents_result,
+        "skills": skills_result,
+        "stale_agents": stale_result,
+    }

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -60,6 +60,22 @@ def _run_core_agents_to_user_level_migration() -> bool:
     return run_migration()
 
 
+def _run_overlap_cleanup_migration() -> bool:
+    """Clean up agent/skill overlap between user-level and project-level."""
+    from pathlib import Path
+
+    from .cleanup_overlap import run_overlap_cleanup
+
+    result = run_overlap_cleanup(project_dir=Path.cwd())
+    # Consider it successful if there are no errors
+    total_errors = (
+        len(result["agents"]["errors"])
+        + len(result["skills"]["errors"])
+        + len(result["stale_agents"]["errors"])
+    )
+    return total_errors == 0
+
+
 # Registry of all migrations, ordered by version
 MIGRATIONS: list[Migration] = [
     Migration(
@@ -97,6 +113,12 @@ MIGRATIONS: list[Migration] = [
         version="6.2.0",
         description="Move CORE agents to user level, remove project-level duplicates",
         run=_run_core_agents_to_user_level_migration,
+    ),
+    Migration(
+        id="6.2.1_overlap_cleanup",
+        version="6.2.1",
+        description="Archive project-level duplicates of user-level agents/skills and stale -agent suffixed names",
+        run=_run_overlap_cleanup_migration,
     ),
 ]
 

--- a/tests/migrations/test_cleanup_overlap.py
+++ b/tests/migrations/test_cleanup_overlap.py
@@ -1,0 +1,357 @@
+"""Tests for the startup overlap cleanup system.
+
+Tests use tmp_path and monkeypatch to avoid touching real ~/.claude/ directories.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_agent_file(base: Path, name: str, content: str = "# agent") -> Path:
+    """Create a .md agent file under base/agents/."""
+    agents_dir = base / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    agent_file = agents_dir / f"{name}.md"
+    agent_file.write_text(content)
+    return agent_file
+
+
+def _setup_skill_dir(base: Path, name: str) -> Path:
+    """Create a skill directory with a SKILL.md under base/skills/."""
+    skill_dir = base / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"# {name} skill")
+    return skill_dir
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Override Path.home() to return a temp directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return home
+
+
+@pytest.fixture
+def fake_project(tmp_path: Path):
+    """Return a temp directory used as the project root."""
+    project = tmp_path / "project"
+    project.mkdir()
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Agent overlap tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupAgentOverlap:
+    """Tests for cleanup_agent_overlap."""
+
+    def test_archives_duplicates(self, fake_home: Path, fake_project: Path):
+        """When both user and project copies exist, project copy is archived."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "pm", content="# user pm")
+        _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+            return_value=frozenset({"pm"}),
+        ):
+            result = cleanup_agent_overlap(fake_project)
+
+        assert "pm" in result["archived"]
+        # Project file removed
+        assert not (fake_project / ".claude" / "agents" / "pm.md").exists()
+        # Archived copy exists
+        archived_files = list(
+            (fake_project / ".claude" / "agents" / "archived").rglob("pm.md")
+        )
+        assert len(archived_files) == 1
+
+    @pytest.mark.usefixtures("fake_home")
+    def test_skips_non_duplicates(self, fake_project: Path):
+        """Agent only at project level should NOT be archived (no user copy)."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
+
+        # Only project copy, no user copy
+        _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+            return_value=frozenset({"pm"}),
+        ):
+            result = cleanup_agent_overlap(fake_project)
+
+        assert "pm" in result["skipped"]
+        assert result["archived"] == []
+        # Project file still there
+        assert (fake_project / ".claude" / "agents" / "pm.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Skill overlap tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupSkillOverlap:
+    """Tests for cleanup_skill_overlap."""
+
+    def test_archives_duplicates(self, fake_home: Path, fake_project: Path):
+        """When both user and project copies exist, project copy is archived."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_skill_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_skill_dir(user_claude, "mpm-help")
+        _setup_skill_dir(fake_project / ".claude", "mpm-help")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_skills",
+            return_value=frozenset({"mpm-help"}),
+        ):
+            result = cleanup_skill_overlap(fake_project)
+
+        assert "mpm-help" in result["archived"]
+        # Project dir removed
+        assert not (fake_project / ".claude" / "skills" / "mpm-help").exists()
+        # Archived copy exists
+        archived_dirs = list(
+            (fake_project / ".claude" / "skills" / "archived").rglob("mpm-help")
+        )
+        assert len(archived_dirs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Stale agent names tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupStaleAgentNames:
+    """Tests for cleanup_stale_agent_names."""
+
+    def test_archives_stale_suffix(self, fake_home: Path):
+        """Stale '-agent' suffixed file gets archived when correct name exists."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "research-agent", content="# stale")
+        _setup_agent_file(user_claude, "research", content="# correct")
+
+        result = cleanup_stale_agent_names()
+
+        assert "research-agent" in result["archived"]
+        # Stale file removed
+        assert not (user_claude / "agents" / "research-agent.md").exists()
+        # Correct file untouched
+        assert (user_claude / "agents" / "research.md").exists()
+
+    def test_skips_when_no_correct_replacement(self, fake_home: Path):
+        """Stale file should NOT be archived if the correct name is missing."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "research-agent", content="# stale")
+        # No "research.md" exists
+
+        result = cleanup_stale_agent_names()
+
+        assert "research-agent" in result["skipped"]
+        # Stale file still there
+        assert (user_claude / "agents" / "research-agent.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run tests
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """Tests for dry_run=True mode."""
+
+    def test_does_not_modify_agents(self, fake_home: Path, fake_project: Path):
+        """dry_run=True leaves all files in place."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "pm", content="# user pm")
+        project_file = _setup_agent_file(
+            fake_project / ".claude", "pm", content="# project pm"
+        )
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+            return_value=frozenset({"pm"}),
+        ):
+            result = cleanup_agent_overlap(fake_project, dry_run=True)
+
+        assert "pm" in result["archived"]  # Reported as would-archive
+        assert project_file.exists()  # But file still there
+        # No archive directory created
+        assert not (fake_project / ".claude" / "agents" / "archived").exists()
+
+    def test_does_not_modify_stale_agents(self, fake_home: Path):
+        """dry_run=True leaves stale agent files in place."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
+
+        user_claude = fake_home / ".claude"
+        stale_file = _setup_agent_file(user_claude, "research-agent")
+        _setup_agent_file(user_claude, "research")
+
+        result = cleanup_stale_agent_names(dry_run=True)
+
+        assert "research-agent" in result["archived"]
+        assert stale_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    """Tests that running cleanup twice does not error or double-archive."""
+
+    def test_second_run_agent_overlap(self, fake_home: Path, fake_project: Path):
+        """Running agent overlap cleanup twice doesn't error."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "pm", content="# user pm")
+        _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+            return_value=frozenset({"pm"}),
+        ):
+            result1 = cleanup_agent_overlap(fake_project)
+            result2 = cleanup_agent_overlap(fake_project)
+
+        assert "pm" in result1["archived"]
+        # Second run: project file gone, so it's skipped
+        assert "pm" in result2["skipped"]
+        assert result2["errors"] == []
+
+    def test_second_run_stale_agents(self, fake_home: Path):
+        """Running stale cleanup twice doesn't error."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "research-agent")
+        _setup_agent_file(user_claude, "research")
+
+        result1 = cleanup_stale_agent_names()
+        result2 = cleanup_stale_agent_names()
+
+        assert "research-agent" in result1["archived"]
+        assert "research-agent" in result2["skipped"]
+        assert result2["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    """Tests for _cleanup_manifest.json creation."""
+
+    def test_manifest_written_for_agent_overlap(
+        self, fake_home: Path, fake_project: Path
+    ):
+        """Verify _cleanup_manifest.json exists and has correct structure."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "pm", content="# user pm")
+        _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+            return_value=frozenset({"pm"}),
+        ):
+            cleanup_agent_overlap(fake_project)
+
+        # Find manifest
+        manifests = list(
+            (fake_project / ".claude" / "agents" / "archived").rglob(
+                "_cleanup_manifest.json"
+            )
+        )
+        assert len(manifests) == 1
+
+        manifest = json.loads(manifests[0].read_text())
+        assert "cleanup_date" in manifest
+        assert "reason" in manifest
+        assert "source_level" in manifest
+        assert manifest["source_level"] == "project"
+        assert "superseded_by" in manifest
+        assert "archived_files" in manifest
+        assert "pm.md" in manifest["archived_files"]
+
+    def test_manifest_written_for_stale_agents(self, fake_home: Path):
+        """Verify manifest is written when stale agents are archived."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
+
+        user_claude = fake_home / ".claude"
+        _setup_agent_file(user_claude, "research-agent")
+        _setup_agent_file(user_claude, "research")
+
+        cleanup_stale_agent_names()
+
+        manifests = list(
+            (user_claude / "agents" / "archived").rglob("_cleanup_manifest.json")
+        )
+        assert len(manifests) == 1
+
+        manifest = json.loads(manifests[0].read_text())
+        assert manifest["source_level"] == "user"
+        assert "research-agent.md" in manifest["archived_files"]
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunOverlapCleanup:
+    """Tests for the run_overlap_cleanup orchestrator."""
+
+    @pytest.mark.usefixtures("fake_home")
+    def test_returns_combined_results(self, fake_project: Path):
+        """Orchestrator returns combined results from all three cleanups."""
+        from claude_mpm.migrations.cleanup_overlap import run_overlap_cleanup
+
+        with (
+            patch(
+                "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
+                return_value=frozenset(),
+            ),
+            patch(
+                "claude_mpm.migrations.cleanup_overlap._get_user_level_skills",
+                return_value=frozenset(),
+            ),
+        ):
+            result = run_overlap_cleanup(fake_project)
+
+        assert "agents" in result
+        assert "skills" in result
+        assert "stale_agents" in result
+        for key in ("agents", "skills", "stale_agents"):
+            assert "archived" in result[key]
+            assert "skipped" in result[key]
+            assert "errors" in result[key]


### PR DESCRIPTION
## Summary
- Adds `cleanup_overlap.py` migration with 3 functions: `cleanup_agent_overlap`, `cleanup_skill_overlap`, `cleanup_stale_agent_names`
- Archives duplicates before removing (non-destructive) and writes `_cleanup_manifest.json` for restore capability
- Registered as migration `6.2.1_overlap_cleanup` in registry
- 12 tests covering all cleanup scenarios

## Details

Addresses the overlap discovered after v6.1.0 user/project level split (#412). After the 6.1.0 and 6.2.0 migrations that split CORE agents/skills into user-level storage, some projects may still have stale copies at the project level. This migration safely archives and removes them at startup.

The cleanup is idempotent -- running multiple times is safe. If the archive already contains the file, the item is skipped.

## Test plan
- [ ] Verify `cleanup_agent_overlap` archives project-level agents that exist at user level
- [ ] Verify `cleanup_skill_overlap` archives project-level skills that exist at user level
- [ ] Verify `cleanup_stale_agent_names` removes `-agent` suffix duplicates
- [ ] Verify `_cleanup_manifest.json` is written correctly for restore capability
- [ ] Verify idempotency (running cleanup twice produces no errors)
- [ ] Run `uv run pytest tests/migrations/test_cleanup_overlap.py` (12 tests)

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)