### PR TITLE
feat: show trusty-memory / trusty-search connection status in startup banner (#598)

### DIFF
--- a/src/claude_mpm/cli/startup_display.py
+++ b/src/claude_mpm/cli/startup_display.py
@@ -12,6 +12,7 @@ import subprocess  # nosec B404 - required for git operations
 from pathlib import Path
 
 from claude_mpm.core.logging_utils import get_logger
+from claude_mpm.services.trusty_status import get_trusty_status
 from claude_mpm.utils.git_analyzer import is_git_repository
 
 logger = get_logger(__name__)
@@ -474,6 +475,12 @@ def display_startup_banner(
         print(f"{CYAN}Claude MPM v{version}{RESET}")
         _, ztk_message = _get_ztk_status()
         print(ztk_message)
+        # Trusty daemon connection status (#598) — suppressed services return
+        # an empty line, so only opted-in (binary present) services print.
+        for service in ("trusty-memory", "trusty-search"):
+            _, trusty_line = get_trusty_status(service)
+            if trusty_line:
+                print(trusty_line)
         print()
         return
 
@@ -704,6 +711,17 @@ def display_startup_banner(
     lines.append(
         _format_two_column_line("", ztk_message, left_panel_width, right_panel_width)
     )
+
+    # Trusty daemon connection status (#598) — suppressed services return an
+    # empty line, so only opted-in (binary present) services add a row.
+    for service in ("trusty-memory", "trusty-search"):
+        _, trusty_line = get_trusty_status(service)
+        if trusty_line:
+            lines.append(
+                _format_two_column_line(
+                    "", trusty_line, left_panel_width, right_panel_width
+                )
+            )
 
     # Line 16: Empty | empty
     lines.append(_format_two_column_line("", "", left_panel_width, right_panel_width))

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -1,0 +1,223 @@
+"""Trusty daemon connection status for the startup banner (GitHub #598).
+
+Self-contained, dependency-light status probe for the ``trusty-memory`` and
+``trusty-search`` daemons. The startup banner imports :func:`get_trusty_status`
+to render a one-line connection indicator per service.
+
+Design (scoped per #598)
+-------------------------
+* **Cold-path short-circuit** — if the service binary is NOT on ``PATH``
+  (``shutil.which``), we render NOTHING for that service. Only opted-in users
+  who installed the binary ever see the indicator, so there is zero HTTP cost
+  for everyone else and no banner clutter.
+* **Bounded, cached health probe** — when the binary IS present we probe
+  ``{base}/health`` with a hard ≤200ms timeout. The probe result is cached
+  keyed by the ``http_addr`` discovery file's mtime (mirroring how
+  ``_get_ztk_status`` caches by binary mtime), so repeat startups within an
+  unchanged session are free. The probe never raises — it fails safe to
+  "not running".
+* **No ``/ui`` path** — the connected line shows ONLY the base ``host:port``;
+  the ``/ui`` dashboard route does not exist in this codebase.
+* **Self-contained** — this module intentionally keeps its own tiny copy of
+  the URL/health/palace logic so the banner does not import the mixin-heavy
+  setup handler. We deliberately do NOT refactor the other existing copies in
+  ``handlers/trusty.py`` / ``memory_capture.py`` here (blast-radius limiting).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+# Hard cap on the health probe. Kept ≤200ms so the banner never stalls startup.
+_HEALTH_TIMEOUT_S = 0.2
+
+# Default ports when the http_addr discovery file is missing/unreadable.
+_DEFAULT_PORTS: dict[str, int] = {
+    "trusty-memory": 7070,
+    "trusty-search": 7878,
+}
+
+# Display emoji per service.
+_SERVICE_EMOJI: dict[str, str] = {
+    "trusty-memory": "🧠",
+    "trusty-search": "🔍",
+}
+
+# Cache: { http_addr_file_path: (mtime, is_healthy) }. Keyed by the discovery
+# file so a daemon restart (which rewrites http_addr) invalidates the cache.
+_HEALTH_CACHE: dict[str, tuple[float, bool]] = {}
+
+
+def _addr_file(service: str) -> Path:
+    """Path to the daemon's ``http_addr`` discovery file."""
+    return Path.home() / f".{service}" / "http_addr"
+
+
+def _base_url(service: str) -> tuple[str, str]:
+    """Resolve the daemon base URL.
+
+    Returns a tuple of ``(base_url, host_port)`` where ``base_url`` is the
+    ``http://host:port`` form used for probing and ``host_port`` is the bare
+    ``host:port`` shown in the banner. Falls back to the default port when the
+    discovery file is missing or unreadable.
+    """
+    try:
+        addr = _addr_file(service).read_text(encoding="utf-8").strip()
+        if addr:
+            return f"http://{addr}", addr
+    except OSError:
+        pass
+    host_port = f"127.0.0.1:{_DEFAULT_PORTS.get(service, 7070)}"
+    return f"http://{host_port}", host_port
+
+
+def _load_config() -> dict[str, Any]:
+    """Best-effort load of ``~/.claude-mpm/config.yaml``. Returns ``{}`` on any failure."""
+    path = Path.home() / ".claude-mpm" / "config.yaml"
+    if not path.is_file():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _palace_name() -> str:
+    """Palace name: ``trusty_memory.palace`` config override, else cwd basename."""
+    config = _load_config()
+    section = config.get("trusty_memory", {})
+    if isinstance(section, dict):
+        configured = section.get("palace") or ""
+        if isinstance(configured, str) and configured.strip():
+            return configured.strip()
+    return Path.cwd().name
+
+
+def _health_check(base_url: str) -> bool:
+    """Probe ``{base_url}/health`` with a hard ≤200ms timeout.
+
+    Never raises — any non-2xx, network error, or timeout is treated as
+    "not healthy". urllib is imported lazily so the banner module keeps a
+    minimal import surface.
+    """
+    import urllib.error
+    import urllib.request
+
+    url = f"{base_url}/health"
+    try:
+        req = urllib.request.Request(url, method="GET")  # nosec B310 - localhost
+        with urllib.request.urlopen(  # nosec B310 - localhost
+            req, timeout=_HEALTH_TIMEOUT_S
+        ) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def _cached_health_check(service: str, base_url: str) -> bool:
+    """Health check cached by the http_addr discovery file's mtime.
+
+    Repeat startups within an unchanged session are free. A daemon restart
+    rewrites ``http_addr`` (changing its mtime) and invalidates the cache.
+    When the discovery file is absent we use mtime ``-1.0`` as a sentinel so
+    the cache still keys consistently on "no file".
+    """
+    addr_file = _addr_file(service)
+    try:
+        mtime = addr_file.stat().st_mtime
+    except OSError:
+        mtime = -1.0
+
+    key = str(addr_file)
+    cached = _HEALTH_CACHE.get(key)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    healthy = _health_check(base_url)
+    _HEALTH_CACHE[key] = (mtime, healthy)
+    return healthy
+
+
+def _is_configured_in_mcp(service: str) -> bool:
+    """Whether ``service`` appears in the CWD ``.mcp.json`` ``mcpServers`` map.
+
+    Best-effort: returns ``False`` on any error (missing file, malformed JSON).
+    """
+    import json
+
+    mcp_path = Path.cwd() / ".mcp.json"
+    try:
+        with mcp_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return False
+    return service in servers
+
+
+def _start_hint(service: str) -> str:
+    """The ``(start: ...)`` hint shown when a service is not running."""
+    if service == "trusty-memory":
+        return "(start: trusty-memory ...)"
+    return "(start: trusty-search serve)"
+
+
+def get_trusty_status(service: str) -> tuple[str, str]:
+    """Return ``(state, display_line)`` for a trusty daemon.
+
+    Args:
+        service: ``"trusty-memory"`` or ``"trusty-search"``.
+
+    Returns:
+        Tuple of ``(state, display_line)``:
+
+        * ``("absent", "")`` — binary not on PATH; render NOTHING. (The empty
+          line lets the caller suppress this service with a truthiness guard.)
+        * ``("on", "🧠 trusty-memory: on   palace: <name>   host:port")`` —
+          binary present and ``/health`` returned 2xx. Palace name only for
+          ``trusty-memory``. The connected form shows ONLY ``host:port`` —
+          never a ``/ui`` path.
+        * ``("configured", "... not running  (start: ...)")`` — binary present,
+          ``/health`` failed, and the service is in CWD ``.mcp.json``.
+        * ``("not_running", "... not running  (start: ...)")`` — binary present,
+          ``/health`` failed, NOT in ``.mcp.json``. (Binary-on-PATH means the
+          user opted in, so we still show ``not running`` rather than a bare
+          ``off`` line; ``.mcp.json`` only tweaks the hint text.)
+
+    Never raises — every failure path falls back to a safe value.
+    """
+    try:
+        # Cold-path short-circuit: not installed → render nothing.
+        if shutil.which(service) is None:
+            return ("absent", "")
+
+        emoji = _SERVICE_EMOJI.get(service, "")
+        base_url, host_port = _base_url(service)
+
+        if _cached_health_check(service, base_url):
+            if service == "trusty-memory":
+                line = f"{emoji} {service}: on   palace: {_palace_name()}   {host_port}"
+            else:
+                line = f"{emoji} {service}: on   {host_port}"
+            return ("on", line)
+
+        # /health failed but binary is installed (opted in) → not running.
+        hint = _start_hint(service)
+        line = f"{emoji} {service}: not running  {hint}"
+        state = "configured" if _is_configured_in_mcp(service) else "not_running"
+        return (state, line)
+    except Exception:
+        # Fail-safe: never break the banner over a status probe.
+        return ("absent", "")

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -6,11 +6,15 @@ to render a one-line connection indicator per service.
 
 Design (scoped per #598)
 -------------------------
-* **Cold-path short-circuit** — if the service binary is NOT on ``PATH``
-  (``shutil.which``), we render NOTHING for that service. Only opted-in users
-  who installed the binary ever see the indicator, so there is zero HTTP cost
-  for everyone else and no banner clutter.
-* **Bounded, cached health probe** — when the binary IS present we probe
+* **Cold-path short-circuit** — if the user has not opted in to the service we
+  render NOTHING for it (zero HTTP cost, no banner clutter). Opt-in is detected
+  via a robust, latency-free filesystem check (see :func:`_is_present`): the
+  service appears in the CWD ``.mcp.json`` ``mcpServers`` map, OR a per-user
+  ``~/.trusty-<service>/http_addr`` discovery file exists. We deliberately do
+  NOT gate on the binary name (``shutil.which``): the launched binary may be a
+  bridge/wrapper (e.g. ``trusty-memory-mcp-bridge``) whose name does not match
+  the service key, which previously suppressed healthy daemons entirely.
+* **Bounded, cached health probe** — when the service is present we probe
   ``{base}/health`` with a hard ≤200ms timeout. The probe result is cached
   keyed by the ``http_addr`` discovery file's mtime (mirroring how
   ``_get_ztk_status`` caches by binary mtime), so repeat startups within an
@@ -26,7 +30,6 @@ Design (scoped per #598)
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from typing import Any
 
@@ -167,6 +170,28 @@ def _is_configured_in_mcp(service: str) -> bool:
     return service in servers
 
 
+def _is_present(service: str) -> bool:
+    """Whether the user has opted in to ``service`` (latency-free, pure filesystem).
+
+    The service is considered present / opted-in if EITHER signal holds:
+
+    1. ``service`` appears in the CWD ``.mcp.json`` ``mcpServers`` map, OR
+    2. the per-user ``~/.trusty-<service>/http_addr`` discovery file exists
+       (proof the daemon has run for this user).
+
+    Both are pure filesystem reads — no subprocess, no ``shutil.which``. This
+    intentionally does NOT depend on the launched binary's name, which may be a
+    bridge/wrapper (e.g. ``trusty-memory-mcp-bridge``) that does not match the
+    service key.
+    """
+    if _is_configured_in_mcp(service):
+        return True
+    try:
+        return _addr_file(service).exists()
+    except OSError:
+        return False
+
+
 def _start_hint(service: str) -> str:
     """The ``(start: ...)`` hint shown when a service is not running."""
     if service == "trusty-memory":
@@ -183,24 +208,30 @@ def get_trusty_status(service: str) -> tuple[str, str]:
     Returns:
         Tuple of ``(state, display_line)``:
 
-        * ``("absent", "")`` — binary not on PATH; render NOTHING. (The empty
-          line lets the caller suppress this service with a truthiness guard.)
+        * ``("absent", "")`` — not opted in (no ``.mcp.json`` entry AND no
+          ``http_addr`` discovery file); render NOTHING. (The empty line lets
+          the caller suppress this service with a truthiness guard.)
         * ``("on", "🧠 trusty-memory: on   palace: <name>   host:port")`` —
-          binary present and ``/health`` returned 2xx. Palace name only for
+          present and ``/health`` returned 2xx. Palace name only for
           ``trusty-memory``. The connected form shows ONLY ``host:port`` —
           never a ``/ui`` path.
-        * ``("configured", "... not running  (start: ...)")`` — binary present,
+        * ``("configured", "... not running  (start: ...)")`` — present,
           ``/health`` failed, and the service is in CWD ``.mcp.json``.
-        * ``("not_running", "... not running  (start: ...)")`` — binary present,
-          ``/health`` failed, NOT in ``.mcp.json``. (Binary-on-PATH means the
-          user opted in, so we still show ``not running`` rather than a bare
-          ``off`` line; ``.mcp.json`` only tweaks the hint text.)
+        * ``("not_running", "... not running  (start: ...)")`` — present (via an
+          ``http_addr`` discovery file), ``/health`` failed, NOT in
+          ``.mcp.json``. (Presence means the user opted in, so we still show
+          ``not running`` rather than a bare ``off`` line; ``.mcp.json`` only
+          tweaks the hint text.)
+
+    Presence is detected by :func:`_is_present` — a latency-free filesystem
+    check that never depends on the launched binary's name (bridges/wrappers
+    such as ``trusty-memory-mcp-bridge`` no longer suppress a healthy daemon).
 
     Never raises — every failure path falls back to a safe value.
     """
     try:
-        # Cold-path short-circuit: not installed → render nothing.
-        if shutil.which(service) is None:
+        # Cold-path short-circuit: not opted in → render nothing.
+        if not _is_present(service):
             return ("absent", "")
 
         emoji = _SERVICE_EMOJI.get(service, "")
@@ -213,7 +244,7 @@ def get_trusty_status(service: str) -> tuple[str, str]:
                 line = f"{emoji} {service}: on   {host_port}"
             return ("on", line)
 
-        # /health failed but binary is installed (opted in) → not running.
+        # /health failed but the service is present (opted in) → not running.
         hint = _start_hint(service)
         line = f"{emoji} {service}: not running  {hint}"
         state = "configured" if _is_configured_in_mcp(service) else "not_running"

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -20,6 +20,17 @@ Design (scoped per #598)
   ``_get_ztk_status`` caches by binary mtime), so repeat startups within an
   unchanged session are free. The probe never raises — it fails safe to
   "not running".
+* **Palace existence verification (#598 option 1)** — when ``trusty-memory``
+  is ``on``, we additionally GET ``{base}/api/v1/palaces`` (the same hard
+  ≤200ms timeout, also mtime-cached) to verify the resolved palace name
+  actually exists in the daemon. ``/health`` only proves the daemon is up,
+  NOT that the palace was ever created — so without this check the banner can
+  show ``palace: <name>`` for a palace that does not exist. When the palace is
+  missing we append ``(not created)``. This is the ONLY extra HTTP call and it
+  fires ONLY after a successful health check (zero added cost when down/absent).
+  It fails SAFE toward NOT appending the suffix: only a successful response
+  that definitively lacks the palace yields ``(not created)``; any
+  error/timeout/non-2xx/parse failure shows the bare name (no false negatives).
 * **No ``/ui`` path** — the connected line shows ONLY the base ``host:port``;
   the ``/ui`` dashboard route does not exist in this codebase.
 * **Self-contained** — this module intentionally keeps its own tiny copy of
@@ -51,6 +62,12 @@ _SERVICE_EMOJI: dict[str, str] = {
 # Cache: { http_addr_file_path: (mtime, is_healthy) }. Keyed by the discovery
 # file so a daemon restart (which rewrites http_addr) invalidates the cache.
 _HEALTH_CACHE: dict[str, tuple[float, bool]] = {}
+
+# Cache: { "<addr_file_path>::<palace>": (mtime, exists) }. SEPARATE from
+# _HEALTH_CACHE (compound key) so the palace-existence result never collides
+# with the health result. Keyed by the discovery file mtime + palace name so a
+# daemon restart (which rewrites http_addr) invalidates it.
+_PALACE_CACHE: dict[str, tuple[float, bool]] = {}
 
 
 def _addr_file(service: str) -> Path:
@@ -149,6 +166,88 @@ def _cached_health_check(service: str, base_url: str) -> bool:
     return healthy
 
 
+def _palace_exists(base_url: str, palace: str) -> bool:
+    """Whether ``palace`` exists in the daemon at ``base_url``.
+
+    GETs ``{base_url}/api/v1/palaces`` with the SAME hard ≤200ms timeout as the
+    health probe. urllib is imported lazily, matching :func:`_health_check`.
+
+    Response shape (confirmed against the trusty-memory daemon source,
+    ``GET /api/v1/palaces`` → ``Json<Vec<PalaceInfo>>``): a top-level JSON array
+    of objects, each with ``id`` and ``name`` string fields. We also defensively
+    accept an ``{"palaces": [...]}`` wrapper and bare-string entries (the form
+    the MCP ``palace_list`` projection emits), and match the resolved palace
+    name case-insensitively against BOTH ``id`` and ``name`` (the daemon derives
+    ``id`` from ``name`` via ``PalaceId::new(&name)``, so either may carry the
+    user-facing identifier).
+
+    Fail-SAFE semantics (#598): never raises. Returns ``True`` on ANY
+    error/timeout/non-2xx/parse failure so the caller does NOT append
+    ``(not created)`` on a probe failure (avoids false negatives). Returns
+    ``False`` ONLY when we got a successful, parseable response that
+    definitively does not contain ``palace``.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    url = f"{base_url}/api/v1/palaces"
+    try:
+        req = urllib.request.Request(url, method="GET")  # nosec B310 - localhost
+        with urllib.request.urlopen(  # nosec B310 - localhost
+            req, timeout=_HEALTH_TIMEOUT_S
+        ) as resp:
+            if not (200 <= resp.status < 300):
+                return True  # fail-safe: unknown → do not claim "not created"
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return True  # fail-safe: probe failure → do not claim "not created"
+
+    # Normalize to a list of palace entries.
+    if isinstance(data, dict):
+        entries = data.get("palaces", [])
+    elif isinstance(data, list):
+        entries = data
+    else:
+        return True  # unexpected shape → fail-safe
+
+    target = palace.strip().lower()
+    names: set[str] = set()
+    for entry in entries:
+        if isinstance(entry, str):
+            names.add(entry.strip().lower())
+        elif isinstance(entry, dict):
+            for field in ("name", "id"):
+                value = entry.get(field)
+                if isinstance(value, str):
+                    names.add(value.strip().lower())
+    return target in names
+
+
+def _cached_palace_exists(service: str, base_url: str, palace: str) -> bool:
+    """Palace-existence check cached by the http_addr file mtime + palace name.
+
+    Uses a SEPARATE cache (compound key ``<addr_file>::<palace>``) from
+    :func:`_cached_health_check` so the two results never collide. A daemon
+    restart rewrites ``http_addr`` (changing its mtime) and invalidates this
+    cache too. Fail-safe: see :func:`_palace_exists`.
+    """
+    addr_file = _addr_file(service)
+    try:
+        mtime = addr_file.stat().st_mtime
+    except OSError:
+        mtime = -1.0
+
+    key = f"{addr_file}::{palace}"
+    cached = _PALACE_CACHE.get(key)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    exists = _palace_exists(base_url, palace)
+    _PALACE_CACHE[key] = (mtime, exists)
+    return exists
+
+
 def _is_configured_in_mcp(service: str) -> bool:
     """Whether ``service`` appears in the CWD ``.mcp.json`` ``mcpServers`` map.
 
@@ -213,8 +312,10 @@ def get_trusty_status(service: str) -> tuple[str, str]:
           the caller suppress this service with a truthiness guard.)
         * ``("on", "🧠 trusty-memory: on   palace: <name>   host:port")`` —
           present and ``/health`` returned 2xx. Palace name only for
-          ``trusty-memory``. The connected form shows ONLY ``host:port`` —
-          never a ``/ui`` path.
+          ``trusty-memory``; the name gains a ``(not created)`` suffix when a
+          successful ``GET /api/v1/palaces`` definitively shows the palace does
+          not exist (#598 option 1). The connected form shows ONLY
+          ``host:port`` — never a ``/ui`` path.
         * ``("configured", "... not running  (start: ...)")`` — present,
           ``/health`` failed, and the service is in CWD ``.mcp.json``.
         * ``("not_running", "... not running  (start: ...)")`` — present (via an
@@ -239,7 +340,15 @@ def get_trusty_status(service: str) -> tuple[str, str]:
 
         if _cached_health_check(service, base_url):
             if service == "trusty-memory":
-                line = f"{emoji} {service}: on   palace: {_palace_name()}   {host_port}"
+                palace = _palace_name()
+                # #598 option 1: /health only proves the daemon is up — verify
+                # the palace actually exists before claiming it. Fail-safe:
+                # only append "(not created)" on a definitive negative.
+                if _cached_palace_exists(service, base_url, palace):
+                    palace_display = f"palace: {palace}"
+                else:
+                    palace_display = f"palace: {palace} (not created)"
+                line = f"{emoji} {service}: on   {palace_display}   {host_port}"
             else:
                 line = f"{emoji} {service}: on   {host_port}"
             return ("on", line)

--- a/tests/test_startup_display.py
+++ b/tests/test_startup_display.py
@@ -611,3 +611,78 @@ class TestDisplayStartupBanner:
         assert "user:" in captured.out
         assert "total:" in captured.out
         assert "Sonnet" in captured.out
+
+
+class TestTrustyBannerStatus:
+    """Tests for trusty daemon status wiring into the banner (#598)."""
+
+    def test_trusty_absent_suppressed_in_wide_banner(self, capsys, monkeypatch):
+        """When both daemons return empty lines, nothing trusty appears."""
+        monkeypatch.setattr(
+            "src.claude_mpm.cli.startup_display.get_trusty_status",
+            lambda service: ("absent", ""),
+        )
+        display_startup_banner("4.24.0")
+        captured = capsys.readouterr()
+        assert "trusty-memory" not in captured.out
+        assert "trusty-search" not in captured.out
+
+    def test_trusty_on_lines_appear_in_wide_banner(self, capsys, monkeypatch):
+        """Non-empty trusty lines are rendered in the wide banner path."""
+        lines = {
+            "trusty-memory": (
+                "on",
+                "trusty-memory: on   palace: demo   localhost:7070",
+            ),
+            "trusty-search": ("on", "trusty-search: on   localhost:7878"),
+        }
+        monkeypatch.setattr(
+            "src.claude_mpm.cli.startup_display.get_trusty_status",
+            lambda service: lines[service],
+        )
+        display_startup_banner("4.24.0")
+        captured = capsys.readouterr()
+        assert "trusty-memory: on" in captured.out
+        assert "trusty-search: on" in captured.out
+        assert "palace: demo" in captured.out
+        assert "/ui" not in captured.out
+
+    def test_only_opted_in_service_rendered(self, capsys, monkeypatch):
+        """A suppressed service adds nothing; the opted-in one still shows."""
+        lines = {
+            "trusty-memory": (
+                "on",
+                "trusty-memory: on   palace: demo   localhost:7070",
+            ),
+            "trusty-search": ("absent", ""),
+        }
+        monkeypatch.setattr(
+            "src.claude_mpm.cli.startup_display.get_trusty_status",
+            lambda service: lines[service],
+        )
+        display_startup_banner("4.24.0")
+        captured = capsys.readouterr()
+        assert "trusty-memory: on" in captured.out
+        assert "trusty-search" not in captured.out
+
+    def test_trusty_lines_appear_in_narrow_banner(self, capsys, monkeypatch):
+        """Narrow-terminal path also renders non-empty trusty lines (#598)."""
+        monkeypatch.setattr(
+            "src.claude_mpm.cli.startup_display._get_terminal_width", lambda: 40
+        )
+        lines = {
+            "trusty-memory": (
+                "not_running",
+                "trusty-memory: not running  (start: x)",
+            ),
+            "trusty-search": ("absent", ""),
+        }
+        monkeypatch.setattr(
+            "src.claude_mpm.cli.startup_display.get_trusty_status",
+            lambda service: lines[service],
+        )
+        display_startup_banner("4.24.0")
+        captured = capsys.readouterr()
+        assert "trusty-memory: not running" in captured.out
+        assert "trusty-search" not in captured.out
+        assert "/ui" not in captured.out

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -1,0 +1,264 @@
+"""Unit tests for trusty daemon connection status (GitHub #598).
+
+Covers the scoped design:
+* binary absent → suppressed (empty line)
+* binary present + health OK → ``on`` line with correct host:port (+ palace for memory)
+* binary present + health fail + in .mcp.json → ``not running``
+* binary present + health fail + not in .mcp.json → ``not running``
+* NO ``/ui`` substring ever appears
+* the ≤0.2s timeout is actually passed to the probe
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.claude_mpm.services import trusty_status
+from src.claude_mpm.services.trusty_status import (
+    _HEALTH_TIMEOUT_S,
+    get_trusty_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_health_cache():
+    """Ensure the module-level health cache never leaks between tests."""
+    trusty_status._HEALTH_CACHE.clear()
+    yield
+    trusty_status._HEALTH_CACHE.clear()
+
+
+def _setup_addr_file(monkeypatch, tmp_path: Path, service: str, addr: str) -> None:
+    """Point ``Path.home()`` at tmp_path and write a discovery file."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    addr_dir = tmp_path / f".{service}"
+    addr_dir.mkdir(parents=True, exist_ok=True)
+    (addr_dir / "http_addr").write_text(addr, encoding="utf-8")
+
+
+class TestBinaryAbsent:
+    """Cold-path short-circuit: binary not on PATH renders nothing."""
+
+    def test_memory_absent_renders_nothing(self, monkeypatch):
+        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "absent"
+        assert line == ""
+
+    def test_search_absent_renders_nothing(self, monkeypatch):
+        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
+        state, line = get_trusty_status("trusty-search")
+        assert state == "absent"
+        assert line == ""
+
+    def test_absent_does_not_probe_health(self, monkeypatch):
+        """When binary absent, no HTTP probe should happen (zero cost)."""
+        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("health check must not run when binary absent")
+
+        monkeypatch.setattr(trusty_status, "_health_check", _boom)
+        state, line = get_trusty_status("trusty-memory")
+        assert (state, line) == ("absent", "")
+
+
+class TestHealthOk:
+    """Binary present + /health OK → ``on`` line."""
+
+    def test_memory_on_includes_host_port_and_palace(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "localhost:7070")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+        monkeypatch.setattr(trusty_status, "_palace_name", lambda: "my-palace")
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "trusty-memory: on" in line
+        assert "localhost:7070" in line
+        assert "palace: my-palace" in line
+        assert "/ui" not in line
+
+    def test_search_on_includes_host_port_no_palace(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        state, line = get_trusty_status("trusty-search")
+        assert state == "on"
+        assert "trusty-search: on" in line
+        assert "localhost:7878" in line
+        assert "palace" not in line
+        assert "/ui" not in line
+
+    def test_on_uses_actual_dynamic_port(self, monkeypatch, tmp_path):
+        """The actual host:port from http_addr is used, not the default port."""
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "127.0.0.1:54321")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        state, line = get_trusty_status("trusty-search")
+        assert state == "on"
+        assert "127.0.0.1:54321" in line
+        assert "7878" not in line
+
+    def test_health_probed_against_correct_base_url(self, monkeypatch, tmp_path):
+        """The /health endpoint is built from the discovered base URL."""
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "127.0.0.1:9999")
+
+        seen: dict[str, str] = {}
+
+        def _capture(base_url: str) -> bool:
+            seen["base_url"] = base_url
+            return True
+
+        monkeypatch.setattr(trusty_status, "_health_check", _capture)
+        monkeypatch.setattr(trusty_status, "_palace_name", lambda: "p")
+        get_trusty_status("trusty-memory")
+        assert seen["base_url"] == "http://127.0.0.1:9999"
+
+
+class TestHealthFail:
+    """Binary present + /health fail → ``not running``."""
+
+    def test_fail_in_mcp_json_state_configured(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "localhost:7070")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: True)
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "configured"
+        assert "not running" in line
+        assert "(start: trusty-memory ...)" in line
+        assert "/ui" not in line
+
+    def test_fail_not_in_mcp_json_still_not_running(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: False)
+
+        state, line = get_trusty_status("trusty-search")
+        assert state == "not_running"
+        assert "not running" in line
+        assert "(start: trusty-search serve)" in line
+        assert "off" not in line  # never a bare "off" line
+        assert "/ui" not in line
+
+
+class TestMcpConfigRead:
+    """.mcp.json read behavior."""
+
+    def test_configured_when_present(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        (tmp_path / ".mcp.json").write_text(
+            '{"mcpServers": {"trusty-memory": {"command": "x"}}}',
+            encoding="utf-8",
+        )
+        assert trusty_status._is_configured_in_mcp("trusty-memory") is True
+        assert trusty_status._is_configured_in_mcp("trusty-search") is False
+
+    def test_not_configured_when_missing_file(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        assert trusty_status._is_configured_in_mcp("trusty-memory") is False
+
+    def test_not_configured_when_malformed_json(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        (tmp_path / ".mcp.json").write_text("{ not valid json", encoding="utf-8")
+        assert trusty_status._is_configured_in_mcp("trusty-memory") is False
+
+
+class TestHealthTimeout:
+    """The probe must use a hard ≤0.2s timeout."""
+
+    def test_timeout_constant_is_at_most_200ms(self):
+        assert _HEALTH_TIMEOUT_S <= 0.2
+
+    def test_timeout_passed_to_urlopen(self, monkeypatch):
+        """_health_check passes _HEALTH_TIMEOUT_S to urllib.request.urlopen."""
+        import urllib.request
+
+        seen: dict[str, float] = {}
+
+        class _FakeResp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+        def _fake_urlopen(_req, timeout=None):
+            seen["timeout"] = timeout
+            return _FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        assert trusty_status._health_check("http://127.0.0.1:7070") is True
+        assert seen["timeout"] == _HEALTH_TIMEOUT_S
+        assert seen["timeout"] <= 0.2
+
+    def test_health_check_never_raises(self, monkeypatch):
+        import urllib.request
+
+        def _boom(*_a, **_k):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+        # Must swallow the error and return False, not raise.
+        assert trusty_status._health_check("http://127.0.0.1:7070") is False
+
+
+class TestHealthCache:
+    """Probe result is cached by the http_addr file mtime."""
+
+    def test_repeat_probe_is_cached(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+
+        calls = {"n": 0}
+
+        def _counting(_url: str) -> bool:
+            calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(trusty_status, "_health_check", _counting)
+        get_trusty_status("trusty-search")
+        get_trusty_status("trusty-search")
+        # Same mtime → second call served from cache.
+        assert calls["n"] == 1
+
+
+class TestNoUiSubstring:
+    """Guarantee: no rendered line ever contains '/ui'."""
+
+    @pytest.mark.parametrize("service", ["trusty-memory", "trusty-search"])
+    @pytest.mark.parametrize("healthy", [True, False])
+    def test_no_ui_in_any_state(self, monkeypatch, tmp_path, service, healthy):
+        monkeypatch.setattr(
+            trusty_status.shutil, "which", lambda _: f"/usr/bin/{service}"
+        )
+        _setup_addr_file(monkeypatch, tmp_path, service, "localhost:7070")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: healthy)
+        monkeypatch.setattr(trusty_status, "_palace_name", lambda: "p")
+        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: False)
+        _, line = get_trusty_status(service)
+        assert "/ui" not in line

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -11,6 +11,15 @@ Covers the scoped design after the presence-signal fix:
 * present + health fail + not in .mcp.json → ``not_running`` / ``not running``
 * NO ``/ui`` substring ever appears
 * the ≤0.2s timeout is actually passed to the probe
+
+Palace existence verification (#598 option 1):
+* memory ``on`` + palace EXISTS → ``palace: <name>`` (no ``(not created)``)
+* memory ``on`` + palace MISSING → ``palace: <name> (not created)``
+* palaces endpoint errors/times out → fail-safe: show the bare name WITHOUT
+  ``(not created)`` (only a successful response that definitively lacks the
+  palace yields the suffix — avoids false negatives)
+* the existence probe uses the same ≤0.2s timeout and runs ONLY after a
+  successful health check (never when not running / absent, never for search)
 """
 
 from __future__ import annotations
@@ -28,10 +37,12 @@ from src.claude_mpm.services.trusty_status import (
 
 @pytest.fixture(autouse=True)
 def _clear_health_cache():
-    """Ensure the module-level health cache never leaks between tests."""
+    """Ensure the module-level caches never leak between tests."""
     trusty_status._HEALTH_CACHE.clear()
+    trusty_status._PALACE_CACHE.clear()
     yield
     trusty_status._HEALTH_CACHE.clear()
+    trusty_status._PALACE_CACHE.clear()
 
 
 def _point_home(monkeypatch, tmp_path: Path) -> None:
@@ -112,6 +123,7 @@ class TestPresentViaMcpJsonOnly:
         _write_mcp_json(proj, "trusty-memory")  # binary name is a bridge, not matching
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
         monkeypatch.setattr(trusty_status, "_palace_name", lambda: "my-palace")
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: True)
 
         state, line = get_trusty_status("trusty-memory")
         assert state == "on"
@@ -119,6 +131,7 @@ class TestPresentViaMcpJsonOnly:
         # Falls back to the default port since there is no discovery file.
         assert "127.0.0.1:7070" in line
         assert "palace: my-palace" in line
+        assert "(not created)" not in line
         assert "/ui" not in line
 
     def test_memory_mcp_only_no_http_addr_file_on_disk(self, monkeypatch, tmp_path):
@@ -189,6 +202,7 @@ class TestPresentViaHttpAddrOnly:
 
         monkeypatch.setattr(trusty_status, "_health_check", _capture)
         monkeypatch.setattr(trusty_status, "_palace_name", lambda: "p")
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: True)
         get_trusty_status("trusty-memory")
         assert seen["base_url"] == "http://127.0.0.1:9999"
 
@@ -372,5 +386,294 @@ class TestNoUiSubstring:
         _write_addr_file(home, service, "localhost:7070")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: healthy)
         monkeypatch.setattr(trusty_status, "_palace_name", lambda: "p")
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: True)
         _, line = get_trusty_status(service)
         assert "/ui" not in line
+
+
+# ---------------------------------------------------------------------------
+# Palace existence verification (#598 option 1)
+# ---------------------------------------------------------------------------
+
+
+def _fake_palaces_resp(status: int, body: str):
+    """Build a context-manager fake urllib response with ``status``/``body``."""
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.status = status
+
+        def read(self) -> bytes:
+            return body.encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+class TestPalaceExistsHelper:
+    """:func:`_palace_exists` parses the confirmed /api/v1/palaces shape.
+
+    Confirmed shape (trusty-memory daemon ``GET /api/v1/palaces`` →
+    ``Json<Vec<PalaceInfo>>``): a top-level JSON array of objects, each with
+    ``id`` and ``name`` string fields. Defensively we also accept an
+    ``{"palaces": [...]}`` wrapper and bare-string entries.
+    """
+
+    def _patch_urlopen(self, monkeypatch, status: int, body: str) -> dict:
+        import urllib.request
+
+        seen: dict[str, object] = {}
+
+        def _fake_urlopen(_req, timeout=None):
+            seen["timeout"] = timeout
+            return _fake_palaces_resp(status, body)
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        return seen
+
+    def test_top_level_array_of_objects_match_by_name(self, monkeypatch):
+        body = '[{"id": "claude-mpm", "name": "claude-mpm"}]'
+        self._patch_urlopen(monkeypatch, 200, body)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_match_is_case_insensitive(self, monkeypatch):
+        body = '[{"id": "Claude-MPM", "name": "Claude-MPM"}]'
+        self._patch_urlopen(monkeypatch, 200, body)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_match_by_id_field(self, monkeypatch):
+        # name differs but id matches the resolved name.
+        body = '[{"id": "claude-mpm", "name": "Some Display Name"}]'
+        self._patch_urlopen(monkeypatch, 200, body)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_wrapped_palaces_key_with_string_entries(self, monkeypatch):
+        # Defensive: the MCP palace_list projection emits bare strings.
+        body = '{"palaces": ["claude-mpm", "other"]}'
+        self._patch_urlopen(monkeypatch, 200, body)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_definitive_absence_returns_false(self, monkeypatch):
+        body = '[{"id": "other-project", "name": "other-project"}]'
+        self._patch_urlopen(monkeypatch, 200, body)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is False
+        )
+
+    def test_empty_list_is_definitive_absence(self, monkeypatch):
+        self._patch_urlopen(monkeypatch, 200, "[]")
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is False
+        )
+
+    def test_uses_health_timeout(self, monkeypatch):
+        seen = self._patch_urlopen(monkeypatch, 200, "[]")
+        trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm")
+        assert seen["timeout"] == _HEALTH_TIMEOUT_S
+        assert seen["timeout"] <= 0.2
+
+    def test_non_2xx_fails_safe_to_true(self, monkeypatch):
+        # 500 → we cannot prove absence → do NOT claim "not created".
+        self._patch_urlopen(monkeypatch, 500, "")
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_network_error_fails_safe_to_true(self, monkeypatch):
+        import urllib.request
+
+        def _boom(*_a, **_k):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_malformed_json_fails_safe_to_true(self, monkeypatch):
+        self._patch_urlopen(monkeypatch, 200, "{ not valid json")
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+    def test_unexpected_shape_fails_safe_to_true(self, monkeypatch):
+        # A bare number is neither a list nor a dict → fail safe.
+        self._patch_urlopen(monkeypatch, 200, "42")
+        assert (
+            trusty_status._palace_exists("http://127.0.0.1:7070", "claude-mpm") is True
+        )
+
+
+class TestPalaceExistsCache:
+    """Existence result is cached by the http_addr mtime, separate from health."""
+
+    def _setup(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-memory", "localhost:7070")
+        return home, proj
+
+    def test_repeat_existence_probe_is_cached(self, monkeypatch, tmp_path):
+        self._setup(monkeypatch, tmp_path)
+        calls = {"n": 0}
+
+        def _counting(_base, _palace):
+            calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(trusty_status, "_palace_exists", _counting)
+        trusty_status._cached_palace_exists("trusty-memory", "http://x", "claude-mpm")
+        trusty_status._cached_palace_exists("trusty-memory", "http://x", "claude-mpm")
+        assert calls["n"] == 1
+
+    def test_cache_does_not_collide_with_health_cache(self, monkeypatch, tmp_path):
+        """Palace cache uses a SEPARATE dict / compound key from health cache."""
+        self._setup(monkeypatch, tmp_path)
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: False)
+        trusty_status._cached_palace_exists("trusty-memory", "http://x", "claude-mpm")
+        # Health cache must remain untouched by the palace probe.
+        assert trusty_status._HEALTH_CACHE == {}
+        assert any("::claude-mpm" in k for k in trusty_status._PALACE_CACHE)
+
+
+class TestGetStatusPalaceVerification:
+    """End-to-end: the 'on' line reflects palace existence (#598 option 1)."""
+
+    def _present_healthy_memory(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-memory", "127.0.0.1:7070")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+        monkeypatch.setattr(trusty_status, "_palace_name", lambda: "claude-mpm")
+
+    def test_palace_exists_no_suffix(self, monkeypatch, tmp_path):
+        self._present_healthy_memory(monkeypatch, tmp_path)
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: True)
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "palace: claude-mpm" in line
+        assert "(not created)" not in line
+        assert "/ui" not in line
+
+    def test_palace_missing_shows_not_created(self, monkeypatch, tmp_path):
+        self._present_healthy_memory(monkeypatch, tmp_path)
+        monkeypatch.setattr(trusty_status, "_palace_exists", lambda *_a: False)
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "palace: claude-mpm (not created)" in line
+        assert "/ui" not in line
+
+    def test_probe_error_fails_safe_no_suffix(self, monkeypatch, tmp_path):
+        """On a real probe failure the bare name is shown (no false negative).
+
+        Documented semantics (#598): only a successful response that
+        definitively lacks the palace yields ``(not created)``. Here the
+        palaces endpoint errors, so ``_palace_exists`` returns True (fail-safe)
+        and the suffix is omitted.
+        """
+        self._present_healthy_memory(monkeypatch, tmp_path)
+
+        import urllib.request
+
+        def _boom(*_a, **_k):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "palace: claude-mpm" in line
+        assert "(not created)" not in line
+
+    def test_existence_probe_uses_timeout_at_most_200ms(self, monkeypatch, tmp_path):
+        self._present_healthy_memory(monkeypatch, tmp_path)
+
+        import urllib.request
+
+        seen: dict[str, object] = {}
+
+        def _fake_urlopen(_req, timeout=None):
+            seen["timeout"] = timeout
+            return _fake_palaces_resp(200, "[]")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        get_trusty_status("trusty-memory")
+        assert seen["timeout"] == _HEALTH_TIMEOUT_S
+        assert seen["timeout"] <= 0.2
+
+    def test_no_existence_probe_when_not_running(self, monkeypatch, tmp_path):
+        """Health fails → palace probe must NOT run (zero added cost)."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-memory", "127.0.0.1:7070")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("palace probe must not run when not running")
+
+        monkeypatch.setattr(trusty_status, "_palace_exists", _boom)
+        state, _line = get_trusty_status("trusty-memory")
+        assert state == "not_running"
+
+    def test_no_existence_probe_when_absent(self, monkeypatch, tmp_path):
+        """Not opted in → neither health nor palace probe runs (zero cost)."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)  # no .mcp.json, no http_addr
+
+        def _boom(*_a, **_k):
+            raise AssertionError("no probe may run when absent")
+
+        monkeypatch.setattr(trusty_status, "_health_check", _boom)
+        monkeypatch.setattr(trusty_status, "_palace_exists", _boom)
+        state, line = get_trusty_status("trusty-memory")
+        assert (state, line) == ("absent", "")
+
+    def test_search_never_does_palace_probe(self, monkeypatch, tmp_path):
+        """trusty-search has no palace concept → existence probe never runs."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-search", "localhost:7878")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("search must not do a palace probe")
+
+        monkeypatch.setattr(trusty_status, "_palace_exists", _boom)
+        state, line = get_trusty_status("trusty-search")
+        assert state == "on"
+        assert "palace" not in line

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -1,10 +1,14 @@
 """Unit tests for trusty daemon connection status (GitHub #598).
 
-Covers the scoped design:
-* binary absent → suppressed (empty line)
-* binary present + health OK → ``on`` line with correct host:port (+ palace for memory)
-* binary present + health fail + in .mcp.json → ``not running``
-* binary present + health fail + not in .mcp.json → ``not running``
+Covers the scoped design after the presence-signal fix:
+* not opted in (no .mcp.json entry, no http_addr file) → suppressed (empty
+  line) AND the health probe is never called (zero cost)
+* present via .mcp.json entry ONLY (no http_addr file, binary name irrelevant)
+  + health OK → ``on`` line — this is the exact regression that was broken when
+  the gate was ``shutil.which`` and the launched binary was a bridge/wrapper
+* present via http_addr file ONLY → probed
+* present + health fail + in .mcp.json → ``configured`` / ``not running``
+* present + health fail + not in .mcp.json → ``not_running`` / ``not running``
 * NO ``/ui`` substring ever appears
 * the ≤0.2s timeout is actually passed to the probe
 """
@@ -30,64 +34,118 @@ def _clear_health_cache():
     trusty_status._HEALTH_CACHE.clear()
 
 
-def _setup_addr_file(monkeypatch, tmp_path: Path, service: str, addr: str) -> None:
-    """Point ``Path.home()`` at tmp_path and write a discovery file."""
+def _point_home(monkeypatch, tmp_path: Path) -> None:
+    """Point ``Path.home()`` at an isolated tmp dir (no discovery files yet)."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+def _point_cwd(monkeypatch, tmp_path: Path) -> None:
+    """Point ``Path.cwd()`` at an isolated tmp dir (no .mcp.json yet)."""
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+
+
+def _write_addr_file(tmp_path: Path, service: str, addr: str) -> None:
+    """Write a ``~/.trusty-<service>/http_addr`` discovery file under tmp_path."""
     addr_dir = tmp_path / f".{service}"
     addr_dir.mkdir(parents=True, exist_ok=True)
     (addr_dir / "http_addr").write_text(addr, encoding="utf-8")
 
 
-class TestBinaryAbsent:
-    """Cold-path short-circuit: binary not on PATH renders nothing."""
+def _write_mcp_json(tmp_path: Path, *services: str) -> None:
+    """Write a CWD ``.mcp.json`` listing ``services`` in ``mcpServers``.
 
-    def test_memory_absent_renders_nothing(self, monkeypatch):
-        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
-        state, line = get_trusty_status("trusty-memory")
+    Each command intentionally uses a NON-matching binary name (a bridge) to
+    prove the presence signal does not depend on the binary name.
+    """
+    import json
+
+    servers = {svc: {"command": f"{svc}-mcp-bridge"} for svc in services}
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": servers}), encoding="utf-8"
+    )
+
+
+class TestNotOptedIn:
+    """Cold-path short-circuit: no .mcp.json entry AND no http_addr → nothing."""
+
+    @pytest.mark.parametrize("service", ["trusty-memory", "trusty-search"])
+    def test_neither_signal_renders_nothing(self, monkeypatch, tmp_path, service):
+        # Isolated home (no discovery file) and isolated cwd (no .mcp.json).
+        _point_home(monkeypatch, tmp_path / "home")
+        _point_cwd(monkeypatch, tmp_path / "proj")
+        (tmp_path / "home").mkdir()
+        (tmp_path / "proj").mkdir()
+
+        state, line = get_trusty_status(service)
         assert state == "absent"
         assert line == ""
 
-    def test_search_absent_renders_nothing(self, monkeypatch):
-        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
-        state, line = get_trusty_status("trusty-search")
-        assert state == "absent"
-        assert line == ""
-
-    def test_absent_does_not_probe_health(self, monkeypatch):
-        """When binary absent, no HTTP probe should happen (zero cost)."""
-        monkeypatch.setattr(trusty_status.shutil, "which", lambda _: None)
+    def test_neither_signal_does_not_probe_health(self, monkeypatch, tmp_path):
+        """No presence signal → no HTTP probe should happen (zero cost)."""
+        _point_home(monkeypatch, tmp_path / "home")
+        _point_cwd(monkeypatch, tmp_path / "proj")
+        (tmp_path / "home").mkdir()
+        (tmp_path / "proj").mkdir()
 
         def _boom(*_args, **_kwargs):
-            raise AssertionError("health check must not run when binary absent")
+            raise AssertionError("health check must not run when not opted in")
 
         monkeypatch.setattr(trusty_status, "_health_check", _boom)
         state, line = get_trusty_status("trusty-memory")
         assert (state, line) == ("absent", "")
 
 
-class TestHealthOk:
-    """Binary present + /health OK → ``on`` line."""
+class TestPresentViaMcpJsonOnly:
+    """Regression for #598: present via .mcp.json with NO http_addr file.
 
-    def test_memory_on_includes_host_port_and_palace(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "localhost:7070")
+    Previously suppressed because the gate was ``shutil.which("trusty-memory")``
+    while the launched binary is ``trusty-memory-mcp-bridge`` (name mismatch).
+    """
+
+    def test_memory_mcp_only_health_ok_renders_on(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)  # no http_addr file written
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-memory")  # binary name is a bridge, not matching
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
         monkeypatch.setattr(trusty_status, "_palace_name", lambda: "my-palace")
 
         state, line = get_trusty_status("trusty-memory")
         assert state == "on"
         assert "trusty-memory: on" in line
-        assert "localhost:7070" in line
+        # Falls back to the default port since there is no discovery file.
+        assert "127.0.0.1:7070" in line
         assert "palace: my-palace" in line
         assert "/ui" not in line
 
-    def test_search_on_includes_host_port_no_palace(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+    def test_memory_mcp_only_no_http_addr_file_on_disk(self, monkeypatch, tmp_path):
+        """Guard: the regression scenario truly has NO discovery file."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-memory")
+
+        assert not (home / ".trusty-memory" / "http_addr").exists()
+        assert trusty_status._is_present("trusty-memory") is True
+
+
+class TestPresentViaHttpAddrOnly:
+    """Present via http_addr discovery file only (no .mcp.json entry)."""
+
+    def test_search_addr_only_health_ok_renders_on(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)  # no .mcp.json
+        _write_addr_file(home, "trusty-search", "localhost:7878")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
 
         state, line = get_trusty_status("trusty-search")
@@ -97,12 +155,15 @@ class TestHealthOk:
         assert "palace" not in line
         assert "/ui" not in line
 
-    def test_on_uses_actual_dynamic_port(self, monkeypatch, tmp_path):
+    def test_addr_only_uses_actual_dynamic_port(self, monkeypatch, tmp_path):
         """The actual host:port from http_addr is used, not the default port."""
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "127.0.0.1:54321")
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-search", "127.0.0.1:54321")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
 
         state, line = get_trusty_status("trusty-search")
@@ -112,10 +173,13 @@ class TestHealthOk:
 
     def test_health_probed_against_correct_base_url(self, monkeypatch, tmp_path):
         """The /health endpoint is built from the discovered base URL."""
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "127.0.0.1:9999")
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-memory", "127.0.0.1:9999")
 
         seen: dict[str, str] = {}
 
@@ -130,15 +194,18 @@ class TestHealthOk:
 
 
 class TestHealthFail:
-    """Binary present + /health fail → ``not running``."""
+    """Present + /health fail → ``not running``."""
 
     def test_fail_in_mcp_json_state_configured(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-memory"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-memory", "localhost:7070")
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-memory")
+        _write_addr_file(home, "trusty-memory", "localhost:7070")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
-        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: True)
 
         state, line = get_trusty_status("trusty-memory")
         assert state == "configured"
@@ -146,13 +213,17 @@ class TestHealthFail:
         assert "(start: trusty-memory ...)" in line
         assert "/ui" not in line
 
-    def test_fail_not_in_mcp_json_still_not_running(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+    def test_fail_addr_only_not_in_mcp_json_still_not_running(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)  # no .mcp.json → not configured
+        _write_addr_file(home, "trusty-search", "localhost:7878")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
-        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: False)
 
         state, line = get_trusty_status("trusty-search")
         assert state == "not_running"
@@ -162,24 +233,60 @@ class TestHealthFail:
         assert "/ui" not in line
 
 
+class TestPresenceSignal:
+    """:func:`_is_present` OR semantics across the two filesystem signals."""
+
+    def test_present_via_mcp_only(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-memory")
+        assert trusty_status._is_present("trusty-memory") is True
+        assert trusty_status._is_present("trusty-search") is False
+
+    def test_present_via_addr_only(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-search", "localhost:7878")
+        assert trusty_status._is_present("trusty-search") is True
+        assert trusty_status._is_present("trusty-memory") is False
+
+    def test_absent_when_neither(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        assert trusty_status._is_present("trusty-memory") is False
+        assert trusty_status._is_present("trusty-search") is False
+
+
 class TestMcpConfigRead:
-    """.mcp.json read behavior."""
+    """.mcp.json read behavior (signal #1 helper)."""
 
     def test_configured_when_present(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        _point_cwd(monkeypatch, tmp_path)
         (tmp_path / ".mcp.json").write_text(
-            '{"mcpServers": {"trusty-memory": {"command": "x"}}}',
+            '{"mcpServers": {"trusty-memory": {"command": "trusty-memory-mcp-bridge"}}}',
             encoding="utf-8",
         )
         assert trusty_status._is_configured_in_mcp("trusty-memory") is True
         assert trusty_status._is_configured_in_mcp("trusty-search") is False
 
     def test_not_configured_when_missing_file(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        _point_cwd(monkeypatch, tmp_path)
         assert trusty_status._is_configured_in_mcp("trusty-memory") is False
 
     def test_not_configured_when_malformed_json(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        _point_cwd(monkeypatch, tmp_path)
         (tmp_path / ".mcp.json").write_text("{ not valid json", encoding="utf-8")
         assert trusty_status._is_configured_in_mcp("trusty-memory") is False
 
@@ -229,10 +336,13 @@ class TestHealthCache:
     """Probe result is cached by the http_addr file mtime."""
 
     def test_repeat_probe_is_cached(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: "/usr/bin/trusty-search"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, "trusty-search", "localhost:7878")
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-search", "localhost:7878")
 
         calls = {"n": 0}
 
@@ -253,12 +363,14 @@ class TestNoUiSubstring:
     @pytest.mark.parametrize("service", ["trusty-memory", "trusty-search"])
     @pytest.mark.parametrize("healthy", [True, False])
     def test_no_ui_in_any_state(self, monkeypatch, tmp_path, service, healthy):
-        monkeypatch.setattr(
-            trusty_status.shutil, "which", lambda _: f"/usr/bin/{service}"
-        )
-        _setup_addr_file(monkeypatch, tmp_path, service, "localhost:7070")
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, service, "localhost:7070")
         monkeypatch.setattr(trusty_status, "_health_check", lambda _url: healthy)
         monkeypatch.setattr(trusty_status, "_palace_name", lambda: "p")
-        monkeypatch.setattr(trusty_status, "_is_configured_in_mcp", lambda _s: False)
         _, line = get_trusty_status(service)
         assert "/ui" not in line


### PR DESCRIPTION
## Summary
Implements #598 — adds trusty-memory and trusty-search connection indicator lines to the startup banner, below the existing `⚡ ztk compression` line.

Scoped design (refined from the issue spec after a research + adversarial review pass):
- **No `/ui` dashboard URL** — that route does not exist in the daemons; the connected line shows only `host:port`.
- **Presence gated on `.mcp.json` mcpServers entry OR `~/.trusty-<service>/http_addr`** — not on binary name. (A binary-name check via `shutil.which` wrongly suppressed trusty-memory, whose launched binary is `trusty-memory-mcp-bridge`.)
- **Bounded, cached health probe** (≤0.2s, keyed by http_addr mtime) — zero added startup latency when daemons are down/absent; nothing rendered for services the user hasn't opted into.
- **Palace existence verified** via `GET /api/v1/palaces` — shows `palace: <name>` only if it exists, else `palace: <name> (not created)`. Probe fires only when the daemon is already healthy; fail-safe omits the suffix on any probe error.

## States per service
- `on` — `/health` 2xx → shows `host:port` (+ verified palace for memory)
- `not running` — present but `/health` failed
- absent (not opted in) → no line rendered

## Testing
- New `tests/test_trusty_status.py` + additions to `tests/test_startup_display.py`.
- `uv run pytest tests/test_trusty_status.py tests/test_startup_display.py -p no:xdist` → 102 passed.

## Notes
- Self-contained module; intentionally does not refactor the other existing copies of URL/health helpers (blast-radius limiting).
- `startup_display.py` wired in both wide and narrow terminal paths.

Closes #598