### PR TITLE
fix: native Claude Code compatibility batch 2 (#576, #579, #583, #580)

### DIFF
--- a/plugin/skills/mpm-message/SKILL.md
+++ b/plugin/skills/mpm-message/SKILL.md
@@ -104,7 +104,17 @@ claude-mpm message sessions                        # List active sessions
 ### Python API (PREFERRED fallback for all versions)
 ```python
 from pathlib import Path
-from claude_mpm.services.communication.message_service import MessageService
+
+try:
+    from claude_mpm.services.communication.message_service import MessageService
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', use the CLI instead:\n"
+        "  claude-mpm message list / send / read / reply\n"
+        "Or activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 service = MessageService(Path.cwd())
 msg = service.send_message(

--- a/plugin/skills/mpm-session-pause/SKILL.md
+++ b/plugin/skills/mpm-session-pause/SKILL.md
@@ -39,7 +39,19 @@ When invoked, this skill:
 
 ```python
 from pathlib import Path
-from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
+
+try:
+    from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', run:\n"
+        "  uv run python -c 'from claude_mpm.services.cli.session_pause_manager "
+        "import SessionPauseManager'\n"
+        "Or invoke directly: claude-mpm session-pause\n"
+        "Alternatively, activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 # Optional: Get message from user's command
 # If user provided message after /mpm-pause, extract it

--- a/plugin/skills/mpm-session-resume/SKILL.md
+++ b/plugin/skills/mpm-session-resume/SKILL.md
@@ -55,7 +55,19 @@ then dispatch to the appropriate code path.**
 ```python
 import sys
 from pathlib import Path
-from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
+
+try:
+    from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', run:\n"
+        "  uv run python -c 'from claude_mpm.services.cli.session_resume_helper "
+        "import SessionResumeHelper'\n"
+        "Or invoke directly: claude-mpm session-resume\n"
+        "Alternatively, activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 # --------------------------------------------------------------------------
 # Argument parsing

--- a/src/claude_mpm/core/capabilities.py
+++ b/src/claude_mpm/core/capabilities.py
@@ -13,19 +13,35 @@ Design constraints
   network calls, no file I/O.
 * **Feature-neutral** — callers should adapt gracefully to the detected value
   rather than hard-coding Agent-Teams-only instructions.
+
+PreToolUse input modification
+-----------------------------
+``supports_pretool_modify()`` checks whether the running Claude Code version
+supports the ``updatedInput`` field in ``hookSpecificOutput`` for PreToolUse
+hooks.  This feature was added in Claude Code v2.0.30.
+
+The check delegates to ``HookInstaller.supports_pretool_modify()`` when that
+class is importable (full install) and falls back to a lightweight
+``claude --version`` subprocess for minimal or hook-only environments.  In
+both cases the result is **not cached here** — callers that need caching
+should cache it themselves or rely on ``HookInstaller``'s own instance cache.
 """
 
 from __future__ import annotations
 
 import os
 
-__all__ = ["agent_teams_active"]
+__all__ = ["agent_teams_active", "supports_pretool_modify"]
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 _TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+# Minimum Claude Code version required for PreToolUse input modification.
+# Kept in sync with HookInstaller.MIN_PRETOOL_MODIFY_VERSION.
+_MIN_PRETOOL_MODIFY_VERSION = "2.0.30"
 
 
 def _env_truthy(name: str) -> bool:
@@ -36,6 +52,27 @@ def _env_truthy(name: str) -> bool:
     """
     raw = os.environ.get(name, "")
     return raw.strip().lower() in _TRUTHY_VALUES
+
+
+def _version_meets_minimum(version: str, min_version: str) -> bool:
+    """Return True iff *version* >= *min_version* (both dotted-decimal strings)."""
+
+    def parse(v: str) -> list[int]:
+        try:
+            return [int(x) for x in v.split(".")]
+        except (ValueError, AttributeError):
+            return [0]
+
+    curr = parse(version)
+    req = parse(min_version)
+    for i in range(max(len(curr), len(req))):
+        c = curr[i] if i < len(curr) else 0
+        r = req[i] if i < len(req) else 0
+        if c < r:
+            return False
+        if c > r:
+            return True
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -69,3 +106,59 @@ def agent_teams_active() -> bool:
     True
     """
     return _env_truthy("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS")
+
+
+def supports_pretool_modify() -> bool:
+    """Return True iff the running Claude Code supports PreToolUse input modification.
+
+    PreToolUse input modification (``updatedInput`` inside
+    ``hookSpecificOutput``) was added in Claude Code **v2.0.30**.  Hooks that
+    inject data via this mechanism must skip injection on older versions to
+    avoid silent failures or "Invalid key" warnings.
+
+    Detection order
+    ---------------
+    1. Try ``HookInstaller.supports_pretool_modify()`` — uses the installer's
+       own cached ``claude --version`` result (preferred, no extra subprocess).
+    2. Fall back to a direct ``claude --version`` subprocess when the full
+       installer cannot be imported (minimal / hook-only environments).
+    3. Return ``False`` conservatively when the version cannot be determined.
+
+    This function is safe to call in hook hot-paths; the installer caches the
+    version after the first subprocess call so subsequent calls are cheap.
+
+    Returns
+    -------
+    bool
+        ``True`` if injection is supported, ``False`` otherwise.
+    """
+    # Fast path: try the installer which already caches the version.
+    try:
+        from claude_mpm.hooks.claude_hooks.installer import (
+            HookInstaller,
+        )
+
+        installer = HookInstaller()
+        return installer.supports_pretool_modify()
+    except Exception:
+        pass
+
+    # Fallback: run claude --version directly.
+    import re
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        output = (result.stdout or result.stderr).strip()
+        match = re.search(r"([\d]+\.[\d]+\.[\d]+)", output)
+        if not match:
+            return False
+        return _version_meets_minimum(match.group(1), _MIN_PRETOOL_MODIFY_VERSION)
+    except Exception:
+        return False

--- a/src/claude_mpm/hooks/model_tier_hook.py
+++ b/src/claude_mpm/hooks/model_tier_hook.py
@@ -23,6 +23,30 @@ from pathlib import Path
 from claude_mpm.hooks import permission_policy
 from claude_mpm.utils.agent_filters import normalize_agent_id
 
+# ---------------------------------------------------------------------------
+# Version-capability guard (PreToolUse input modification, v2.0.30+)
+# ---------------------------------------------------------------------------
+# Import lazily so the module itself can be imported in any environment; the
+# guard is only evaluated when build_model_tier_response is called.
+_pretool_modify_supported: bool | None = None  # None = not yet checked
+
+
+def _check_pretool_modify_supported() -> bool:
+    """Return (and cache) whether PreToolUse input modification is supported."""
+    global _pretool_modify_supported
+    if _pretool_modify_supported is not None:
+        return _pretool_modify_supported
+    try:
+        from claude_mpm.core.capabilities import (
+            supports_pretool_modify,
+        )
+
+        _pretool_modify_supported = supports_pretool_modify()
+    except Exception:
+        _pretool_modify_supported = False
+    return _pretool_modify_supported
+
+
 # Agent type -> model mapping (fallback when frontmatter unavailable).
 # Only haiku-tier agents are listed here; all other agents (including
 # engineering agents) default to opus.  Callers that need sonnet or haiku for a
@@ -73,6 +97,25 @@ _TIER_ALIASES: dict[str, str] = {
     # callers referencing either generation get consistent routing.
     "claude-opus-4-6": _OPUS_MODEL,
     "claude-opus-4-7": _OPUS_MODEL,
+}
+
+# When injecting into the Agent tool's ``model`` field, some Claude Code
+# versions only accept the short alias forms (sonnet|opus|haiku).  Using
+# a dated ID such as "claude-opus-4-7" causes "expected one of sonnet|opus|haiku"
+# errors in those versions.  This map converts a resolved model value to its
+# safe short alias for injection so Claude Code always accepts it.
+_INJECT_SHORT_ALIAS: dict[str, str] = {
+    # opus tier — all dated opus IDs → "opus"
+    _OPUS_MODEL: "opus",
+    "claude-opus-4-6": "opus",
+    # sonnet tier
+    _SONNET_MODEL: "sonnet",
+    "claude-sonnet-4-5": "sonnet",
+    "claude-sonnet-4": "sonnet",
+    # haiku tier
+    "haiku": "haiku",
+    "claude-haiku-3-5": "haiku",
+    "claude-haiku-3": "haiku",
 }
 
 # Module-level cache for per-agent model preferences. ``None`` means not yet
@@ -199,15 +242,38 @@ def build_model_tier_response(event: dict) -> dict:
     """Resolve and inject the model tier for an Agent tool call.
 
     Returns the full ``hookSpecificOutput``-wrapped payload dict, or
-    ``{"continue": True}`` when the event is not an Agent call or already has a
-    model set. Exposed as an importable function so ``pretooluse_dispatcher``
-    can call it directly without spawning a subprocess.
+    ``{"continue": True}`` when the event is not an Agent call, already has a
+    model set, or the running Claude Code does not support PreToolUse input
+    modification (requires v2.0.30+).
+
+    Exposed as an importable function so ``pretooluse_dispatcher`` can call it
+    directly without spawning a subprocess.
+
+    Model injection is version-gated
+    ---------------------------------
+    Claude Code v2.0.30+ is required for the ``updatedInput`` field in
+    ``hookSpecificOutput``.  On older versions the field is silently ignored or
+    causes warnings, so we skip injection entirely when the running version does
+    not meet the minimum.
+
+    Short-alias form
+    ----------------
+    The Agent tool's ``model`` field accepts the short alias forms
+    (``opus``, ``sonnet``, ``haiku``) on all supported versions.  Dated IDs
+    such as ``claude-opus-4-7`` can cause "expected one of sonnet|opus|haiku"
+    validation errors on some versions.  We map known dated IDs to their short
+    alias before injecting; unknown/custom model IDs are passed through as-is.
     """
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 
     # Only intercept Agent tool calls that don't already have a model
     if tool_name != "Agent" or "model" in tool_input:
+        return {"continue": True}
+
+    # Version gate: skip injection when PreToolUse input modification is
+    # unsupported (pre-v2.0.30).  Fail open so Claude Code is never blocked.
+    if not _check_pretool_modify_supported():
         return {"continue": True}
 
     agent_type = tool_input.get("subagent_type", "")
@@ -219,7 +285,7 @@ def build_model_tier_response(event: dict) -> dict:
     #      (with project-level .claude-mpm/configuration.yaml as override).
     #   3. Frontmatter ``model:`` field in .claude/agents/<name>.md.
     #   4. Built-in haiku-tier mapping (_HAIKU_AGENTS).
-    #   5. Default sonnet for all other agents (including engineering agents).
+    #   5. Default opus for all other agents (including engineering agents).
     model = _read_model_from_config(agent_type, cwd)
     if model is None:
         model = _read_model_from_frontmatter(agent_type, cwd)
@@ -230,11 +296,15 @@ def build_model_tier_response(event: dict) -> dict:
         else:
             model = _DEFAULT_MODEL
 
+    # Map to short alias form for maximum Claude Code version compatibility.
+    # Unknown model IDs (custom / future) are passed through unchanged.
+    inject_model = _INJECT_SHORT_ALIAS.get(model, model)
+
     # Return modified tool_input via hookSpecificOutput.updatedInput.
     # Use additionalContext instead of permissionDecision/reason so the model
     # tier info is injected into the context window rather than surfaced as a
     # chat message (Claude Code v2.1.133+ additionalContext support).
-    tool_input["model"] = model
+    tool_input["model"] = inject_model
 
     # Mark sub-agents so their hooks can self-guard with CLAUDE_MPM_SUB_AGENT.
     # Merge with any existing env dict to avoid overwriting other keys.
@@ -244,7 +314,7 @@ def build_model_tier_response(event: dict) -> dict:
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "additionalContext": f"Model tier resolved for agent '{agent_type}': {model}",
+            "additionalContext": f"Model tier resolved for agent '{agent_type}': {inject_model}",
             "updatedInput": tool_input,
         }
     }

--- a/src/claude_mpm/skills/bundled/pm/mpm-message/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-message/SKILL.md
@@ -105,7 +105,17 @@ claude-mpm message sessions                        # List active sessions
 ### Python API (PREFERRED fallback for all versions)
 ```python
 from pathlib import Path
-from claude_mpm.services.communication.message_service import MessageService
+
+try:
+    from claude_mpm.services.communication.message_service import MessageService
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', use the CLI instead:\n"
+        "  claude-mpm message list / send / read / reply\n"
+        "Or activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 service = MessageService(Path.cwd())
 msg = service.send_message(

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
@@ -40,7 +40,19 @@ When invoked, this skill:
 
 ```python
 from pathlib import Path
-from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
+
+try:
+    from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', run:\n"
+        "  uv run python -c 'from claude_mpm.services.cli.session_pause_manager "
+        "import SessionPauseManager'\n"
+        "Or invoke directly: claude-mpm session-pause\n"
+        "Alternatively, activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 # Optional: Get message from user's command
 # If user provided message after /mpm-pause, extract it

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -56,7 +56,19 @@ then dispatch to the appropriate code path.**
 ```python
 import sys
 from pathlib import Path
-from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
+
+try:
+    from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
+except ImportError:
+    print(
+        "ERROR: claude_mpm is not importable in the current Python environment.\n"
+        "If you installed via 'uv tool install claude-mpm', run:\n"
+        "  uv run python -c 'from claude_mpm.services.cli.session_resume_helper "
+        "import SessionResumeHelper'\n"
+        "Or invoke directly: claude-mpm session-resume\n"
+        "Alternatively, activate the virtual environment where claude-mpm is installed."
+    )
+    raise SystemExit(1)
 
 # --------------------------------------------------------------------------
 # Argument parsing

--- a/src/claude_mpm/templates/claude/commands/agent-list.md
+++ b/src/claude_mpm/templates/claude/commands/agent-list.md
@@ -1,6 +1,10 @@
 ---
-description: "List all available agents with their capabilities"
+description: "List all available agents with their capabilities (MPM-provided — may be shadowed by a user /agent-list command)"
 ---
+
+> **Note (MPM-provided command)**: This `/agent-list` command is shipped by claude-mpm.
+> If you have a project or user-level command also named `/agent-list`, it will shadow
+> this one.  User commands take precedence by design.
 
 List all available agents in the claude-mpm project.
 

--- a/src/claude_mpm/templates/claude/commands/release.md
+++ b/src/claude_mpm/templates/claude/commands/release.md
@@ -1,7 +1,11 @@
 ---
-description: "Release a new version of claude-mpm (patch/minor/major)"
+description: "Release a new version of claude-mpm (MPM-provided — may be shadowed by a user /release command)"
 argument-hint: "[patch|minor|major]"
 ---
+
+> **Note (MPM-provided command)**: This `/release` command is shipped by claude-mpm.
+> If you have a project or user-level command also named `/release`, it will shadow
+> this one.  User commands take precedence by design.
 
 Release a new version of claude-mpm using the Makefile workflow.
 

--- a/src/claude_mpm/templates/claude/commands/test.md
+++ b/src/claude_mpm/templates/claude/commands/test.md
@@ -1,7 +1,13 @@
 ---
-description: "Run the test suite"
+description: "Run the test suite (MPM-provided command — may be shadowed by a user command of the same name)"
 argument-hint: "[path or pytest flags]"
 ---
+
+> **Note (MPM-provided command)**: This `/test` command is shipped by claude-mpm.
+> If you have a project or user-level command also named `/test`, it will shadow
+> this one.  The collision is intentional — user commands take precedence.  If
+> you need both, rename your local command or invoke this via `/test` while the
+> MPM copy is active.
 
 Run the claude-mpm test suite.
 

--- a/src/claude_mpm/templates/claude/settings.json
+++ b/src/claude_mpm/templates/claude/settings.json
@@ -78,19 +78,6 @@
         ]
       }
     ],
