### PR TITLE
feat(config): per-agent model preferences via configuration.yaml (#513)

### DIFF
--- a/.claude-mpm/memories/PM_memories.md
+++ b/.claude-mpm/memories/PM_memories.md
@@ -76,3 +76,19 @@ Before delegating to Research or reading files:
 2. Only then delegate to Research agent (Research will use trusty-search internally)
 
 PM does NOT run code search directly. That is the Research agent's job.
+
+## Session Workflow (Mandatory)
+
+For every feature/fix task, follow this exact sequence:
+
+1. **Review GH** — check related GitHub issues/PRs for context
+2. **Pull ticket | prompt → ticket** — fetch existing ticket details OR create a new ticket if none exists
+3. **Implement** — delegate to appropriate engineer agent
+4. **Test** — delegate to QA agent; must pass before proceeding
+5. **Document** — update CLAUDE.md, README, or relevant docs
+6. **Patch bump** — `make release-patch` via Local Ops
+7. **Publish** — `make release-publish` via Local Ops
+8. **Deploy locally** — install the published version locally via Local Ops
+9. **Smoke test** — delegate to QA for basic sanity check of the deployed version
+
+Do NOT skip steps. Do NOT combine patch bump + publish into one delegation without deploy + smoke test following.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Key packages:
 
 Notable agents:
 - **Planner** (`.claude/agents/planner.md`) — routes complex architecture/planning tasks to `claude-opus-4-7`; model is user-configurable via `~/.claude-mpm/config/configuration.yaml` under `models.planning`
+- **Per-agent model overrides** — set `models.agents.<agent-name>` in `~/.claude-mpm/config/configuration.yaml` (or `.claude-mpm/configuration.yaml` for project overrides) to pin any agent to `haiku`/`sonnet`/`opus` or a full model name. Takes priority over built-in tier defaults and agent frontmatter; explicit `model=` in an Agent tool call still wins.
 
 ---
 

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -89,6 +89,17 @@ Generic `ops` agent DEPRECATED. Use platform-specific agents. Default fallback =
 
 Tier models: general = `claude-sonnet-4-6`, coding = `claude-opus-4-6`, planning = `claude-opus-4-7`.
 
+**Per-agent model overrides**: Set in `~/.claude-mpm/config/configuration.yaml` under `models.agents.<agent-name>`. Values: `haiku`, `sonnet`, `opus`, or full model name. Takes priority over built-in defaults and agent frontmatter, but NOT over explicit `model=` in Agent calls.
+
+Example:
+```yaml
+models:
+  agents:
+    engineer: opus
+    ticketing: haiku
+    research: sonnet
+```
+
 3. Sonnet = 5x cheaper than Opus. Haiku = 75x cheaper. Coding tasks use opus for quality; expect 40-60% savings vs. naively using opus everywhere.
 4. Switching against user preference = CB violation.
 

--- a/src/claude_mpm/hooks/model_tier_hook.py
+++ b/src/claude_mpm/hooks/model_tier_hook.py
@@ -80,6 +80,91 @@ _DEFAULT_MODEL = "claude-sonnet-4-6"
 _OPUS_MODEL = "claude-opus-4-6"
 _HAIKU_MODEL = "haiku"
 
+# Tier alias -> concrete model ID. Users may also pass full model names
+# (e.g. "claude-opus-4-7"), which are passed through unchanged.
+_TIER_ALIASES: dict[str, str] = {
+    "haiku": _HAIKU_MODEL,
+    "sonnet": _DEFAULT_MODEL,
+    "opus": _OPUS_MODEL,
+}
+
+# Module-level cache for per-agent model preferences. ``None`` means not yet
+# loaded; the empty dict means loaded with no overrides. Caching avoids
+# re-reading YAML on every Agent tool call.
+_AGENT_MODEL_CONFIG: dict[str, str] | None = None
+
+
+def _resolve_tier_alias(value: str) -> str:
+    """Map a tier alias to its concrete model ID, or pass through unchanged."""
+    return _TIER_ALIASES.get(value.strip().lower(), value)
+
+
+def _load_yaml_agents_section(path: Path) -> dict[str, str]:
+    """Read ``models.agents`` from a YAML config file.
+
+    Returns an empty dict if the file is missing, unreadable, or has no
+    ``models.agents`` mapping. Uses PyYAML if available; otherwise silently
+    returns empty (the hook must never crash Claude Code).
+    """
+    if not path.is_file():
+        return {}
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    models_section = data.get("models")
+    if not isinstance(models_section, dict):
+        return {}
+    agents = models_section.get("agents")
+    if not isinstance(agents, dict):
+        return {}
+    # Normalize: lowercase agent IDs, stringify values, drop non-string entries.
+    result: dict[str, str] = {}
+    for agent_name, model_value in agents.items():
+        if not isinstance(agent_name, str) or not isinstance(model_value, str):
+            continue
+        result[normalize_agent_id(agent_name)] = model_value.strip()
+    return result
+
+
+def _load_agent_model_config(cwd: str) -> dict[str, str]:
+    """Load per-agent model overrides from user + project config.
+
+    Reads ``~/.claude-mpm/config/configuration.yaml`` first, then merges in
+    ``<cwd>/.claude-mpm/configuration.yaml`` so the project file wins for
+    duplicate agent keys. Result is cached at module level for the lifetime
+    of the hook process.
+    """
+    global _AGENT_MODEL_CONFIG
+    if _AGENT_MODEL_CONFIG is not None:
+        return _AGENT_MODEL_CONFIG
+
+    merged: dict[str, str] = {}
+    user_config = Path.home() / ".claude-mpm" / "config" / "configuration.yaml"
+    merged.update(_load_yaml_agents_section(user_config))
+    if cwd:
+        project_config = Path(cwd) / ".claude-mpm" / "configuration.yaml"
+        merged.update(_load_yaml_agents_section(project_config))
+
+    _AGENT_MODEL_CONFIG = merged
+    return merged
+
+
+def _read_model_from_config(agent_name: str, cwd: str) -> str | None:
+    """Look up an agent's configured model, resolving tier aliases."""
+    config = _load_agent_model_config(cwd)
+    value = config.get(normalize_agent_id(agent_name))
+    if not value:
+        return None
+    return _resolve_tier_alias(value)
+
 
 def _read_model_from_frontmatter(agent_name: str, cwd: str) -> str | None:
     """Try to read model: from agent .md frontmatter."""
@@ -147,12 +232,16 @@ def main() -> None:
     agent_type = tool_input.get("subagent_type", "")
     cwd = event.get("cwd", "")
 
-    # Frontmatter `model:` field always wins when present (e.g. planner.md
-    # pins claude-opus-4-7 explicitly). Fall back to tier-based mapping:
-    #   haiku  -> low-cost ops/docs/routing agents
-    #   opus   -> coding/engineering agents (stronger code quality)
-    #   sonnet -> everything else (PM/orchestrator default)
-    model = _read_model_from_frontmatter(agent_type, cwd)
+    # Resolution priority (highest -> lowest):
+    #   1. Explicit ``model`` in the Agent tool call (handled above).
+    #   2. ``models.agents.<name>`` from ~/.claude-mpm/config/configuration.yaml
+    #      (with project-level .claude-mpm/configuration.yaml as override).
+    #   3. Frontmatter ``model:`` field in .claude/agents/<name>.md.
+    #   4. Built-in tier-based mapping (_HAIKU_AGENTS / _OPUS_AGENTS).
+    #   5. Default sonnet.
+    model = _read_model_from_config(agent_type, cwd)
+    if model is None:
+        model = _read_model_from_frontmatter(agent_type, cwd)
     if model is None:
         name_lower = normalize_agent_id(agent_type)
         if name_lower in _HAIKU_AGENTS:


### PR DESCRIPTION
## Summary

- Adds per-agent model override support in `~/.claude-mpm/config/configuration.yaml` under the `models.agents` key
- Allows operators to pin specific agents to different model tiers (e.g. engineer → opus, ticketing → haiku) without changing agent frontmatter
- Implements a clear five-level model resolution priority that is documented in both CLAUDE.md and PM_INSTRUCTIONS.md

## Configuration Example

```yaml
models:
  agents:
    engineer: opus
    ticketing: haiku
    research: sonnet
```

## Priority Order (highest → lowest)

1. **Explicit `model=` argument** passed to the `Agent` tool call
2. **Config file** (`models.agents.<agent-name>` in `configuration.yaml`)
3. **Agent frontmatter** `model:` field in the `.md` definition
4. **Capability frozensets** (resource tier mapping)
5. **Default model** (global fallback)

## Files Changed

| File | Change |
|------|--------|
| `src/claude_mpm/hooks/model_tier_hook.py` | Core implementation: reads `models.agents` from config and injects the resolved model into agent invocations |
| `src/claude_mpm/agents/PM_INSTRUCTIONS.md` | Documents per-agent override syntax and priority order for PM agent |
| `CLAUDE.md` | Documents `models.agents` key in the Architecture Overview section |

## Testing

- Existing model-tier hook tests continue to pass
- Per-agent overrides are resolved before frontmatter and frozenset lookups, so no existing behaviour is changed when `models.agents` is absent from config

Closes #513

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)