### PR TITLE
fix: write trusty-memory-mcp-bridge MCP entry instead of broken serve --mcp (#567)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,12 +2,8 @@
   "mcpServers": {
     "trusty-memory": {
       "type": "stdio",
-      "command": "trusty-memory",
-      "args": [
-        "serve",
-        "--palace",
-        "claude-mpm"
-      ]
+      "command": "trusty-memory-mcp-bridge",
+      "args": []
     },
     "trusty-search": {
       "type": "stdio",

--- a/src/claude_mpm/cli/commands/setup/handlers/trusty.py
+++ b/src/claude_mpm/cli/commands/setup/handlers/trusty.py
@@ -665,7 +665,7 @@ class TrustyMixin:
         1. Install via cargo (or cargo-binstall) if missing.
         2. Ensure daemon is running (launchd plist + HTTP health check).
         3. Create palace named after current project via HTTP API.
-        4. Write ``.mcp.json`` entry pointing at ``trusty-memory serve --mcp``.
+        4. Write ``.mcp.json`` entry pointing at ``trusty-memory-mcp-bridge``.
         5. Inject SessionStart/Stop/SubagentStop hooks via claude-hook architecture.
         """
         import json as _json
@@ -814,8 +814,8 @@ class TrustyMixin:
                 mcp_config.setdefault("mcpServers", {})
                 mcp_config["mcpServers"]["trusty-memory"] = {
                     "type": "stdio",
-                    "command": "trusty-memory",
-                    "args": ["serve", "--mcp"],
+                    "command": "trusty-memory-mcp-bridge",
+                    "args": [],
                 }
                 self._save_mcp_config(mcp_config)
                 console.print("[green]✓ Added trusty-memory to .mcp.json[/green]")
@@ -830,7 +830,7 @@ class TrustyMixin:
             "\n[bold green]✓ trusty-memory setup complete![/bold green]\n"
             f"  • Palace: {palace_name}\n"
             f"  • Daemon HTTP: {base_url}\n"
-            "  • MCP server: stdio via `trusty-memory serve --mcp`\n"
+            "  • MCP server: stdio via `trusty-memory-mcp-bridge`\n"
             "  • Logs: /tmp/trusty-memory.log\n"
         )
         return CommandResult.success_result("trusty-memory setup complete")

--- a/src/claude_mpm/migrations/migrate_fix_trusty_memory_bridge.py
+++ b/src/claude_mpm/migrations/migrate_fix_trusty_memory_bridge.py
@@ -1,0 +1,172 @@
+"""Repair broken trusty-memory MCP entries to use the bridge binary.
+
+Bug (#567): earlier versions of claude-mpm wrote a broken trusty-memory MCP
+server entry of the form ``command="trusty-memory", args=["serve", "--mcp"]``
+(and variant forms such as ``args=["serve", "--palace", "claude-mpm", "--mcp"]``).
+``trusty-memory serve`` starts the HTTP daemon, not an MCP stdio server, so
+Claude Code could never speak MCP to it. The correct invocation is the
+dedicated bridge binary ``trusty-memory-mcp-bridge`` (no args), which ships
+alongside ``trusty-memory``.
+
+This migration scans the same config locations as
+:mod:`migrate_fix_mcp_command_args` and rewrites any entry where
+``command == "trusty-memory"`` AND ``args`` contains ``"--mcp"`` to
+``command="trusty-memory-mcp-bridge", args=[]``.
+
+Scanned locations (each optional — missing files are skipped):
+
+* ``./.mcp.json`` (project-scoped)
+* ``./.claude/settings.json`` and ``./.claude/settings.local.json``
+* ``~/.claude/.mcp.json``
+* ``~/.claude/settings.json``
+
+Design constraints:
+
+* **Match on presence of ``--mcp``**, not exact-array equality, so variant
+  forms (extra ``--palace`` flags, etc.) are also repaired.
+* **Idempotent**: an already-bridged entry has ``command`` of
+  ``trusty-memory-mcp-bridge`` (not ``trusty-memory``), so re-running is a
+  no-op. An absent entry is also a no-op.
+* **Targeted**: only ``trusty-memory`` entries are touched. ``trusty-search``
+  (``args=["serve"]``) and ``trusty-analyzer`` (``args=["mcp"]``) are left
+  alone — they have no ``--mcp`` flag and a different ``command``.
+* **Graceful**: malformed JSON or unreadable files are skipped with a warning
+  rather than aborting the whole migration.
+* **Conservative writes**: the file is only rewritten when at least one entry
+  in it was actually modified.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def fix_trusty_memory_entry(server_config: dict[str, Any]) -> bool:
+    """Fix a single broken trusty-memory entry in place.
+
+    Rewrites entries where ``command == "trusty-memory"`` and ``args``
+    contains ``"--mcp"`` to ``command="trusty-memory-mcp-bridge", args=[]``.
+
+    Args:
+        server_config: A single entry from an ``mcpServers`` mapping.
+
+    Returns:
+        True if the entry was modified, False otherwise.
+    """
+    if server_config.get("command") != "trusty-memory":
+        return False
+
+    args = server_config.get("args")
+    if not isinstance(args, list) or "--mcp" not in args:
+        return False
+
+    server_config["command"] = "trusty-memory-mcp-bridge"
+    server_config["args"] = []
+    return True
+
+
+def _fix_mcp_servers(servers: Any) -> int:
+    """Apply :func:`fix_trusty_memory_entry` to every ``mcpServers`` entry.
+
+    Returns the number of entries modified. A non-dict ``servers`` value (or
+    a non-dict entry within it) is silently skipped — we don't want a single
+    weird entry to abort the whole migration.
+    """
+    if not isinstance(servers, dict):
+        return 0
+
+    fixed = 0
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            continue
+        if fix_trusty_memory_entry(entry):
+            fixed += 1
+            logger.info(
+                "Fixed MCP server '%s': rewired to trusty-memory-mcp-bridge",
+                name,
+            )
+    return fixed
+
+
+def _process_file(path: Path) -> bool:
+    """Load ``path``, fix any broken trusty-memory entries, write back.
+
+    Returns True iff the file was modified (and therefore rewritten). Missing
+    files, non-JSON files, and files without ``mcpServers`` are all no-ops.
+    """
+    if not path.exists():
+        return False
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Skipping %s: cannot parse JSON (%s)", path, exc)
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    servers = data.get("mcpServers")
+    fixed = _fix_mcp_servers(servers)
+    if not fixed:
+        return False
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+    except OSError as exc:
+        logger.warning("Failed to write %s: %s", path, exc)
+        return False
+
+    logger.info(
+        "Fixed %d trusty-memory entr%s in %s",
+        fixed,
+        "y" if fixed == 1 else "ies",
+        path,
+    )
+    return True
+
+
+def _candidate_paths(project_dir: Path) -> list[Path]:
+    """Return the set of config files we should scan.
+
+    Mirrors :func:`migrate_fix_mcp_command_args._candidate_paths`. Order
+    doesn't matter — each file is independent — but we keep project-level
+    files first for log readability.
+    """
+    home = Path.home()
+    return [
+        project_dir / ".mcp.json",
+        project_dir / ".claude" / "settings.json",
+        project_dir / ".claude" / "settings.local.json",
+        home / ".claude" / ".mcp.json",
+        home / ".claude" / "settings.json",
+    ]
+
+
+def run_migration(project_dir: Path | None = None) -> bool:
+    """Scan known config locations and repair broken trusty-memory entries.
+
+    Args:
+        project_dir: Project root to scan (defaults to CWD). Tests inject a
+            temp directory here.
+
+    Returns:
+        True if any file was modified, False if everything was already valid
+        (or no relevant files existed).
+    """
+    project_dir = project_dir or Path.cwd()
+
+    any_changed = False
+    for path in _candidate_paths(project_dir):
+        if _process_file(path):
+            any_changed = True
+
+    return any_changed

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -67,8 +67,8 @@ _SERVICES: tuple[dict[str, Any], ...] = (
         "fallback_addr": "127.0.0.1:7070",
         "mcp_entry": {
             "type": "stdio",
-            "command": "trusty-memory",
-            "args": ["serve", "--mcp"],
+            "command": "trusty-memory-mcp-bridge",
+            "args": [],
         },
     },
 )

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -190,6 +190,13 @@ def _run_remove_memory_capture_hook_migration() -> bool:
     return run_migration()
 
 
+def _run_fix_trusty_memory_bridge_migration() -> bool:
+    """Repair broken trusty-memory MCP entries to use the bridge binary (issue #567)."""
+    from .migrate_fix_trusty_memory_bridge import run_migration
+
+    return run_migration()
+
+
 def _run_remove_absolute_hook_paths_migration() -> bool:
     """Replace absolute MPM hook paths with the portable 'claude-hook' entry point (issue #563)."""
     from pathlib import Path
@@ -339,6 +346,12 @@ MIGRATIONS: list[Migration] = [
         version="6.4.18",
         description="Replace absolute MPM hook script paths with portable 'claude-hook' entry point in .claude/settings.json (issue #563)",
         run=_run_remove_absolute_hook_paths_migration,
+    ),
+    Migration(
+        id="fix_trusty_memory_bridge",
+        version="6.5.0",
+        description="Repair broken trusty-memory MCP entries (command=trusty-memory args=[serve,--mcp]) to use the trusty-memory-mcp-bridge binary (issue #567)",
+        run=_run_fix_trusty_memory_bridge_migration,
     ),
 ]
 

--- a/src/claude_mpm/services/mcp/config_builder.py
+++ b/src/claude_mpm/services/mcp/config_builder.py
@@ -60,8 +60,8 @@ class MCPServiceConfigBuilder:
         },
         "trusty-memory": {
             "type": "stdio",
-            "command": "trusty-memory",
-            "args": ["serve", "--mcp"],
+            "command": "trusty-memory-mcp-bridge",
+            "args": [],
         },
         "trusty-analyzer": {
             "type": "stdio",

--- a/tests/migrations/test_fix_trusty_memory_bridge.py
+++ b/tests/migrations/test_fix_trusty_memory_bridge.py
@@ -1,0 +1,172 @@
+"""Tests for the trusty-memory bridge repair migration (issue #567).
+
+The migration rewrites broken ``trusty-memory`` MCP entries
+(``command="trusty-memory"`` with ``"--mcp"`` in ``args``) to the dedicated
+bridge form ``command="trusty-memory-mcp-bridge", args=[]``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - used at runtime in fixtures & call sites
+
+from claude_mpm.migrations import migrate_fix_trusty_memory_bridge as mod
+
+_BRIDGE_ENTRY = {
+    "type": "stdio",
+    "command": "trusty-memory-mcp-bridge",
+    "args": [],
+}
+
+
+def _write_mcp(project_dir: Path, config: dict) -> Path:
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(config, indent=2) + "\n")
+    return mcp_path
+
+
+def test_broken_entry_is_fixed(tmp_path: Path) -> None:
+    """Broken serve/--mcp entry → rewritten to the bridge form."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-memory": {
+                    "type": "stdio",
+                    "command": "trusty-memory",
+                    "args": ["serve", "--mcp"],
+                }
+            }
+        },
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert servers["trusty-memory"] == _BRIDGE_ENTRY
+
+
+def test_variant_broken_form_is_fixed(tmp_path: Path) -> None:
+    """Variant with extra flags but containing --mcp → fixed (presence match)."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-memory": {
+                    "type": "stdio",
+                    "command": "trusty-memory",
+                    "args": ["serve", "--palace", "claude-mpm", "--mcp"],
+                }
+            }
+        },
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert servers["trusty-memory"] == _BRIDGE_ENTRY
+
+
+def test_already_fixed_is_noop(tmp_path: Path) -> None:
+    """Already-bridged entry → no change, returns False, file untouched."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}},
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_absent_entry_is_noop(tmp_path: Path) -> None:
+    """No trusty-memory entry at all → no change, returns False."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "some-other-server": {"type": "stdio", "command": "whatever"}
+            }
+        },
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_no_files_is_noop(tmp_path: Path) -> None:
+    """Empty project dir (no config files) → no change, returns False."""
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_search_and_analyzer_untouched(tmp_path: Path) -> None:
+    """trusty-search and trusty-analyzer entries must never be modified."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-memory": {
+                    "type": "stdio",
+                    "command": "trusty-memory",
+                    "args": ["serve", "--mcp"],
+                },
+                "trusty-search": {
+                    "type": "stdio",
+                    "command": "trusty-search",
+                    "args": ["serve"],
+                },
+                "trusty-analyzer": {
+                    "type": "stdio",
+                    "command": "trusty-analyzer",
+                    "args": ["mcp"],
+                },
+            }
+        },
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    # Memory repaired...
+    assert servers["trusty-memory"] == _BRIDGE_ENTRY
+    # ...search and analyzer left exactly as they were.
+    assert servers["trusty-search"] == {
+        "type": "stdio",
+        "command": "trusty-search",
+        "args": ["serve"],
+    }
+    assert servers["trusty-analyzer"] == {
+        "type": "stdio",
+        "command": "trusty-analyzer",
+        "args": ["mcp"],
+    }
+
+
+def test_idempotent_after_fix(tmp_path: Path) -> None:
+    """Running twice: first run fixes, second run is a no-op."""
+    _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-memory": {
+                    "type": "stdio",
+                    "command": "trusty-memory",
+                    "args": ["serve", "--mcp"],
+                }
+            }
+        },
+    )
+
+    assert mod.run_migration(project_dir=tmp_path) is True
+    assert mod.run_migration(project_dir=tmp_path) is False

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -72,8 +72,8 @@ def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
     }
     assert servers["trusty-memory"] == {
         "type": "stdio",
-        "command": "trusty-memory",
-        "args": ["serve", "--mcp"],
+        "command": "trusty-memory-mcp-bridge",
+        "args": [],
     }
 
 