-    "StopFailure": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "claude-hook-fast.sh StopFailure",
-            "timeout": 60,
-            "_mpm": true
-          }
-        ]
-      }
-    ],
     "SubagentStop": [
       {
         "matcher": "*",
@@ -129,19 +116,6 @@
             "timeout": 5,
             "_mpm": true,
             "_mpm_service": "memory-capture"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "claude-hook-fast.sh SessionEnd",
-            "timeout": 60,
-            "_mpm": true
           }
         ]
       }
@@ -192,19 +166,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "claude-hook-fast.sh PostCompact",
-            "timeout": 60,
             "_mpm": true
           }
         ]

--- a/tests/hooks/test_permission_policy.py
+++ b/tests/hooks/test_permission_policy.py
@@ -199,24 +199,78 @@ def test_wire_format_deny_for_destructive_bash() -> None:
 
 @pytest.mark.unit
 def test_pre_tool_use_agent_path_still_works() -> None:
-    """Non-PermissionRequest events keep the legacy Agent-injection path."""
-    # Tool=Agent without ``model`` should get a default model injected.
-    out = _run_main(
-        {
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Agent",
-            "tool_input": {"subagent_type": "engineer"},
-            "cwd": "/nonexistent",
-        }
-    )
+    """Non-PermissionRequest events keep the legacy Agent-injection path.
+
+    The injected ``model`` value must be the short-alias form (opus/sonnet/haiku)
+    so that all supported Claude Code versions accept it.  The test forces
+    ``_pretool_modify_supported = True`` so the version gate does not depend on
+    whether the ``claude`` binary is present in the test environment.
+    """
+    # Force version gate to "supported" so injection always runs in tests.
+    model_tier_hook._pretool_modify_supported = True
+    try:
+        out = _run_main(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "engineer"},
+                "cwd": "/nonexistent",
+            }
+        )
+    finally:
+        # Reset cache so other tests are not affected.
+        model_tier_hook._pretool_modify_supported = None
+
     spec = out["hookSpecificOutput"]
     assert spec["hookEventName"] == "PreToolUse"
     # The newer wire format uses additionalContext + updatedInput instead of
     # permissionDecision so the model-routing info is injected as context
     # rather than surfaced as a chat message (Claude Code v2.1.133+).
     assert "additionalContext" in spec
