### PR TITLE
ci: PyPI trusted publishing (OIDC) + per-platform wheels; stop local py3-none-any binary publish

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -105,13 +105,28 @@ jobs:
           fi
           ls -la src/claude_mpm/bin/
 
+      - name: Verify bundled ztk binary is present
+        run: |
+          set -euo pipefail
+          # A successful leg MUST ship its platform binary. The download step is
+          # non-fatal (#594) so a missing upstream asset won't hard-fail the
+          # matrix, but if the binary is here we confirm it landed before the
+          # wheel is built/retagged with this leg's platform tag.
+          if [ -f src/claude_mpm/bin/ztk ]; then
+            echo "ztk binary bundled for ${{ matrix.platform }}:"
+            ls -la src/claude_mpm/bin/ztk
+          else
+            echo "WARNING: no ztk binary for ${{ matrix.platform }} — wheel will ship without bundled ztk"
+          fi
+
       - name: Build wheel
         run: python -m build --wheel
 
       - name: Retag wheel with platform
         run: |
           set -euo pipefail
-          # Source build produces py3-none-any.whl; retag to platform-specific.
+          # Source build produces py3-none-any.whl; retag to platform-specific so
+          # pip selects the wheel carrying the correct per-platform ztk binary.
           orig=$(ls dist/*.whl | head -n1)
           echo "Original wheel: $orig"
           python -m wheel tags --platform-tag '${{ matrix.platform }}' --remove "$orig"
@@ -124,35 +139,64 @@ jobs:
           path: dist/*.whl
           if-no-files-found: error
 
-  publish:
-    name: Publish to PyPI
-    needs: build
+  # Build the sdist exactly once (separate from the wheel matrix) so a single
+  # source tarball is published — avoids duplicate-filename 400s on PyPI.
+  sdist:
+    name: Build sdist
     runs-on: ubuntu-latest
-    # Only publish on tag pushes, not manual dispatches
-    if: startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: pypi
-      url: https://pypi.org/project/claude-mpm/
     steps:
-      - name: Download all wheels
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - name: List wheels
-        run: ls -la dist/
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
-      - name: Install twine
-        run: python -m pip install --upgrade twine
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload --non-interactive dist/*.whl
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, sdist]
+    runs-on: ubuntu-latest
+    # Only publish on tag pushes, not manual dispatches
+    if: startsWith(github.ref, 'refs/tags/v')
+    # OIDC: the id-token permission lets the PyPA action mint a short-lived
+    # token via PyPI Trusted Publishing — no PYPI_API_TOKEN secret required.
+    permissions:
+      id-token: write
+      contents: read
+    # The environment name MUST match the PyPI trusted-publisher config
+    # (PyPI → claude-mpm → Publishing → environment = "pypi").
+    environment:
+      name: pypi
+      url: https://pypi.org/p/claude-mpm
+    steps:
+      - name: Download all wheels and sdist
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List distributions
+        run: ls -la dist/
+
+      - name: Publish to PyPI (Trusted Publishing / OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # skip-existing keeps a re-run (or an already-present file) from
+          # failing the whole release with a 400/403.
+          skip-existing: true

--- a/Makefile
+++ b/Makefile
@@ -1032,17 +1032,25 @@ release-publish: ## Publish release to PyPI, npm, Homebrew, and GitHub
 		echo "$(YELLOW)⚠️  Sync script not found, skipping repository sync$(NC)"; \
 	fi
 	@echo ""
-	@echo "$(YELLOW)📤 Publishing to PyPI...$(NC)"
-	@if command -v uv >/dev/null 2>&1; then \
-		if [ -f .env.local ]; then \
-			set -a && . .env.local && set +a; \
-		fi; \
-		twine upload dist/*; \
-		echo "$(GREEN)✓ Published to PyPI$(NC)"; \
-	else \
-		echo "$(RED)✗ uv not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh$(NC)"; \
-		exit 1; \
-	fi
+	@echo "$(YELLOW)📤 Pushing bump commit + tag (triggers PyPI publish via CI)...$(NC)"
+	@# PyPI publishing is owned ENTIRELY by .github/workflows/release-wheels.yml.
+	@# That CI builds the per-platform wheels (each with the CORRECT platform's
+	@# ztk binary) + the sdist and publishes them via Trusted Publishing (OIDC).
+	@# The local flow must NOT twine-upload the py3-none-any wheel: it bundles
+	@# only THIS host's ztk binary (e.g. arm64-mac) and would ship the wrong
+	@# binary cross-platform AND collide with the CI-built platform wheels.
+	@# Pushing the bump commit and the v* tag is what triggers that CI.
+	@VERSION=$$(cat VERSION); \
+	BRANCH=$$(git branch --show-current); \
+	echo "Pushing $$BRANCH and tag v$$VERSION to origin..."; \
+	git push origin "$$BRANCH" && \
+	git push origin "v$$VERSION" && \
+		echo "$(GREEN)✓ Pushed — release-wheels.yml will publish to PyPI (OIDC)$(NC)" || { \
+			echo "$(RED)✗ git push failed — PyPI publish (CI) NOT triggered$(NC)"; \
+			exit 1; \
+		}
+	@echo "$(BLUE)ℹ PyPI publish runs in GitHub Actions; watch:$(NC)"
+	@echo "  https://github.com/bobmatnyc/claude-mpm/actions/workflows/release-wheels.yml"
 	@echo ""
 	@echo "$(YELLOW)🍺 Updating Homebrew tap (non-blocking)...$(NC)"
 	@$(MAKE) update-homebrew-tap || echo "$(YELLOW)⚠️  Homebrew update failed, continuing with release$(NC)"
@@ -1055,11 +1063,16 @@ release-publish: ## Publish release to PyPI, npm, Homebrew, and GitHub
 		echo "$(YELLOW)⚠ npm not found, skipping npm publish$(NC)"; \
 	fi
 	@echo "$(YELLOW)📤 Creating GitHub release...$(NC)"
+	@# Attach ONLY the sdist tarball, never the local py3-none-any wheel: that
+	@# wheel bundles only this host's ztk binary and would mislead users on other
+	@# platforms. The per-platform wheels live on PyPI (published by CI).
 	@VERSION=$$(cat VERSION); \
+	SDIST="dist/claude_mpm-$$VERSION.tar.gz"; \
+	if [ ! -f "$$SDIST" ]; then SDIST="$$(ls dist/*.tar.gz 2>/dev/null | head -n1)"; fi; \
 	gh release create "v$$VERSION" \
 		--title "Claude MPM v$$VERSION" \
 		--notes-from-tag \
-		dist/* || echo "$(YELLOW)⚠ GitHub release creation failed, continuing...$(NC)"
+		$$SDIST || echo "$(YELLOW)⚠ GitHub release creation failed, continuing...$(NC)"
 	@echo "$(GREEN)✓ GitHub release created$(NC)"
 	@$(MAKE) release-verify
 
@@ -1133,12 +1146,17 @@ release-publish-current: ## Publish current built version
 		echo "$(RED)Publishing aborted$(NC)"; \
 		exit 1; \
 	fi
-	@echo "$(YELLOW)📤 Publishing to PyPI...$(NC)"
-	@if command -v uv >/dev/null 2>&1; then \
-		twine upload dist/*; \
-		echo "$(GREEN)✓ Published to PyPI$(NC)"; \
+	@echo "$(YELLOW)📤 Pushing tag (triggers PyPI publish via CI)...$(NC)"
+	@# PyPI publishing is owned by release-wheels.yml (per-platform wheels + sdist
+	@# via OIDC). Push the v* tag to trigger it instead of a local twine upload of
+	@# the single-platform py3-none-any wheel.
+	@VERSION=$$(cat VERSION); \
+	if git rev-parse "v$$VERSION" >/dev/null 2>&1; then \
+		git push origin "v$$VERSION" && \
+			echo "$(GREEN)✓ Pushed tag v$$VERSION — CI will publish to PyPI (OIDC)$(NC)" || \
+			echo "$(YELLOW)⚠ tag push failed (may already exist on origin); continuing$(NC)"; \
 	else \
-		echo "$(RED)✗ uv not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh$(NC)"; \
+		echo "$(RED)✗ tag v$$VERSION not found locally; run a release-* bump first$(NC)"; \
 		exit 1; \
 	fi
 	@echo "$(YELLOW)📤 Publishing to npm...$(NC)"
@@ -1150,10 +1168,12 @@ release-publish-current: ## Publish current built version
 	fi
 	@echo "$(YELLOW)📤 Creating GitHub release...$(NC)"
 	@VERSION=$$(cat VERSION); \
+	SDIST="dist/claude_mpm-$$VERSION.tar.gz"; \
+	if [ ! -f "$$SDIST" ]; then SDIST="$$(ls dist/*.tar.gz 2>/dev/null | head -n1)"; fi; \
 	gh release create "v$$VERSION" \
 		--title "Claude MPM v$$VERSION" \
 		--notes-from-tag \
-		dist/* || echo "$(YELLOW)⚠ GitHub release creation failed, continuing...$(NC)"
+		$$SDIST || echo "$(YELLOW)⚠ GitHub release creation failed, continuing...$(NC)"
 	@echo "$(GREEN)✓ GitHub release created$(NC)"
 	@$(MAKE) release-verify
 

--- a/docs/developer/pypi-trusted-publishing.md
+++ b/docs/developer/pypi-trusted-publishing.md
@@ -1,0 +1,65 @@
+# PyPI Trusted Publishing (OIDC) — Release Setup
+
+`claude-mpm` publishes per-platform wheels and the sdist to PyPI from CI using
+**PyPI Trusted Publishing (OIDC)** — no long-lived `PYPI_API_TOKEN` secret.
+
+- **Workflow:** `.github/workflows/release-wheels.yml`
+- **Publish job environment name:** `pypi` (must match the PyPI config exactly)
+- **Publish action:** `pypa/gh-action-pypi-publish@release/v1` with
+  `permissions: id-token: write` and `skip-existing: true`
+
+## Why this changed
+
+The old publish job used `twine upload` with
+`TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}`. That secret was empty/unset, so
+**every release got a 403 Forbidden** (v6.5.0 / 6.5.1 / 6.5.2 all failed). OIDC
+removes the token entirely: GitHub mints a short-lived, audience-scoped token at
+publish time and PyPI validates it against a trusted-publisher entry you create.
+
+## One-time owner setup (REQUIRED before the next release)
+
+Do this once on PyPI as a maintainer of the `claude-mpm` project:
+
+1. Go to <https://pypi.org/manage/project/claude-mpm/settings/publishing/>
+   (PyPI → your account → **claude-mpm** → **Publishing**).
+2. Under **Add a new trusted publisher → GitHub**, enter **exactly**:
+   - **Owner:** `bobmatnyc`
+   - **Repository name:** `claude-mpm`
+   - **Workflow filename:** `release-wheels.yml`
+   - **Environment name:** `pypi`
+3. Click **Add**.
+
+That's it. The next time a `v*` tag is pushed (via `make release-publish`), the
+`publish` job authenticates via OIDC and uploads all platform wheels + the sdist.
+
+### If the project did not yet exist on PyPI ("pending publisher")
+
+If `claude-mpm` already exists on PyPI (it does), use the steps above. If you
+were bootstrapping a brand-new project name, you would instead use
+<https://pypi.org/manage/account/publishing/> → **Add a pending publisher** with
+the same four fields plus the **PyPI project name** (`claude-mpm`). The pending
+entry is consumed on the first successful publish and becomes a normal trusted
+publisher.
+
+## Who publishes what (local vs CI)
+
+| Channel                          | Owner | Trigger                          |
+|----------------------------------|-------|----------------------------------|
+| PyPI per-platform wheels + sdist | CI    | push of `v*` tag (OIDC publish)  |
+| Homebrew tap                     | local | `make release-publish` (waits for the CI-published sdist on PyPI, then computes sha256) |
+| npm (`@bobmatnyc/claude-mpm`)    | local | `make release-publish`           |
+| GitHub release (sdist asset)     | local | `make release-publish`           |
+
+`make release-publish` no longer runs `twine upload`. It pushes the bump commit
+and the `v*` tag (which triggers the CI publish), then runs the Homebrew / npm /
+GitHub-release steps. `scripts/publish_to_pypi.sh` is a **local fallback that
+uploads the sdist only** (via `uv publish --check-url`, the skip-existing
+equivalent) and never the binary-bundled `py3-none-any` wheel.
+
+## Verifying a release
+
+- Watch the workflow:
+  <https://github.com/bobmatnyc/claude-mpm/actions/workflows/release-wheels.yml>
+- Confirm platform wheels on PyPI (each carries a platform tag, e.g.
+  `claude_mpm-X.Y.Z-py3-none-macosx_11_0_arm64.whl`), not a single
+  `py3-none-any` wheel.

--- a/scripts/publish_to_pypi.sh
+++ b/scripts/publish_to_pypi.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 set -e  # Exit on error
 
-# Script: Automated PyPI Publishing
-# Description: Publishes Claude MPM to PyPI using credentials from ~/.pypirc
+# Script: Local sdist fallback publisher for PyPI
+#
+# IMPORTANT (deconfliction): The canonical PyPI publisher is the GitHub Actions
+# workflow .github/workflows/release-wheels.yml, which builds and publishes the
+# per-platform wheels (each with the CORRECT platform's ztk binary) AND the
+# sdist via Trusted Publishing (OIDC). That CI is triggered by pushing the v*
+# release tag (handled by `make release-publish`).
+#
+# This script is a LOCAL FALLBACK that uploads the SDIST ONLY (never the
+# py3-none-any wheel — that wheel bundles only this host's ztk binary and would
+# ship the wrong binary cross-platform / collide with the CI platform wheels).
+# It uses --skip-existing so re-runs never fail on an already-present file.
+#
+# Description: Publishes the claude-mpm SDIST to PyPI using credentials from ~/.pypirc
 
 # Colors for output
 RED='\033[0;31m'
@@ -59,15 +71,8 @@ fi
 VERSION=$(cat VERSION | tr -d '[:space:]')
 print_message "$YELLOW" "Publishing version: $VERSION"
 
-# 5. Verify distribution files exist
-WHEEL_FILE="dist/claude_mpm-${VERSION}-py3-none-any.whl"
+# 5. Verify the SDIST exists (we publish the sdist ONLY — wheels come from CI)
 TAR_FILE="dist/claude_mpm-${VERSION}.tar.gz"
-
-if [ ! -f "$WHEEL_FILE" ]; then
-    print_message "$RED" "Error: Wheel file not found: $WHEEL_FILE"
-    print_message "$YELLOW" "Please run 'make safe-release-build' first"
-    exit 1
-fi
 
 if [ ! -f "$TAR_FILE" ]; then
     print_message "$RED" "Error: Tar file not found: $TAR_FILE"
@@ -75,13 +80,11 @@ if [ ! -f "$TAR_FILE" ]; then
     exit 1
 fi
 
-print_message "$GREEN" "✓ Found wheel: $WHEEL_FILE"
 print_message "$GREEN" "✓ Found tarball: $TAR_FILE"
+print_message "$YELLOW" "ℹ Per-platform wheels are published by CI (release-wheels.yml), not here."
 
-# Show file sizes
-WHEEL_SIZE=$(ls -lh "$WHEEL_FILE" | awk '{print $5}')
+# Show file size
 TAR_SIZE=$(ls -lh "$TAR_FILE" | awk '{print $5}')
-print_message "$BLUE" "  Wheel size: $WHEEL_SIZE"
 print_message "$BLUE" "  Tarball size: $TAR_SIZE"
 
 # 6. Verify uv is available
@@ -98,7 +101,7 @@ echo ""
 print_message "$YELLOW" "Ready to upload to PyPI:"
 print_message "$BLUE" "  Package: claude-mpm"
 print_message "$BLUE" "  Version: $VERSION"
-print_message "$BLUE" "  Files: 2 (wheel + tarball)"
+print_message "$BLUE" "  Files: 1 (sdist tarball only; wheels published by CI)"
 echo ""
 read -p "Continue with upload? [y/N]: " -n 1 -r
 echo ""
@@ -114,9 +117,9 @@ print_message "$YELLOW" "Uploading to PyPI..."
 print_message "$BLUE" "This may take a moment..."
 echo ""
 
-# Use uv publish with credentials from ~/.pypirc
-# UV will automatically read the [pypi] section from ~/.pypirc
-if uv publish "$WHEEL_FILE" "$TAR_FILE"; then
+# Use uv publish with credentials from ~/.pypirc. Publish the SDIST ONLY and
+# skip if it already exists (CI may have already published it).
+if uv publish --check-url https://pypi.org/simple/ "$TAR_FILE"; then
 
     echo ""
     print_message "$GREEN" "========================================"

--- a/scripts/update_homebrew_tap.sh
+++ b/scripts/update_homebrew_tap.sh
@@ -110,7 +110,10 @@ validate_version() {
 
 wait_for_pypi_package() {
     local version="$1"
-    local max_attempts=10
+    # PyPI publishing now happens in CI (release-wheels.yml), not locally, so
+    # the sdist may take a few minutes to build + publish after the tag push.
+    # Use a longer retry window so the Homebrew update rarely falls back.
+    local max_attempts=20
     local attempt=1
     local wait_time=3
 


### PR DESCRIPTION
## Root cause

`release-wheels.yml`'s `Publish to PyPI` job used `twine upload --non-interactive dist/*.whl` with `TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}`, but that secret was **empty/unset** → **403 Forbidden** on every release. v6.5.0 / 6.5.1 / 6.5.2 all failed to publish.

Compounding it, the **local** `make release-publish` ran `twine upload dist/*`, pushing a single `py3-none-any` wheel that bundles **only the build host's** `ztk` binary (arm64-mac). That collides with the CI per-platform wheels and ships the wrong binary to every other platform.

## Owner decisions implemented

1. **Auth → PyPI Trusted Publishing (OIDC).** Token-based twine replaced with `pypa/gh-action-pypi-publish@release/v1`.
2. **Distribution → per-platform wheels built + published by CI.** The local flow no longer publishes a binary-bundled `py3-none-any` wheel to PyPI.

## Workflow changes (`.github/workflows/release-wheels.yml`)

- **OIDC publish:** replaced `twine` with `pypa/gh-action-pypi-publish@release/v1`; added `permissions: { id-token: write, contents: read }`; removed all `TWINE_USERNAME` / `TWINE_PASSWORD` / `PYPI_API_TOKEN` references.
- **Topology:** kept the standard **matrix build → upload-artifact → single `publish` job**. The publish job downloads all wheel artifacts + the sdist (`merge-multiple: true`) and runs **one** publish step. Chosen because the existing structure already used this pattern (lowest risk, no per-leg 403/400 races, one OIDC exchange).
- **`skip-existing: true`** so a re-run or an already-present file can't 400/403 the whole release.
- **Environment:** kept `environment: { name: pypi, url: https://pypi.org/p/claude-mpm }`. **Environment name = `pypi`** — the owner must match this in the PyPI trusted-publisher config.
- **sdist built exactly once:** new dedicated `sdist` job (CI previously never built/published the sdist). `publish` now `needs: [build, sdist]`. Prevents duplicate-filename 400s.
- **Per-platform binary bundling:** each matrix leg downloads its platform's `ztk` tarball (#594, non-fatal), a new **"Verify bundled ztk binary"** step confirms the binary landed **before** `build`/retag, then `wheel tags --platform-tag <platform> --remove` retags `py3-none-any` → platform-specific. A missing upstream asset still degrades gracefully (warn, no bundled binary) without failing the matrix.

## Local-flow deconfliction (`Makefile`, `scripts/publish_to_pypi.sh`, `scripts/update_homebrew_tap.sh`)

- `make release-publish` / `release-publish-current`: replaced local `twine upload dist/*` with a **push of the bump commit + `v*` tag**, which triggers the CI publish. GitHub release now attaches **only the sdist tarball**, never the local binary wheel.
- `scripts/publish_to_pypi.sh`: now a **local fallback that uploads the sdist only**, via `uv publish --check-url` (uv's skip-existing). Never the `py3-none-any` binary wheel.
- `scripts/update_homebrew_tap.sh`: widened the PyPI wait window (`max_attempts` 10 → 20) since the sdist is now published by CI a few minutes after the tag push.

| Channel | Owner |
|---|---|
| PyPI per-platform wheels + sdist | **CI** (OIDC, on `v*` tag) |
| Homebrew tap | local (waits for CI-published sdist, then sha256) |
| npm | local |
| GitHub release (sdist asset) | local |

## Validation (no real release)

- `python3 -c "import yaml; yaml.safe_load(...)"` → **YAML OK**; `bash -n` on both changed shell scripts → OK.
- Built a wheel locally the way CI does (this host = darwin-arm64): downloaded `ztk` v0.3.1, `uv build --wheel`, then `wheel tags --platform-tag macosx_11_0_arm64 --remove`.
  - Result tag: **`claude_mpm-6.5.2-py3-none-macosx_11_0_arm64.whl`** (platform-tagged, **not** `py3-none-any`).
  - Bundled binary inside the wheel: `claude_mpm/bin/ztk` → **Mach-O 64-bit arm64**.
  - Round-trip: **`ztk run echo OK` → `OK` (exit 0)**.
- `uv run pytest -k "release or wheel or packaging or ztk" -p no:xdist` → **69 passed, 1 skipped** (skip = unrelated `pyngrok` import).

## ⚠️ OWNER SETUP — required before the next release

On PyPI, add the trusted publisher (one-time): <https://pypi.org/manage/project/claude-mpm/settings/publishing/> → **Add a new trusted publisher → GitHub**:

- **Owner:** `bobmatnyc`
- **Repository name:** `claude-mpm`
- **Workflow filename:** `release-wheels.yml`
- **Environment name:** `pypi`

If bootstrapping a brand-new project name instead, use <https://pypi.org/manage/account/publishing/> → **Add a pending publisher** with the same four fields plus PyPI project name `claude-mpm`; it's consumed on first publish.

Full details: `docs/developer/pypi-trusted-publishing.md`.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
