### PR TITLE
Fix pre-existing test failures #568 #569 #570 #571

### DIFF
--- a/src/claude_mpm/core/unified_paths.py
+++ b/src/claude_mpm/core/unified_paths.py
@@ -25,6 +25,7 @@ Architecture:
 
 import os
 import sys
+import tempfile
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
@@ -422,12 +423,19 @@ class UnifiedPathManager:
             logger.debug(f"Using CLAUDE_MPM_USER_PWD as project root: {user_pwd}")
             return Path(user_pwd)
 
+        # Resolve OS temp root (including /private/tmp on macOS) so the walk
+        # never escapes into shared temp storage and picks up stray markers.
+        _tmp_root = Path(tempfile.gettempdir()).resolve()
+
         current = _safe_cwd()
         while current != current.parent:
             for marker in self._project_markers:
                 if (current / marker).exists():
                     logger.debug(f"Found project root at {current} via {marker}")
                     return current
+            # Do not ascend into or past the OS temp directory.
+            if current == _tmp_root:
+                break
             current = current.parent
 
         # Fallback to current directory

--- a/src/claude_mpm/services/core/path_resolver.py
+++ b/src/claude_mpm/services/core/path_resolver.py
@@ -15,6 +15,7 @@ The service consolidates path management logic while maintaining backward compat
 
 import os
 import subprocess  # nosec B404
+import tempfile
 from enum import Enum
 from pathlib import Path
 
@@ -167,6 +168,10 @@ class PathResolver(IPathResolver):
             "CLAUDE.md",  # Claude project instructions
         ]
 
+        # Resolve OS temp root (including /private/tmp on macOS) so the walk
+        # never escapes into shared temp storage and picks up stray markers.
+        _tmp_root = Path(tempfile.gettempdir()).resolve()
+
         current = start_path
         while current != current.parent:  # Stop at filesystem root
             for indicator in root_indicators:
@@ -175,6 +180,9 @@ class PathResolver(IPathResolver):
                         f"Found project root at {current} (indicator: {indicator})"
                     )
                     return current
+            # Do not ascend into or past the OS temp directory.
+            if current == _tmp_root:
+                break
             current = current.parent
 
         # If no indicators found, return None

--- a/tests/hooks/test_permission_policy.py
+++ b/tests/hooks/test_permission_policy.py
@@ -215,8 +215,8 @@ def test_pre_tool_use_agent_path_still_works() -> None:
     # permissionDecision so the model-routing info is injected as context
     # rather than surfaced as a chat message (Claude Code v2.1.133+).
     assert "additionalContext" in spec
-    # Engineering agents default to the sonnet model (same as all non-haiku agents).
-    assert spec["updatedInput"]["model"] == "claude-sonnet-4-6"
+    # Assert against the module constant so this test can't drift again.
+    assert spec["updatedInput"]["model"] == model_tier_hook._DEFAULT_MODEL
 
 
 @pytest.mark.unit

