### PR TITLE
fix: update sonnet alias to claude-sonnet-4-6-20260124

### DIFF
--- a/src/claude_mpm/services/agents/agent_runtime.py
+++ b/src/claude_mpm/services/agents/agent_runtime.py
@@ -61,7 +61,7 @@ class AgentConfig:
 
 # MPM short names -> SDK / API model identifiers
 _MPM_TO_SDK_MODEL: dict[str, str] = {
-    "sonnet": "claude-sonnet-4-20250514",
+    "sonnet": "claude-sonnet-4-6-20260124",
     "opus": "claude-opus-4-20250514",
     "haiku": "claude-haiku-3-20250307",
 }


### PR DESCRIPTION
## Fixes #490

Update the  alias in  from the stale May 2025 Sonnet 4 ID to the current  model used elsewhere in the codebase.

### Changes
- :  -> 
- Reverse map entry for  ->  preserved for legacy callers

### Background
Other parts of the codebase (model_tier_hook.py, run.py, core/enums.py) already use ; this mapping was the outlier causing silent model downgrades.