@@ -131,8 +131,8 @@ def test_idempotent_when_entries_already_present(project_dir: Path) -> None:
             },
             "trusty-memory": {
                 "type": "stdio",
-                "command": "trusty-memory",
-                "args": ["serve", "--mcp"],
+                "command": "trusty-memory-mcp-bridge",
+                "args": [],
             },
         }
     }


### PR DESCRIPTION
## Summary

claude-mpm was emitting a **broken MCP server entry** for the trusty-memory bridge. It wrote:

```jsonc
"trusty-memory": { "command": "trusty-memory", "args": ["serve", "--mcp"] }
```

but `trusty-memory` has no `serve --mcp` subcommand, so the MCP server never started. The correct invocation uses the dedicated bridge entry point with no extra args:

```jsonc
"trusty-memory": { "command": "trusty-memory-mcp-bridge", "args": [] }
```

## What changed

- **3 production emit-sites corrected** to write `command="trusty-memory-mcp-bridge", args=[]`:
  - `src/claude_mpm/cli/commands/setup/handlers/trusty.py` (setup handler)
  - `src/claude_mpm/services/mcp/config_builder.py` (static MCP config)
  - `src/claude_mpm/migrations/migrate_trusty_autodetect.py` (autodetect migration)
- **New repair migration** `src/claude_mpm/migrations/migrate_fix_trusty_memory_bridge.py` that rewrites existing broken `trusty-memory` entries in user configs to the correct bridge form, registered in `src/claude_mpm/migrations/registry.py` (v6.5.0).
- **Tests** covering the repair migration and the corrected autodetect output:
  - `tests/migrations/test_fix_trusty_memory_bridge.py`
  - `tests/migrations/test_trusty_autodetect.py`
- **`.mcp.json`** normalized to the bridge form so the repo itself is self-consistent.

## QA results

- 62 migration tests pass.
- E2E repair verified: existing broken `trusty-memory` entries are rewritten to the bridge form.
- Migration is idempotent (running it again on already-fixed configs is a no-op).
- Safe for sibling entries: `trusty-search` and `trusty-analyzer` are left untouched.

Closes #567

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
