### PR TITLE
feat: AgentLair async cross-machine messaging

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,7 +9,7 @@ and MCP server configuration without needing to run `claude-mpm configure` manua
 | Component | Description |
 |-----------|-------------|
 | **Hooks** | Agent delegation tracking, session monitoring, and event handling across all hook events (PreToolUse, PostToolUse, Stop, UserPromptSubmit, SubagentStop) |
-| **Skills** | MPM orchestrator skill -- delegation-first agent management, available agent types, verification protocol |
+| **Skills** | MPM orchestrator skill -- delegation-first agent management, available agent types, verification protocol; AgentLair async cross-machine messaging |
 | **Commands** | `/mpm-status` and `/mpm-help` slash commands for quick system status and reference |
 | **MCP Servers** | `mpm-messaging` -- cross-project messaging between Claude instances |
 
@@ -102,6 +102,39 @@ uv pip install -e .
 # Install the plugin from local path
 claude plugin install ./plugin
 ```
+
+## AgentLair: Cross-Machine Async Messaging
+
+The built-in `claude-mpm message` CLI uses a shared SQLite database —
+fast and zero-dependency, but **local-filesystem-only** (same user, same machine).
+
+For distributed deployments — CI/CD pipelines, cross-team agents, remote workers —
+the `agentlair` skill provides a REST-backed async inbox via
+[AgentLair](https://agentlair.dev).  Each MPM instance claims a persistent
+``@agentlair.dev`` address and sends/receives messages across any network.
+
+**Quick setup:**
+
+```bash
+# Get a free API key (no signup required)
+export AGENTLAIR_API_KEY=$(curl -s -X POST https://agentlair.dev/v1/auth/keys | jq -r '.api_key')
+
+# Claim an inbox for this instance
+python -c "
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import claim_inbox
+asyncio.run(claim_inbox('myproject@agentlair.dev'))
+print('Inbox ready')
+"
+```
+
+See [plugin/skills/agentlair/SKILL.md](skills/agentlair/SKILL.md) for the full API reference.
+
+| Messaging scenario | Solution |
+|---|---|
+| Same machine, same user | `claude-mpm message` (SQLite) |
+| Different machines / CI | AgentLair skill (REST, async) |
+| Cross-org / external agents | AgentLair skill |
 
 ## License
 

--- a/plugin/skills/agentlair/SKILL.md
+++ b/plugin/skills/agentlair/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: agentlair
+description: >
+  Send and receive async messages between Claude MPM instances across machines
+  using AgentLair (https://agentlair.dev). Use when you need cross-machine
+  agent communication beyond localhost SQLite messaging.
+user-invocable: true
+version: "1.0.0"
+category: communication
+tags: [communication, async, cross-machine, agentlair]
+---
+
+# AgentLair Cross-Machine Messaging
+
+AgentLair gives each Claude MPM instance a persistent ``@agentlair.dev`` inbox
+that works across machines, networks, and sessions — no shared filesystem required.
+
+> **When to use AgentLair vs built-in MPM messaging**
+>
+> | Scenario | Use |
+> |---|---|
+> | Same machine, same user | `claude-mpm message` (SQLite, instant) |
+> | Different machines / CI/CD | AgentLair (REST, async, persistent) |
+> | Cross-team or cross-org agents | AgentLair |
+
+## Prerequisites
+
+Set ``AGENTLAIR_API_KEY`` in your environment.  Get a free key at
+https://agentlair.dev (no account required — self-service via the API).
+
+```bash
+# Quick self-service key (no signup required)
+curl -s -X POST https://agentlair.dev/v1/auth/keys | jq -r '.api_key'
+# → al_live_...
+
+export AGENTLAIR_API_KEY="al_live_..."
+```
+
+Confirm availability:
+
+```python
+from claude_mpm.services.agents.agentlair_agent import is_agentlair_available
+print(is_agentlair_available())  # True when AGENTLAIR_API_KEY is set
+```
+
+## Claim an inbox
+
+Each MPM instance claims a unique ``@agentlair.dev`` address.  Use a name that
+reflects the project or machine so senders know where to route tasks.
+
+```python
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import claim_inbox
+
+result = asyncio.run(claim_inbox("myproject@agentlair.dev"))
+print(result.success)  # True
+print(result.data)     # {"claimed": true, "address": "myproject@agentlair.dev"}
+```
+
+## Send a message to another MPM instance
+
+```python
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import send_message
+
+result = asyncio.run(send_message(
+    from_address="sender@agentlair.dev",
+    to_address="receiver@agentlair.dev",
+    subject="Delegation request",
+    body="Please summarise the last 5 git commits in /repo/foo",
+))
+print(result.data)  # {"id": "out_...", "status": "sent", ...}
+```
+
+## Check inbox for incoming messages
+
+```python
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import receive_messages
+
+messages = asyncio.run(receive_messages(
+    "myproject@agentlair.dev",
+    unread_only=True,
+))
+for msg in messages:
+    print(f"[{msg.received_at}] {msg.from_address}: {msg.subject}")
+```
+
+## Read full message body
+
+```python
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import read_message
+
+result = asyncio.run(read_message(
+    address="myproject@agentlair.dev",
+    message_id=msg.message_id,  # angle brackets stripped automatically
+))
+text_body = result.data.get("text", "")
+```
+
+## Full async workflow example
+
+```python
+import asyncio
+from claude_mpm.services.agents.agentlair_agent import (
+    claim_inbox, send_message, receive_messages, read_message,
+)
+
+async def main():
+    # 1. Ensure this instance has an inbox
+    await claim_inbox("worker@agentlair.dev")
+
+    # 2. Notify another instance that a task is ready
+    await send_message(
+        from_address="worker@agentlair.dev",
+        to_address="orchestrator@agentlair.dev",
+        subject="Task complete",
+        body="Benchmark run finished. Results at /results/bench-2026-04-10.json",
+    )
+
+    # 3. Poll for replies
+    messages = await receive_messages("worker@agentlair.dev", unread_only=True)
+    for msg in messages:
+        full = await read_message("worker@agentlair.dev", msg.message_id)
+        print(full.data.get("text", ""))
+
+asyncio.run(main())
+```
+
+## Limitations
+
+- Messages are delivered asynchronously — not real-time.  Poll with
+  `receive_messages()` on a schedule or at session start.
+- ``AGENTLAIR_API_KEY`` must be present in the environment on both sender and
+  receiver instances (they may use different keys from separate accounts).
+- Daily send quota applies (see ``rate_limit.daily_remaining`` in send response).
+
+## Architecture note
+
+AgentLair messaging is a **transport layer** — it replaces the shared SQLite
+database for cross-machine scenarios but does not change how the MPM PM decides
+what to do with incoming messages.  The PM still reads the body, decides
+locally what tasks to create, and replies via the same channel.
+
+This complements rather than replaces the built-in `claude-mpm message` CLI:
+use SQLite for fast local work, AgentLair for distributed deployments.
+
+---
+
+**Version**: 1.0.0
+**Requires**: `httpx` (`pip install httpx`), `AGENTLAIR_API_KEY` env var
+**Module**: `claude_mpm.services.agents.agentlair_agent`

--- a/src/claude_mpm/services/agents/agentlair_agent.py
+++ b/src/claude_mpm/services/agents/agentlair_agent.py
@@ -1,0 +1,437 @@
+"""AgentLair async messaging integration for Claude MPM.
+
+Provides a persistent, cross-machine async inbox for Claude MPM instances via
+the AgentLair REST API (https://agentlair.dev).  Unlike the SQLite-backed
+``MessageService`` (which is local-filesystem-only), AgentLair messages work
+across machines, networks, and sessions.
+
+Each MPM instance claims an ``@agentlair.dev`` address and can send or receive
+messages from any other MPM instance worldwide — no shared filesystem needed.
+
+Usage::
+
+    from claude_mpm.services.agents.agentlair_agent import (
+        is_agentlair_available,
+        claim_inbox,
+        send_message,
+        receive_messages,
+        AgentLairMessage,
+    )
+
+    # Check whether AGENTLAIR_API_KEY is configured
+    if is_agentlair_available():
+        # Claim a persistent inbox for this MPM instance
+        await claim_inbox("myproject@agentlair.dev")
+
+        # Send a message to another MPM instance
+        result = await send_message(
+            from_address="myproject@agentlair.dev",
+            to_address="otherproject@agentlair.dev",
+            subject="Task delegation request",
+            body="Please summarise the recent git log for /repo/foo",
+        )
+
+        # Poll for incoming messages
+        messages = await receive_messages("myproject@agentlair.dev")
+        for msg in messages:
+            print(f"From: {msg.from_address}  Subject: {msg.subject}")
+            print(msg.body)
+
+Configuration::
+
+    Set ``AGENTLAIR_API_KEY`` in the environment (or export it from
+    ``~/.claude-mpm/.env``).  A free key is available at https://agentlair.dev.
+    If the variable is absent the module degrades gracefully — all functions
+    return error results instead of raising exceptions.
+
+API reference:
+    https://agentlair.dev (GET / returns full machine-readable API manifest)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://agentlair.dev/v1"
+
+# ---------------------------------------------------------------------------
+# Module-level availability cache
+# ---------------------------------------------------------------------------
+
+_agentlair_available: bool | None = None  # None = not yet checked
+
+
+def is_agentlair_available() -> bool:
+    """Return True when ``AGENTLAIR_API_KEY`` is present in the environment.
+
+    The result is cached after the first call so repeated checks are free.
+    The key is not validated against the remote API at check time; the first
+    real API call will surface an authentication error if the key is invalid.
+
+    Returns:
+        True when the environment variable is set to a non-empty string.
+    """
+    global _agentlair_available
+    if _agentlair_available is not None:
+        return _agentlair_available
+
+    api_key = os.environ.get("AGENTLAIR_API_KEY", "").strip()
+    _agentlair_available = bool(api_key)
+
+    if _agentlair_available:
+        logger.debug("AgentLair API key found; async messaging available")
+    else:
+        logger.debug("AGENTLAIR_API_KEY not set; AgentLair messaging unavailable")
+
+    return _agentlair_available
+
+
+def _get_api_key() -> str:
+    """Return the API key from the environment."""
+    return os.environ.get("AGENTLAIR_API_KEY", "").strip()
+
+
+def _auth_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_get_api_key()}",
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Result / message dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentLairResult:
+    """Outcome of an AgentLair API call.
+
+    Attributes:
+        success: True when the API call completed without error.
+        data: Parsed JSON response body (dict or list).
+        error: Human-readable error description when ``success`` is False.
+        duration_ms: Wall-clock milliseconds for the HTTP round-trip.
+        status_code: HTTP status code returned by the server (0 if no response).
+    """
+
+    success: bool
+    data: dict[str, Any] | list[Any]
+    error: str = ""
+    duration_ms: int = 0
+    status_code: int = 0
+
+
+@dataclass
+class AgentLairMessage:
+    """A single message retrieved from an AgentLair inbox.
+
+    Attributes:
+        message_id: Unique message identifier (RFC 2822 Message-ID, may include
+            angle brackets — use :func:`strip_message_id` for URL encoding).
+        from_address: Sender email address.
+        subject: Message subject line.
+        body: Plain-text message body (empty when not yet fetched).
+        received_at: ISO-8601 timestamp when the message arrived.
+        read: Whether the message has been marked as read.
+        raw: The raw API response dict for this message.
+    """
+
+    message_id: str
+    from_address: str
+    subject: str
+    body: str = ""
+    received_at: str = ""
+    read: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def strip_message_id(message_id: str) -> str:
+        """Strip RFC 2822 angle brackets from a message ID for URL use."""
+        return message_id.lstrip("<").rstrip(">")
+
+
+# ---------------------------------------------------------------------------
+# Low-level HTTP helper
+# ---------------------------------------------------------------------------
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    json: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+    timeout: int = 30,
+) -> AgentLairResult:
+    """Perform an authenticated HTTP request against the AgentLair API.
+
+    Imports ``httpx`` lazily so that environments without httpx installed do not
+    crash on import — they will receive a clear error on the first real call.
+
+    Args:
+        method: HTTP verb (``"GET"``, ``"POST"``, etc.).
+        path: API path (e.g. ``"/email/claim"``).
+        json: Optional request body, serialised as JSON.
+        params: Optional query-string parameters.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        An :class:`AgentLairResult` with ``success=True`` and ``data`` populated
+        on HTTP 2xx, or ``success=False`` with ``error`` set on failure.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return AgentLairResult(
+            success=False,
+            data={},
+            error=(
+                "httpx is not installed.  "
+                "Run `pip install httpx` or `uv add httpx` to enable AgentLair messaging."
+            ),
+        )
+
+    url = f"{_BASE_URL}{path}"
+    start_ms = int(time.monotonic() * 1000)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method,
+                url,
+                headers=_auth_headers(),
+                json=json,
+                params=params,
+                timeout=timeout,
+            )
+    except httpx.TimeoutException as exc:
+        elapsed = int(time.monotonic() * 1000) - start_ms
+        logger.warning("AgentLair request timed out: %s", exc)
+        return AgentLairResult(
+            success=False,
+            data={},
+            error=f"Request timed out after {timeout}s: {exc}",
+            duration_ms=elapsed,
+        )
+    except httpx.RequestError as exc:
+        elapsed = int(time.monotonic() * 1000) - start_ms
+        logger.error("AgentLair request error: %s", exc)
+        return AgentLairResult(
+            success=False,
+            data={},
+            error=f"HTTP request failed: {exc}",
+            duration_ms=elapsed,
+        )
+
+    elapsed = int(time.monotonic() * 1000) - start_ms
+
+    try:
+        data = response.json()
+    except Exception:
+        data = {"raw": response.text}
+
+    if response.is_success:
+        return AgentLairResult(
+            success=True,
+            data=data,
+            duration_ms=elapsed,
+            status_code=response.status_code,
+        )
+
+    error_msg = (
+        data.get("error", data.get("message", response.text))
+        if isinstance(data, dict)
+        else str(data)
+    )
+    logger.warning(
+        "AgentLair API error %d: %s", response.status_code, error_msg
+    )
+    return AgentLairResult(
+        success=False,
+        data=data,
+        error=f"API error {response.status_code}: {error_msg}",
+        duration_ms=elapsed,
+        status_code=response.status_code,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def claim_inbox(address: str) -> AgentLairResult:
+    """Claim an ``@agentlair.dev`` inbox for this MPM instance.
+
+    Idempotent — calling this repeatedly with the same address is safe.  The
+    address must end with ``@agentlair.dev``.
+
+    Args:
+        address: The desired inbox address, e.g. ``"myproject@agentlair.dev"``.
+
+    Returns:
+        An :class:`AgentLairResult`.  On success ``data`` contains
+        ``{"claimed": true, "address": "..."}`` (or ``{"already_owned": true}``
+        if the inbox was previously claimed by this account).
+    """
+    if not is_agentlair_available():
+        return AgentLairResult(
+            success=False,
+            data={},
+            error="AGENTLAIR_API_KEY is not set.",
+        )
+
+    logger.debug("Claiming AgentLair inbox: %s", address)
+    result = await _request("POST", "/email/claim", json={"address": address})
+
+    if result.success:
+        logger.info("AgentLair inbox ready: %s", address)
+    return result
+
+
+async def send_message(
+    *,
+    from_address: str,
+    to_address: str,
+    subject: str,
+    body: str,
+    html: str | None = None,
+) -> AgentLairResult:
+    """Send a message from one MPM instance to another via AgentLair.
+
+    The ``from_address`` must have been previously claimed with
+    :func:`claim_inbox`.  The ``to_address`` can be any email address —
+    both ``@agentlair.dev`` inboxes and external addresses are supported.
+
+    Args:
+        from_address: Sender ``@agentlair.dev`` address.
+        to_address: Recipient address (``@agentlair.dev`` or external).
+        subject: Message subject.
+        body: Plain-text message body.
+        html: Optional HTML version of the body.
+
+    Returns:
+        An :class:`AgentLairResult`.  On success ``data`` contains
+        ``{"id": "out_...", "status": "sent", ...}``.
+    """
+    if not is_agentlair_available():
+        return AgentLairResult(
+            success=False,
+            data={},
+            error="AGENTLAIR_API_KEY is not set.",
+        )
+
+    payload: dict[str, Any] = {
+        "from": from_address,
+        "to": [to_address],
+        "subject": subject,
+        "text": body,
+    }
+    if html:
+        payload["html"] = html
+
+    logger.debug(
+        "Sending AgentLair message: %s -> %s [%s]", from_address, to_address, subject
+    )
+    result = await _request("POST", "/email/send", json=payload)
+
+    if result.success:
+        msg_id = result.data.get("id", "") if isinstance(result.data, dict) else ""
+        logger.info("Message sent via AgentLair: %s", msg_id)
+    return result
+
+
+async def receive_messages(
+    address: str,
+    *,
+    limit: int = 20,
+    unread_only: bool = False,
+) -> list[AgentLairMessage]:
+    """Retrieve messages from an AgentLair inbox.
+
+    Args:
+        address: The ``@agentlair.dev`` inbox address to check.
+        limit: Maximum number of messages to return (default 20).
+        unread_only: When True, only return unread messages.
+
+    Returns:
+        A list of :class:`AgentLairMessage` objects.  Returns an empty list
+        when the inbox is empty or the API call fails.
+    """
+    if not is_agentlair_available():
+        logger.warning("AGENTLAIR_API_KEY not set; cannot receive messages")
+        return []
+
+    params: dict[str, str] = {
+        "address": address,
+        "limit": str(limit),
+    }
+
+    result = await _request("GET", "/email/inbox", params=params)
+    if not result.success:
+        logger.warning("Failed to fetch AgentLair inbox %s: %s", address, result.error)
+        return []
+
+    raw_messages = (
+        result.data.get("messages", []) if isinstance(result.data, dict) else []
+    )
+
+    messages: list[AgentLairMessage] = []
+    for raw in raw_messages:
+        if not isinstance(raw, dict):
+            continue
+        msg = AgentLairMessage(
+            message_id=raw.get("message_id", ""),
+            from_address=raw.get("from", ""),
+            subject=raw.get("subject", ""),
+            received_at=raw.get("received_at", ""),
+            read=raw.get("read", False),
+            raw=raw,
+        )
+        if unread_only and msg.read:
+            continue
+        messages.append(msg)
+
+    logger.debug(
+        "AgentLair inbox %s: %d message(s) retrieved", address, len(messages)
+    )
+    return messages
+
+
+async def read_message(address: str, message_id: str) -> AgentLairResult:
+    """Fetch the full body of a specific message.
+
+    Args:
+        address: The inbox address that owns the message.
+        message_id: The message ID as returned by :func:`receive_messages`
+            (angle brackets are stripped automatically).
+
+    Returns:
+        An :class:`AgentLairResult`.  On success ``data`` contains the full
+        message dict including ``"text"`` and ``"html"`` body fields.
+    """
+    if not is_agentlair_available():
+        return AgentLairResult(
+            success=False,
+            data={},
+            error="AGENTLAIR_API_KEY is not set.",
+        )
+
+    import urllib.parse
+
+    clean_id = AgentLairMessage.strip_message_id(message_id)
+    encoded_id = urllib.parse.quote(clean_id, safe="")
+    params = {"address": address}
+
+    return await _request("GET", f"/email/messages/{encoded_id}", params=params)


### PR DESCRIPTION
## Summary

Adds an async cross-machine messaging integration for MPM instances that can't share a filesystem — CI/CD pipelines, remote workers, cross-team deployments.

The existing `claude-mpm message` CLI uses a shared SQLite database (`~/.claude-mpm/messaging.db`), which is fast and zero-dependency but limited to **same machine, same user**. This PR adds a complementary REST-backed transport layer via [AgentLair](https://agentlair.dev).

### What's added

- **`src/claude_mpm/services/agents/agentlair_agent.py`** — async wrapper (httpx) for the AgentLair REST API: claim inbox, send, receive, and read messages. Follows the same structure as `copilot_agent.py` / `cursor_agent.py`. Degrades gracefully when `AGENTLAIR_API_KEY` is absent — no import errors.

- **`plugin/skills/agentlair/SKILL.md`** — full skill doc with code examples for claim → send → receive → read workflow, and a table comparing when to use AgentLair vs built-in SQLite messaging.

- **`plugin/README.md`** — documents the new option with a quick-start snippet and a routing table.

### Design decisions

- **Optional dependency**: `httpx` is imported lazily — existing installations don't break
- **No routing changes**: This is additive. `external_agents.py` is untouched; the new module is standalone
- **Free tier**: AgentLair issues keys self-service (`POST /v1/auth/keys`, no signup)

### Relationship to #434

Issue #434 shelved Copilot/Cursor integrations because subprocess-based agents are 2–10× slower than haiku and lack project context. AgentLair solves a different, adjacent problem: **the SQLite message bus doesn't cross machine boundaries**. These are complementary — use haiku subagents for task execution, AgentLair for async coordination between distributed MPM instances.

## Test plan

- [ ] `is_agentlair_available()` returns `False` when `AGENTLAIR_API_KEY` is unset, `True` when set
- [ ] `claim_inbox("test@agentlair.dev")` returns `{"claimed": true, ...}` with a valid key
- [ ] `send_message(...)` returns `{"status": "sent", ...}`
- [ ] `receive_messages(address)` returns list of `AgentLairMessage` objects
- [ ] All functions return graceful error results (not exceptions) when key is missing or API fails
- [ ] Import with no `httpx` installed returns a clear error message rather than `ImportError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)