--- a/tests/services/core/test_memory_manager.py
+++ b/tests/services/core/test_memory_manager.py
@@ -9,6 +9,7 @@ Tests cover:
 - Memory search and statistics
 """
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -86,10 +87,15 @@ class TestMemoryManager:
             agent_file = memories_dir / "test_memories.md"
             agent_file.write_text("# Agent Memory: test\n- Test agent memory")
 
-            # Mock Path.cwd() to return our temp directory
-            with patch(
-                "claude_mpm.services.core.memory_manager.Path.cwd",
-                return_value=Path(tmpdir),
+            # Mock Path.cwd() to return our temp directory.
+            # Force flat-file mode so a live MCP memory backend on this host
+            # doesn't cause actual_memories to be cleared.
+            with (
+                patch(
+                    "claude_mpm.services.core.memory_manager.Path.cwd",
+                    return_value=Path(tmpdir),
+                ),
+                patch.dict(os.environ, {"MPM_USE_MCP_MEMORY": "false"}),
             ):
                 # Load memories
                 result = memory_manager.load_memories()
@@ -388,7 +394,8 @@ class TestMemoryManager:
             project_pm = project_dir / "PM_memories.md"
             project_pm.write_text("# PM Memory\n- Project task 1\n- Common task")
 
-            # Mock paths
+            # Mock paths.  Force flat-file mode so a live MCP memory backend
+            # on this host doesn't cause actual_memories to be cleared.
             with (
                 patch(
                     "claude_mpm.services.core.memory_manager.Path.home",
@@ -398,6 +405,7 @@ class TestMemoryManager:
                     "claude_mpm.services.core.memory_manager.Path.cwd",
                     return_value=Path(tmpdir) / "project",
                 ),
+                patch.dict(os.environ, {"MPM_USE_MCP_MEMORY": "false"}),
             ):
                 # Load memories
                 result = memory_manager.load_memories()

--- a/tests/test_claude_mpm_directory_loading.py
+++ b/tests/test_claude_mpm_directory_loading.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 # Add src to path for tests
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -199,22 +200,31 @@ class TestClaudeMpmDirectoryLoading:
         pm_content = "# PM Memories\n- Project uses Python\n- Testing is important"
         (memories_dir / "PM_memories.md").write_text(pm_content)
 
-        # Change to test directory
+        # Change to test directory.
+        # Force flat-file mode so a live MCP memory backend on this host does
+        # not clear actual_memories before the assertions.
         original_cwd = Path.cwd()
         try:
             os.chdir(tmp_path)
-            loader = FrameworkLoader()
+            with patch.dict(os.environ, {"MPM_USE_MCP_MEMORY": "false"}):
+                loader = FrameworkLoader()
 
-            # The FrameworkLoader uses a singleton DI container shared across instances.
-            # Clear the memory cache to force reload from the current (tmp_path) directory,
-            # then re-populate framework_content with fresh memories.
-            loader.clear_memory_caches()
-            loader._load_actual_memories(loader.framework_content)
+                # The FrameworkLoader uses a singleton DI container shared across
+                # instances.  Clear the memory cache to force reload from the
+                # current (tmp_path) directory, then re-populate framework_content
+                # with fresh memories.
+                loader.clear_memory_caches()
+                loader._load_actual_memories(loader.framework_content)
 
-            # Verify PM memories were loaded
-            assert loader.framework_content.get("actual_memories") is not None
-            assert "Project uses Python" in loader.framework_content["actual_memories"]
-            assert "Testing is important" in loader.framework_content["actual_memories"]
+                # Verify PM memories were loaded
+                assert loader.framework_content.get("actual_memories") is not None
+                assert (
+                    "Project uses Python" in loader.framework_content["actual_memories"]
+                )
+                assert (
+                    "Testing is important"
+                    in loader.framework_content["actual_memories"]
+                )
         finally:
             os.chdir(original_cwd)
 

--- a/tests/test_lazy_load_workflow.py
+++ b/tests/test_lazy_load_workflow.py
@@ -57,9 +57,29 @@ WORKFLOW_COMPACT_INDICATORS = [
 
 @pytest.fixture(scope="module")
 def base_prompt() -> str:
-    """Assembled PM system prompt with no project/user WORKFLOW.md override."""
-    loader = FrameworkLoader()
-    return loader.get_framework_instructions()
+    """Assembled PM system prompt with no project/user WORKFLOW.md override.
+
+    The fixture uses a clean temporary directory as the working directory so
+    that any project-local .claude-mpm/PM_INSTRUCTIONS_DEPLOYED.md artefact
+    (a gitignored compiled file that may pre-date the lazy-load change) is not
+    picked up by InstructionLoader.  Without this isolation the stale deployed
+    file would inline the full WORKFLOW.md content and cause the 'not in base
+    prompt' assertions to fail.
+    """
+    with tempfile.TemporaryDirectory() as _clean_cwd:
+        clean_path = Path(_clean_cwd)
+        # Patch cwd inside both the framework_loader module and the
+        # instruction_loader so that InstructionLoader.current_dir resolves to
+        # a directory that has no PM_INSTRUCTIONS_DEPLOYED.md.
+        with (
+            patch(
+                "claude_mpm.core.framework.loaders.instruction_loader.Path.cwd",
+                return_value=clean_path,
+            ),
+            patch("claude_mpm.core.framework_loader.Path.cwd", return_value=clean_path),
+        ):
+            loader = FrameworkLoader()
+            return loader.get_framework_instructions()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_lazy_load_workflow.py
+++ b/tests/test_lazy_load_workflow.py
@@ -26,6 +26,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from claude_mpm.core.framework.loaders.instruction_loader import InstructionLoader
 from claude_mpm.core.framework_loader import FrameworkLoader
+from claude_mpm.services.core.service_container import get_global_container
+from claude_mpm.services.core.service_interfaces import ICacheManager
 
 # Path to the actual WORKFLOW.md file (used for content checks)
 WORKFLOW_MD_PATH = (
@@ -354,6 +356,13 @@ def test_pm_memories_excluded_with_mcp_backend(
     (the explicit opt-in path in MemoryManager._detect_mcp_memory_backend).
     """
     monkeypatch.setenv("MPM_USE_MCP_MEMORY", "true")
+
+    # Clear any stale memory cache from earlier tests that share the global DI
+    # container so the MCP detection code is actually exercised (not bypassed
+    # by a cached result with non-empty actual_memories).
+    container = get_global_container()
+    if container.is_registered(ICacheManager):
+        container.resolve(ICacheManager).clear_memory_caches()
 
     loader = FrameworkLoader()
     prompt = loader.get_framework_instructions()

