### PR TITLE
docs: mitigate #573 Bash stdout-drop defect (agent + PM guidance)

### DIFF
--- a/src/claude_mpm/agents/BASE_AGENT.md
+++ b/src/claude_mpm/agents/BASE_AGENT.md
@@ -114,3 +114,31 @@ Anti-patterns:
 - Testing only the changed function, not the full suite
 - Treating "0 tests collected" as "0 failures"
 - Reporting counts without showing actual command output
+
+## Empty Output Protocol (KNOWN HARNESS DEFECT — issue #573)
+
+The Claude Code Bash tool intermittently drops a command's stdout: the command
+exits 0 but returns **empty or partial** output (often the head/body is lost and
+only the tail survives). This is a harness-level defect, NOT a real command
+result, and it is more frequent under heavy multi-subagent concurrency.
+
+**An empty result is NOT a real result. Never fabricate output you did not see,
+and never report success or failure you could not observe.**
+
+When a command that should produce output returns empty/blank with exit 0:
+
+1. **Retry the exact command up to 2 more times.** It usually succeeds on retry.
+2. **If still empty, use the write-to-file + Read-tool pattern** (this bypasses
+   the Bash-tool output capture and is reliable):
+   ```
+   <command> > /tmp/out.txt 2>&1      # run via Bash tool
+   ```
+   then open `/tmp/out.txt` with the **Read tool** — NOT `cat` (cat goes back
+   through the same Bash-capture race). The Read tool returns the real content.
+3. **If you still cannot observe the output**, report explicitly:
+   "Could not verify — command output unavailable (harness defect #573)" and
+   hand back to the PM. Do NOT claim a pass/fail you did not witness.
+
+This applies to verification-critical commands especially: test runs,
+`gh`/`git` reads and writes, build output. An unobservable result is never a
+passing result.

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -137,8 +137,11 @@ When delegated work fails (build error, test failure, lint issue):
 | Engineer reports "tests pass" but no raw output | Re-dispatch with instruction to show raw test output |
 | Agent failed 3+ times on same issue | Re-delegate to different agent or escalate |
 | README missing from deliverables | Re-dispatch with instruction that README is required |
+| Agent reports a command returned empty output (exit 0) | Known harness defect #573 — instruct agent to retry, then use the write-to-file + Read-tool pattern. If PM-side verification is needed, the PM MAY re-run that single read-only command directly as a #573 exception (parallel to CB#11's emergency carve-out). Never accept an unobserved result as pass/fail. |
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
+
+**Empty Output Defect (#573):** The Claude Code Bash tool intermittently drops command stdout (exit 0, empty/partial output), worse under heavy parallel delegation. Mitigations: (1) when output observation is verification-critical (tests, `gh`/`git` writes), prefer **sequential** delegation over large parallel fan-out until the upstream fix lands; (2) an unobservable command result is NEVER a passing result — agents must retry, use write-to-file + Read tool, or report "could not verify (#573)" rather than fabricate.
 
 ## Task Complexity Detection
 


### PR DESCRIPTION
## Summary
Mitigations for **#573** — the Claude Code Bash tool intermittently drops command stdout (exit 0, empty/partial output; head/body lost, tail survives; worse under heavy multi-subagent concurrency). Root-cause investigation confirmed this is an **upstream Claude Code harness defect** — MPM never owns the subagent Bash stdout stream, so there is no in-repo code fix. These are the high-leverage, docs-only mitigations.

Addresses #573 (the underlying bug must be fixed upstream in Claude Code; this PR reduces wasted tokens and eliminates the fabrication risk our own instructions previously encouraged).

## Changes (one file per commit)
- **`BASE_AGENT.md`** — new **Empty Output Protocol**: on empty/exit-0 output, retry up to 2×, then use the **write-to-file + Read-tool** workaround (bypasses the Bash-capture race — verified reliable), and if still unobservable report "could not verify (#573)" rather than fabricate. "An unobservable result is never a passing result."
- **`PM_INSTRUCTIONS.md`** — Retry Protocol row for empty-output + an **Empty Output Defect** note: prefer **sequential** delegation for verification-critical work (tests, `gh`/`git` writes) until the upstream fix lands; PM may re-run a single read-only command directly as a #573 exception (parallel to CB#11).

## Why docs-only
Evidence (from investigation): MPM hooks read only their own event JSON (`hook_handler.py:547-577`), the fast hook early-exits inside subagents (`claude-hook-fast.sh:217-220`), and no MPM code sits in the subagent Bash-output path. The bug reproduced live in the main-loop shell too — confirming it's harness-level, not MPM.

## Follow-up
Recommend filing/tracking an upstream Claude Code issue (Bash tool stdout-capture race under concurrent subagents). #573 should remain as the upstream-tracking ticket after these mitigations merge.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)