### PR TITLE
fix: silence migration log noise on clean no-op scans

### DIFF
--- a/src/claude_mpm/migrations/runner.py
+++ b/src/claude_mpm/migrations/runner.py
@@ -108,11 +108,18 @@ def run_pending_migrations(current_version: str | None = None) -> int:
     count = 0
     for migration in pending:
         # run_always migrations are silent probes (e.g., daemon autodetect):
-        # avoid noisy "Running migration..." output on every startup.
+        # avoid noisy output on every startup.
+        #
+        # For all other migrations, we only emit user-facing output when a
+        # migration actually APPLIES a change (run() returns True). Many
+        # migrations are "scan-and-repair-if-present" probes (e.g.
+        # fix_mcp_command_args, fix_trusty_memory_bridge) that return False on a
+        # clean system and are re-run every launch. Printing "Running
+        # migration..." up front — or "Migration skipped" on a clean no-op —
+        # produced cosmetic noise on every startup (issue #595). We therefore
+        # log/print only on the applied path; a clean no-op (False) is silent
+        # except for a debug trace. Genuine errors (run() raises) stay visible.
         verbose = not migration.run_always
-        if verbose:
-            logger.info(f"Running migration: {migration.description}")
-            print(f"🔄 Running migration: {migration.description}")
 
         try:
             success = migration.run()
@@ -120,13 +127,15 @@ def run_pending_migrations(current_version: str | None = None) -> int:
                 if not migration.run_always:
                     # Only persist completion for one-shot migrations.
                     mark_migration_complete(migration.id, current_version)
-                logger.info(f"Migration complete: {migration.id}")
+                logger.info(f"Migration applied: {migration.description}")
                 if verbose:
+                    print(f"🔄 Migration applied: {migration.description}")
                     print(f"✅ Migration complete: {migration.id}")
                 count += 1
-            elif verbose:
-                logger.warning(f"Migration returned False: {migration.id}")
-                print(f"⚠️ Migration skipped: {migration.id}")
+            else:
+                # No-op clean scan: nothing to fix. Keep a debug trace only —
+                # no user-facing stdout (issue #595).
+                logger.debug(f"Migration returned False (no-op): {migration.id}")
         except Exception as e:
             # Always surface failures, even for run_always migrations.
             logger.error(f"Migration failed: {migration.id}: {e}")

--- a/tests/migrations/test_runner_output.py
+++ b/tests/migrations/test_runner_output.py
@@ -1,0 +1,109 @@
+"""
+Tests for migration runner stdout/logging behavior (issue #595).
+
+The corrective "scan-and-repair-if-present" migrations (e.g.
+``fix_mcp_command_args``, ``fix_trusty_memory_bridge``) return ``False`` on a
+clean system and are re-run on every launch. They must NOT print noise on a
+no-op. Output is only expected when a migration actually APPLIES a change
+(``run()`` returns ``True``). Genuine errors (``run()`` raises) must remain
+visible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from claude_mpm.migrations import runner
+from claude_mpm.migrations.registry import Migration
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    """Point the runner's STATE_FILE at a temp location so completion tracking
+    does not touch the real ~/.claude-mpm/migrations.json."""
+    state_file = tmp_path / "migrations.json"
+    monkeypatch.setattr(runner, "STATE_FILE", state_file)
+    return state_file
+
+
+def _run_with_migrations(migrations):
+    """Run the runner with a patched MIGRATIONS list and capture nothing else."""
+    with patch.object(runner, "MIGRATIONS", migrations):
+        return runner.run_pending_migrations(current_version="test")
+
+
+def test_noop_migration_produces_no_stdout(isolated_state, capsys):
+    """A migration returning False (clean no-op) must print nothing."""
+    noop = Migration(
+        id="noop_clean_scan",
+        version="6.4.0",
+        description="Fix MCP server configs where command contains spaces",
+        run=lambda: False,
+    )
+
+    count = _run_with_migrations([noop])
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "skipped" not in captured.out
+    assert "🔄" not in captured.out
+    assert count == 0
+
+
+def test_applied_migration_prints_applied_line(isolated_state, capsys):
+    """A migration returning True (applied) still prints its applied line."""
+    applied = Migration(
+        id="applied_migration",
+        version="6.4.0",
+        description="Repair broken trusty-memory MCP entries",
+        run=lambda: True,
+    )
+
+    count = _run_with_migrations([applied])
+
+    captured = capsys.readouterr()
+    assert "Migration applied: Repair broken trusty-memory MCP entries" in captured.out
+    assert "✅ Migration complete: applied_migration" in captured.out
+    assert count == 1
+
+
+def test_exception_is_still_surfaced(isolated_state, capsys):
+    """A migration that raises must still be surfaced on stdout (not silenced)."""
+
+    def boom() -> bool:
+        raise RuntimeError("kaboom")
+
+    failing = Migration(
+        id="failing_migration",
+        version="6.4.0",
+        description="Migration that explodes",
+        run=boom,
+    )
+
+    count = _run_with_migrations([failing])
+
+    captured = capsys.readouterr()
+    assert "❌ Migration failed: failing_migration" in captured.out
+    assert "kaboom" in captured.out
+    # Exception path does not count as an applied migration.
+    assert count == 0
+
+
+def test_noop_logs_debug_not_warning(isolated_state, caplog):
+    """No-op path downgrades to a debug trace (no user-facing warning)."""
+    import logging
+
+    noop = Migration(
+        id="noop_debug",
+        version="6.4.0",
+        description="Clean scan no-op",
+        run=lambda: False,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=runner.logger.name):
+        _run_with_migrations([noop])
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("no-op" in r.getMessage() for r in debug_records)
+    assert warning_records == []


### PR DESCRIPTION
## Summary
Corrective migrations (`fix_mcp_command_args`, `fix_trusty_memory_bridge`) scan per-project + global MCP config files and only mutate a file when they find a broken entry. On a clean system they return `False` (nothing to fix), are never marked complete, and re-print `🔄 Running migration` + `⚠️ Migration skipped` on every launch. Purely cosmetic noise.

This restructures `run_pending_migrations()` so migration output appears **only when a migration actually applies a change**:
- No-op clean scan (`False`) → silent (downgraded to `logger.debug`)
- Applied a fix (`True`) → prints `🔄 Migration applied` + `✅ Migration complete`
- Raised exception → unchanged, still surfaced as `❌ Migration failed`

Completion-state semantics and `run_always` behavior are untouched — self-healing re-run-until-applied logic is intact. Logging-only change.

## Testing
- New `tests/migrations/test_runner_output.py` (4 cases): no-op produces no stdout; applied still prints; exceptions still surface; no-op logs at DEBUG not WARNING.
- `ruff format` + `ruff check`: clean. Migrations tests: 79 passed.

Closes #595

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
