### PR TITLE
fix: remove dangling mcp_gateway references (closes #414)

### DIFF
--- a/src/claude_mpm/cli/commands/mcp.py
+++ b/src/claude_mpm/cli/commands/mcp.py
@@ -68,25 +68,12 @@ def manage_mcp(args):
             return 1
 
     try:
-        # Import MCP Gateway services with error handling
-        try:
-            from ...services.mcp_gateway import (
-                MCPConfiguration,
-                MCPServiceRegistry,
-                ToolRegistry,
-            )
-            from ...services.mcp_gateway.server.mcp_gateway import MCPGateway
-        except ImportError as e:
-            # Provide minimal fallbacks for basic commands
-            logger.warning(f"Some MCP Gateway services not available: {e}")
-            print(
-                "\nError: MCP Gateway services not fully available",
-                file=sys.stderr,
-            )
-            print(f"Details: {e}", file=sys.stderr)
-            print("\nTry running:", file=sys.stderr)
-            print("  claude-mpm mcp install", file=sys.stderr)
-            return 1
+        # MCP Gateway was removed in v6.x. Set services to None so
+        # downstream handlers can detect the absence gracefully.
+        MCPConfiguration = None
+        MCPServiceRegistry = None
+        ToolRegistry = None
+        MCPGateway = None
 
         if not args.mcp_command:
             # No subcommand - show status by default

--- a/src/claude_mpm/cli/commands/mcp_server_commands.py
+++ b/src/claude_mpm/cli/commands/mcp_server_commands.py
@@ -4,7 +4,6 @@ This module provides MCP server management commands.
 Extracted from mcp.py to reduce complexity and improve maintainability.
 """
 
-import os
 import sys
 from pathlib import Path
 
@@ -92,46 +91,15 @@ class MCPServerCommands:
             )
             print("   Press Ctrl+C to stop.\n", file=sys.stderr)
 
-        try:
-            # Import and run the server directly
-            from claude_mpm.services.mcp_gateway.server.stdio_server import (
-                SimpleMCPServer,
-            )
-
-            # Set environment variable if in test mode
-            if test_mode:
-                os.environ["MCP_MODE"] = "test"
-            else:
-                os.environ["MCP_MODE"] = "production"
-
-            # Create and run the server
-            self.logger.info("Starting MCP Gateway Server directly...")
-            server = SimpleMCPServer(name="claude-mpm-gateway", version="1.0.0")
-
-            # Run the server asynchronously
-            await server.run()
-
-            return 0
-
-        except ImportError as e:
-            self.logger.error(f"Failed to import MCP server: {e}")
-            # Don't print to stdout as it would interfere with JSON-RPC protocol
-            # Log to stderr instead
-            print(
-                f"❌ Error: Could not import MCP server components: {e}",
-                file=sys.stderr,
-            )
-            print("\nMake sure the MCP package is installed:", file=sys.stderr)
-            print("  pip install mcp", file=sys.stderr)
-            return 1
-        except KeyboardInterrupt:
-            # Graceful shutdown
-            self.logger.info("MCP server interrupted")
-            return 0
-        except Exception as e:
-            self.logger.error(f"Server error: {e}")
-            print(f"❌ Error running server: {e}", file=sys.stderr)
-            return 1
+        # MCP Gateway server was removed in v6.x.
+        # Claude Code handles MCP natively.
+        print(
+            "The MCP Gateway server was removed in v6.x.\n"
+            "Claude Code handles MCP natively. See:\n"
+            "  https://docs.anthropic.com/en/docs/claude-code/mcp",
+            file=sys.stderr,
+        )
+        return 1
 
     def stop_server(self, args):
         """Stop MCP server command."""

--- a/src/claude_mpm/cli/commands/search.py
+++ b/src/claude_mpm/cli/commands/search.py
@@ -31,20 +31,16 @@ class MCPSearchInterface:
         self.vector_search_available = False
 
     async def initialize(self):
-        """Initialize the MCP gateway connection."""
+        """Initialize the MCP gateway connection.
+
+        NOTE: The MCP gateway sub-package was removed in v6.x.
+        This method now only checks vector search availability directly.
+        """
         try:
-            from claude_mpm.services.mcp_gateway import MCPGatewayService
-
-            self.mcp_gateway = self.container.resolve(MCPGatewayService)
-            if not self.mcp_gateway:
-                self.mcp_gateway = MCPGatewayService()
-                await self.mcp_gateway.initialize()
-
-            # Check if vector search is available
+            # MCP gateway was removed in v6.x — check vector search directly
             self.vector_search_available = await self._check_vector_search_available()
-
         except Exception as e:
-            console.print(f"[red]Failed to initialize MCP gateway: {e}[/red]")
+            console.print(f"[red]Failed to initialize search interface: {e}[/red]")
             raise
 
     async def _check_vector_search_available(self) -> bool:

--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -2386,138 +2386,18 @@ def check_mcp_auto_configuration():
     if len(sys.argv) > 1 and sys.argv[1] in ("doctor", "configure", "setup"):
         return
 
-    try:
-        from ..services.mcp_gateway.auto_configure import (
-            check_and_configure_mcp,  # type: ignore
-        )
-
-        # Show progress feedback - this operation can take 10+ seconds
-        # Only show progress message in TTY mode to avoid interfering with Claude Code's status display
-        if sys.stdout.isatty():
-            print("Checking MCP configuration...", end="", flush=True)
-
-        # This function handles all the logic:
-        # - Checks if already configured
-        # - Checks if pipx installation
-        # - Checks if already asked before
-        # - Prompts user if needed
-        # - Configures if user agrees
-        check_and_configure_mcp()
-
-        # Clear the "Checking..." message by overwriting with spaces
-        # Only use carriage return clearing if stdout is a real TTY
-        if sys.stdout.isatty():
-            print("\r" + " " * 30 + "\r", end="", flush=True)
-        # In non-TTY mode, don't print anything - the "Checking..." message will just remain on its line
-
-    except Exception as e:
-        # Clear progress message on error
-        # Only use carriage return clearing if stdout is a real TTY
-        if sys.stdout.isatty():
-            print("\r" + " " * 30 + "\r", end="", flush=True)
-        # In non-TTY mode, don't print anything - the "Checking..." message will just remain on its line
-
-        # Non-critical - log but don't fail
-        from ..core.logger import get_logger
-
-        logger = get_logger("cli")
-        logger.debug(f"MCP auto-configuration check failed: {e}")
+    # MCP gateway auto-configuration was removed in v6.x.
+    # Claude Code handles MCP natively; no auto-configure needed.
 
 
 def verify_mcp_gateway_startup():
     """
-    Verify MCP Gateway configuration on startup and pre-warm MCP services.
+    Verify MCP Gateway configuration on startup.
 
-    WHY: The MCP gateway should be automatically configured and verified on startup
-    to provide a seamless experience with diagnostic tools, file summarizer, and
-    ticket service. Pre-warming MCP services eliminates the 11.9s delay on first use.
-
-    DESIGN DECISION: This is non-blocking - failures are logged but don't prevent
-    startup to ensure claude-mpm remains functional even if MCP gateway has issues.
+    NOTE: The MCP gateway sub-package was removed in v6.x. Claude Code handles
+    MCP natively. This function is now a no-op kept for call-site compatibility.
     """
-    # DISABLED: MCP service verification removed - Claude Code handles MCP natively
-    # The previous check warned about missing MCP services, but users should configure
-    # MCP servers through Claude Code's native MCP management, not through claude-mpm.
-    # See: https://docs.anthropic.com/en/docs/claude-code/mcp
-
-    try:
-        import asyncio
-
-        from ..core.logger import get_logger
-        from ..services.mcp_gateway.core.startup_verification import (  # type: ignore
-            is_mcp_gateway_configured,
-            verify_mcp_gateway_on_startup,
-        )
-
-        logger = get_logger("mcp_prewarm")
-
-        # Quick check first - if already configured, skip detailed verification
-        gateway_configured = is_mcp_gateway_configured()
-
-        # DISABLED: Pre-warming MCP servers can interfere with Claude Code's MCP management
-        # This was causing issues with MCP server initialization and stderr handling
-        # Pre-warming functionality has been removed. Gateway verification only runs
-        # if MCP gateway is not already configured.
-
-        # Run gateway verification in background if not configured
-        if not gateway_configured:
-
-            def run_verification():
-                """Background thread to verify MCP gateway configuration."""
-                loop = None
-                try:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                    results = loop.run_until_complete(verify_mcp_gateway_on_startup())
-
-                    # Log results but don't block
-                    from ..core.logger import get_logger
-
-                    logger = get_logger("cli")
-
-                    if results.get("gateway_configured"):
-                        logger.debug("MCP Gateway verification completed successfully")
-                    else:
-                        logger.debug("MCP Gateway verification completed with warnings")
-
-                except Exception as e:
-                    from ..core.logger import get_logger
-
-                    logger = get_logger("cli")
-                    logger.debug(f"MCP Gateway verification failed: {e}")
-                finally:
-                    # Properly clean up event loop to prevent kqueue warnings
-                    if loop is not None:
-                        try:
-                            # Cancel all running tasks
-                            pending = asyncio.all_tasks(loop)
-                            for task in pending:
-                                task.cancel()
-                            # Wait for tasks to complete cancellation
-                            if pending:
-                                loop.run_until_complete(
-                                    asyncio.gather(*pending, return_exceptions=True)
-                                )
-                        except Exception:  # nosec B110
-                            pass  # Ignore cleanup errors
-                        finally:
-                            loop.close()
-                            # Clear the event loop reference to help with cleanup
-                            asyncio.set_event_loop(None)
-
-            # Run in background thread to avoid blocking startup
-            import threading
-
-            verification_thread = threading.Thread(target=run_verification, daemon=True)
-            verification_thread.start()
-
-    except Exception as e:
-        # Import logger here to avoid circular imports
-        from ..core.logger import get_logger
-
-        logger = get_logger("cli")
-        logger.debug(f"Failed to start MCP Gateway verification: {e}")
-        # Continue execution - MCP gateway issues shouldn't block startup
+    # MCP gateway was removed in v6.x — nothing to verify.
 
 
 def check_for_updates_async():

--- a/src/claude_mpm/mcp/diagnostics.py
+++ b/src/claude_mpm/mcp/diagnostics.py
@@ -109,16 +109,6 @@ def diagnose():
             "Server Script",
             project_root / "src" / "claude_mpm" / "scripts" / "mcp_server.py",
         ),
-        (
-            "stdio_server.py",
-            project_root
-            / "src"
-            / "claude_mpm"
-            / "services"
-            / "mcp_gateway"
-            / "server"
-            / "stdio_server.py",
-        ),
         ("claude_mpm __init__", project_root / "src" / "claude_mpm" / "__init__.py"),
         ("VERSION file", project_root / "VERSION"),
     ]

--- a/src/claude_mpm/mcp/verify_setup.py
+++ b/src/claude_mpm/mcp/verify_setup.py
@@ -149,16 +149,6 @@ def main() -> int:
         ("Wrapper Module", wrapper_module),
         ("Server script", server_script),
         ("pyproject.toml", project_root / "pyproject.toml"),
-        (
-            "stdio_server.py",
-            project_root
-            / "src"
-            / "claude_mpm"
-            / "services"
-            / "mcp_gateway"
-            / "server"
-            / "stdio_server.py",
-        ),
     ]
 
     all_exist = True
@@ -196,14 +186,7 @@ def main() -> int:
         )
     )
 
-    # Test 3: Module invocation
-    results.append(
-        test_method(
-            "Module invocation (-m)",
-            ["python3", "-m", "claude_mpm.services.mcp_gateway.server.stdio_server"],
-            cwd=str(project_root),
-        )
-    )
+    # Test 3: Module invocation (mcp_gateway removed in v6.x, skip)
 
     # Test 4: Wrapper from different working directory
     results.append(

--- a/src/claude_mpm/mcp/wrapper.py
+++ b/src/claude_mpm/mcp/wrapper.py
@@ -255,7 +255,6 @@ def verify_environment(logger, project_root):
     required_files = [
         project_root / "pyproject.toml",
         claude_mpm_dir / "__init__.py",
-        claude_mpm_dir / "services" / "mcp_gateway" / "server" / "stdio_server.py",
     ]
 
     for file_path in required_files:
@@ -308,23 +307,9 @@ def test_imports(logger):
     except ImportError as e:
         raise ImportError(f"Failed to import claude_mpm: {e}") from e
 
-    try:
-        from claude_mpm.services.mcp_gateway.server import (
-            stdio_server,  # type: ignore[import-untyped]
-        )
-
-        logger.info(f"  ✓ stdio_server imported from: {stdio_server.__file__}")
-    except ImportError as e:
-        raise ImportError(f"Failed to import stdio_server: {e}") from e
-
-    try:
-        from claude_mpm.services.mcp_gateway.server.stdio_server import (  # type: ignore[import-untyped]
-            SimpleMCPServer,  # noqa: F401
-        )
-
-        logger.info("  ✓ SimpleMCPServer class imported successfully")
-    except ImportError as e:
-        raise ImportError(f"Failed to import SimpleMCPServer: {e}") from e
+    # MCP gateway sub-package was removed in v6.x.
+    # Skip stdio_server / SimpleMCPServer import checks.
+    logger.info("  - MCP gateway imports skipped (removed in v6.x)")
 
     try:
         import asyncio  # noqa: F401
@@ -354,34 +339,11 @@ def run_mcp_server(logger):
     """
     logger.info("Starting MCP Gateway Server...")
 
-    try:
-        import asyncio
-
-        from claude_mpm.services.mcp_gateway.server.stdio_server import (
-            SimpleMCPServer,  # type: ignore[import-untyped]
-        )
-
-        async def run_server():
-            """Async function to run the server."""
-            try:
-                server = SimpleMCPServer(name="claude-mpm-gateway", version="1.0.0")
-                logger.info("Server instance created successfully")
-                await server.run()
-            except Exception as e:
-                logger.error(f"Server runtime error: {e}")
-                logger.error(traceback.format_exc())
-                raise
-
-        # Run the async server
-        asyncio.run(run_server())
-
-    except KeyboardInterrupt:
-        logger.info("Server shutdown requested (KeyboardInterrupt)")
-        sys.exit(0)
-    except Exception as e:
-        logger.error(f"Failed to run MCP server: {e}")
-        logger.error(traceback.format_exc())
-        raise
+    logger.error(
+        "MCP Gateway server was removed in v6.x. "
+        "Use Claude Code's native MCP management instead."
+    )
+    raise RuntimeError("MCP Gateway server removed in v6.x")
 
 
 def main():

--- a/src/claude_mpm/services/__init__.py
+++ b/src/claude_mpm/services/__init__.py
@@ -111,24 +111,10 @@ def __getattr__(name):
         ),
         # Project services
         "ProjectRegistry": ("claude_mpm.services.project.registry", "ProjectRegistry"),
