### PR TITLE
feat: auto-detect trusty-search and trusty-memory on session start

### DIFF
--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -17,6 +17,16 @@ Design constraints:
   when the binary isn't installed.
 * **Safe writes**: uses :func:`_mcp_config_transaction` so a write failure
   rolls ``.mcp.json`` back to its prior state.
+
+Address discovery:
+
+Both ``trusty-search`` and ``trusty-memory`` use OS-chosen dynamic ports
+written to ``~/.trusty-<svc>/http_addr`` (format: ``host:port`` on a single
+line). Hardcoded ports (7878 / 3038) would cause the autodetect to silently
+fail whenever the daemons picked different ports. We mirror the discovery
+logic used by the ``claude-mpm setup trusty-*`` handlers: read the addr file
+when present, fall back to the legacy port only when the file is missing or
+unreadable.
 """
 
 from __future__ import annotations
@@ -34,12 +44,16 @@ logger = logging.getLogger(__name__)
 
 # Service descriptors. Kept inline (not a dataclass) to avoid pulling in
 # extra modules during the startup-hot migration path.
+#
+# ``addr_file`` points at the daemon's discovery file (single-line
+# ``host:port``). ``fallback_addr`` is the legacy hardcoded address used only
+# when the discovery file is missing/unreadable.
 _SERVICES: tuple[dict[str, Any], ...] = (
     {
         "name": "trusty-search",
         "binary": "trusty-search",
-        "health_url": "http://127.0.0.1:7878/health",
-        "port": 7878,
+        "addr_file": Path.home() / ".trusty-search" / "http_addr",
+        "fallback_addr": "127.0.0.1:7878",
         "mcp_entry": {
             "type": "stdio",
             "command": "trusty-search",
@@ -49,8 +63,8 @@ _SERVICES: tuple[dict[str, Any], ...] = (
     {
         "name": "trusty-memory",
         "binary": "trusty-memory",
-        "health_url": "http://127.0.0.1:3038/health",
-        "port": 3038,
+        "addr_file": Path.home() / ".trusty-memory" / "http_addr",
+        "fallback_addr": "127.0.0.1:3038",
         "mcp_entry": {
             "type": "stdio",
             "command": "trusty-memory",
@@ -58,6 +72,22 @@ _SERVICES: tuple[dict[str, Any], ...] = (
         },
     },
 )
+
+
+def _resolve_base_url(addr_file: Path, fallback_addr: str) -> str:
+    """Return the daemon's base URL ``http://host:port``.
+
+    Reads ``addr_file`` (canonical dynamic-port discovery file) when present;
+    falls back to ``fallback_addr`` otherwise. Mirrors the logic in
+    :meth:`TrustyMixin._trusty_search_base_url`.
+    """
+    try:
+        addr = addr_file.read_text(encoding="utf-8").strip()
+        if addr:
+            return f"http://{addr}"
+    except OSError:
+        pass
+    return f"http://{fallback_addr}"
 
 
 def _http_health_check(url: str, timeout: float = 2.0) -> bool:
@@ -120,7 +150,8 @@ def run_migration(project_dir: Path | None = None) -> bool:
     for svc in _SERVICES:
         if shutil.which(svc["binary"]) is None:
             continue
-        if not _http_health_check(svc["health_url"]):
+        base_url = _resolve_base_url(svc["addr_file"], svc["fallback_addr"])
+        if not _http_health_check(f"{base_url}/health"):
             continue
         detected.append(svc)
 
@@ -147,9 +178,9 @@ def run_migration(project_dir: Path | None = None) -> bool:
             for svc in to_write:
                 servers[svc["name"]] = svc["mcp_entry"]
                 logger.info(
-                    "Auto-configured %s MCP server (daemon detected at port %d)",
+                    "Auto-configured %s MCP server (daemon detected via %s)",
                     svc["name"],
-                    svc["port"],
+                    svc["addr_file"],
                 )
             _save_mcp_config(mcp_path, config)
     except Exception as exc:

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -1,0 +1,160 @@
+"""Auto-detect running trusty-search and trusty-memory daemons.
+
+When either daemon is detected (binary on PATH + HTTP health probe succeeds),
+inject the corresponding MCP server entry into the project's ``.mcp.json`` so
+users don't have to run ``claude-mpm setup trusty-*`` manually.
+
+This migration is registered as ``run_always`` in :mod:`registry` because
+daemon state can change between invocations — a user might install/start
+``trusty-search`` after the first ``claude-mpm`` run, and we want their next
+session to pick it up automatically.
+
+Design constraints:
+
+* **Idempotent**: if the ``.mcp.json`` entry already exists, do nothing.
+* **Silent on absence**: missing binary or unhealthy daemon = no-op, no logs.
+* **Cheap**: ``shutil.which`` + 2s HTTP probe per daemon; skipped entirely
+  when the binary isn't installed.
+* **Safe writes**: uses :func:`_mcp_config_transaction` so a write failure
+  rolls ``.mcp.json`` back to its prior state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Service descriptors. Kept inline (not a dataclass) to avoid pulling in
+# extra modules during the startup-hot migration path.
+_SERVICES: tuple[dict[str, Any], ...] = (
+    {
+        "name": "trusty-search",
+        "binary": "trusty-search",
+        "health_url": "http://127.0.0.1:7878/health",
+        "port": 7878,
+        "mcp_entry": {
+            "type": "stdio",
+            "command": "trusty-search",
+            "args": ["serve"],
+        },
+    },
+    {
+        "name": "trusty-memory",
+        "binary": "trusty-memory",
+        "health_url": "http://127.0.0.1:3038/health",
+        "port": 3038,
+        "mcp_entry": {
+            "type": "stdio",
+            "command": "trusty-memory",
+            "args": ["serve", "--mcp"],
+        },
+    },
+)
+
+
+def _http_health_check(url: str, timeout: float = 2.0) -> bool:
+    """Return True iff ``url`` responds 2xx within ``timeout`` seconds.
+
+    Uses stdlib urllib to avoid adding dependencies. Connection refused,
+    timeouts, and unexpected status codes all map to ``False``.
+    """
+    try:
+        req = urllib.request.Request(url, method="GET")  # nosec B310 - localhost
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _load_mcp_config(mcp_path: Path) -> dict[str, Any]:
+    """Load ``.mcp.json`` or return an empty config skeleton.
+
+    A malformed file returns an empty skeleton so the autodetect path can
+    still inject entries without nuking unrelated state (the broader project
+    write happens transactionally below).
+    """
+    if not mcp_path.exists():
+        return {"mcpServers": {}}
+    try:
+        with open(mcp_path, encoding="utf-8") as f:
+            data = json.load(f)
+            if not isinstance(data, dict):
+                return {"mcpServers": {}}
+            return data
+    except (json.JSONDecodeError, OSError):
+        return {"mcpServers": {}}
+
+
+def _save_mcp_config(mcp_path: Path, config: dict[str, Any]) -> None:
+    """Write ``.mcp.json`` with a trailing newline (matches setup handler)."""
+    with open(mcp_path, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+
+def run_migration(project_dir: Path | None = None) -> bool:
+    """Detect running trusty daemons and inject MCP entries.
+
+    Args:
+        project_dir: Directory containing ``.mcp.json`` (defaults to CWD).
+
+    Returns:
+        True if any change was made, False if everything was already
+        configured or no daemons were detected. Never raises on the absence
+        path — only propagates exceptions from disk writes.
+    """
+    project_dir = project_dir or Path.cwd()
+    mcp_path = project_dir / ".mcp.json"
+
+    # Determine which services are detectable BEFORE touching .mcp.json so a
+    # cold path (no daemons running) doesn't open the file at all.
+    detected: list[dict[str, Any]] = []
+    for svc in _SERVICES:
+        if shutil.which(svc["binary"]) is None:
+            continue
+        if not _http_health_check(svc["health_url"]):
+            continue
+        detected.append(svc)
+
+    if not detected:
+        return False
+
+    # Defer the import to avoid a circular dependency at module-load time
+    # (mcp_config lives under cli.commands.setup, which itself may import
+    # migration code indirectly during CLI bootstrap).
+    from ..cli.commands.setup.mcp_config import _mcp_config_transaction
+
+    config = _load_mcp_config(mcp_path)
+    servers = config.setdefault("mcpServers", {})
+
+    to_write: list[dict[str, Any]] = [
+        svc for svc in detected if svc["name"] not in servers
+    ]
+
+    if not to_write:
+        return False
+
+    try:
+        with _mcp_config_transaction(project_dir):
+            for svc in to_write:
+                servers[svc["name"]] = svc["mcp_entry"]
+                logger.info(
+                    "Auto-configured %s MCP server (daemon detected at port %d)",
+                    svc["name"],
+                    svc["port"],
+                )
+            _save_mcp_config(mcp_path, config)
+    except Exception as exc:
+        # Transaction context will roll back; log and report no-op upward.
+        logger.warning("trusty autodetect failed to write .mcp.json: %s", exc)
+        return False
+
+    return True

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -69,7 +69,7 @@ def _http_health_check(url: str, timeout: float = 2.0) -> bool:
     try:
         req = urllib.request.Request(url, method="GET")  # nosec B310 - localhost
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
-            return 200 <= resp.status < 300
+            return 200 <= int(resp.status) < 300
     except (urllib.error.URLError, TimeoutError, OSError):
         return False
 

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -10,12 +10,20 @@ from typing import NamedTuple
 
 
 class Migration(NamedTuple):
-    """A migration definition."""
+    """A migration definition.
+
+    Set ``run_always=True`` for migrations that should re-run on every startup
+    (e.g., environment auto-detection probes). Run-always migrations are NOT
+    persisted to the ``completed`` state file and must therefore be cheap and
+    idempotent — see :mod:`migrate_trusty_autodetect` for the canonical
+    example.
+    """
 
     id: str  # Unique identifier (e.g., "5.6.91_async_hooks")
     version: str  # Version this migration applies to
     description: str  # Human-readable description
     run: Callable[[], bool]  # Function that returns True on success
+    run_always: bool = False  # If True, run every startup (skip completion gate)
 
 
 def _run_async_hooks_migration() -> bool:
@@ -154,6 +162,13 @@ def _run_statusline_user_level_migration() -> bool:
     return run_migration(installation_dir=Path.cwd())
 
 
+def _run_trusty_autodetect_migration() -> bool:
+    """Detect running trusty-search / trusty-memory daemons and wire into .mcp.json."""
+    from .migrate_trusty_autodetect import run_migration
+
+    return run_migration()
+
+
 # Registry of all migrations, ordered by version
 MIGRATIONS: list[Migration] = [
     Migration(
@@ -245,6 +260,13 @@ MIGRATIONS: list[Migration] = [
         version="6.3.2",
         description="Move legacy project-level statusline.sh and settings entries to ~/.claude/",
         run=_run_statusline_user_level_migration,
+    ),
+    Migration(
+        id="trusty_autodetect",
+        version="6.3.10",
+        description="Auto-detect and configure trusty-search/trusty-memory MCP servers",
+        run=_run_trusty_autodetect_migration,
+        run_always=True,
     ),
 ]
 

--- a/src/claude_mpm/migrations/runner.py
+++ b/src/claude_mpm/migrations/runner.py
@@ -45,15 +45,19 @@ def _save_state(state: dict) -> None:
 
 
 def get_pending_migrations() -> list[Migration]:
-    """Get migrations that haven't been run yet.
+    """Get migrations that should run this startup.
 
-    Returns:
-        List of pending migrations in order
+    Includes:
+      * One-shot migrations that haven't been recorded in the completed list.
+      * All ``run_always`` migrations regardless of completion state.
+
+    ``run_always`` migrations are expected to be cheap and idempotent — see
+    :class:`Migration` for the contract.
     """
     state = _load_state()
     completed = set(state.get("completed", []))
 
-    return [m for m in MIGRATIONS if m.id not in completed]
+    return [m for m in MIGRATIONS if m.run_always or m.id not in completed]
 
 
 def mark_migration_complete(migration_id: str, version: str) -> None:
@@ -103,22 +107,31 @@ def run_pending_migrations(current_version: str | None = None) -> int:
 
     count = 0
     for migration in pending:
-        logger.info(f"Running migration: {migration.description}")
-        print(f"🔄 Running migration: {migration.description}")
+        # run_always migrations are silent probes (e.g., daemon autodetect):
+        # avoid noisy "Running migration..." output on every startup.
+        verbose = not migration.run_always
+        if verbose:
+            logger.info(f"Running migration: {migration.description}")
+            print(f"🔄 Running migration: {migration.description}")
 
         try:
             success = migration.run()
             if success:
-                mark_migration_complete(migration.id, current_version)
+                if not migration.run_always:
+                    # Only persist completion for one-shot migrations.
+                    mark_migration_complete(migration.id, current_version)
                 logger.info(f"Migration complete: {migration.id}")
-                print(f"✅ Migration complete: {migration.id}")
+                if verbose:
+                    print(f"✅ Migration complete: {migration.id}")
                 count += 1
-            else:
+            elif verbose:
                 logger.warning(f"Migration returned False: {migration.id}")
                 print(f"⚠️ Migration skipped: {migration.id}")
         except Exception as e:
+            # Always surface failures, even for run_always migrations.
             logger.error(f"Migration failed: {migration.id}: {e}")
-            print(f"❌ Migration failed: {migration.id}: {e}")
+            if verbose:
+                print(f"❌ Migration failed: {migration.id}: {e}")
             # Continue with other migrations
 
     return count

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -8,14 +8,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path  # noqa: TC003 - used at runtime in fixtures & call sites
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import pytest
 
 from claude_mpm.migrations import migrate_trusty_autodetect as mod
 
 
-def _make_which(installed: set[str]):
+def _make_which(installed: set[str]) -> Callable[[str], str | None]:
     """Return a ``shutil.which`` stand-in matching the given binary set."""
 
     def fake_which(name: str) -> str | None:
@@ -82,7 +86,7 @@ def test_no_op_when_binaries_missing(project_dir: Path) -> None:
     """No binary on PATH → skip without probing HTTP."""
     probe_called = []
 
-    def tracking_probe(url: str, timeout: float = 2.0) -> bool:
+    def tracking_probe(url: str, _timeout: float = 2.0) -> bool:
         probe_called.append(url)
         return True
 

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -29,7 +29,7 @@ def _make_which(installed: set[str]) -> Callable[[str], str | None]:
     return fake_which
 
 
-def _fake_resolve_base_url(addr_file: Path, fallback_addr: str) -> str:
+def _fake_resolve_base_url(_: Path, fallback_addr: str) -> str:
     """Deterministic addr resolver: always returns the fallback.
 
     Avoids depending on real ``~/.trusty-*/http_addr`` files on the test

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -1,7 +1,8 @@
 """Tests for the trusty-search / trusty-memory autodetect migration.
 
-These tests deliberately mock both ``shutil.which`` and the HTTP health probe
-so they never depend on a real daemon being installed on the test runner.
+These tests deliberately mock ``shutil.which``, the addr-file resolver, and
+the HTTP health probe so they never depend on a real daemon being installed
+on the test runner or on real ``~/.trusty-*/http_addr`` files existing.
 """
 
 from __future__ import annotations
@@ -28,6 +29,15 @@ def _make_which(installed: set[str]) -> Callable[[str], str | None]:
     return fake_which
 
 
+def _fake_resolve_base_url(addr_file: Path, fallback_addr: str) -> str:
+    """Deterministic addr resolver: always returns the fallback.
+
+    Avoids depending on real ``~/.trusty-*/http_addr`` files on the test
+    runner.
+    """
+    return f"http://{fallback_addr}"
+
+
 @pytest.fixture
 def project_dir(tmp_path: Path) -> Path:
     """Empty project directory (no pre-existing .mcp.json)."""
@@ -42,6 +52,7 @@ def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
             "which",
             side_effect=_make_which({"trusty-search", "trusty-memory"}),
         ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
@@ -74,6 +85,7 @@ def test_no_op_when_daemons_not_running(project_dir: Path) -> None:
             "which",
             side_effect=_make_which({"trusty-search", "trusty-memory"}),
         ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=False),
     ):
         changed = mod.run_migration(project_dir=project_dir)
