### PR TITLE
fix: agent cache discovery missing branch segment in auto_configure

### DIFF
--- a/src/claude_mpm/cli/commands/auto_configure.py
+++ b/src/claude_mpm/cli/commands/auto_configure.py
@@ -1158,20 +1158,21 @@ class AutoConfigureCommand(BaseCommand):
         if not agent_preview:
             return None
 
+        from ...config.agent_sources import AgentSourceConfiguration
         from ...services.agents.agent_review_service import AgentReviewService
         from ...services.agents.deployment.remote_agent_discovery_service import (
             RemoteAgentDiscoveryService,
         )
 
-        # Get managed agents from cache
-        agents_cache_dir = Path.home() / ".claude-mpm" / "cache" / "agents"
-        if not agents_cache_dir.exists():
-            self.logger.debug("No agents cache found")
-            return None
-
-        # Discover managed agents
-        discovery_service = RemoteAgentDiscoveryService(agents_cache_dir)
-        managed_agents = discovery_service.discover_remote_agents()
+        # Discover managed agents per-repo so RemoteAgentDiscoveryService
+        # receives the full 4-level cache path (owner/repo/branch/subdir)
+        # rather than the root cache dir, which lacks the {branch} segment.
+        config = AgentSourceConfiguration.load()
+        managed_agents = []
+        for repo in config.repositories:
+            if repo.enabled and repo.cache_path.exists():
+                discovery_service = RemoteAgentDiscoveryService(repo.cache_path)
+                managed_agents.extend(discovery_service.discover_remote_agents())
 
         if not managed_agents:
             self.logger.debug("No managed agents found in cache")


### PR DESCRIPTION
# Fix agent cache discovery missing branch segment in auto_configure

## Motivation

The `auto_configure` path for discovering locally cached agents was silently failing despite agents being available. Users saw misleading warnings about missing agent directories while the UI correctly displayed available agents from the same cache. This inconsistency needed to be resolved to ensure reliable agent discovery across all code paths.

## Problem

`RemoteAgentDiscoveryService` expects a fully-qualified repo cache path (4-level structure: `owner/repo/branch/subdirectory`), but `auto_configure.py` was passing the root cache directory. This caused the service to search only 2 levels deep (`owner/repo/agents/`), completely missing the `branch` directory segment. Cached agents at `~/.claude-mpm/cache/agents/bobmatnyc/claude-mpm-agents/main/agents/` were never discovered, resulting in "No agent directories found" warnings despite 53 agents being present and visible in the UI.

Two other callers (`git_source_manager.py` and `single_tier_deployment_service.py`) already used the correct pattern by passing `repo.cache_path` to the discovery service.

## Changes

Modified `auto_configure.py` to iterate over configured repositories and instantiate `RemoteAgentDiscoveryService` with each repo's full cache path (`repo.cache_path`), consistent with existing patterns elsewhere in the codebase. This ensures the service operates on the correct 4-level directory structure.

- Single file changed: `src/claude_mpm/cli/commands/auto_configure.py`
- No behavior change for deployments with no configured repositories
- Aligns with established patterns in `git_source_manager.py` and `single_tier_deployment_service.py`

## Notes for Reviewers

- Only one file modified (`src/claude_mpm/cli/commands/auto_configure.py`)
- This change aligns `auto_configure` with the correct pattern already established in `git_source_manager.py` and `single_tier_deployment_service.py`
- No breaking changes: if no repositories are configured, the function returns `None` as before
- All 40 auto_configure tests pass, plus 162 agent source/discovery tests and 8,534 other tests
