### PR TITLE
feat: add initialPrompt frontmatter for self-starting agent delegation

### DIFF
--- a/src/claude_mpm/schemas/frontmatter_schema.json
+++ b/src/claude_mpm/schemas/frontmatter_schema.json
@@ -122,6 +122,12 @@
         "type": "string"
       },
       "description": "List of agent capabilities"
+    },
+    "initialPrompt": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "description": "Auto-submitted first turn when agent is spawned, eliminating one round-trip in delegation"
     }
   },
   "additionalProperties": true,

--- a/src/claude_mpm/services/agents/deployment/agent_template_builder.py
+++ b/src/claude_mpm/services/agents/deployment/agent_template_builder.py
@@ -16,6 +16,72 @@ import yaml
 
 from claude_mpm.core.logging_config import get_logger
 
+# Mapping of agent names and types to their initialPrompt for self-starting delegation.
+# When an agent is spawned, the initialPrompt auto-submits as the first turn,
+# eliminating one round-trip in delegation.
+# See: https://github.com/bobmatnyc/claude-mpm/issues/418
+INITIAL_PROMPT_BY_NAME: dict[str, str] = {
+    # Research agents
+    "research": "Begin investigation. Analyze the task context, search for relevant files, and report findings.",
+    "code-analyzer": "Begin investigation. Analyze the task context, search for relevant files, and report findings.",
+    # Documentation agents
+    "documentation": "Begin documentation. Read the task context and start writing immediately.",
+    # Security agents
+    "security": "Begin security analysis. Read the task context and start scanning immediately.",
+    # Memory manager and special agents intentionally excluded (interactive/special purpose)
+    # prompt-engineer excluded (needs user interaction)
+    # real-user excluded (persona-based, needs configuration)
+    # memory-manager excluded (special purpose)
+}
+
+INITIAL_PROMPT_BY_TYPE: dict[str, str] = {
+    "engineer": "Begin implementation. Read the task context and start coding immediately.",
+    "refactoring": "Begin implementation. Read the task context and start coding immediately.",
+    "qa": "Begin verification. Read the task context and start testing immediately.",
+    "ops": "Begin operations. Read the task context and execute immediately.",
+    "research": "Begin investigation. Analyze the task context, search for relevant files, and report findings.",
+    "documentation": "Begin documentation. Read the task context and start writing immediately.",
+    "security": "Begin security analysis. Read the task context and start scanning immediately.",
+}
+
+# Agents that should NOT get initialPrompt (interactive/special purpose)
+INITIAL_PROMPT_EXCLUDED_NAMES: set[str] = {
+    "prompt-engineer",
+    "real-user",
+    "memory-manager",
+    "memory-manager-agent",
+    "mpm-agent-manager",
+    "mpm-skills-manager",
+    "ticketing",
+}
+
+
+def get_initial_prompt(agent_name: str, agent_type: str | None) -> str | None:
+    """Get the initialPrompt for an agent based on name or type.
+
+    Name-based lookup takes precedence over type-based lookup.
+    Excluded agents never get an initialPrompt.
+
+    Args:
+        agent_name: The kebab-case agent name
+        agent_type: The agent type category
+
+    Returns:
+        The initialPrompt string, or None if the agent should not have one
+    """
+    if agent_name in INITIAL_PROMPT_EXCLUDED_NAMES:
+        return None
+
+    # Name-based lookup first (highest priority)
+    if agent_name in INITIAL_PROMPT_BY_NAME:
+        return INITIAL_PROMPT_BY_NAME[agent_name]
+
+    # Type-based lookup (fallback)
+    if agent_type and agent_type in INITIAL_PROMPT_BY_TYPE:
+        return INITIAL_PROMPT_BY_TYPE[agent_type]
+
+    return None
+
 
 class AgentTemplateBuilder:
     """Service for building agent templates from JSON and base agent data.
@@ -593,6 +659,16 @@ class AgentTemplateBuilder:
             frontmatter_lines.append("skills:")
             for skill in skills:
                 frontmatter_lines.append(f"- {skill}")
+
+        # Add initialPrompt for self-starting delegation (issue #418)
+        # Check template data first (explicit override), then use type/name mapping
+        initial_prompt = template_data.get("initialPrompt")
+        if not initial_prompt:
+            initial_prompt = get_initial_prompt(claude_code_name, agent_type)
+        if initial_prompt:
+            # Quote the value to ensure valid YAML
+            escaped = initial_prompt.replace('"', '\\"')
+            frontmatter_lines.append(f'initialPrompt: "{escaped}"')
 
         frontmatter_lines.extend(
             [

--- a/tests/services/agents/deployment/test_initial_prompt.py
+++ b/tests/services/agents/deployment/test_initial_prompt.py
@@ -1,0 +1,182 @@
+"""Tests for initialPrompt frontmatter support (issue #418).
+
+Tests the get_initial_prompt function and verifies that the template builder
+correctly injects initialPrompt into agent frontmatter.
+"""
+
+import pytest
+
+from claude_mpm.services.agents.deployment.agent_template_builder import (
+    INITIAL_PROMPT_BY_NAME,
+    INITIAL_PROMPT_BY_TYPE,
+    INITIAL_PROMPT_EXCLUDED_NAMES,
+    get_initial_prompt,
+)
+
+
+class TestGetInitialPrompt:
+    """Tests for the get_initial_prompt function."""
+
+    def test_research_agent_by_name(self):
+        result = get_initial_prompt("research", "research")
+        assert result is not None
+        assert "investigation" in result.lower()
+
+    def test_documentation_agent_by_name(self):
+        result = get_initial_prompt("documentation", "documentation")
+        assert result is not None
+        assert "documentation" in result.lower()
+
+    def test_security_agent_by_name(self):
+        result = get_initial_prompt("security", "security")
+        assert result is not None
+        assert "security" in result.lower()
+
+    def test_engineer_agent_by_type(self):
+        result = get_initial_prompt("python-engineer", "engineer")
+        assert result is not None
+        assert "implementation" in result.lower()
+
+    def test_qa_agent_by_type(self):
+        result = get_initial_prompt("qa", "qa")
+        assert result is not None
+        assert "verification" in result.lower()
+
+    def test_web_qa_agent_by_type(self):
+        result = get_initial_prompt("web-qa", "qa")
+        assert result is not None
+        assert "verification" in result.lower()
+
+    def test_api_qa_agent_by_type(self):
+        result = get_initial_prompt("api-qa", "qa")
+        assert result is not None
+        assert "verification" in result.lower()
+
+    def test_ops_agent_by_type(self):
+        result = get_initial_prompt("ops", "ops")
+        assert result is not None
+        assert "operations" in result.lower()
+
+    def test_local_ops_agent_by_type(self):
+        result = get_initial_prompt("local-ops", "ops")
+        assert result is not None
+        assert "operations" in result.lower()
+
+    def test_all_language_engineers_get_implementation_prompt(self):
+        """All language-specific engineers should get the engineer type prompt."""
+        engineers = [
+            "python-engineer",
+            "typescript-engineer",
+            "javascript-engineer",
+            "golang-engineer",
+            "java-engineer",
+            "ruby-engineer",
+            "rust-engineer",
+            "php-engineer",
+            "phoenix-engineer",
+            "dart-engineer",
+            "react-engineer",
+            "nextjs-engineer",
+            "svelte-engineer",
+            "tauri-engineer",
+            "data-engineer",
+        ]
+        for name in engineers:
+            result = get_initial_prompt(name, "engineer")
+            assert result is not None, f"{name} should have an initialPrompt"
+            assert "implementation" in result.lower(), (
+                f"{name} should mention implementation"
+            )
+
+    def test_refactoring_engineer_by_type(self):
+        result = get_initial_prompt("refactoring-engineer", "refactoring")
+        assert result is not None
+        assert "implementation" in result.lower()
+
+
+class TestExcludedAgents:
+    """Test that excluded agents do not get initialPrompt."""
+
+    def test_prompt_engineer_excluded(self):
+        result = get_initial_prompt("prompt-engineer", "analysis")
+        assert result is None
+
+    def test_real_user_excluded(self):
+        result = get_initial_prompt("real-user", "qa")
+        assert result is None
+
+    def test_memory_manager_excluded(self):
+        result = get_initial_prompt("memory-manager", "memory_manager")
+        assert result is None
+
+    def test_memory_manager_agent_excluded(self):
+        result = get_initial_prompt("memory-manager-agent", "memory_manager")
+        assert result is None
+
+    def test_ticketing_excluded(self):
+        result = get_initial_prompt("ticketing", None)
+        assert result is None
+
+    def test_mpm_agent_manager_excluded(self):
+        result = get_initial_prompt("mpm-agent-manager", None)
+        assert result is None
+
+
+class TestNamePrecedenceOverType:
+    """Test that name-based lookup takes precedence over type-based."""
+
+    def test_research_name_takes_precedence(self):
+        """Research has both name and type mappings; name should win."""
+        name_result = INITIAL_PROMPT_BY_NAME.get("research")
+        type_result = INITIAL_PROMPT_BY_TYPE.get("research")
+        # Both should exist
+        assert name_result is not None
+        assert type_result is not None
+        # get_initial_prompt should return the name-based one
+        result = get_initial_prompt("research", "research")
+        assert result == name_result
+
+
+class TestUnknownAgents:
+    """Test behavior for unknown agent names/types."""
+
+    def test_unknown_name_and_type_returns_none(self):
+        result = get_initial_prompt("unknown-agent", "unknown-type")
+        assert result is None
+
+    def test_unknown_name_with_known_type(self):
+        result = get_initial_prompt("custom-engineer", "engineer")
+        assert result is not None
+        assert "implementation" in result.lower()
+
+    def test_known_name_with_none_type(self):
+        result = get_initial_prompt("research", None)
+        assert result is not None
+
+    def test_none_type_unknown_name(self):
+        result = get_initial_prompt("completely-unknown", None)
+        assert result is None
+
+
+class TestInitialPromptMappingConsistency:
+    """Verify that the mapping constants are well-formed."""
+
+    def test_all_name_prompts_are_nonempty_strings(self):
+        for name, prompt in INITIAL_PROMPT_BY_NAME.items():
+            assert isinstance(prompt, str), f"{name} prompt must be string"
+            assert len(prompt) > 10, f"{name} prompt too short"
+
+    def test_all_type_prompts_are_nonempty_strings(self):
+        for agent_type, prompt in INITIAL_PROMPT_BY_TYPE.items():
+            assert isinstance(prompt, str), f"{agent_type} prompt must be string"
+            assert len(prompt) > 10, f"{agent_type} prompt too short"
+
+    def test_excluded_names_are_strings(self):
+        for name in INITIAL_PROMPT_EXCLUDED_NAMES:
+            assert isinstance(name, str), f"Excluded name must be string: {name}"
+            assert len(name) > 0, "Excluded name must not be empty"
+
+    def test_no_overlap_between_excluded_and_name_map(self):
+        """Excluded names should not appear in the name-based map."""
+        overlap = INITIAL_PROMPT_EXCLUDED_NAMES & set(INITIAL_PROMPT_BY_NAME.keys())
+        assert not overlap, f"Names in both excluded and map: {overlap}"


### PR DESCRIPTION
## Summary
- Add `initialPrompt` frontmatter support to the agent deployment pipeline so spawned agents auto-submit their first turn, eliminating one round-trip in delegation
- Agents are mapped by name (highest priority) or type (fallback) to appropriate initialPrompt strings
- Interactive/special agents (prompt-engineer, real-user, memory-manager, ticketing) are explicitly excluded

## Details

### Agent categories and their prompts
| Category | Prompt | Agents |
|----------|--------|--------|
| Research | "Begin investigation..." | research, code-analyzer |
| Engineer | "Begin implementation..." | python-engineer, typescript-engineer, all language engineers, data-engineer, refactoring-engineer |
| QA | "Begin verification..." | qa, web-qa, api-qa |
| Ops | "Begin operations..." | ops, local-ops, gcp-ops, vercel-ops, etc. |
| Documentation | "Begin documentation..." | documentation |
| Security | "Begin security analysis..." | security |

### Files changed
- `src/claude_mpm/services/agents/deployment/agent_template_builder.py` - Core logic: mappings, `get_initial_prompt()`, and frontmatter injection
- `src/claude_mpm/schemas/frontmatter_schema.json` - Added `initialPrompt` to schema
- `tests/services/agents/deployment/test_initial_prompt.py` - 26 unit tests

### How it works
1. During agent deployment, `build_agent_markdown()` generates YAML frontmatter
2. The new code checks `template_data.get("initialPrompt")` first (explicit override)
3. Falls back to `get_initial_prompt(name, type)` which uses name-based then type-based mapping
4. Excluded agents (interactive/special purpose) never get initialPrompt

## Test plan
- [x] 26 new unit tests covering all categories, exclusions, precedence, and edge cases
- [x] All 222 existing deployment tests pass
- [x] All 209 frontmatter/template tests pass
- [x] Pre-commit hooks (ruff, bandit, secrets scan) all pass

Closes #418

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)