@@ -83,21 +95,28 @@ def test_no_op_when_daemons_not_running(project_dir: Path) -> None:
 
 
 def test_no_op_when_binaries_missing(project_dir: Path) -> None:
-    """No binary on PATH → skip without probing HTTP."""
-    probe_called = []
+    """No binary on PATH → skip without probing HTTP or reading addr files."""
+    probe_called: list[str] = []
+    resolve_called: list[Path] = []
 
     def tracking_probe(url: str) -> bool:
         probe_called.append(url)
         return True
 
+    def tracking_resolve(addr_file: Path, fallback_addr: str) -> str:
+        resolve_called.append(addr_file)
+        return f"http://{fallback_addr}"
+
     with (
         patch.object(mod.shutil, "which", side_effect=_make_which(set())),
+        patch.object(mod, "_resolve_base_url", side_effect=tracking_resolve),
         patch.object(mod, "_http_health_check", side_effect=tracking_probe),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
     assert changed is False
     assert probe_called == [], "Health probe should be skipped when binary missing"
+    assert resolve_called == [], "addr resolution should be skipped when binary missing"
     assert not (project_dir / ".mcp.json").exists()
 
 
@@ -127,6 +146,7 @@ def test_idempotent_when_entries_already_present(project_dir: Path) -> None:
             "which",
             side_effect=_make_which({"trusty-search", "trusty-memory"}),
         ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
@@ -157,6 +177,7 @@ def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> Non
             "which",
             side_effect=_make_which({"trusty-search", "trusty-memory"}),
         ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -1,0 +1,166 @@
+"""Tests for the trusty-search / trusty-memory autodetect migration.
+
+These tests deliberately mock both ``shutil.which`` and the HTTP health probe
+so they never depend on a real daemon being installed on the test runner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - used at runtime in fixtures & call sites
+from unittest.mock import patch
+
+import pytest
+
+from claude_mpm.migrations import migrate_trusty_autodetect as mod
+
+
+def _make_which(installed: set[str]):
+    """Return a ``shutil.which`` stand-in matching the given binary set."""
+
+    def fake_which(name: str) -> str | None:
+        return f"/fake/bin/{name}" if name in installed else None
+
+    return fake_which
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """Empty project directory (no pre-existing .mcp.json)."""
+    return tmp_path
+
+
+def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
+    """Both binaries on PATH + both daemons healthy → both entries written."""
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-search", "trusty-memory"}),
+        ),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+
+    mcp_json = project_dir / ".mcp.json"
+    assert mcp_json.exists()
+
+    config = json.loads(mcp_json.read_text())
+    servers = config["mcpServers"]
+
+    assert servers["trusty-search"] == {
+        "type": "stdio",
+        "command": "trusty-search",
+        "args": ["serve"],
+    }
+    assert servers["trusty-memory"] == {
+        "type": "stdio",
+        "command": "trusty-memory",
+        "args": ["serve", "--mcp"],
+    }
+
+
+def test_no_op_when_daemons_not_running(project_dir: Path) -> None:
+    """Binary present but health probe fails → no file written, no exception."""
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-search", "trusty-memory"}),
+        ),
+        patch.object(mod, "_http_health_check", return_value=False),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_no_op_when_binaries_missing(project_dir: Path) -> None:
+    """No binary on PATH → skip without probing HTTP."""
+    probe_called = []
+
+    def tracking_probe(url: str, timeout: float = 2.0) -> bool:
+        probe_called.append(url)
+        return True
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which(set())),
+        patch.object(mod, "_http_health_check", side_effect=tracking_probe),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert probe_called == [], "Health probe should be skipped when binary missing"
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_idempotent_when_entries_already_present(project_dir: Path) -> None:
+    """Existing entries → migration is a no-op and returns False."""
+    existing = {
+        "mcpServers": {
+            "trusty-search": {
+                "type": "stdio",
+                "command": "trusty-search",
+                "args": ["serve"],
+            },
+            "trusty-memory": {
+                "type": "stdio",
+                "command": "trusty-memory",
+                "args": ["serve", "--mcp"],
+            },
+        }
+    }
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
+    original_contents = mcp_path.read_text()
+
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-search", "trusty-memory"}),
+        ),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    # File untouched.
+    assert mcp_path.read_text() == original_contents
+
+
+def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> None:
+    """Only the missing daemon is added; unrelated MCP servers stay intact."""
+    existing = {
+        "mcpServers": {
+            "trusty-search": {
+                "type": "stdio",
+                "command": "trusty-search",
+                "args": ["serve"],
+            },
+            "some-other-server": {"type": "stdio", "command": "whatever"},
+        }
+    }
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
+
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-search", "trusty-memory"}),
+        ),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    config = json.loads(mcp_path.read_text())
+    servers = config["mcpServers"]
+    assert "trusty-memory" in servers
+    assert "trusty-search" in servers
+    # Pre-existing unrelated entry must survive.
+    assert servers["some-other-server"] == {"type": "stdio", "command": "whatever"}

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -86,7 +86,7 @@ def test_no_op_when_binaries_missing(project_dir: Path) -> None:
     """No binary on PATH → skip without probing HTTP."""
     probe_called = []
 
-    def tracking_probe(url: str, _timeout: float = 2.0) -> bool:
+    def tracking_probe(url: str) -> bool:
         probe_called.append(url)
         return True
 


### PR DESCRIPTION
## Summary
- Adds a `run_always` migration that probes trusty-search (port 7878) and trusty-memory (port 3038) on every session start
- If a daemon is running and its binary is on PATH, automatically injects the MCP entry into `.mcp.json` if not already present
- Extends the migration system with a `run_always` flag so certain migrations execute on every startup rather than once

## Behaviour
- Binary not installed or daemon not running → silent no-op (one `shutil.which` syscall, no HTTP call)
- Already configured → idempotent, no duplicate entries
- Auto-injection logged at INFO level

## Changes
- `src/claude_mpm/migrations/migrate_trusty_autodetect.py` — new migration
- `src/claude_mpm/migrations/registry.py` — `run_always` field on `Migration` NamedTuple + registration
- `src/claude_mpm/migrations/runner.py` — `run_always` migrations always included in pending set
- `tests/migrations/test_trusty_autodetect.py` — 5 tests (inject, no-op, idempotent, partial, missing binary)

Closes #521

🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)