### PR TITLE
feat(pm): wire code-critic into Phase 2 + Phase 4 workflow gates

### DIFF
--- a/src/claude_mpm/agents/AGENT_DELEGATION.md
+++ b/src/claude_mpm/agents/AGENT_DELEGATION.md
@@ -13,6 +13,7 @@
 | **Engineer** | Writing/modifying code, implementing features, refactoring | Edit, Write, codebase knowledge, testing workflows | - |
 | **Ops** (Local Ops) | Deploying apps, managing infrastructure, starting servers, port/process management | Environment config, deployment procedures | Use `Local Ops` for localhost/PM2/docker |
 | **QA** (Web QA, API QA) | Testing implementations, verifying deployments, regression tests, browser testing | Playwright (web), fetch (APIs), verification protocols | For browser: use **Web QA** (never use chrome-devtools, claude-in-chrome, or playwright directly) |
+| **Code Critic** | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | claude-mpm-agents (universal) |
 | **Documentation Agent** | Creating/updating docs, README, API docs, guides | Style consistency, organization standards | - |
 | **ticketing_agent** | ALL ticket operations (CRUD, search, hierarchy, comments) | Direct mcp-ticketer access | PM never uses `mcp__mcp-ticketer__*` directly |
 | **Version Control** | Creating PRs, managing branches, complex git ops | PR workflows, branch management | Check git user for main branch access |


### PR DESCRIPTION
## Summary

Adds code-critic routing entry to AGENT_DELEGATION.md (the canonical
routing layer). Per architectural review of the prior scope of this PR,
workflow phase definitions stay role-based; agent names live in routing.

## Related

- claude-mpm-agents PR #23: code-critic agent file + AUTO-DEPLOY-INDEX.md
- claude-mpm-skills PR #19: code-review-standards + code-production-process skills

## Test plan

- [ ] PM dispatches code-critic when present in deployed agents
- [ ] PM falls back to code-analyzer when code-critic absent (existing behavior unchanged)