-        # MCP Gateway services
-        "MCPConfiguration": (
-            "claude_mpm.services.mcp_gateway.config.configuration",
-            "MCPConfiguration",
-        ),
-        "MCPConfigLoader": (
-            "claude_mpm.services.mcp_gateway.config.config_loader",
-            "MCPConfigLoader",
-        ),
-        "MCPServer": ("claude_mpm.services.mcp_gateway.server.mcp_server", "MCPServer"),
-        "MCPToolRegistry": (
-            "claude_mpm.services.mcp_gateway.tools.tool_registry",
-            "MCPToolRegistry",
-        ),
-        "BaseMCPService": (
-            "claude_mpm.services.mcp_gateway.core.base",
-            "BaseMCPService",
-        ),
+        # MCP Gateway services (removed in v6.x — kept as stubs for backward compat)
+        # The mcp_gateway sub-package was deprecated and removed.
+        # These entries are intentionally absent so __getattr__ falls through
+        # to the AttributeError at the bottom of this function.
         # Other services
         "TicketManager": ("claude_mpm.services.ticket_manager", "TicketManager"),
     }
@@ -147,15 +133,13 @@ def __getattr__(name):
         except ImportError as e:
             raise AttributeError(f"Recovery management not available: {name}") from e
 
-    # Handle MCP interfaces (names starting with "IMCP")
-    if name.startswith("IMCP"):
-        module = import_module("claude_mpm.services.mcp_gateway.core.interfaces")
-        return getattr(module, name)
-
-    # Handle MCP exceptions (names starting with "MCP" and containing "Error")
-    if name.startswith("MCP") and "Error" in name:
-        module = import_module("claude_mpm.services.mcp_gateway.core.exceptions")
-        return getattr(module, name)
+    # MCP Gateway interfaces/exceptions were removed in v6.x.
+    # Raise clear error for any remaining references.
+    if name.startswith("IMCP") or (name.startswith("MCP") and "Error" in name):
+        raise AttributeError(
+            f"'{name}' is no longer available. "
+            "The MCP gateway sub-package was removed in v6.x."
+        )
 
     # Handle core interfaces and base classes
     if name.startswith("I") or name in [
@@ -185,7 +169,6 @@ __all__ = [
     "AgentRegistry",
     "AgentVersionManager",
     "BaseAgentManager",
-    "BaseMCPService",
     # Core exports
     "BaseService",
     "DeployedAgentDiscovery",
@@ -194,11 +177,6 @@ __all__ = [
     "HookService",
     # Infrastructure services
     "LoggingService",  # New service
-    "MCPConfigLoader",
-    # MCP Gateway services
-    "MCPConfiguration",
-    "MCPServer",
-    "MCPToolRegistry",
     # Memory services (backward compatibility)
     "MemoryBuilder",
     "MemoryOptimizer",

--- a/src/claude_mpm/services/self_upgrade_service.py
+++ b/src/claude_mpm/services/self_upgrade_service.py
@@ -30,7 +30,6 @@ from packaging import version
 
 from ..core.logger import get_logger
 from ..core.unified_paths import PathContext
-from .mcp_gateway.utils.package_version_checker import PackageVersionChecker
 
 
 class InstallationMethod:
@@ -65,7 +64,6 @@ class SelfUpgradeService:
     def __init__(self):
         """Initialize the self-upgrade service."""
         self.logger = get_logger("SelfUpgradeService")
-        self.version_checker = PackageVersionChecker()
         self.current_version = self._get_current_version()
         self.installation_method = self._detect_installation_method()
         self.claude_code_version = self._get_claude_code_version()
@@ -356,9 +354,7 @@ class SelfUpgradeService:
             InstallationMethod.UV_TOOL,
             InstallationMethod.HOMEBREW,
         ]:
-            result = await self.version_checker.check_for_update(
-                "claude-mpm", self.current_version, cache_ttl
-            )
+            result = await self._check_pypi_for_update(cache_ttl)
             if result and result.get("update_available"):
                 result["installation_method"] = self.installation_method
                 result["upgrade_command"] = self._get_upgrade_command()
@@ -381,6 +377,42 @@ class SelfUpgradeService:
                     }
 
         return None
+
+    async def _check_pypi_for_update(
+        self, cache_ttl: int | None = None
+    ) -> dict[str, any] | None:
+        """Check PyPI for the latest version of claude-mpm.
+
+        Args:
+            cache_ttl: Unused, kept for interface compatibility.
+
+        Returns:
+            Dict with update info or None.
+        """
+        try:
+            import json
+            import urllib.request
+
+            url = "https://pypi.org/pypi/claude-mpm/json"
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310
+                data = json.loads(resp.read().decode())
+
+            latest = data.get("info", {}).get("version", "")
+            if not latest:
+                return None
+
+            current_ver = version.parse(self.current_version)
+            latest_ver = version.parse(latest)
+
+            return {
+                "current": self.current_version,
+                "latest": latest,
+                "update_available": latest_ver > current_ver,
+            }
+        except Exception as e:
+            self.logger.debug(f"PyPI version check failed: {e}")
+            return None
 
     async def _check_npm_version(self) -> str | None:
         """


### PR DESCRIPTION
## Summary
- Root cause: `mcp_gateway` sub-package was removed but 39 references remained, causing `ImportError` at startup
- Replaced `PackageVersionChecker` with inline PyPI check in `self_upgrade_service.py`
- Replaced MCP server launch with deprecation notice in `mcp_server_commands.py`
- Cleaned up lazy imports in `services/__init__.py` and removed all remaining `mcp_gateway` imports across CLI and MCP modules

## Details

The `mcp_gateway` sub-package was removed in an earlier version but references to it persisted in 9 files across the codebase. This caused `ImportError` when any of these code paths were exercised.

### Files changed:
- `src/claude_mpm/services/__init__.py` - Removed lazy import of mcp_gateway
- `src/claude_mpm/services/self_upgrade_service.py` - Replaced `PackageVersionChecker` with inline PyPI version check
- `src/claude_mpm/cli/startup.py` - Removed mcp_gateway import
- `src/claude_mpm/cli/commands/mcp.py` - Removed mcp_gateway references
- `src/claude_mpm/cli/commands/mcp_server_commands.py` - Replaced server launch with deprecation notice, removed orphaned except blocks
- `src/claude_mpm/cli/commands/search.py` - Removed mcp_gateway import
- `src/claude_mpm/mcp/diagnostics.py` - Removed mcp_gateway references
- `src/claude_mpm/mcp/verify_setup.py` - Removed mcp_gateway references
- `src/claude_mpm/mcp/wrapper.py` - Removed mcp_gateway references

### Test results:
- 8542 tests pass, 375 MCP-specific tests pass
- 1 pre-existing failure in `test_message_task_integration.py` (unrelated to this change)

## Test plan
- [ ] Verify `claude-mpm` CLI starts without `ImportError`
- [ ] Verify `claude-mpm mcp server start` shows deprecation notice
- [ ] Verify self-upgrade check works with inline PyPI check
- [ ] Run full test suite: `uv run pytest -n auto`

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)