### PR TITLE
fix(ztk): verify binary function on startup; never rewrite to a non-functional binary (real #573 root cause)

### DIFF
--- a/src/claude_mpm/cli/startup_display.py
+++ b/src/claude_mpm/cli/startup_display.py
@@ -274,36 +274,36 @@ def _get_ztk_status() -> tuple[bool, str]:
         Tuple of (is_active, display_line) where display_line is a one-line
         startup message string (without trailing newline).
 
-    Resolution:
-        active = ztk binary resolvable AND CLAUDE_MPM_DISABLE_ZTK not set
+    Truthful status: ``on`` only when a ztk binary is present AND passes a
+    functional round-trip self-test (run + cached here at startup by
+    ``ztk_hook.ztk_status``). A present-but-empty/invalid binary reports ``off``
+    so the banner never claims compression is active while commands actually
+    pass through unchanged (the #573 root cause). The self-test result is cached
+    by binary mtime/size, so this does not add per-startup subprocess cost once
+    the binary is unchanged.
     """
-    # Check disable env var first (fast path)
-    disable_val = os.environ.get("CLAUDE_MPM_DISABLE_ZTK", "").lower()
-    disabled_via_env = disable_val in ("1", "true", "yes")
+    try:
+        from claude_mpm.hooks.ztk_hook import ztk_status as _ztk_status
 
-    # Resolve binary: system PATH or bundled
-    ztk_found = bool(shutil.which("ztk"))
-    if not ztk_found:
-        try:
-            from importlib import resources as _res
+        active, reason = _ztk_status()
+    except Exception:
+        # Fail-safe: if status probing breaks, report off rather than lie.
+        return (False, "  ztk compression: off  (status unavailable)")
 
-            bundled = _res.files("claude_mpm").joinpath("bin", "ztk")
-            from pathlib import Path as _Path
+    if active:
+        return (True, "⚡ ztk compression: on   (disable with --no-ztk)")
 
-            bundled_path = _Path(str(bundled))
-            ztk_found = bundled_path.is_file()
-        except Exception:
-            ztk_found = False
-
-    if not ztk_found:
+    if reason == "disabled via --no-ztk":
+        return (False, "  ztk compression: off  (disabled via --no-ztk)")
+    if reason == "binary present but non-functional":
         return (
             False,
-            "  ztk compression: off  (binary not found — run: make download-ztk)",
+            "  ztk compression: off  (binary non-functional — run: make download-ztk)",
         )
-    if disabled_via_env:
-        return (False, "  ztk compression: off  (disabled via --no-ztk)")
-
-    return (True, "⚡ ztk compression: on   (disable with --no-ztk)")
+    return (
+        False,
+        "  ztk compression: off  (binary not found — run: make download-ztk)",
+    )
 
 
 def _get_cwd_display(max_width: int = 40) -> str:

--- a/src/claude_mpm/hooks/ztk_hook.py
+++ b/src/claude_mpm/hooks/ztk_hook.py
@@ -19,10 +19,12 @@ Behavior:
 Returns hookSpecificOutput with updatedInput to modify the Bash command parameter.
 """
 
+import hashlib
 import json
 import os
 import shutil
 import stat
+import subprocess
 import sys
 from datetime import UTC, datetime
 from importlib import resources
@@ -42,6 +44,111 @@ from pathlib import Path
 _DISABLE_ENV_VAR = "CLAUDE_MPM_DISABLE_ZTK"
 _MPM_LOG_DIR = Path.home() / ".claude-mpm"
 _MPM_ZTK_LOG = _MPM_LOG_DIR / "ztk-savings.log"
+
+# ---------------------------------------------------------------------------
+# Functional verification cache + self-test
+# ---------------------------------------------------------------------------
+# WHY a functional self-test (not just existence + exec-bit):
+#   The bundled binary at `claude_mpm/bin/ztk` is a 0-byte placeholder that is
+#   gitignored and only populated at release time by
+#   `scripts/download_ztk_binaries.sh`. A 0-byte file still passes `is_file()`
+#   and (once chmod'd) the exec-bit check, yet running it produces exit-0 with
+#   EMPTY stdout. The hook then rewrites every Bash command to `<ztk> run <cmd>`,
+#   so the broken binary silently swallows ALL command output. This is the real
+#   root cause of the "#573/#587 Bash stdout-drop" defect (misattributed to the
+#   Claude Code harness). Existence + exec-bit are therefore INSUFFICIENT — we
+#   must prove the binary round-trips output before trusting it.
+_VERIFY_SENTINEL = "ztk_selftest_8f3a2c"
+_VERIFY_TIMEOUT_S = 3.0
+_VERIFY_CACHE = _MPM_LOG_DIR / "ztk-verify-cache.json"
+
+# Process-local memo so repeated calls within one process don't re-stat/re-read.
+_RESOLVE_MEMO: dict[str, str | None] = {}
+_WARNED_NONFUNCTIONAL = False
+
+
+def _binary_fingerprint(path: Path) -> str:
+    """Return a cache key derived from path + mtime_ns + size.
+
+    Per the CLAUDE.md stability pattern, expensive verification is keyed by the
+    binary's identity so a probe only re-runs when the binary actually changes
+    (e.g. populated at release, upgraded, or swapped on PATH).
+    """
+    st = path.stat()
+    raw = f"{path}|{st.st_mtime_ns}|{st.st_size}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _read_verify_cache() -> dict:
+    try:
+        with _VERIFY_CACHE.open() as fh:
+            data = json.load(fh)
+            return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_verify_cache(cache: dict) -> None:
+    try:
+        _MPM_LOG_DIR.mkdir(parents=True, exist_ok=True)
+        with _VERIFY_CACHE.open("w") as fh:
+            json.dump(cache, fh)
+    except OSError as exc:
+        _log_debug(f"failed to write verify cache: {exc}")
+
+
+def verify_ztk_binary(path: str, *, use_cache: bool = True) -> bool:
+    """Functionally verify that the ztk binary round-trips command output.
+
+    Runs ``<path> run echo <SENTINEL>`` and confirms the sentinel appears in
+    stdout. This is the AUTHORITATIVE health check: the failure mode is
+    exit-0-with-empty-stdout, so checking the exit code alone is not enough —
+    we must observe the binary actually passing output through.
+
+    The boolean result is cached to ``~/.claude-mpm/ztk-verify-cache.json``
+    keyed by the binary's path + mtime + size, so the (subprocess) probe runs
+    once per binary version rather than on every Bash call.
+    """
+    try:
+        bin_path = Path(path)
+        fp = _binary_fingerprint(bin_path)
+    except OSError as exc:
+        _log_debug(f"verify: cannot stat {path}: {exc}")
+        return False
+
+    cache = _read_verify_cache() if use_cache else {}
+    if use_cache and fp in cache:
+        _log_debug(f"verify: cache hit for {path} -> {cache[fp]}")
+        return bool(cache[fp])
+
+    ok = _run_ztk_selftest(path)
+    if use_cache:
+        cache[fp] = ok
+        # Bound the cache: keep only the most recent entries so it never grows
+        # unbounded across many binary versions.
+        if len(cache) > 16:
+            cache = dict(list(cache.items())[-16:])
+        _write_verify_cache(cache)
+    _log_debug(f"verify: self-test for {path} -> {ok}")
+    return ok
+
+
+def _run_ztk_selftest(path: str) -> bool:
+    """Run the sentinel round-trip probe. Returns True only if stdout matches."""
+    try:
+        proc = subprocess.run(
+            [path, "run", "echo", _VERIFY_SENTINEL],
+            capture_output=True,
+            text=True,
+            timeout=_VERIFY_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log_debug(f"verify: self-test raised {exc!r}")
+        return False
+    # Authoritative check: the sentinel must be present in stdout. An empty/
+    # broken binary exits 0 with no output and fails here.
+    return _VERIFY_SENTINEL in (proc.stdout or "")
 
 
 def _log_debug(message: str) -> None:
@@ -78,45 +185,124 @@ def _log_intercepted(command: str) -> None:
         _log_debug(f"failed to write MPM savings log: {exc}")
 
 
-def _resolve_ztk() -> str | None:
-    """Resolve the ztk executable path.
+def _candidate_is_usable(path: Path) -> bool:
+    """Return True only if `path` is a non-empty, executable regular file.
+
+    WHY size > 0: the bundled binary ships as a 0-byte placeholder until a
+    release populates it. A 0-byte file is `is_file()` True and can carry an
+    exec-bit, but running it yields exit-0 with EMPTY stdout — the binary that
+    silently swallows all Bash output (the #573 root cause). Existence and the
+    exec-bit are necessary but NOT sufficient; we reject empty files here and
+    follow up with a functional round-trip self-test in `_resolve_ztk()`.
+    """
+    try:
+        if not path.is_file():
+            return False
+        st = path.stat()
+        if st.st_size == 0:
+            _log_debug(f"ztk candidate {path} is 0 bytes; rejecting")
+            return False
+        if not st.st_mode & stat.S_IXUSR:
+            # Wheels can drop the exec-bit; try to restore it for the bundle.
+            try:
+                path.chmod(st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+                _log_debug(f"chmod +x applied to {path}")
+            except OSError as exc:
+                _log_debug(f"failed to chmod ztk candidate {path}: {exc}")
+                return False
+        return True
+    except OSError as exc:
+        _log_debug(f"ztk candidate {path} stat failed: {exc}")
+        return False
+
+
+def _warn_nonfunctional_once() -> None:
+    """Emit a single clear warning that ztk is present but non-functional."""
+    global _WARNED_NONFUNCTIONAL
+    if _WARNED_NONFUNCTIONAL:
+        return
+    _WARNED_NONFUNCTIONAL = True
+    print(
+        "[ztk-hook] ztk binary present but non-functional "
+        "(0-byte/invalid/no output) — shell compression DISABLED, "
+        "commands pass through unchanged.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _resolve_ztk(*, verify: bool = True) -> str | None:
+    """Resolve a FUNCTIONAL ztk executable path, or None for passthrough.
 
     Resolution order:
     1. System PATH (`shutil.which("ztk")`) — user's install takes precedence
     2. Bundled binary at `claude_mpm/bin/ztk` (chmod +x if needed)
 
-    Returns absolute path string, or None if neither is available.
+    A candidate must pass THREE gates before it is returned:
+      (a) non-empty regular file (size > 0),
+      (b) executable bit set (restored for the bundle if missing),
+      (c) a cached functional round-trip self-test (`verify_ztk_binary`).
+
+    WHY gate (c): existence + exec-bit are insufficient because an empty or
+    invalid binary exits 0 with no output, silently swallowing all Bash stdout
+    (the #573/#587 root cause). If no candidate verifies, we return None so the
+    caller passes the command through UNCHANGED — never rewriting to a binary we
+    have not proven works. Pass `verify=False` to skip the self-test (used by
+    callers that only need a path candidate for status display).
     """
+    memo_key = "1" if verify else "0"
+    if memo_key in _RESOLVE_MEMO:
+        return _RESOLVE_MEMO[memo_key]
+
+    candidates: list[Path] = []
+
     # 1. System install
     system_ztk = shutil.which("ztk")
     if system_ztk:
-        _log_debug(f"using system ztk: {system_ztk}")
-        return system_ztk
+        candidates.append(Path(system_ztk))
 
     # 2. Bundled binary via importlib.resources
     try:
         bundled = resources.files("claude_mpm").joinpath("bin", "ztk")
-        # `files()` returns a Traversable; for filesystem-based packages this is
-        # a concrete path. Coerce via str() and confirm existence.
-        bundled_path = Path(str(bundled))
-        if bundled_path.is_file():
-            # Ensure executable bit is set (wheels can lose it)
-            mode = bundled_path.stat().st_mode
-            if not mode & stat.S_IXUSR:
-                try:
-                    bundled_path.chmod(
-                        mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                    )
-                    _log_debug(f"chmod +x applied to {bundled_path}")
-                except OSError as exc:
-                    _log_debug(f"failed to chmod bundled ztk: {exc}")
-                    return None
-            _log_debug(f"using bundled ztk: {bundled_path}")
-            return str(bundled_path)
+        candidates.append(Path(str(bundled)))
     except (ModuleNotFoundError, FileNotFoundError, AttributeError) as exc:
         _log_debug(f"bundled ztk not available: {exc}")
 
-    return None
+    result: str | None = None
+    saw_present_but_broken = False
+    for cand in candidates:
+        if not _candidate_is_usable(cand):
+            continue
+        if verify and not verify_ztk_binary(str(cand)):
+            saw_present_but_broken = True
+            _log_debug(f"ztk candidate {cand} failed functional verification")
+            continue
+        _log_debug(f"using verified ztk: {cand}")
+        result = str(cand)
+        break
+
+    if result is None and saw_present_but_broken:
+        _warn_nonfunctional_once()
+
+    _RESOLVE_MEMO[memo_key] = result
+    return result
+
+
+def ztk_status() -> tuple[bool, str]:
+    """Single source of truth for ztk functional status (for banner/statusline).
+
+    Returns (active, reason). ``active`` is True only when ztk is disabled via
+    neither env var nor flag AND a binary verifies functional. The reason string
+    explains the off-state so the banner/statusline can be truthful.
+    """
+    if os.environ.get(_DISABLE_ENV_VAR, "").lower() in ("1", "true", "yes"):
+        return (False, "disabled via --no-ztk")
+    if _resolve_ztk() is not None:
+        return (True, "verified functional")
+    # Distinguish "no binary at all" from "present but broken" for the message.
+    if _resolve_ztk(verify=False) is not None:
+        return (False, "binary present but non-functional")
+    return (False, "binary not found")
 
 
 def build_ztk_response(event: dict) -> dict:
@@ -157,9 +343,15 @@ def build_ztk_response(event: dict) -> dict:
         _log_debug("command contains ' -c ' or ' -e '; ztk blocks these patterns")
         return {"continue": True}
 
-    # Skip multi-statement compound commands (contain newlines)
-    if "\n" in command:
-        _log_debug("command contains newlines; skipping multi-statement compound")
+    # Skip multi-statement compound commands.
+    # WHY: `ztk run <cmd>` wraps a SINGLE program invocation. The naive rewrite
+    # `f"{ztk} run {command}"` parses only the FIRST segment as ztk's target;
+    # everything after a shell operator (`&&`, `||`, `;`, `|`) is run by the
+    # outer shell OUTSIDE ztk, so only the first segment's output is captured —
+    # the partial-output bug. Newlines have the same effect. We therefore pass
+    # any compound/piped command through UNCHANGED rather than wrap it.
+    if "\n" in command or any(op in command for op in ("&&", "||", ";", "|")):
+        _log_debug("command is compound/piped; passing through (avoids partial output)")
         return {"continue": True}
 
     # Graceful degradation: ztk must be resolvable

--- a/src/claude_mpm/templates/claude/hooks/scripts/statusline.sh
+++ b/src/claude_mpm/templates/claude/hooks/scripts/statusline.sh
@@ -141,26 +141,19 @@ fi
 
 # ---------------------------------------------------------------------------
 # ztk compression segment.
-# on  = binary resolvable (PATH or bundled) AND CLAUDE_MPM_DISABLE_ZTK not set
-# off = binary missing OR CLAUDE_MPM_DISABLE_ZTK=1|true|yes
+# on  = binary resolvable AND functionally VERIFIED AND CLAUDE_MPM_DISABLE_ZTK
+#       not set
+# off = disabled, binary missing, OR binary present-but-non-functional
+#
+# Truthfulness: a present-but-empty/invalid binary exits 0 with no output and
+# silently swallows all Bash stdout (the #573 root cause). We therefore defer to
+# ztk_hook.ztk_status(), which runs a cached functional self-test, instead of a
+# bare is_file() existence check that would falsely report "on".
 # ---------------------------------------------------------------------------
 ZTK_SEGMENT=""
-_ZTK_DISABLED="${CLAUDE_MPM_DISABLE_ZTK:-}"
-case "$_ZTK_DISABLED" in
-    1|true|yes) _ZTK_ACTIVE=0 ;;
-    *)          _ZTK_ACTIVE=1 ;;
-esac
-if [ "$_ZTK_ACTIVE" = "1" ]; then
-    if ! command -v ztk >/dev/null 2>&1; then
-        # Check bundled path (importlib.resources puts it next to the package)
-        _BUNDLED_ZTK="$(python3 -c \
-            "from importlib import resources; import pathlib; p=pathlib.Path(str(resources.files('claude_mpm').joinpath('bin','ztk'))); print(p if p.is_file() else '')" \
-            2>/dev/null || echo "")"
-        if [ -z "$_BUNDLED_ZTK" ]; then
-            _ZTK_ACTIVE=0
-        fi
-    fi
-fi
+_ZTK_ACTIVE="$(python3 -c \
+    "from claude_mpm.hooks.ztk_hook import ztk_status; print('1' if ztk_status()[0] else '0')" \
+    2>/dev/null || echo "0")"
 if [ "$_ZTK_ACTIVE" = "1" ]; then
     ZTK_SEGMENT="${SEP}${DIM}ztk: on${RESET}"
 else

--- a/tests/test_ztk_hook.py
+++ b/tests/test_ztk_hook.py
@@ -1,0 +1,267 @@
+"""Tests for the ztk PreToolUse hook (src/claude_mpm/hooks/ztk_hook.py).
+
+Focus: the #573/#587 "Bash stdout-drop" root cause and its fix.
+
+The bundled ztk binary ships as a 0-byte placeholder (gitignored, populated
+only at release). The old resolver gated only on is_file() + exec-bit, so a
+0-byte binary was accepted and every Bash command was rewritten to
+``<ztk> run <cmd>`` — running an empty binary that exits 0 with EMPTY stdout,
+silently swallowing all command output.
+
+These tests assert the hardened behaviour:
+  * 0-byte / missing / non-functional binary -> resolver returns None ->
+    build_ztk_response passes the command through UNCHANGED (no rewrite).
+  * A functional ztk stub (echoes its args back) -> verified True -> command
+    rewritten to ``<stub> run <cmd>``.
+  * A broken ztk stub (exit 0, empty stdout) -> verified False -> passthrough.
+  * Compound / piped commands (&&, ||, ;, |, newline) -> passthrough.
+  * The functional self-test is cached by binary mtime/size and not re-run when
+    the binary is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import TYPE_CHECKING
+
+import pytest
+
+from claude_mpm.hooks import ztk_hook
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Redirect the verify cache to a temp dir and clear process-local memo.
+
+    Also ensures CLAUDE_MPM_DISABLE_ZTK is unset so we exercise the real path.
+    """
+    cache = tmp_path / "ztk-verify-cache.json"
+    monkeypatch.setattr(ztk_hook, "_MPM_LOG_DIR", tmp_path)
+    monkeypatch.setattr(ztk_hook, "_VERIFY_CACHE", cache)
+    monkeypatch.setattr(ztk_hook, "_MPM_ZTK_LOG", tmp_path / "ztk-savings.log")
+    ztk_hook._RESOLVE_MEMO.clear()
+    ztk_hook._WARNED_NONFUNCTIONAL = False
+    monkeypatch.delenv("CLAUDE_MPM_DISABLE_ZTK", raising=False)
+    yield
+
+
+def _make_exec(path: Path, body: str) -> Path:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _working_ztk(path: Path) -> Path:
+    """A stub that round-trips output: ``ztk run echo X`` prints X.
+
+    Implemented as a shell script that drops the leading ``run`` arg and execs
+    the remaining command, so stdout passes through (the real ztk contract).
+    """
+    return _make_exec(
+        path,
+        '#!/bin/sh\nshift\nexec "$@"\n',  # drop "run", exec the wrapped command
+    )
+
+
+def _broken_ztk(path: Path) -> Path:
+    """A stub that mimics the failure mode: exit 0 with EMPTY stdout."""
+    return _make_exec(path, "#!/bin/sh\nexit 0\n")
+
+
+def _bash_event(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _force_candidate(monkeypatch, path: Path | None) -> None:
+    """Make _resolve_ztk consider exactly `path` (no system/bundled lookup)."""
+    monkeypatch.setattr(ztk_hook.shutil, "which", lambda _name: None)
+
+    class _Bundled:
+        def joinpath(self, *_parts):
+            # Point the bundled lookup at our stub (or a nonexistent path).
+            return str(path) if path is not None else "/nonexistent/ztk"
+
+    monkeypatch.setattr(ztk_hook.resources, "files", lambda _pkg: _Bundled())
+
+
+# ---------------------------------------------------------------------------
+# verify_ztk_binary
+# ---------------------------------------------------------------------------
+def test_verify_working_binary_true(tmp_path):
+    ztk = _working_ztk(tmp_path / "ztk")
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is True
+
+
+def test_verify_broken_binary_false(tmp_path):
+    ztk = _broken_ztk(tmp_path / "ztk")
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is False
+
+
+def test_verify_zero_byte_binary_false(tmp_path):
+    empty = tmp_path / "ztk"
+    empty.touch()
+    empty.chmod(empty.stat().st_mode | stat.S_IXUSR)
+    # 0-byte cannot exec meaningfully -> self-test fails.
+    assert ztk_hook.verify_ztk_binary(str(empty)) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_ztk gating
+# ---------------------------------------------------------------------------
+def test_resolve_zero_byte_bundled_returns_none(tmp_path, monkeypatch):
+    """0-byte bundled binary -> None (the core #573 fix)."""
+    empty = tmp_path / "ztk"
+    empty.touch()
+    empty.chmod(empty.stat().st_mode | stat.S_IXUSR)
+    _force_candidate(monkeypatch, empty)
+    assert ztk_hook._resolve_ztk() is None
+
+
+def test_resolve_missing_returns_none(tmp_path, monkeypatch):
+    _force_candidate(monkeypatch, None)
+    assert ztk_hook._resolve_ztk() is None
+
+
+def test_resolve_working_binary_returns_path(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    assert ztk_hook._resolve_ztk() == str(ztk)
+
+
+def test_resolve_broken_binary_returns_none(tmp_path, monkeypatch):
+    ztk = _broken_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    assert ztk_hook._resolve_ztk() is None
+
+
+# ---------------------------------------------------------------------------
+# build_ztk_response: passthrough vs rewrite
+# ---------------------------------------------------------------------------
+def test_zero_byte_passthrough_no_rewrite(tmp_path, monkeypatch):
+    empty = tmp_path / "ztk"
+    empty.touch()
+    empty.chmod(empty.stat().st_mode | stat.S_IXUSR)
+    _force_candidate(monkeypatch, empty)
+    resp = ztk_hook.build_ztk_response(_bash_event("git status"))
+    assert resp == {"continue": True}
+    assert "hookSpecificOutput" not in resp
+
+
+def test_working_binary_rewrites_command(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event("git status"))
+    assert "hookSpecificOutput" in resp
+    rewritten = resp["hookSpecificOutput"]["updatedInput"]["command"]
+    assert rewritten == f"{ztk} run git status"
+
+
+def test_broken_binary_passthrough(tmp_path, monkeypatch):
+    ztk = _broken_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event("ls -la"))
+    assert resp == {"continue": True}
+
+
+# ---------------------------------------------------------------------------
+# Compound / piped commands -> passthrough (partial-output bug fix)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo a && echo b",
+        "echo a || echo b",
+        "echo a; echo b",
+        "cat file | grep x",
+        "echo a\necho b",
+    ],
+)
+def test_compound_commands_passthrough(tmp_path, monkeypatch, command):
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event(command))
+    assert resp == {"continue": True}, f"compound command was rewritten: {command!r}"
+
+
+def test_simple_command_still_rewritten(tmp_path, monkeypatch):
+    """Sanity: a single simple command IS still wrapped."""
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event("git diff"))
+    assert "hookSpecificOutput" in resp
+
+
+# ---------------------------------------------------------------------------
+# Caching: self-test not re-run when binary unchanged
+# ---------------------------------------------------------------------------
+def test_verification_cached_not_rerun(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    calls = {"n": 0}
+    real = ztk_hook._run_ztk_selftest
+
+    def _counting(path):
+        calls["n"] += 1
+        return real(path)
+
+    monkeypatch.setattr(ztk_hook, "_run_ztk_selftest", _counting)
+
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is True
+    assert calls["n"] == 1
+    # Second call with unchanged binary -> cache hit, no new self-test.
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is True
+    assert calls["n"] == 1
+
+
+def test_verification_rerun_when_binary_changes(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    calls = {"n": 0}
+    real = ztk_hook._run_ztk_selftest
+
+    def _counting(path):
+        calls["n"] += 1
+        return real(path)
+
+    monkeypatch.setattr(ztk_hook, "_run_ztk_selftest", _counting)
+
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is True
+    assert calls["n"] == 1
+    # Mutate the binary (new size + mtime) -> fingerprint changes -> re-verify.
+    ztk.write_text('#!/bin/sh\nshift\nexec "$@"\n# changed\n')
+    os.utime(ztk, None)
+    assert ztk_hook.verify_ztk_binary(str(ztk)) is True
+    assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# ztk_status: truthful on/off
+# ---------------------------------------------------------------------------
+def test_status_off_when_broken(tmp_path, monkeypatch):
+    ztk = _broken_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    active, reason = ztk_hook.ztk_status()
+    assert active is False
+    assert reason == "binary present but non-functional"
+
+
+def test_status_on_when_functional(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    active, reason = ztk_hook.ztk_status()
+    assert active is True
+    assert reason == "verified functional"
+
+
+def test_status_off_when_disabled(tmp_path, monkeypatch):
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    monkeypatch.setenv("CLAUDE_MPM_DISABLE_ZTK", "1")
+    active, reason = ztk_hook.ztk_status()
+    assert active is False
+    assert reason == "disabled via --no-ztk"


### PR DESCRIPTION
## Real root cause of the #573/#587 "Bash stdout-drop"

The empty/invalid bundled `ztk` binary silently swallowed **all** Bash stdout because `_resolve_ztk()` only checked existence + exec-bit.

### What was happening

- The bundled binary at `claude_mpm/bin/ztk` ships as a **0-byte placeholder** (gitignored; populated only at release by `scripts/download_ztk_binaries.sh`).
- `_resolve_ztk()` gated only on `is_file()` + exec-bit — both `True` for a 0-byte file — so it returned the empty binary path.
- `build_ztk_response()` then rewrote every Bash command to `"<ztk> run <command>"`. Running an empty binary exits `0` with **empty stdout**, so every command's output was dropped.

This is the actual root cause of the "#573/#587 Bash stdout-drop" defect, which was **misattributed to the Claude Code harness** (#587 was docs-only mitigation).

### Fix

1. **Harden `_resolve_ztk()`** — a candidate must now pass three gates before it is trusted: `size > 0`, exec-bit, **and** a cached functional round-trip self-test (`verify_ztk_binary`). If none verifies, it resolves to `None` and the command passes through **unchanged** — never rewritten to an unverified binary. A one-time warning is emitted when a binary is present but non-functional.

2. **Functional self-test at startup** — `verify_ztk_binary()` runs `"<ztk> run echo <SENTINEL>"` (short timeout) and confirms the sentinel appears in stdout (exit-0-empty is the failure mode, so checking the exit code alone is insufficient). The boolean is cached to `~/.claude-mpm/ztk-verify-cache.json` keyed by binary **path + mtime + size**, so the probe runs once per binary version, not on every Bash call. The probe runs (and caches) at startup via the banner/statusline path, so a broken binary is caught immediately and the session starts in known-good passthrough mode.

3. **Truthful `ztk: on/off` status** — both the startup banner (`startup_display._get_ztk_status`) and the statusline segment now defer to `ztk_hook.ztk_status()`, reporting `on` **only** when a binary verifies functional; otherwise `off` with a reason (`binary not found` / `binary non-functional` / `disabled via --no-ztk`).

4. **Compound-command partial-output fix** — commands containing `&&`, `||`, `;`, `|`, or newlines are now passed through unchanged. The naive `"<ztk> run <cmd>"` rewrite only made `ztk` the target of the **first** segment, so later segments ran outside `ztk` and only partial output was captured.

### Tests

`tests/test_ztk_hook.py` (21 tests, all passing):

- 0-byte / missing / broken binary → `_resolve_ztk` returns `None` → passthrough (no rewrite)
- working `ztk` stub → verified → command rewritten to `<ztk> run <cmd>`
- compound/piped commands (`&&`, `||`, `;`, `|`, newline) → passthrough
- verification cached by mtime/size: self-test not re-run when binary unchanged; re-run when it changes
- `ztk_status` truthful on/off (functional / non-functional / disabled)

```
21 passed in 2.32s
```

`uv run ruff format` + `uv run ruff check` clean on all changed files.

Corrects #573 / #587, which misattributed this to the Claude Code harness.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
