### PR TITLE
feat: PR-based delivery workflow as framework default (#602)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,15 @@ Closes #447"
 
 ---
 
+## 🔴 Delivery Workflow (PR-based)
+
+**No direct-to-main for substantive work.** Feature / fix / refactor work lands on `main` only via a squash-merged Pull Request: `issue → branch → build/test → commit → PR → squash-merge`. Create/reference a GitHub issue first, branch off latest `main` (`feat/<issue>-<slug>`, `fix/<issue>-<slug>`), then open a PR and squash-merge after CI passes (delete the branch).
+
+- **Trivial work** (docs / chore / typo): issue optional, but branch + PR are still required — never commit trivial work directly to `main`.
+- **Exemption (direct-to-main allowed):** release tooling only — `make release-*` version bumps and `chore: update uv.lock` commits.
+
+---
+
 ## 🔴 Release Workflow
 
 Always use Makefile targets. Never manually edit version files.

--- a/docs/developer/AGENT_ASSEMBLY_PIPELINE.md
+++ b/docs/developer/AGENT_ASSEMBLY_PIPELINE.md
@@ -47,7 +47,7 @@ Four input blocks are merged into a single `PM_INSTRUCTIONS_DEPLOYED.md`:
 
 1. **PM_INSTRUCTIONS.md** — PM core identity and responsibilities
 2. **AGENT_DELEGATION.md** — available agent capabilities and how to invoke them
-3. **WORKFLOW.md** — mandatory 5-phase workflow sequence (special lazy-load logic)
+3. **WORKFLOW.md** — mandatory Delivery Workflow (issue → branch → build/test → commit → PR → squash-merge → publish) plus the 5-phase workflow sequence (special lazy-load logic)
 4. **MEMORY.md** — static memory management guidance
 
 Each block has a 3-level resolution priority:

--- a/docs/specs/agents.md
+++ b/docs/specs/agents.md
@@ -402,7 +402,11 @@ debugging deployed files.
   `InstructionLoader.load_workflow_instructions()`. When no override exists, a short
   `WORKFLOW_SYSTEM_REFERENCE` stub is inlined rather than the full system-level
   `WORKFLOW.md`. This keeps the deployed file concise while preserving the live prompt
-  behaviour.
+  behaviour. The system-level `WORKFLOW.md` contains a mandatory **Delivery Workflow**
+  section (issue → branch → build/test → commit → PR → squash-merge → publish, with
+  trivial-work and release-tooling exemptions) in addition to the
+  `## Mandatory 5-Phase Sequence`; the latter heading remains the stale-override
+  fingerprint used by `BLOCK_MARKERS` / `_detect_stale_override`.
 
 - **Error conditions:** If no blocks resolve to any content, an error is appended to
   `results["errors"]` and the function returns without writing. Individual block

--- a/docs/workflow/PM_WORKFLOW.md
+++ b/docs/workflow/PM_WORKFLOW.md
@@ -2,6 +2,26 @@
 
 # PM Workflow Configuration
 
+## Delivery Workflow (MANDATORY)
+
+No direct commits to `main`. Substantive work lands on `main` only via a squash-merged Pull Request. Do not bypass branch protection with `git push origin main`.
+
+**Substantive work (feature / fix / refactor):**
+`prompt → issue → branch → build/test → commit → PR → squash-merge → publish/deploy`
+1. **Issue** — create/reference a GitHub issue (intent + acceptance criteria). Delegate to ticketing_agent / Version Control.
+2. **Branch** — feature branch off latest `main` (`feat/<issue>-<slug>`, `fix/<issue>-<slug>`).
+3. **Build/test** — implement; run linters + full test suite (show raw output); QA verifies the runtime artifact.
+4. **Commit** — ONE FILE PER COMMIT, conventional prefixes, `Closes #N` in the functional commit body.
+5. **PR** — open via Version Control agent; link the issue.
+6. **Squash-merge** — after CI + QA pass; delete the branch.
+7. **Publish/deploy** — release via `make release-*` (Local Ops); verify the published artifact.
+
+**Trivial work (docs / chore / typo):** issue OPTIONAL; branch + PR still REQUIRED (never direct-to-main): `branch → commit → PR → squash-merge`.
+
+**Exemptions (direct-to-main allowed):** release tooling only — `make release-*` version bumps and `chore: update uv.lock` commits. Nothing else.
+
+**Branch hygiene:** delete feature branches after squash-merge; never run parallel agents on the same branch; keep `main` clean (no throwaway commits).
+
 ## Mandatory 5-Phase Sequence
 
 ### Phase 1: Research (CONDITIONAL)

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -1,4 +1,4 @@
-<!-- PM_INSTRUCTIONS_VERSION: 0014 -->
+<!-- PM_INSTRUCTIONS_VERSION: 0015 -->
 <!-- PURPOSE: Token-optimized PM instructions. All rules preserved, compressed format. -->
 
 # PM Agent -- Claude MPM
@@ -163,6 +163,8 @@ Skip Research, Code Analysis, QA, Documentation phases. Engineer handles everyth
 
 ## Workflow (5-phase)
 
+**Delivery (MANDATORY):** No direct commits to `main`. Substantive work (feature/fix/refactor) follows `prompt → issue → branch → build/test → commit → PR → squash-merge → publish`. Trivial docs/chore = branch + PR (issue optional), still never direct-to-main. Exemption: release tooling only (`make release-*`, `chore: update uv.lock`). See WORKFLOW.md → Delivery Workflow.
+
 See WORKFLOW.md for details. Summary:
 
 | Phase | Agent | Gate | Skip When |
@@ -311,7 +313,7 @@ Final `git status` before session end.
 
 **[SKILL: mpm-pr-workflow]**
 
-All pushes to main/master require feature branch + PR. Delegate to Version Control agent.
+No direct-to-main. Substantive work (feature/fix/refactor) is issue-first: create/reference a GitHub issue, branch off latest `main` (`feat/<issue>-<slug>`), implement + test, open PR (link issue), squash-merge after CI + QA pass, then delete the branch. Trivial docs/chore work skips the issue but still requires branch + PR + squash-merge. Direct-to-main is allowed ONLY for release tooling (`make release-*` version bumps, `chore: update uv.lock`). Delegate all branch/PR/merge operations to the Version Control agent.
 
 ## Ticketing Integration
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -2,6 +2,26 @@
 
 # PM Workflow Configuration
 
+## Delivery Workflow (MANDATORY)
+
+No direct commits to `main`. Substantive work lands on `main` only via a squash-merged Pull Request. Do not bypass branch protection with `git push origin main`.
+
+**Substantive work (feature / fix / refactor):**
+`prompt → issue → branch → build/test → commit → PR → squash-merge → publish/deploy`
+1. **Issue** — create/reference a GitHub issue (intent + acceptance criteria). Delegate to ticketing_agent / Version Control.
+2. **Branch** — feature branch off latest `main` (`feat/<issue>-<slug>`, `fix/<issue>-<slug>`).
+3. **Build/test** — implement; run linters + full test suite (show raw output); QA verifies the runtime artifact.
+4. **Commit** — ONE FILE PER COMMIT, conventional prefixes, `Closes #N` in the functional commit body.
+5. **PR** — open via Version Control agent; link the issue.
+6. **Squash-merge** — after CI + QA pass; delete the branch.
+7. **Publish/deploy** — release via `make release-*` (Local Ops); verify the published artifact.
+
+**Trivial work (docs / chore / typo):** issue OPTIONAL; branch + PR still REQUIRED (never direct-to-main): `branch → commit → PR → squash-merge`.
+
+**Exemptions (direct-to-main allowed):** release tooling only — `make release-*` version bumps and `chore: update uv.lock` commits. Nothing else.
+
+**Branch hygiene:** delete feature branches after squash-merge; never run parallel agents on the same branch; keep `main` clean (no throwaway commits).
+
 ## Mandatory 5-Phase Sequence
 
 ### Phase 1: Research (CONDITIONAL)

--- a/src/claude_mpm/agents/templates/pr-workflow-examples.md
+++ b/src/claude_mpm/agents/templates/pr-workflow-examples.md
@@ -415,6 +415,88 @@ Ready for review"
 
 ---
 
+## Delivery Workflow Examples
+
+The framework default delivery flow: substantive work lands on `main` ONLY via a squash-merged PR. These examples cover the three canonical paths.
+
+### Example 1: Full Substantive Flow (issue → branch → commit → PR → squash-merge)
+
+**Scenario**: Implement a new feature (`feat`).
+
+```
+prompt → issue → branch → build/test → commit → PR → squash-merge → publish
+
+1. Issue
+   PM → Ticketing: "Create issue: add retry policy to HTTP client
+   (intent + acceptance criteria)"
+   Ticketing: "Created #512"
+
+2. Branch
+   PM → Version Control: "Branch feat/512-http-retry-policy off latest main"
+
+3. Build/test
+   Engineer: implements; runs `uv run ruff check` + full `pytest` suite
+   QA: verifies the runtime artifact, attaches raw test output
+
+4. Commit (ONE FILE PER COMMIT, conventional prefix)
+   feat: add retry policy to HTTP client
+
+   Closes #512
+
+5. PR
+   PM → Version Control: "Open PR for feat/512-http-retry-policy, link #512"
+   Version Control: "PR #88 created, base main"
+
+6. Squash-merge
+   After CI + QA pass → squash-merge PR #88 → delete branch feat/512-http-retry-policy
+
+7. Publish
+   PM → Local Ops: "Release via make release-minor && make release-publish;
+   verify published artifact"
+```
+
+### Example 2: Trivial Change Flow (branch → PR → squash, NO issue)
+
+**Scenario**: Fix a typo in the README (`docs`/`chore`). Issue is OPTIONAL; branch + PR are still REQUIRED — never direct-to-main.
+
+```
+branch → commit → PR → squash-merge
+
+1. Branch
+   PM → Version Control: "Branch docs/readme-typo off latest main" (no issue needed)
+
+2. Commit
+   docs: fix typo in installation instructions
+
+3. PR
+   PM → Version Control: "Open PR for docs/readme-typo"
+   Version Control: "PR #89 created, base main"
+
+4. Squash-merge
+   After CI passes → squash-merge PR #89 → delete branch docs/readme-typo
+```
+
+### Example 3: Release-Tooling Exemption (direct-to-main ALLOWED)
+
+**Scenario**: Version bump and lockfile update during a release. These are the ONLY operations permitted to commit directly to `main`.
+
+```
+1. PM → Local Ops: "Run make release-patch"
+   Local Ops: bumps version files (pyproject.toml, package.json, VERSION)
+   Commit lands directly on main:
+     bump: version 6.5.8 → 6.5.9
+
+2. Lockfile sync also direct-to-main:
+     chore: update uv.lock for 6.5.9 version bump
+
+3. PM → Local Ops: "Run make release-publish; verify PyPI/npm/Homebrew artifacts"
+
+NOTE: This exemption covers release tooling ONLY (make release-* bumps and
+uv.lock sync). All feature/fix/refactor work still requires the PR flow above.
+```
+
+---
+
 ## Related References
 
 - **Version Control Agent**: See [version-control.md](version-control.md)

--- a/src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md
@@ -30,6 +30,26 @@ When users request main branch operations:
 
 **Error Prevention**: PM proactively guides users to feature branch + PR workflow (don't wait for git errors).
 
+## Delivery Workflow Requirements
+
+The PR workflow is the framework default for landing work on `main`. Enforce these rules:
+
+### Issue-First (Substantive Work)
+
+For substantive work (feature / fix / refactor), **create or reference a GitHub issue before creating the branch**. The issue captures intent + acceptance criteria. Delegate issue creation to the ticketing_agent / Version Control agent. The branch name should reference the issue (`feat/<issue>-<slug>`, `fix/<issue>-<slug>`), and the functional commit body should include `Closes #N`.
+
+### Squash-Merge Is Required
+
+PRs MUST be merged using the **squash-merge** strategy (one clean commit on `main` per PR). **Delete the feature branch immediately after the squash-merge.** Do not use merge commits or rebase-merge for these PRs.
+
+### Trivial-Work Exemption (Issue Optional)
+
+Trivial work (docs / chore / typo) may **skip the issue**, but still REQUIRES a branch + PR + squash-merge. Never commit trivial work directly to `main`.
+
+### Release-Tooling Exemption (Direct-to-Main Allowed)
+
+Direct commits to `main` are permitted ONLY for release tooling: `make release-*` version bumps and `chore: update uv.lock` commits. Nothing else may bypass the PR workflow.
+
 ## PR Workflow Delegation
 
 **Default**: Main-based PRs (unless user explicitly requests stacked)


### PR DESCRIPTION
This makes `prompt → issue → branch → build/test → commit → PR → squash-merge → publish` the **framework default** delivery workflow.

## Workflow tiers
- **Substantive work**: full sequence (issue → branch → build/test → commit → PR → squash-merge → publish).
- **Trivial docs/chore**: branch + PR (issue optional).
- **Release tooling**: exempt (`make release-*` retains its own flow).

## Changed files (8)
1. `src/claude_mpm/agents/WORKFLOW.md` — delivery workflow definition.
2. `docs/workflow/PM_WORKFLOW.md` — byte-identical mirror of WORKFLOW.md.
3. `src/claude_mpm/agents/PM_INSTRUCTIONS.md` — bumped to v0015.
4. `src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md` — mpm-pr-workflow skill.
5. `src/claude_mpm/agents/templates/pr-workflow-examples.md` — pr-workflow-examples template.
6. `docs/specs/agents.md` — agents spec update.
7. `docs/developer/AGENT_ASSEMBLY_PIPELINE.md` — pipeline doc update.
8. `CLAUDE.md` — project instructions update.

## Validation
- 52 focused guard tests pass.
- The `## Mandatory 5-Phase Sequence` stale-override marker is preserved.

Closes #602

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