--- a/tests/test_memory_system_qa_comprehensive.py
+++ b/tests/test_memory_system_qa_comprehensive.py
@@ -10,6 +10,7 @@ Tests all aspects requested:
 5. Loading Order: User memories load first, then project memories (project overrides)
 """
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -493,8 +494,13 @@ class TestMemorySystemQA:
             stub_agent = deployed_agents_dir / "stub-agent.md"
             stub_agent.write_text("# Stub Agent\nFor testing only.\n")
 
-            # Mock working directory for framework loader
-            with patch("pathlib.Path.cwd", return_value=self.test_project_dir):
+            # Mock working directory for framework loader.
+            # Force flat-file mode so a live MCP memory backend on this host
+            # does not suppress PM_memories.md injection.
+            with (
+                patch("pathlib.Path.cwd", return_value=self.test_project_dir),
+                patch.dict(os.environ, {"MPM_USE_MCP_MEMORY": "false"}),
+            ):
                 framework_loader = FrameworkLoader()
                 framework_instructions = framework_loader.get_framework_instructions()
 

--- a/tests/test_memory_system_qa_comprehensive.py
+++ b/tests/test_memory_system_qa_comprehensive.py
@@ -21,6 +21,8 @@ import pytest
 from claude_mpm.core.config import Config
 from claude_mpm.core.framework_loader import FrameworkLoader
 from claude_mpm.services.agents.memory.agent_memory_manager import AgentMemoryManager
+from claude_mpm.services.core.service_container import get_global_container
+from claude_mpm.services.core.service_interfaces import ICacheManager
 
 
 class TestMemorySystemQA:
@@ -497,10 +499,15 @@ class TestMemorySystemQA:
             # Mock working directory for framework loader.
             # Force flat-file mode so a live MCP memory backend on this host
             # does not suppress PM_memories.md injection.
+            # Also clear any stale cached memories from earlier test runs that
+            # share the global DI container's CacheManager singleton.
             with (
                 patch("pathlib.Path.cwd", return_value=self.test_project_dir),
                 patch.dict(os.environ, {"MPM_USE_MCP_MEMORY": "false"}),
             ):
+                container = get_global_container()
+                if container.is_registered(ICacheManager):
+                    container.resolve(ICacheManager).clear_memory_caches()
                 framework_loader = FrameworkLoader()
                 framework_instructions = framework_loader.get_framework_instructions()
 


### PR DESCRIPTION
Fixes 4 pre-existing test-suite failures that were present at the v6.5.0 baseline (commit 2dc7b585), filed during the #552–#566 batch triage. All product code was behaving correctly; most fixes are test-isolation, with one real product fix.

## Fixes
- Closes #571 — model-tier test asserted the old `claude-sonnet-4-6` default; now asserts against `model_tier_hook._DEFAULT_MODEL` (currently `claude-opus-4-7`) so it can't drift again. *(test-only)*
- Closes #569 — 4 memory tests were not isolated from a live MCP memory backend (port probe succeeds when trusty-memory is running), which clears `actual_memories`. Tests now force `MPM_USE_MCP_MEMORY=false` and clear the DI memory cache. *(test-only)*
- Closes #570 — `find_project_root` / `UnifiedPathManager` walked up past pytest's tmp dir and matched a stray `/private/tmp/package.json`. The walk-up now stops at the OS temp boundary (`tempfile.gettempdir()` resolved). *(product fix in `path_resolver.py` + `unified_paths.py`)*
- Addresses #568 (test isolation only — see follow-up below) — lazy-load test picked up a stale local `.claude-mpm/PM_INSTRUCTIONS_DEPLOYED.md` that inlines full WORKFLOW.md. The `base_prompt` fixture is now isolated from project-local deployed files. *(test-only)*

## Known follow-up (not in this PR)
- #568 has a remaining **product gap**: the compiler that writes `PM_INSTRUCTIONS_DEPLOYED.md` still inlines the full WORKFLOW.md instead of the lazy-load reference, so deployed prompts don't realize the token savings. The deployed file is gitignored (won't affect CI), but the compiler should be fixed separately. Recommend leaving #568 open (or filing a focused follow-up) for that compiler change.

## Verification
`uv run pytest tests/hooks/test_permission_policy.py tests/services/core/test_memory_manager.py tests/test_claude_mpm_directory_loading.py tests/test_memory_system_qa_comprehensive.py tests/test_path_resolver.py tests/services/core/test_path_resolver.py tests/test_lazy_load_workflow.py -p no:xdist -q` → **140 passed, 7 skipped**.

One file per commit per CLAUDE.md.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)