### PR TITLE
fix: feature-neutral native Claude Code compatibility (#578, #582)

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -127,16 +127,16 @@ Each delegation reloads ~95K tokens of context. Fewer, larger delegations = chea
 ## Retry Protocol
 
 When delegated work fails (build error, test failure, lint issue):
-1. **SendMessage to the SAME agent** — never spawn a new delegation to fix a previous one
+1. **Re-dispatch a fresh `Agent` call** to the same `subagent_type` with the prior context and error output embedded in the prompt — subagents are stateless one-shot calls, so re-dispatching is the correct MPM continuation pattern. If Agent Teams mode is active (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), you MAY use `SendMessage` to continue the same agent in place instead.
 2. Agent fixes and re-verifies within its own context (zero context reload cost)
 3. Only re-delegate if agent has failed 3+ times on the same issue
 
 | Scenario | Action |
 |----------|--------|
-| Build/test/lint failure | SendMessage to originating agent with error output |
-| Engineer reports "tests pass" but no raw output | SendMessage: "show raw test output" |
+| Build/test/lint failure | Re-dispatch to same agent type, embed error output in new prompt |
+| Engineer reports "tests pass" but no raw output | Re-dispatch with instruction to show raw test output |
 | Agent failed 3+ times on same issue | Re-delegate to different agent or escalate |
-| README missing from deliverables | SendMessage: "prompt requires README, please create" |
+| README missing from deliverables | Re-dispatch with instruction that README is required |
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
@@ -300,7 +300,7 @@ Use `run_in_background: true` for fire-and-forget parallel work.
 
 ## Agent Teams Note
 
-Native Claude Code Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) and MPM orchestration should not be layered — use one or the other. Default to MPM (richer workflow, verification gates, specialization).
+Native Claude Code Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) and MPM orchestration should not be layered — use one or the other. Default to MPM (richer workflow, verification gates, specialization). When Agent Teams mode is active, `SendMessage` may be used for same-agent retry continuation as described in the Retry Protocol above; in all other cases, re-dispatch a fresh `Agent` call.
 
 ## Skills System
 

