### PR TITLE
feat(pm): native trusty-memory get_prompt_context startup (6.4.2)

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -61,6 +61,14 @@ Sequence:
 
 If neither memory backend nor code search backend is configured, skip directly to Research delegation.
 
+## MCP Context Loading (Optional)
+
+At session start, if the `trusty-memory` MCP server is connected, call `get_prompt_context()` to load project aliases and conventions into working context. This enables automatic abbreviation resolution (e.g. `tga` → `trusty-git-analytics`) without manual context-setting each session.
+
+- If trusty-memory MCP is not available: **skip silently** — never block or warn the user
+- If available: call `get_prompt_context()` once, apply returned aliases for the session
+- Delegated agents encountering an unrecognized abbreviation should also call `get_prompt_context(query: "<abbrev>")` before guessing
+
 ## Agent Routing
 
 See AGENT_DELEGATION.md for the full routing table and trigger keywords.


### PR DESCRIPTION
## Summary

- Adds optional **MCP Context Loading** section to `PM_INSTRUCTIONS.md`, positioned after the existing Context-First Protocol
- At session start, if `trusty-memory` MCP is connected, PM calls `get_prompt_context()` once to load project aliases and conventions (e.g. `tga` → `trusty-git-analytics`)
- Silently skipped when trusty-memory is not available — no blocking, no user-visible warnings
- Delegated agents can also call `get_prompt_context(query: "<abbrev>")` to resolve unrecognized abbreviations before guessing
- Bumps version `6.4.1` → `6.4.2` across `VERSION`, `src/claude_mpm/VERSION`, `pyproject.toml`, and `package.json`

## Motivation

Projects using trusty-tools define abbreviations (e.g. `tga` = `trusty-git-analytics`, `open-mpm` crate names, etc.) in the trusty-memory knowledge graph. Without this change, every project needed a per-project `INSTRUCTIONS.md` to surface those aliases. Native PM-level integration means any project with trusty-memory connected gets abbreviation resolution automatically.

## Files Modified

- `src/claude_mpm/agents/PM_INSTRUCTIONS.md` — new "MCP Context Loading (Optional)" section
- `VERSION`, `src/claude_mpm/VERSION`, `pyproject.toml`, `package.json` — version bump to 6.4.2

## Test plan

- [ ] Verify PM_INSTRUCTIONS.md renders correctly (no broken markdown)
- [ ] Confirm version reads as `6.4.2` via `claude-mpm --version`
- [ ] In a session with trusty-memory MCP connected: confirm `get_prompt_context()` is called at startup
- [ ] In a session without trusty-memory MCP: confirm no error or warning is surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)