-    # Assert against the module constant so this test can't drift again.
-    assert spec["updatedInput"]["model"] == model_tier_hook._DEFAULT_MODEL
+    # The injected model must be the short-alias form (opus) so all Claude Code
+    # versions accept it.  _DEFAULT_MODEL is the resolved dated ID; the short
+    # alias is looked up from _INJECT_SHORT_ALIAS.
+    injected = spec["updatedInput"]["model"]
+    assert injected == model_tier_hook._INJECT_SHORT_ALIAS.get(
+        model_tier_hook._DEFAULT_MODEL, model_tier_hook._DEFAULT_MODEL
+    ), f"Expected short-alias form for default model, got: {injected!r}"
+    # Sanity check: for the opus default the short alias must be "opus".
+    assert injected == "opus"
+
+
+@pytest.mark.unit
+def test_pre_tool_use_injection_skipped_when_unsupported() -> None:
+    """Injection must be skipped when the running Claude Code is too old (<v2.0.30)."""
+    model_tier_hook._pretool_modify_supported = False
+    try:
+        out = _run_main(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "engineer"},
+                "cwd": "/nonexistent",
+            }
+        )
+    finally:
+        model_tier_hook._pretool_modify_supported = None
+
+    # When unsupported, fall through gracefully without injection.
+    assert out == {"continue": True}, (
+        f"Expected {{continue: true}} when pretool-modify is unsupported, got: {out!r}"
+    )
+
+
+@pytest.mark.unit
+def test_default_model_is_opus() -> None:
+    """The default model constant must be in the opus tier (regression guard)."""
+    # _DEFAULT_MODEL is a dated ID; its short alias must be "opus".
+    assert model_tier_hook._DEFAULT_MODEL.startswith("claude-opus"), (
+        f"Expected an opus-tier model, got: {model_tier_hook._DEFAULT_MODEL!r}"
+    )
+    assert (
+        model_tier_hook._INJECT_SHORT_ALIAS.get(model_tier_hook._DEFAULT_MODEL)
+        == "opus"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
Second batch of native-Claude-Code compatibility fixes from the conflict audit. Feature-neutral; reuses `core/capabilities.py`. One file per commit per CLAUDE.md (13 commits).

Closes #576
Closes #579
Closes #583
Closes #580

## Fixes
- **#576 (HIGH)** — `mpm-session-resume` / `mpm-session-pause` / `mpm-message` skills failed with `ModuleNotFoundError: No module named 'claude_mpm'` when invoked via bare `python -c` under `uv tool install` (isolated venv). Wrapped the `from claude_mpm...` imports in try/except ImportError with an actionable message instead of a raw traceback. Updated BOTH bundled (`src/claude_mpm/skills/bundled/pm/`) and plugin (`plugin/skills/`) copies of all three skills.
- **#579 (HIGH)** — model-tier PreToolUse hook: (1) added `supports_pretool_modify()` capability gate (in `core/capabilities.py`) so injection is skipped gracefully on Claude Code < v2.0.30; (2) map injected dated model IDs to short aliases (`opus`/`sonnet`/`haiku`) to avoid "expected one of sonnet|opus|haiku" Agent schema-validation failures; (3) fixed stale "Default sonnet" comment (actual default is opus).
- **#583 (HIGH)** — settings.json template: removed the dead positional event-name arg (the fast hook reads the event from stdin, never `$1`); removed invalid/unhandled events; kept verified events.
- **#580 (LOW)** — documented that the unprefixed `/test`, `/release`, `/agent-list` project commands are MPM-provided and may be shadowed by a user's same-named commands (doc note only; no rename, to avoid breaking users).

## Verification
- `tests/hooks/` green incl. `test_pre_tool_use_agent_path_still_works`
- `tests/core/test_capabilities.py` green
- updated `tests/hooks/test_permission_policy.py` for short-alias injection + version gating

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)