--- a/src/claude_mpm/core/capabilities.py
+++ b/src/claude_mpm/core/capabilities.py
@@ -1,0 +1,71 @@
+"""Shared capability-detection helpers for Claude MPM.
+
+This module provides a single, cheap, side-effect-free surface for querying
+runtime capabilities that affect MPM behaviour.  All checks are environment-
+variable reads so they are suitable for use in hooks, startup code, and hot
+paths without adding latency.
+
+Design constraints
+------------------
+* **No heavy imports** — importing this module must not pull in the full MPM
+  stack.  Pure stdlib only.
+* **No side effects** — every function is a pure read; no caching state, no
+  network calls, no file I/O.
+* **Feature-neutral** — callers should adapt gracefully to the detected value
+  rather than hard-coding Agent-Teams-only instructions.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["agent_teams_active"]
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_truthy(name: str) -> bool:
+    """Return True if *name* is set to a truthy value in the environment.
+
+    Recognised truthy strings (case-insensitive): ``1``, ``true``, ``yes``,
+    ``on``.  An unset or empty variable returns False.
+    """
+    raw = os.environ.get(name, "")
+    return raw.strip().lower() in _TRUTHY_VALUES
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def agent_teams_active() -> bool:
+    """Return True iff Claude Code Agent Teams mode is currently active.
+
+    The primary signal is the environment variable
+    ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS``.  Recognised truthy values:
+    ``1``, ``true``, ``yes``, ``on`` (case-insensitive).
+
+    When the variable is unset or empty this function returns ``False``,
+    preserving the default (non-Teams) experience.
+
+    This function is intentionally cheap — it performs only an environment
+    lookup and a string comparison.  It is safe to call in hot paths such as
+    hook handlers.
+
+    Examples
+    --------
+    >>> import os
+    >>> os.environ.pop("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", None)
+    >>> from claude_mpm.core.capabilities import agent_teams_active
+    >>> agent_teams_active()
+    False
+    >>> os.environ["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+    >>> agent_teams_active()
+    True
+    """
+    return _env_truthy("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS")

--- a/src/claude_mpm/scripts/claude-hook-fast.sh
+++ b/src/claude_mpm/scripts/claude-hook-fast.sh
@@ -52,15 +52,27 @@ fi
 # =============================================================================
 EVENT=""
 
-# Try hook_event_name first (Claude Code's primary field)
+# Try hook_event_name first (Claude Code's primary field).
+# Claude Code serialises JSON with a space after ':', e.g.:
+#   {"hook_event_name": "PreToolUse", ...}
+# Strip everything up to (and including) the opening quote of the value,
+# accounting for an optional space between ':' and '"'.
 if [[ "$INPUT" == *'"hook_event_name":'* ]]; then
-    TEMP=${INPUT#*\"hook_event_name\":\"}
+    # Remove the prefix up to and including 'hook_event_name": ' (with space)
+    TEMP=${INPUT#*\"hook_event_name\": \"}
+    if [[ "$TEMP" == "$INPUT" ]]; then
+        # No space variant: 'hook_event_name":"'
+        TEMP=${INPUT#*\"hook_event_name\":\"}
+    fi
     EVENT=${TEMP%%\"*}
 fi
 
 # Fallback to "event" field if hook_event_name not found
 if [[ -z "$EVENT" ]] && [[ "$INPUT" == *'"event":'* ]]; then
-    TEMP=${INPUT#*\"event\":\"}
+    TEMP=${INPUT#*\"event\": \"}
+    if [[ "$TEMP" == "$INPUT" ]]; then
+        TEMP=${INPUT#*\"event\":\"}
+    fi
     EVENT=${TEMP%%\"*}
 fi
 
@@ -144,9 +156,34 @@ PORT="${CLAUDE_MPM_SOCKETIO_PORT:-8765}"
 } &
 
 # =============================================================================
-# Return async response immediately
-# async: true tells Claude Code this hook runs in background (non-blocking)
-# asyncTimeout: 60000ms (60s) - maximum time for background operations
-# This is the critical path - must be fast to not block Claude Code
+# Return the correct response shape for each event type.
+#
+# IMPORTANT: Claude Code's hook contract differs by event:
+#
+#   PreToolUse, PermissionRequest — these are DECISION events.  Claude Code
+#     expects a synchronous response that includes a "continue" or "block"
+#     decision.  Returning {"async": true} here is contractually wrong: it
+#     silently breaks model-tier injection (model_tier_hook.py) and the
+#     context circuit-breaker, and would hang PermissionRequest.
+#     We emit {"continue": true} — a safe pass-through no-op decision.
+#     The dedicated full Python handler (model_tier_hook.py / claude-hook
+#     entry point) is separately wired in settings.json for these events
+#     and handles the actual decision injection.
+#
+#   All other events (PostToolUse, Stop, SubagentStop, UserPromptSubmit,
+#     SessionStart, Notification, AssistantResponse, WorktreeCreate,
+#     WorktreeRemove, etc.) — pure fire-and-forget observability events.
+#     {"async": true} is correct: it lets the background dashboard curl
+#     complete without blocking Claude Code's hot path.
 # =============================================================================
-echo '{"async": true, "asyncTimeout": 60000}'
+case "$EVENT" in
+    PreToolUse|PermissionRequest)
+        # Decision events require synchronous "continue" (safe pass-through).
+        # The full Python handler is wired separately for actual logic.
+        echo '{"continue": true}'
+        ;;
+    *)
+        # Observability events: fire-and-forget async is safe and fast.
+        echo '{"async": true, "asyncTimeout": 60000}'
+        ;;
+esac

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -1,0 +1,148 @@
+"""Unit tests for src/claude_mpm/core/capabilities.py.
+
+Tests cover agent_teams_active() across all truthy/falsy env-var values and
+the unset-variable (default) case.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from claude_mpm.core.capabilities import agent_teams_active
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ENV_VAR = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+
+
+def _with_env(value: str | None):
+    """Context manager: set or unset the Agent Teams env var."""
+    if value is None:
+        return (
+            mock.patch.dict(os.environ, {}, clear=False)
+            if _ENV_VAR not in os.environ
+            else mock.patch.dict(os.environ, {_ENV_VAR: ""})
+        )
+    return mock.patch.dict(os.environ, {_ENV_VAR: value})
+
+
+# ---------------------------------------------------------------------------
+# Default / unset behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAgentTeamsActiveDefault:
+    """agent_teams_active() must return False when the env var is unset."""
+
+    def test_returns_false_when_unset(self) -> None:
+        env_without_var = {k: v for k, v in os.environ.items() if k != _ENV_VAR}
+        with mock.patch.dict(os.environ, env_without_var, clear=True):
+            assert agent_teams_active() is False
+
+    def test_returns_false_when_empty_string(self) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: ""}):
+            assert agent_teams_active() is False
+
+    def test_returns_false_when_whitespace_only(self) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: "   "}):
+            assert agent_teams_active() is False
+
+
+# ---------------------------------------------------------------------------
+# Truthy values
+# ---------------------------------------------------------------------------
+
+
+class TestAgentTeamsActiveTruthy:
+    """agent_teams_active() must return True for all recognised truthy strings."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "1",
+            "true",
+            "True",
+            "TRUE",
+            "yes",
+            "Yes",
+            "YES",
+            "on",
+            "On",
+            "ON",
+        ],
+    )
+    def test_truthy_values(self, value: str) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: value}):
+            assert agent_teams_active() is True, (
+                f"Expected True for {_ENV_VAR}={value!r}"
+            )
+
+    def test_truthy_with_leading_trailing_whitespace(self) -> None:
+        # strip() is applied; "  1  " should be truthy
+        with mock.patch.dict(os.environ, {_ENV_VAR: "  1  "}):
+            assert agent_teams_active() is True
+
+    def test_truthy_true_with_whitespace(self) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: "  true  "}):
+            assert agent_teams_active() is True
+
+
+# ---------------------------------------------------------------------------
+# Falsy values (explicit non-truthy strings)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentTeamsActiveFalsy:
+    """agent_teams_active() must return False for non-truthy string values."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "0",
+            "false",
+            "False",
+            "FALSE",
+            "no",
+            "No",
+            "NO",
+            "off",
+            "Off",
+            "OFF",
+            "2",
+            "enabled",
+            "disabled",
+            "maybe",
+        ],
+    )
+    def test_falsy_values(self, value: str) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: value}):
+            assert agent_teams_active() is False, (
+                f"Expected False for {_ENV_VAR}={value!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Return type
+# ---------------------------------------------------------------------------
+
+
+class TestAgentTeamsActiveReturnType:
+    """agent_teams_active() must always return a plain bool."""
+
+    def test_returns_bool_when_false(self) -> None:
+        env_without_var = {k: v for k, v in os.environ.items() if k != _ENV_VAR}
+        with mock.patch.dict(os.environ, env_without_var, clear=True):
+            result = agent_teams_active()
+            assert isinstance(result, bool)
+            assert result is False
+
+    def test_returns_bool_when_true(self) -> None:
+        with mock.patch.dict(os.environ, {_ENV_VAR: "1"}):
+            result = agent_teams_active()
+            assert isinstance(result, bool)
+            assert result is True

--- a/tests/test_worktree_create_hook.py
+++ b/tests/test_worktree_create_hook.py
@@ -1,0 +1,242 @@
+"""Tests for claude-hook-fast.sh event-type response shapes.
+
+Verifies the hook script's output contract:
+  - PreToolUse / PermissionRequest (decision events) → {"continue": true}
+  - All other events (observability events) → {"async": true, "asyncTimeout": 60000}
+
+Also exercises WorktreeCreate / WorktreeRemove branches that were added in an
+earlier fix, ensuring they still fall through to the async path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT = (
+    Path(__file__).parent.parent
+    / "src"
+    / "claude_mpm"
+    / "scripts"
+    / "claude-hook-fast.sh"
+)
+
+
+def _run_hook(event_payload: dict) -> subprocess.CompletedProcess:
+    """Invoke the fast hook script with the given JSON payload on stdin."""
+    return subprocess.run(
+        [str(SCRIPT)],
+        input=json.dumps(event_payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _output_json(result: subprocess.CompletedProcess) -> dict:
+    """Parse the hook script's last JSON line from stdout."""
+    stdout = result.stdout.strip()
+    # Take the last non-empty line (the script may print nothing else)
+    last_line = [ln for ln in stdout.splitlines() if ln.strip()][-1]
+    return json.loads(last_line)
+
+
+# ---------------------------------------------------------------------------
+# Script presence check
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_exists() -> None:
+    """The fast hook script must exist and be executable."""
+    assert SCRIPT.exists(), f"Expected {SCRIPT} to exist"
+    assert SCRIPT.stat().st_mode & 0o111, f"Expected {SCRIPT} to be executable"
+
+
+# ---------------------------------------------------------------------------
+# Decision events: PreToolUse, PermissionRequest
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionEvents:
+    """Decision events must NOT return {async: true}.
+
+    The correct response is a synchronous decision shape, at minimum
+    {"continue": true}, so Claude Code can read the decision immediately.
+    """
+
+    @pytest.mark.parametrize("event", ["PreToolUse", "PermissionRequest"])
+    def test_decision_event_is_not_async(self, event: str) -> None:
+        """Decision events must not return {"async": true}."""
+        payload = {
+            "hook_event_name": event,
+            "tool_name": "Bash",
+            "session_id": "test-session-123",
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 0, (
+            f"Script exited {result.returncode}: {result.stderr}"
+        )
+
+        data = _output_json(result)
+        assert data.get("async") is not True, (
+            f"Event={event!r}: expected non-async decision response, got {data}"
+        )
+
+    @pytest.mark.parametrize("event", ["PreToolUse", "PermissionRequest"])
+    def test_decision_event_returns_continue(self, event: str) -> None:
+        """Decision events must include a continue/block decision key."""
+        payload = {
+            "hook_event_name": event,
+            "tool_name": "Write",
+            "session_id": "test-session-456",
+        }
+        result = _run_hook(payload)
+        data = _output_json(result)
+        # Either continue or block must be present; continue=true is the safe no-op
+        assert "continue" in data or "block" in data, (
+            f"Event={event!r}: response must contain 'continue' or 'block', got {data}"
+        )
+
+    def test_pretooluse_continue_is_true(self) -> None:
+        """PreToolUse specifically should return continue=true (safe pass-through)."""
+        payload = {"hook_event_name": "PreToolUse", "tool_name": "Bash"}
+        result = _run_hook(payload)
+        data = _output_json(result)
+        assert data.get("continue") is True, (
+            f"PreToolUse: expected continue=true, got {data}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Observability events: PostToolUse, Stop, etc.
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityEvents:
+    """Pure observability events must return the async JSON shape."""
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            "PostToolUse",
+            "Stop",
+            "SubagentStop",
+            "UserPromptSubmit",
+            "SessionStart",
+            "Notification",
+            "AssistantResponse",
+        ],
+    )
+    def test_observability_event_returns_async(self, event: str) -> None:
+        """Observability events must return {"async": true, "asyncTimeout": ...}."""
+        payload = {
+            "hook_event_name": event,
+            "session_id": "test-session-789",
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 0, (
+            f"Script exited {result.returncode}: {result.stderr}"
+        )
+
+        data = _output_json(result)
+        assert data.get("async") is True, (
+            f"Event={event!r}: expected async=true, got {data}"
+        )
+        assert "asyncTimeout" in data, (
+            f"Event={event!r}: expected asyncTimeout in response, got {data}"
+        )
+
+    def test_posttooluse_preserves_async_shape(self) -> None:
+        """PostToolUse must still return the async shape after the Part C fix."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_output": "some output",
+        }
+        result = _run_hook(payload)
+        data = _output_json(result)
+        assert data == {"async": True, "asyncTimeout": 60000}, (
+            f"PostToolUse: expected exact async shape, got {data}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# WorktreeCreate / WorktreeRemove (existing branches from earlier fix)
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeEvents:
+    """WorktreeCreate and WorktreeRemove fall through to the observability path."""
+
+    @pytest.mark.parametrize("event", ["WorktreeCreate", "WorktreeRemove"])
+    def test_worktree_event_returns_async(self, event: str) -> None:
+        """Worktree events are observability events and must return async shape."""
+        payload = {
+            "hook_event_name": event,
+            "session_id": "test-session-wt",
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 0, (
+            f"Script exited {result.returncode} for {event}: {result.stderr}"
+        )
+
+        data = _output_json(result)
+        assert data.get("async") is True, (
+            f"Event={event!r}: expected async=true, got {data}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unknown / missing event field
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases: empty input, missing event field, unknown events."""
+
+    def test_empty_input_returns_continue(self) -> None:
+        """Empty stdin should produce {"continue": true} immediately (early exit)."""
+        result = subprocess.run(
+            [str(SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        # Early exit path returns {"continue": true}
+        assert '{"continue": true}' in result.stdout
+
+    def test_unknown_event_returns_async(self) -> None:
+        """Unknown event types fall through to the async shape."""
+        payload = {"hook_event_name": "SomeUnknownEvent"}
+        result = _run_hook(payload)
+        data = _output_json(result)
+        assert data.get("async") is True, (
+            f"Unknown event: expected async=true, got {data}"
+        )
+
+    def test_sub_agent_env_returns_continue_early(self) -> None:
+        """When CLAUDE_MPM_SUB_AGENT is set, hook exits early with continue."""
+        import os
+
+        env = os.environ.copy()
+        env["CLAUDE_MPM_SUB_AGENT"] = "1"
+        payload = {"hook_event_name": "PreToolUse", "tool_name": "Bash"}
+        result = subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert '{"continue": true}' in result.stdout


### PR DESCRIPTION
## Summary
Resolves two CRITICAL native-Claude-Code conflicts found in the compatibility audit, built on a new shared capability-detection helper so MPM is **feature-neutral** with respect to Agent Teams (works correctly whether or not `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`).

Closes #578
Closes #582

## Changes
- **New `src/claude_mpm/core/capabilities.py`** — `agent_teams_active()` (pure stdlib, reads `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, default False). Single capability surface for future feature-neutral gating. 31 unit tests.
- **#578 — PM retry protocol made feature-neutral** (`PM_INSTRUCTIONS.md`): default behavior is now re-dispatching a fresh `Agent` call with prior context/error embedded (correct pattern for stateless subagents); `SendMessage` is offered only as an option when Agent Teams mode is active. Reconciled with the "Agent Teams Note" so the file no longer contradicts itself. (Previously the protocol told the PM to use `SendMessage`, an Agent Teams tool unavailable in default sessions → "SendMessage isn't available here".)
- **#582 — fast hook returns event-correct response shapes** (`claude-hook-fast.sh`): `PreToolUse`/`PermissionRequest` now return `{"continue": true}` (safe synchronous pass-through; the full Python handler wired in settings.json does the actual model-tier/decision injection) instead of `{"async": true}`, which silently broke those decision contracts. Observability events still return `{"async": true}`. Also fixed a latent bash JSON-parsing bug: `"hook_event_name": "..."` (with a space after the colon) was mis-parsed, sending every event to the async branch.

## Verification
- `tests/core/test_capabilities.py` — 31 passed
- `tests/test_worktree_create_hook.py` — 19 passed (extended with PreToolUse/observability shape assertions)
- `bash -n claude-hook-fast.sh` — clean
- `tests/hooks/` — 138 passed, 23 skipped, 1 pre-existing failure (`test_pre_tool_use_agent_path_still_works`, fixed separately on the #571 branch / PR #574)

One file per commit per CLAUDE.md.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)