### PR TITLE
perf: switch pytest-xdist to work-stealing scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,14 @@ TEST_WORKERS := $(or $(CLAUDE_MPM_TEST_WORKERS),auto)
 
 # Environment-specific settings
 ifeq ($(ENV),production)
-    PYTEST_ARGS := -n $(TEST_WORKERS) -v --tb=short --strict-markers
+    PYTEST_ARGS := -n $(TEST_WORKERS) --dist worksteal -v --tb=short --strict-markers
     BUILD_FLAGS := --no-isolation
 else ifeq ($(ENV),staging)
-    PYTEST_ARGS := -n $(TEST_WORKERS) -v --tb=line
+    PYTEST_ARGS := -n $(TEST_WORKERS) --dist worksteal -v --tb=line
     BUILD_FLAGS :=
 else
     # development (default)
-    PYTEST_ARGS := -n $(TEST_WORKERS) -v --tb=long
+    PYTEST_ARGS := -n $(TEST_WORKERS) --dist worksteal -v --tb=long
     BUILD_FLAGS :=
 endif
 
@@ -517,7 +517,7 @@ test-serial: ## Run tests serially for debugging (disables parallelization)
 
 test-fast: ## Run unit tests only in parallel (fastest)
 	@echo "$(YELLOW)⚡ Running unit tests in parallel...$(NC)"
-	@uv run pytest tests/ -n $(TEST_WORKERS) -m unit -v
+	@uv run pytest tests/ -n $(TEST_WORKERS) --dist worksteal -m unit -v
 	@echo "$(GREEN)✓ Unit tests completed$(NC)"
 
 test-coverage: ## Run tests with coverage report (parallel)


### PR DESCRIPTION
## Summary
- Adds `--dist worksteal` to all `PYTEST_ARGS` assignments in the Makefile (production, staging, development branches and the `test-fast` target)
- No change to `test-serial` or any target that opts out of parallelism

## Why
Analysis of a full test run (8,507 tests, 8m 6s) identified 23 slow tests (>5s each) that together account for ~40% of total wall-clock time. With the default round-robin (`--dist load`) scheduler, idle workers sit waiting at the end of the run while slow tests finish — classic tail-latency problem.

The work-stealing scheduler (`--dist worksteal`, available since pytest-xdist 3.0) allows idle workers to pick up pending tests from busy workers' queues, reducing tail latency without any changes to test code.

`pytest-xdist >= 3.8.0` is already pinned in `pyproject.toml`, so no new dependency is needed.

## Test plan
- [ ] `make test` completes without errors
- [ ] `ENV=production make test` uses `--dist worksteal` in the pytest invocation
- [ ] `make test-fast` uses `--dist worksteal`
- [ ] `make test-serial` is unaffected (uses `-n 0`)

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)