### PR TITLE
fix: scope PM-only parallel-dispatch guidance away from subagents (#581)

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -291,7 +291,9 @@ Ticket detection: PROJ-123, #123, linear/github URLs, "ticket"/"issue" keywords.
 
 Default `docs_path`: `docs/research/`. Configurable via `.claude-mpm/config.yaml` key `documentation.docs_path`.
 
-## Worktree Isolation
+## Worktree Isolation (PM-level only)
+
+> **PM-ONLY.** `isolation: "worktree"` and `run_in_background: true` are Agent-tool parameters available exclusively to the top-level PM orchestrator. Subagents do not have access to the Agent tool and must not attempt to spawn agents.
 
 Use `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents that modify files.
 Not needed for: sequential agents, read-only research, separate file trees.
@@ -304,6 +306,8 @@ Use `run_in_background: true` for fire-and-forget parallel work.
 ## Agent Teams Note
 
 Native Claude Code Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) and MPM orchestration should not be layered — use one or the other. Default to MPM (richer workflow, verification gates, specialization). When Agent Teams mode is active, `SendMessage` may be used for same-agent retry continuation as described in the Retry Protocol above; in all other cases, re-dispatch a fresh `Agent` call.
+
+**Subagent constraint (always applies):** Subagents (engineer, research, qa, etc.) do not have access to the Agent tool in any mode. They complete their assigned scope and return results to the PM. Any guidance about parallel dispatch or worktree isolation in skills or shared instructions is PM-level only.
 
 ## Skills System
 

--- a/src/claude_mpm/config/skill_to_agent_mapping.yaml
+++ b/src/claude_mpm/config/skill_to_agent_mapping.yaml
@@ -370,7 +370,15 @@ skill_mappings:
     - code-analyzer
 
   universal/collaboration/brainstorming: *all_agents
-  universal/collaboration/dispatching-parallel-agents: *all_agents
+
+  # universal/collaboration/dispatching-parallel-agents is intentionally NOT
+  # mapped to any agent (#581). Spawning/dispatching parallel agents is a
+  # PM-orchestration-level capability: only the top-level PM has access to the
+  # Agent tool, and subagents cannot spawn sub-subagents (harness-enforced).
+  # This schema only enumerates deployable subagents (all_agents_list) and has
+  # no PM/orchestrator target, so leaving the skill unmapped keeps the PM-only
+  # parallel-dispatch guidance out of every subagent's skills frontmatter.
+
   universal/collaboration/finishing-a-development-branch:
     - python-engineer
     - typescript-engineer

--- a/src/claude_mpm/skills/bundled/collaboration/dispatching-parallel-agents/SKILL.md
+++ b/src/claude_mpm/skills/bundled/collaboration/dispatching-parallel-agents/SKILL.md
@@ -18,6 +18,15 @@ effort: medium
 
 # Dispatching Parallel Agents
 
+> **SCOPE: ORCHESTRATOR / PM-LEVEL ONLY (#581).** This skill describes the
+> top-level orchestrator (PM) capability to spawn parallel agents via the
+> `Agent`/`Task` tool. **Subagents do not have access to the Agent tool and
+> cannot spawn sub-subagents** — agent-spawning is harness-enforced at the
+> top level. If you are a subagent (engineer, qa, research, etc.), this skill
+> does not apply to you: complete your assigned scope and return results to
+> the PM. (This skill is intentionally not deployed to subagents; see
+> `config/skill_to_agent_mapping.yaml`.)
+
 ## Overview
 
 When you have multiple unrelated failures (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel.

--- a/src/claude_mpm/skills/bundled/collaboration/dispatching-parallel-agents/references/coordination-patterns.md
+++ b/src/claude_mpm/skills/bundled/collaboration/dispatching-parallel-agents/references/coordination-patterns.md
@@ -113,30 +113,39 @@ Task("Fix retry logic in notification service")
 
 ### Strategy 3: Hierarchical Dispatch
 
-**Best for:** Large-scale problems with clear subsystem boundaries
+> **⚠️ CONCEPTUAL / NOT SUPPORTED (#581).** This strategy depicts spawned
+> subsystem-lead agents that themselves dispatch further sub-tasks (Level 2).
+> In Claude MPM / Claude Code, **only the top-level PM orchestrator has access
+> to the `Agent`/`Task` tool; spawned subagents cannot spawn sub-subagents**
+> (harness-enforced). The "subsystem agent creates Task(...)" calls below do
+> NOT work in practice. To achieve the same scale, the **PM itself** flattens
+> the hierarchy and dispatches the Level-2 focused tasks directly (optionally
+> in waves), reviewing each subsystem's results before launching the next.
+> Treat the example below as an org-chart of work, not as runnable nesting.
+
+**Best for (PM-level only):** Large-scale problems with clear subsystem boundaries
 
 ```typescript
-// Level 1: Subsystem leads
+// CONCEPTUAL MODEL — illustrates the logical grouping, NOT real nesting.
+// Level 1: Subsystem leads (conceptual grouping of work)
 Task("Auth subsystem: Investigate and delegate 5 test failures")
 Task("Payments subsystem: Investigate and delegate 4 test failures")
 
-// Level 2: Each subsystem agent dispatches focused tasks
-// Auth agent creates:
+// Level 2: NOT spawned by the subsystem agents (subagents cannot spawn agents).
+// The PM dispatches these focused tasks directly instead:
   Task("Fix OAuth token refresh logic")
   Task("Fix session timeout handling")
-
-// Payments agent creates:
   Task("Fix Stripe webhook handling")
   Task("Fix refund processing")
 ```
 
 **Advantages:**
-- Scales to large problem sets
-- Domain experts coordinate sub-tasks
+- Scales to large problem sets (PM-flattened waves)
+- Domain grouping aids verification
 - Natural verification points
 
 **Disadvantages:**
-- Higher coordination overhead
+- Higher coordination overhead (all on the PM — no real sub-delegation)
 - More complex integration
 - Requires clear subsystem boundaries
 


### PR DESCRIPTION
## Summary

- The root cause of #581: `dispatching-parallel-agents` skill was mapped to `*all_agents`, injecting PM-only parallel-dispatch guidance into every subagent's skill frontmatter. Removed the mapping entirely — the skill is now unmapped (with a comment explaining why).
- `PM_INSTRUCTIONS.md` Worktree Isolation section header marked "(PM-level only)" with an explicit PM-ONLY callout block. A new Subagent constraint paragraph added after the Agent Teams Note to reinforce that subagents never have access to the Agent tool in any mode.
- `dispatching-parallel-agents/SKILL.md` carries an orchestrator-only scope warning at the top so if the skill is ever loaded by other means, it is unambiguous.
- `dispatching-parallel-agents/references/coordination-patterns.md` Strategy 3 (Hierarchical Dispatch) annotated as conceptual-only — sub-agents dispatching sub-tasks is not harness-supported; the PM flattens the hierarchy directly.

Note: The related `base_agent.json` / `BASE_AGENT.md` source-of-truth defect (subagent constraint duplication) is handled in a separate PR per the task spec.

## Test plan

- [x] YAML parses cleanly: `python3 -c "import yaml; yaml.safe_load(open(...))"` — confirmed
- [x] `dispatching-parallel-agents` key absent from `skill_mappings` — confirmed
- [x] No other skill mappings changed (diff shows only the one entry removed)
- [x] Full test suite: 625 passed, 6 skipped (pre-existing), 0 failures
- [x] All 4 commits are single-file, conventional-prefix, with Co-Authored-By trailer
- [x] `Closes #581` in last commit body

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)