### PR TITLE
fix: remove hardcoded contributor path from shared hook settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,12 +10,6 @@
             "command": "claude-hook",
             "timeout": 15,
             "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
-            "_mpm": true
           }
         ]
       }
@@ -28,12 +22,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]
@@ -65,12 +53,6 @@
             "command": "claude-hook",
             "timeout": 15,
             "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
-            "_mpm": true
           }
         ]
       }
@@ -83,12 +65,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]
@@ -115,12 +91,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]


### PR DESCRIPTION
## Summary

`.claude/settings.json` had 5 hook commands pointing to `/Users/masa/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh`, which silently failed for every contributor whose home directory wasn't masa's. This PR removes the redundant `.sh` command blocks from `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, and `UserPromptSubmit`, leaving only the portable `claude-hook` Python entry point (registered in `pyproject.toml` `[project.scripts]`).

## Why this is safe

A research investigation confirmed the `.sh` handler and the `claude-hook` Python entry point invoke the **same** Python function: `claude_mpm.hooks.claude_hooks.hook_handler:main` (`src/claude_mpm/hooks/claude_hooks/hook_handler.py:911`). The `.sh` script is a bash bootstrap that resolves the Python interpreter and exec's the same module that `claude-hook` already runs directly via PATH.

Effect on masa's machine: the handler was running **twice** per event (once via `claude-hook`, once via the `.sh` bootstrap). Effect on every other contributor: the `.sh` entry silently failed and only `claude-hook` ran. After this PR, all contributors get exactly one invocation of the handler per event.

## Cross-references

- Canonical template (`src/claude_mpm/templates/claude/settings.json`) never had the `.sh` entries — this confirms the design intent is a single `claude-hook` entry per event.
- The hardcoded path was introduced when a locally-generated settings file got committed in `1aaaf794` (2026-05-01).
- The recently-merged `_upgrade_to_fast_hook` migration (`98206fe7`, today) would have auto-rewritten this on first contributor run, but only after a `claude-mpm` invocation — which creates a chicken-and-egg problem if contributors `claude` into the project first. This PR fixes the source of truth so the migration never needs to run for new clones.

## Verification

- `python3 -c "import json; json.load(open('.claude/settings.json'))"` → `JSON valid`
- `grep -c 'claude-hook-handler.sh\|/Users/masa/' .claude/settings.json` → `0`
- Diff is 30 lines removed, 0 added, one file
- Untouched: `PostToolUseFailure`, `SessionStart`, `PermissionRequest`, `tool_failure_hook`, `message_check_hook`, `permissions`, `spinnerTipsOverride`, all other top-level keys

## Test plan

- [ ] PR reviewer pulls branch and verifies `.claude/settings.json` validates with `jq . .claude/settings.json`
- [ ] Reviewer runs a Claude Code session in this repo and confirms dashboard events still stream (proves `claude-hook` alone is sufficient)
- [ ] Reviewer confirms PreToolUse / PostToolUse hooks no longer fire twice on masa's machine

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)