### PR TITLE
feat: auto-detect & link trusty-memory/-search per project on startup (palace + hooks)

### DIFF
--- a/src/claude_mpm/cli/commands/setup/handlers/trusty.py
+++ b/src/claude_mpm/cli/commands/setup/handlers/trusty.py
@@ -9,58 +9,16 @@ Each `_setup_trusty_*` follows the same shape:
 
 from __future__ import annotations
 
-import json
-import os
 import shutil
 import subprocess  # nosec B404
-import tempfile
 from pathlib import Path
 from typing import Any
 
+from .....services.trusty_hooks import inject_trusty_hooks
 from ....constants import SetupService
 from ....shared import CommandResult
 from .._shared import console
 from ..mcp_config import _mcp_config_transaction
-
-# Legacy services whose hooks should be removed when injecting trusty hooks.
-# These are the predecessors of trusty-search / trusty-memory and would
-# duplicate or conflict with the new daemons.
-_LEGACY_SERVICES = {"kuzu-memory", "mcp-vector-search"}
-
-# Hook specifications keyed by trusty service name. Each entry lists the
-# (event, matcher, hook_dict) tuples to inject. The ``_mpm_service`` tag is
-# the dedup key — re-running setup will not duplicate hooks.
-_TRUSTY_HOOK_SPECS: dict[str, list[tuple[str, str, dict[str, Any]]]] = {
-    "trusty-memory": [
-        (
-            event,
-            "*",
-            {
-                "type": "command",
-                "command": "claude-hook",
-                "timeout": 15,
-                "_mpm": True,
-                "_mpm_service": "trusty-memory",
-            },
-        )
-        for event in ("SessionStart", "Stop", "SubagentStop")
-    ],
-    "trusty-search": [
-        (
-            "PostToolUse",
-            "Write|MultiEdit|Edit|NotebookEdit",
-            {
-                "type": "command",
-                "command": "python3",
-                "args": ["-m", "claude_mpm.hooks.trusty_index_hook"],
-                "timeout": 10,
-                "async": True,
-                "_mpm": True,
-                "_mpm_service": "trusty-search",
-            },
-        ),
-    ],
-}
 
 
 class TrustyMixin:
@@ -322,204 +280,49 @@ class TrustyMixin:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
-        """Write JSON atomically: write to a sibling temp file, then rename.
+    def _console_hook_report(msg: str) -> None:
+        """Re-wrap a plain hook-injection status line in rich markup.
 
-        Why atomic: settings.json is read by Claude Code on every hook
-        invocation; a partial write would crash hooks until repaired.
+        Why: the shared :mod:`claude_mpm.services.trusty_hooks` helper is
+        console-free (so the startup migration can reuse it); the interactive
+        setup command still wants colored output. This maps the leading glyph
+        of each status line back to the original rich color so the setup UX is
+        unchanged after the extraction.
+        What: dispatches on the first character (``✓``→green, ``⚠``→yellow,
+        ``✗``→red, anything else→dim) and prints via the rich console.
+        Test: ``tests/test_trusty_hooks.py`` asserts structural parity; this
+        wrapper is presentation-only.
         """
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # Use a NamedTemporaryFile in the same directory so os.replace is
-        # guaranteed to be atomic (same filesystem).
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-                f.write("\n")
-            Path(tmp_path).replace(path)
-        except Exception:
-            # Best effort cleanup of temp file.
-            try:
-                Path(tmp_path).unlink()
-            except OSError:
-                pass
-            raise
-
-    @staticmethod
-    def _load_settings(path: Path) -> dict[str, Any]:
-        """Load a Claude Code settings.json, returning skeleton on absence.
-
-        Tolerates an existing file that lacks the ``hooks`` key.
-        """
-        if not path.exists():
-            return {"hooks": {}}
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise RuntimeError(f"Could not parse {path}: {exc}") from exc
-        if not isinstance(data, dict):
-            raise RuntimeError(f"{path} root is not a JSON object")
-        data.setdefault("hooks", {})
-        if not isinstance(data["hooks"], dict):
-            raise RuntimeError(f"{path}: 'hooks' is not an object")
-        return data
-
-    def _inject_hooks_to_settings(
-        self, settings_path: Path, services: list[str]
-    ) -> None:
-        """Inject trusty hook entries into a Claude Code settings.json.
-
-        For each requested service:
-        - Remove any hooks tagged with ``_mpm_service`` in ``_LEGACY_SERVICES``
-          across all events (cleanup of predecessor hooks).
-        - Add the hooks declared in ``_TRUSTY_HOOK_SPECS[service]`` to the
-          matching (event, matcher) group, skipping any whose
-          ``_mpm_service`` already exists in that group (idempotent).
-
-        File handling:
-        - Creates the file with ``{"hooks": {}}`` if missing.
-        - Preserves all unrelated hooks (e.g. user personal scripts).
-        - Writes atomically (temp file + rename).
-        - Reports removals and additions via the rich console.
-        """
-        try:
-            settings = self._load_settings(settings_path)
-        except RuntimeError as exc:
-            console.print(f"[yellow]⚠ Skipping {settings_path}: {exc}[/yellow]")
-            return
-
-        hooks_root: dict[str, Any] = settings["hooks"]
-        removed_count = 0
-        added: list[str] = []
-        skipped: list[str] = []
-
-        # ----- Removal pass: drop legacy-service hooks across all events.
-        for event_name, groups in list(hooks_root.items()):
-            if not isinstance(groups, list):
-                continue
-            new_groups: list[dict[str, Any]] = []
-            for group in groups:
-                if not isinstance(group, dict):
-                    new_groups.append(group)
-                    continue
-                inner = group.get("hooks")
-                if not isinstance(inner, list):
-                    new_groups.append(group)
-                    continue
-                filtered_inner = [
-                    h
-                    for h in inner
-                    if not (
-                        isinstance(h, dict)
-                        and h.get("_mpm_service") in _LEGACY_SERVICES
-                    )
-                ]
-                dropped = len(inner) - len(filtered_inner)
-                if dropped:
-                    removed_count += dropped
-                # Drop the entire group if its hooks list is now empty AND
-                # the group only held legacy hooks (no other meaningful keys).
-                if filtered_inner:
-                    group["hooks"] = filtered_inner
-                    new_groups.append(group)
-                elif not inner:
-                    new_groups.append(group)
-                # else: group is empty after removal, drop it.
-            if new_groups:
-                hooks_root[event_name] = new_groups
-            else:
-                del hooks_root[event_name]
-
-        # ----- Injection pass: add trusty hooks idempotently.
-        for service in services:
-            for event, matcher, hook_def in _TRUSTY_HOOK_SPECS.get(service, []):
-                groups = hooks_root.setdefault(event, [])
-                if not isinstance(groups, list):
-                    console.print(
-                        f"[yellow]⚠ {settings_path}: '{event}' is not a list — "
-                        f"skipping injection.[/yellow]"
-                    )
-                    continue
-
-                # Find a group with the matching matcher, or create one.
-                target_group: dict[str, Any] | None = None
-                for group in groups:
-                    if (
-                        isinstance(group, dict)
-                        and group.get("matcher") == matcher
-                        and isinstance(group.get("hooks"), list)
-                    ):
-                        target_group = group
-                        break
-                if target_group is None:
-                    target_group = {"matcher": matcher, "hooks": []}
-                    groups.append(target_group)
-
-                inner_hooks: list[Any] = target_group["hooks"]
-                tag = hook_def.get("_mpm_service")
-                # Dedup by _mpm_service within the same (event, matcher) group.
-                already_present = any(
-                    isinstance(h, dict) and h.get("_mpm_service") == tag
-                    for h in inner_hooks
-                )
-                if already_present:
-                    skipped.append(f"{event}[{matcher}]:{tag}")
-                    continue
-                inner_hooks.append(hook_def)
-                added.append(f"{event}[{matcher}]:{tag}")
-
-        # ----- Write back atomically.
-        try:
-            self._atomic_write_json(settings_path, settings)
-        except OSError as exc:
-            console.print(f"[red]✗ Failed to write {settings_path}: {exc}[/red]")
-            return
-
-        # ----- Report.
-        rel = str(settings_path)
-        if removed_count:
-            console.print(
-                f"[yellow]• {rel}: removed {removed_count} legacy hook(s) "
-                f"({', '.join(sorted(_LEGACY_SERVICES))})[/yellow]"
-            )
-        if added:
-            console.print(
-                f"[green]✓ {rel}: added {len(added)} hook(s): "
-                f"{', '.join(added)}[/green]"
-            )
-        if skipped:
-            console.print(
-                f"[dim]• {rel}: {len(skipped)} hook(s) already present, skipped[/dim]"
-            )
-        if not (removed_count or added or skipped):
-            console.print(f"[dim]• {rel}: no hook changes needed[/dim]")
+        if msg.startswith("✓"):
+            console.print(f"[green]{msg}[/green]")
+        elif msg.startswith("⚠"):
+            console.print(f"[yellow]{msg}[/yellow]")
+        elif msg.startswith("✗"):
+            console.print(f"[red]{msg}[/red]")
+        else:
+            console.print(f"[dim]{msg}[/dim]")
 
     def _inject_trusty_hooks(self, services: list[str]) -> None:
         """Inject hooks into both project and user-level settings.
 
-        Project settings (``./.claude/settings.json``) are only touched if
-        the file already exists — we don't want to create a project-level
-        config silently. User settings (``~/.claude/settings.json``) are
-        created if missing because per-user hook injection is the documented
-        intent of this setup step.
+        Why: delegates to the shared, console-free
+        :func:`claude_mpm.services.trusty_hooks.inject_trusty_hooks` so the
+        interactive setup path and the startup autodetect migration produce
+        identical hook structures from one implementation.
+        What: prints the intro line, then calls the shared helper with a
+        console-printing reporter. Project settings
+        (``./.claude/settings.json``) are only touched if the file already
+        exists; user settings (``~/.claude/settings.json``) are created if
+        missing — the shared helper enforces this rule.
+        Test: ``tests/test_trusty_hooks.py`` covers the merge behavior; the
+        existing setup tests cover the console wiring.
         """
-        project_settings = Path.cwd() / ".claude" / "settings.json"
-        user_settings = Path.home() / ".claude" / "settings.json"
-
         console.print("[cyan]Injecting trusty hooks into Claude settings...[/cyan]")
-
-        if project_settings.exists():
-            self._inject_hooks_to_settings(project_settings, services)
-        else:
-            console.print(
-                f"[dim]• {project_settings} not found — skipping project-level "
-                f"hook injection.[/dim]"
-            )
-
-        # Always inject into user settings (create if missing).
-        self._inject_hooks_to_settings(user_settings, services)
+        inject_trusty_hooks(
+            services,
+            project_dir=Path.cwd(),
+            report=self._console_hook_report,
+        )
 
     # ------------------------------------------------------------------
     # Service-specific setup methods

--- a/src/claude_mpm/core/unified_config.py
+++ b/src/claude_mpm/core/unified_config.py
@@ -310,6 +310,28 @@ class SkillConfig(BaseModel):
     )
 
 
+class TrustyConfig(BaseModel):
+    """Trusty (Rust) daemon auto-linkage configuration.
+
+    Why: when trusty-memory / trusty-search are installed and healthy,
+    claude-mpm auto-links them per project on startup (registers ``.mcp.json``,
+    creates the project memory palace, injects capture/index hooks). Some users
+    want to disable that auto-link entirely; this exposes a typed flag for it.
+    What: ``auto_link`` (default ``True``) gates the startup autodetect
+    migration. The ``CLAUDE_MPM_NO_TRUSTY_AUTO_LINK`` env var also disables it.
+    Test: ``tests/migrations/test_trusty_autodetect.py`` exercises the opt-out.
+    """
+
+    auto_link: bool = Field(
+        default=True,
+        description=(
+            "Auto-detect installed trusty-memory/-search daemons and link them "
+            "to the current project on startup (palace + MCP + hooks). Set to "
+            "false (or export CLAUDE_MPM_NO_TRUSTY_AUTO_LINK=1) to disable."
+        ),
+    )
+
+
 class UnifiedConfig(BaseSettings):
     """
     Unified configuration model for Claude MPM.
@@ -331,6 +353,7 @@ class UnifiedConfig(BaseSettings):
     agents: AgentConfig = Field(default_factory=AgentConfig)
     skills: SkillConfig = Field(default_factory=SkillConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
+    trusty: TrustyConfig = Field(default_factory=TrustyConfig)
     security: SecurityConfig = Field(default_factory=SecurityConfig)
     performance: PerformanceConfig = Field(default_factory=PerformanceConfig)
     sessions: SessionConfig = Field(default_factory=SessionConfig)

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import urllib.error
 import urllib.request
@@ -40,6 +41,12 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Env-var kill-switch for the entire auto-link behavior. Mirrors the
+# ``CLAUDE_MPM_DISABLE_AUTO_DEPLOY_PM_SKILLS`` precedent. Any truthy value
+# disables palace creation, hook injection, AND the .mcp.json write.
+_OPT_OUT_ENV = "CLAUDE_MPM_NO_TRUSTY_AUTO_LINK"
+_TRUTHY = {"1", "true", "yes", "on"}
 
 
 # Service descriptors. Kept inline (not a dataclass) to avoid pulling in
@@ -130,19 +137,138 @@ def _save_mcp_config(mcp_path: Path, config: dict[str, Any]) -> None:
         f.write("\n")
 
 
+def _auto_link_disabled(project_dir: Path) -> bool:
+    """Return True iff auto-link is opted out (env var or project config).
+
+    Why: users must be able to fully disable trusty auto-linkage — both via a
+    quick env-var kill-switch and via a durable project config flag.
+    What: returns True if ``CLAUDE_MPM_NO_TRUSTY_AUTO_LINK`` is truthy, or if
+    ``.claude-mpm/configuration.yaml`` sets ``trusty.auto_link: false``. The
+    config is read best-effort (any error → treated as not-disabled) so a
+    malformed file never blocks startup.
+    Test: ``tests/migrations/test_trusty_autodetect.py`` covers both paths.
+    """
+    if os.environ.get(_OPT_OUT_ENV, "").strip().lower() in _TRUTHY:
+        return True
+
+    config = _load_project_config(project_dir)
+    trusty = config.get("trusty")
+    if isinstance(trusty, dict) and trusty.get("auto_link") is False:
+        return True
+    return False
+
+
+def _load_project_config(project_dir: Path) -> dict[str, Any]:
+    """Load ``.claude-mpm/configuration.yaml`` best-effort.
+
+    Why: the migration runs on the startup hot path and must not depend on the
+    full ``UnifiedConfig`` machinery (which loads env, merges sources, etc.).
+    What: parses the project's ``configuration.yaml`` and returns the resulting
+    dict, or ``{}`` on any error (missing file, parse failure, non-dict root).
+    Test: ``tests/migrations/test_trusty_autodetect.py::test_opt_out_via_config``.
+    """
+    config_path = project_dir / ".claude-mpm" / "configuration.yaml"
+    try:
+        import yaml
+
+        with open(config_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _ensure_palace(base_url: str, palace_name: str) -> None:
+    """Idempotently ensure a memory palace named ``palace_name`` exists.
+
+    Why: without a per-project palace, every trusty-memory MCP call silently
+    no-ops — registering the MCP server in ``.mcp.json`` is not enough on its
+    own. Mirrors the manual ``claude-mpm setup trusty-memory`` behavior so the
+    startup path reaches the same end state.
+    What: ``GET {base_url}/api/v1/palaces`` (case-insensitive existence check);
+    if absent, ``POST`` ``{"name": palace_name, "description": ...}``. All
+    failures are warning-level and swallowed — never raises.
+    Test: ``tests/migrations/test_trusty_autodetect.py`` (created-when-absent,
+    skip-when-present, non-fatal-on-failure).
+    """
+    palaces_url = f"{base_url}/api/v1/palaces"
+
+    # 1. Existence check (case-insensitive). On any error, fall through to the
+    #    POST attempt — a 409/duplicate from the daemon is also non-fatal.
+    palace_found = False
+    try:
+        req = urllib.request.Request(palaces_url, method="GET")  # nosec B310
+        with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310
+            raw = resp.read().decode("utf-8")
+            data = json.loads(raw)
+            palace_list = data if isinstance(data, list) else data.get("palaces", [])
+            for p in palace_list:
+                if (
+                    isinstance(p, dict)
+                    and p.get("name", "").lower() == palace_name.lower()
+                ):
+                    palace_found = True
+                    break
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "trusty autodetect could not list palaces (%s); attempting create", exc
+        )
+
+    if palace_found:
+        logger.info("trusty-memory palace already exists: %s", palace_name)
+        return
+
+    # 2. Create the palace.
+    try:
+        body = json.dumps(
+            {
+                "name": palace_name,
+                "description": "Claude Code session memory for project",
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(  # nosec B310
+            palaces_url,
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310
+            if 200 <= int(resp.status) < 300:
+                logger.info("trusty-memory palace created: %s", palace_name)
+            else:
+                logger.warning(
+                    "trusty-memory palace creation returned HTTP %s", resp.status
+                )
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        logger.warning(
+            "trusty autodetect could not create palace '%s': %s", palace_name, exc
+        )
+
+
 def run_migration(project_dir: Path | None = None) -> bool:
-    """Detect running trusty daemons and inject MCP entries.
+    """Detect running trusty daemons and auto-link them to this project.
+
+    Beyond the original ``.mcp.json`` wiring, this also (idempotently):
+
+    * creates the per-project memory palace when ``trusty-memory`` is healthy,
+    * injects the trusty capture/index hooks into Claude Code settings.
 
     Args:
         project_dir: Directory containing ``.mcp.json`` (defaults to CWD).
 
     Returns:
-        True if any change was made, False if everything was already
-        configured or no daemons were detected. Never raises on the absence
-        path — only propagates exceptions from disk writes.
+        True if any change was made (``.mcp.json`` write or hook injection),
+        False if everything was already configured, no daemons were detected,
+        or auto-link is opted out. Never raises on the absence/opt-out path —
+        only propagates exceptions from disk writes.
     """
     project_dir = project_dir or Path.cwd()
     mcp_path = project_dir / ".mcp.json"
+
+    # Opt-out short-circuit: env-var kill-switch or project config flag.
+    if _auto_link_disabled(project_dir):
+        logger.debug("trusty auto-link disabled via env var or project config")
+        return False
 
     # Determine which services are detectable BEFORE touching .mcp.json so a
     # cold path (no daemons running) doesn't open the file at all.
@@ -153,39 +279,62 @@ def run_migration(project_dir: Path | None = None) -> bool:
         base_url = _resolve_base_url(svc["addr_file"], svc["fallback_addr"])
         if not _http_health_check(f"{base_url}/health"):
             continue
-        detected.append(svc)
+        # Stash the resolved base URL so palace creation reuses it.
+        detected.append({**svc, "base_url": base_url})
 
     if not detected:
         return False
 
-    # Defer the import to avoid a circular dependency at module-load time
-    # (mcp_config lives under cli.commands.setup, which itself may import
-    # migration code indirectly during CLI bootstrap).
+    changed = False
+
+    # 1. Wire .mcp.json entries for any not-yet-registered detected services.
+    #    Deferred import avoids a circular dependency at module-load time
+    #    (mcp_config lives under cli.commands.setup, which itself may import
+    #    migration code indirectly during CLI bootstrap).
     from ..cli.commands.setup.mcp_config import _mcp_config_transaction
 
     config = _load_mcp_config(mcp_path)
     servers = config.setdefault("mcpServers", {})
-
     to_write: list[dict[str, Any]] = [
         svc for svc in detected if svc["name"] not in servers
     ]
+    if to_write:
+        try:
+            with _mcp_config_transaction(project_dir):
+                for svc in to_write:
+                    servers[svc["name"]] = svc["mcp_entry"]
+                    logger.info(
+                        "Auto-configured %s MCP server (daemon detected via %s)",
+                        svc["name"],
+                        svc["addr_file"],
+                    )
+                _save_mcp_config(mcp_path, config)
+            changed = True
+        except Exception as exc:
+            # Transaction context will roll back; log and continue (palace +
+            # hooks are still worth attempting on subsequent detected services).
+            logger.warning("trusty autodetect failed to write .mcp.json: %s", exc)
 
-    if not to_write:
-        return False
+    # 2. Ensure the per-project palace exists for a healthy trusty-memory. This
+    #    runs every startup (idempotent GET/POST) regardless of whether the
+    #    .mcp.json entry already existed — registering the MCP server is not
+    #    enough; the palace must exist for memory calls to persist anything.
+    for svc in detected:
+        if svc["name"] == "trusty-memory":
+            _ensure_palace(svc["base_url"], project_dir.name)
 
+    # 3. Inject the capture/index hooks for whatever was detected. Idempotent
+    #    via _mpm_service dedup keys; only touches ./.claude/settings.json when
+    #    it already exists, always (creates if absent) ~/.claude/settings.json.
     try:
-        with _mcp_config_transaction(project_dir):
-            for svc in to_write:
-                servers[svc["name"]] = svc["mcp_entry"]
-                logger.info(
-                    "Auto-configured %s MCP server (daemon detected via %s)",
-                    svc["name"],
-                    svc["addr_file"],
-                )
-            _save_mcp_config(mcp_path, config)
-    except Exception as exc:
-        # Transaction context will roll back; log and report no-op upward.
-        logger.warning("trusty autodetect failed to write .mcp.json: %s", exc)
-        return False
+        from ..services.trusty_hooks import inject_trusty_hooks
 
-    return True
+        hooks_changed = inject_trusty_hooks(
+            [svc["name"] for svc in detected],
+            project_dir=project_dir,
+        )
+        changed = changed or hooks_changed
+    except Exception as exc:
+        logger.warning("trusty autodetect failed to inject hooks: %s", exc)
+
+    return changed

--- a/src/claude_mpm/services/trusty_hooks.py
+++ b/src/claude_mpm/services/trusty_hooks.py
@@ -1,0 +1,306 @@
+"""Shared, console-free trusty hook-injection logic.
+
+Why: both the interactive ``claude-mpm setup trusty-*`` path
+(:class:`~claude_mpm.cli.commands.setup.handlers.trusty.TrustyMixin`) and the
+startup autodetect migration
+(:mod:`claude_mpm.migrations.migrate_trusty_autodetect`) need to inject the same
+Claude Code settings hooks (SessionStart/Stop/SubagentStop for trusty-memory,
+PostToolUse index for trusty-search). Previously that logic lived inside
+``TrustyMixin`` and was coupled to a rich ``console``, so the migration — which
+must stay dependency-light and silent — could not reuse it.
+
+What: pure functions that read/merge/atomically-write a Claude Code
+``settings.json`` hook block, deduping by ``_mpm_service`` and stripping legacy
+predecessor hooks (kuzu-memory / mcp-vector-search). Reporting is delegated to an
+optional ``report`` callback so callers choose their own sink (rich console for
+setup, ``logging`` for the migration, or ``None`` for total silence).
+
+Test: ``tests/test_trusty_hooks.py`` and ``tests/migrations/test_trusty_autodetect.py``
+cover idempotency, legacy-hook stripping, the "project settings only if it
+already exists" rule, and parity with the old ``TrustyMixin`` output structure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Legacy services whose hooks should be removed when injecting trusty hooks.
+# These are the predecessors of trusty-search / trusty-memory and would
+# duplicate or conflict with the new daemons.
+_LEGACY_SERVICES = {"kuzu-memory", "mcp-vector-search"}
+
+# Hook specifications keyed by trusty service name. Each entry lists the
+# (event, matcher, hook_dict) tuples to inject. The ``_mpm_service`` tag is
+# the dedup key — re-running injection will not duplicate hooks.
+_TRUSTY_HOOK_SPECS: dict[str, list[tuple[str, str, dict[str, Any]]]] = {
+    "trusty-memory": [
+        (
+            event,
+            "*",
+            {
+                "type": "command",
+                "command": "claude-hook",
+                "timeout": 15,
+                "_mpm": True,
+                "_mpm_service": "trusty-memory",
+            },
+        )
+        for event in ("SessionStart", "Stop", "SubagentStop")
+    ],
+    "trusty-search": [
+        (
+            "PostToolUse",
+            "Write|MultiEdit|Edit|NotebookEdit",
+            {
+                "type": "command",
+                "command": "python3",
+                "args": ["-m", "claude_mpm.hooks.trusty_index_hook"],
+                "timeout": 10,
+                "async": True,
+                "_mpm": True,
+                "_mpm_service": "trusty-search",
+            },
+        ),
+    ],
+}
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON atomically: write to a sibling temp file, then rename.
+
+    Why: settings.json is read by Claude Code on every hook invocation; a
+    partial write would crash hooks until repaired.
+    What: dumps ``data`` to a temp file in the same directory, then
+    ``os.replace`` (atomic on the same filesystem) over the target.
+    Test: covered indirectly by hook-injection tests that re-read the file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        Path(tmp_path).replace(path)
+    except Exception:
+        # Best effort cleanup of temp file.
+        try:
+            Path(tmp_path).unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _load_settings(path: Path) -> dict[str, Any]:
+    """Load a Claude Code settings.json, returning a skeleton on absence.
+
+    Why: callers need a dict with a guaranteed ``hooks`` object to merge into,
+    whether or not the file already exists.
+    What: returns ``{"hooks": {}}`` when absent; otherwise parses the file and
+    ensures a dict ``hooks`` key exists. Raises :class:`RuntimeError` on a
+    malformed file so the caller can skip it without corrupting it.
+    Test: ``tests/test_trusty_hooks.py`` exercises absent / valid / malformed.
+    """
+    if not path.exists():
+        return {"hooks": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Could not parse {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{path} root is not a JSON object")
+    data.setdefault("hooks", {})
+    if not isinstance(data["hooks"], dict):
+        raise RuntimeError(f"{path}: 'hooks' is not an object")
+    return data
+
+
+def _strip_legacy_hooks(hooks_root: dict[str, Any]) -> int:
+    """Remove legacy-service hooks across all events, in place.
+
+    Why: trusty-memory / trusty-search supersede kuzu-memory / mcp-vector-search;
+    leaving the predecessors wired up duplicates or conflicts with the new ones.
+    What: drops any hook tagged ``_mpm_service in _LEGACY_SERVICES``, collapses
+    now-empty groups, and deletes now-empty event lists. Returns the count of
+    removed hooks.
+    Test: ``tests/test_trusty_hooks.py::test_strips_legacy_hooks``.
+    """
+    removed_count = 0
+    for event_name, groups in list(hooks_root.items()):
+        if not isinstance(groups, list):
+            continue
+        new_groups: list[dict[str, Any]] = []
+        for group in groups:
+            if not isinstance(group, dict):
+                new_groups.append(group)
+                continue
+            inner = group.get("hooks")
+            if not isinstance(inner, list):
+                new_groups.append(group)
+                continue
+            filtered_inner = [
+                h
+                for h in inner
+                if not (
+                    isinstance(h, dict) and h.get("_mpm_service") in _LEGACY_SERVICES
+                )
+            ]
+            dropped = len(inner) - len(filtered_inner)
+            if dropped:
+                removed_count += dropped
+            # Keep the group if it still has hooks, or if it was already empty
+            # (we only drop groups that became empty as a result of removal).
+            if filtered_inner:
+                group["hooks"] = filtered_inner
+                new_groups.append(group)
+            elif not inner:
+                new_groups.append(group)
+            # else: group emptied by removal — drop it.
+        if new_groups:
+            hooks_root[event_name] = new_groups
+        else:
+            del hooks_root[event_name]
+    return removed_count
+
+
+def inject_hooks_to_settings(
+    settings_path: Path,
+    services: list[str],
+    report: Callable[[str], None] | None = None,
+) -> bool:
+    """Inject trusty hook entries into a Claude Code settings.json.
+
+    Why: centralizes the merge so the interactive setup command and the startup
+    migration produce byte-identical hook structures from one implementation.
+    What: for each requested service, strips legacy-service hooks across all
+    events, then adds the hooks declared in ``_TRUSTY_HOOK_SPECS[service]`` to
+    the matching ``(event, matcher)`` group, skipping any whose ``_mpm_service``
+    already exists in that group (idempotent). Creates the file with
+    ``{"hooks": {}}`` if missing, preserves unrelated hooks, and writes
+    atomically. ``report`` (if given) receives human-readable status lines.
+    Returns ``True`` if the file was changed (removals or additions), else
+    ``False``.
+    Test: ``tests/test_trusty_hooks.py`` (idempotency, legacy strip, parity) and
+    ``tests/migrations/test_trusty_autodetect.py``.
+    """
+
+    def _say(msg: str) -> None:
+        if report is not None:
+            report(msg)
+
+    try:
+        settings = _load_settings(settings_path)
+    except RuntimeError as exc:
+        _say(f"⚠ Skipping {settings_path}: {exc}")
+        return False
+
+    hooks_root: dict[str, Any] = settings["hooks"]
+    added: list[str] = []
+    skipped: list[str] = []
+
+    # ----- Removal pass: drop legacy-service hooks across all events.
+    removed_count = _strip_legacy_hooks(hooks_root)
+
+    # ----- Injection pass: add trusty hooks idempotently.
+    for service in services:
+        for event, matcher, hook_def in _TRUSTY_HOOK_SPECS.get(service, []):
+            groups = hooks_root.setdefault(event, [])
+            if not isinstance(groups, list):
+                _say(
+                    f"⚠ {settings_path}: '{event}' is not a list — skipping injection."
+                )
+                continue
+
+            # Find a group with the matching matcher, or create one.
+            target_group: dict[str, Any] | None = None
+            for group in groups:
+                if (
+                    isinstance(group, dict)
+                    and group.get("matcher") == matcher
+                    and isinstance(group.get("hooks"), list)
+                ):
+                    target_group = group
+                    break
+            if target_group is None:
+                target_group = {"matcher": matcher, "hooks": []}
+                groups.append(target_group)
+
+            inner_hooks: list[Any] = target_group["hooks"]
+            tag = hook_def.get("_mpm_service")
+            # Dedup by _mpm_service within the same (event, matcher) group.
+            already_present = any(
+                isinstance(h, dict) and h.get("_mpm_service") == tag
+                for h in inner_hooks
+            )
+            if already_present:
+                skipped.append(f"{event}[{matcher}]:{tag}")
+                continue
+            inner_hooks.append(hook_def)
+            added.append(f"{event}[{matcher}]:{tag}")
+
+    changed = bool(removed_count or added)
+
+    # ----- Write back atomically (only when something actually changed).
+    if changed:
+        try:
+            _atomic_write_json(settings_path, settings)
+        except OSError as exc:
+            _say(f"✗ Failed to write {settings_path}: {exc}")
+            return False
+
+    # ----- Report.
+    rel = str(settings_path)
+    if removed_count:
+        _say(
+            f"• {rel}: removed {removed_count} legacy hook(s) "
+            f"({', '.join(sorted(_LEGACY_SERVICES))})"
+        )
+    if added:
+        _say(f"✓ {rel}: added {len(added)} hook(s): {', '.join(added)}")
+    if skipped:
+        _say(f"• {rel}: {len(skipped)} hook(s) already present, skipped")
+    if not (removed_count or added or skipped):
+        _say(f"• {rel}: no hook changes needed")
+
+    return changed
+
+
+def inject_trusty_hooks(
+    services: list[str],
+    project_dir: Path | None = None,
+    report: Callable[[str], None] | None = None,
+) -> bool:
+    """Inject hooks into both project and user-level Claude Code settings.
+
+    Why: hooks must apply both per-user (the documented setup intent) and
+    per-project (when a project already opts into shared settings), without
+    silently creating a project-level config a user never asked for.
+    What: injects into ``<project_dir>/.claude/settings.json`` **only if that
+    file already exists**, and always into ``~/.claude/settings.json`` (creating
+    it if missing). Returns ``True`` if either file changed.
+    Test: ``tests/test_trusty_hooks.py`` verifies the project file is untouched
+    when absent and the user file is created/updated.
+    """
+    project_dir = project_dir or Path.cwd()
+    project_settings = project_dir / ".claude" / "settings.json"
+    user_settings = Path.home() / ".claude" / "settings.json"
+
+    changed = False
+    if project_settings.exists():
+        changed |= inject_hooks_to_settings(project_settings, services, report)
+    elif report is not None:
+        report(
+            f"• {project_settings} not found — skipping project-level hook injection."
+        )
+
+    # Always inject into user settings (create if missing).
+    changed |= inject_hooks_to_settings(user_settings, services, report)
+    return changed

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -19,6 +19,29 @@ import pytest
 
 from claude_mpm.migrations import migrate_trusty_autodetect as mod
 
+# Capture the real palace helper BEFORE the autouse fixture stubs it, so the
+# dedicated palace tests can re-install the genuine implementation.
+_REAL_ENSURE_PALACE = mod._ensure_palace
+
+
+@pytest.fixture(autouse=True)
+def _isolate_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize palace creation + hook injection for the .mcp.json tests.
+
+    The autodetect migration now also creates a palace and injects Claude Code
+    hooks once a daemon is healthy. The existing tests in this module only
+    assert ``.mcp.json`` behavior, so we stub those two side effects out by
+    default (dedicated tests below patch them back in to assert their behavior)
+    and ensure no opt-out env var leaks in from the host environment.
+    """
+    from claude_mpm.services import trusty_hooks
+
+    monkeypatch.delenv("CLAUDE_MPM_NO_TRUSTY_AUTO_LINK", raising=False)
+    monkeypatch.setattr(mod, "_ensure_palace", lambda *a, **k: None)
+    # inject_trusty_hooks is imported lazily inside run_migration, so patch it
+    # on its source module rather than on ``mod``.
+    monkeypatch.setattr(trusty_hooks, "inject_trusty_hooks", lambda *a, **k: False)
+
 
 def _make_which(installed: set[str]) -> Callable[[str], str | None]:
     """Return a ``shutil.which`` stand-in matching the given binary set."""
@@ -189,3 +212,233 @@ def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> Non
     assert "trusty-search" in servers
     # Pre-existing unrelated entry must survive.
     assert servers["some-other-server"] == {"type": "stdio", "command": "whatever"}
+
+
+# ---------------------------------------------------------------------------
+# Palace auto-create
+# ---------------------------------------------------------------------------
+
+
+def _detect_only_memory() -> Callable[[str], str | None]:
+    """which() that reports only trusty-memory installed."""
+    return _make_which({"trusty-memory"})
+
+
+def test_palace_created_when_absent(project_dir: Path) -> None:
+    """Healthy trusty-memory + no matching palace → POST issued once."""
+    calls: list[tuple[str, str]] = []
+
+    class _Resp:
+        status = 200
+
+        def read(self) -> bytes:
+            return b"[]"  # GET /palaces → empty list
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+    def fake_urlopen(req, timeout=5):  # noqa: ANN001, ARG001
+        calls.append((req.get_method(), req.full_url))
+        return _Resp()
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
+        patch.object(mod.urllib.request, "urlopen", side_effect=fake_urlopen),
+    ):
+        mod.run_migration(project_dir=project_dir)
+
+    methods = [m for m, _ in calls]
+    assert "GET" in methods, "must list palaces first"
+    assert "POST" in methods, "must create palace when absent"
+
+
+def test_palace_not_created_when_present(project_dir: Path) -> None:
+    """Healthy trusty-memory + matching palace exists → no POST (idempotent)."""
+    palace_name = project_dir.name
+    payload = json.dumps([{"name": palace_name}]).encode("utf-8")
+    calls: list[str] = []
+
+    class _Resp:
+        status = 200
+
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def read(self) -> bytes:
+            return self._body
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+    def fake_urlopen(req, timeout=5):  # noqa: ANN001, ARG001
+        calls.append(req.get_method())
+        return _Resp(payload)
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
+        patch.object(mod.urllib.request, "urlopen", side_effect=fake_urlopen),
+    ):
+        mod.run_migration(project_dir=project_dir)
+
+    assert "GET" in calls
+    assert "POST" not in calls, "palace already present — must not re-create"
+
+
+def test_palace_failure_is_non_fatal(project_dir: Path) -> None:
+    """Palace HTTP errors never raise and never block the .mcp.json write."""
+
+    def boom(req, timeout=5):  # noqa: ANN001, ARG001
+        raise OSError("connection refused")
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
+        patch.object(mod.urllib.request, "urlopen", side_effect=boom),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    # .mcp.json still written despite palace failure.
+    assert changed is True
+    config = json.loads((project_dir / ".mcp.json").read_text())
+    assert "trusty-memory" in config["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# Opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_opt_out_via_env_var(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLAUDE_MPM_NO_TRUSTY_AUTO_LINK truthy → full no-op, no detection."""
+    monkeypatch.setenv("CLAUDE_MPM_NO_TRUSTY_AUTO_LINK", "1")
+    which_calls: list[str] = []
+
+    def tracking_which(name: str) -> str | None:
+        which_calls.append(name)
+        return f"/fake/bin/{name}"
+
+    with patch.object(mod.shutil, "which", side_effect=tracking_which):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert which_calls == [], "opt-out must short-circuit before detection"
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_opt_out_via_config(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """configuration.yaml trusty.auto_link: false → no-op."""
+    monkeypatch.delenv("CLAUDE_MPM_NO_TRUSTY_AUTO_LINK", raising=False)
+    cfg_dir = project_dir / ".claude-mpm"
+    cfg_dir.mkdir()
+    (cfg_dir / "configuration.yaml").write_text("trusty:\n  auto_link: false\n")
+
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-memory", "trusty-search"}),
+        ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_config_auto_link_true_does_not_block(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """auto_link: true (explicit) still runs detection normally."""
+    monkeypatch.delenv("CLAUDE_MPM_NO_TRUSTY_AUTO_LINK", raising=False)
+    cfg_dir = project_dir / ".claude-mpm"
+    cfg_dir.mkdir()
+    (cfg_dir / "configuration.yaml").write_text("trusty:\n  auto_link: true\n")
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-memory"})),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    assert (project_dir / ".mcp.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Hook injection wiring
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_injected_for_detected_services(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The migration forwards detected service names to inject_trusty_hooks."""
+    from claude_mpm.services import trusty_hooks
+
+    captured: dict[str, object] = {}
+
+    def fake_inject(services, project_dir=None, report=None):  # noqa: ANN001
+        captured["services"] = list(services)
+        captured["project_dir"] = project_dir
+        return True
+
+    monkeypatch.setattr(trusty_hooks, "inject_trusty_hooks", fake_inject)
+
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-memory", "trusty-search"}),
+        ),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    assert set(captured["services"]) == {"trusty-memory", "trusty-search"}
+    assert captured["project_dir"] == project_dir
+
+
+def test_no_hooks_or_palace_when_binaries_missing(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No binary on PATH → no palace HTTP, no hook injection, no settings."""
+    from claude_mpm.services import trusty_hooks
+
+    palace_calls: list[object] = []
+    hook_calls: list[object] = []
+
+    monkeypatch.setattr(mod, "_ensure_palace", lambda *a, **k: palace_calls.append(a))
+    monkeypatch.setattr(
+        trusty_hooks,
+        "inject_trusty_hooks",
+        lambda *a, **k: hook_calls.append(a) or False,
+    )
+
+    with patch.object(mod.shutil, "which", side_effect=_make_which(set())):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert palace_calls == []
+    assert hook_calls == []
+    assert not (project_dir / ".mcp.json").exists()

--- a/tests/test_trusty_hooks.py
+++ b/tests/test_trusty_hooks.py
@@ -1,0 +1,198 @@
+"""Tests for the shared trusty hook-injection module.
+
+These cover the console-free :mod:`claude_mpm.services.trusty_hooks` helpers
+used by both the interactive setup command and the startup autodetect
+migration: idempotent injection, legacy-hook stripping, the "project settings
+only if it already exists" rule, and structural parity with the hook layout the
+old ``TrustyMixin`` path produced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - used at runtime in fixtures
+
+import pytest
+
+from claude_mpm.services import trusty_hooks as th
+
+
+@pytest.fixture
+def user_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` to a temp dir so ~/.claude is sandboxed."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+    return home
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _all_hooks(settings: dict) -> list[dict]:
+    """Flatten every hook dict across all events/groups."""
+    out: list[dict] = []
+    for groups in settings.get("hooks", {}).values():
+        for group in groups:
+            out.extend(group.get("hooks", []))
+    return out
+
+
+def test_injects_memory_hooks_into_new_user_settings(user_home: Path) -> None:
+    """Memory hooks land in a freshly-created ~/.claude/settings.json."""
+    settings_path = user_home / ".claude" / "settings.json"
+    assert not settings_path.exists()
+
+    changed = th.inject_hooks_to_settings(settings_path, ["trusty-memory"])
+
+    assert changed is True
+    data = _read(settings_path)
+    services = {h.get("_mpm_service") for h in _all_hooks(data)}
+    assert services == {"trusty-memory"}
+    # SessionStart, Stop, SubagentStop → three groups under matcher "*".
+    assert set(data["hooks"]) == {"SessionStart", "Stop", "SubagentStop"}
+
+
+def test_idempotent_second_run_is_noop(user_home: Path) -> None:
+    """Re-running injection does not duplicate hooks and reports no change."""
+    settings_path = user_home / ".claude" / "settings.json"
+
+    first = th.inject_hooks_to_settings(settings_path, ["trusty-memory"])
+    snapshot = settings_path.read_text(encoding="utf-8")
+    second = th.inject_hooks_to_settings(settings_path, ["trusty-memory"])
+
+    assert first is True
+    assert second is False, "Second run must be a no-op (dedup by _mpm_service)"
+    assert settings_path.read_text(encoding="utf-8") == snapshot
+
+
+def test_strips_legacy_hooks(user_home: Path) -> None:
+    """kuzu-memory / mcp-vector-search hooks are removed on injection."""
+    settings_path = user_home / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {"type": "command", "_mpm_service": "kuzu-memory"},
+                                {"type": "command", "command": "user-script.sh"},
+                            ],
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "matcher": "Write",
+                            "hooks": [
+                                {"_mpm_service": "mcp-vector-search"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            indent=2,
+        )
+    )
+
+    changed = th.inject_hooks_to_settings(settings_path, ["trusty-memory"])
+
+    assert changed is True
+    data = _read(settings_path)
+    services = {h.get("_mpm_service") for h in _all_hooks(data)}
+    assert "kuzu-memory" not in services
+    assert "mcp-vector-search" not in services
+    assert "trusty-memory" in services
+    # Unrelated user hook survives.
+    commands = {h.get("command") for h in _all_hooks(data)}
+    assert "user-script.sh" in commands
+
+
+def test_inject_trusty_hooks_skips_absent_project_settings(
+    user_home: Path, tmp_path: Path
+) -> None:
+    """Project settings are NOT created when ./.claude/settings.json is absent."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    project_settings = project / ".claude" / "settings.json"
+    user_settings = user_home / ".claude" / "settings.json"
+
+    changed = th.inject_trusty_hooks(["trusty-memory"], project_dir=project)
+
+    assert changed is True
+    assert not project_settings.exists(), "Must not create project settings silently"
+    assert user_settings.exists(), "User settings must be created/updated"
+
+
+def test_inject_trusty_hooks_updates_existing_project_settings(
+    user_home: Path, tmp_path: Path
+) -> None:
+    """Project settings ARE updated when the file already exists."""
+    project = tmp_path / "proj"
+    project_settings = project / ".claude" / "settings.json"
+    project_settings.parent.mkdir(parents=True)
+    project_settings.write_text(json.dumps({"hooks": {}}, indent=2))
+
+    changed = th.inject_trusty_hooks(["trusty-search"], project_dir=project)
+
+    assert changed is True
+    data = _read(project_settings)
+    services = {h.get("_mpm_service") for h in _all_hooks(data)}
+    assert services == {"trusty-search"}
+
+
+def test_parity_with_legacy_specs_structure(user_home: Path) -> None:
+    """Lock the produced structure to the historical TrustyMixin layout.
+
+    The old ``TrustyMixin._inject_hooks_to_settings`` produced, for
+    trusty-memory + trusty-search, hooks tagged ``_mpm: True`` /
+    ``_mpm_service: <name>`` grouped by (event, matcher) with the exact specs
+    in ``_TRUSTY_HOOK_SPECS``. This test pins that contract.
+    """
+    settings_path = user_home / ".claude" / "settings.json"
+    th.inject_hooks_to_settings(settings_path, ["trusty-memory", "trusty-search"])
+    data = _read(settings_path)
+
+    # Memory: three events under matcher "*", each one claude-hook command.
+    for event in ("SessionStart", "Stop", "SubagentStop"):
+        groups = data["hooks"][event]
+        assert len(groups) == 1
+        assert groups[0]["matcher"] == "*"
+        hook = groups[0]["hooks"][0]
+        assert hook == {
+            "type": "command",
+            "command": "claude-hook",
+            "timeout": 15,
+            "_mpm": True,
+            "_mpm_service": "trusty-memory",
+        }
+
+    # Search: PostToolUse under the edit matcher, async python module hook.
+    ptu = data["hooks"]["PostToolUse"]
+    assert len(ptu) == 1
+    assert ptu[0]["matcher"] == "Write|MultiEdit|Edit|NotebookEdit"
+    assert ptu[0]["hooks"][0] == {
+        "type": "command",
+        "command": "python3",
+        "args": ["-m", "claude_mpm.hooks.trusty_index_hook"],
+        "timeout": 10,
+        "async": True,
+        "_mpm": True,
+        "_mpm_service": "trusty-search",
+    }
+
+
+def test_malformed_settings_is_skipped_not_corrupted(user_home: Path) -> None:
+    """A non-JSON settings file is left untouched (skip, never corrupt)."""
+    settings_path = user_home / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text("{ this is not json")
+
+    changed = th.inject_hooks_to_settings(settings_path, ["trusty-memory"])
+
+    assert changed is False
+    # File preserved verbatim — not overwritten with a skeleton.
+    assert settings_path.read_text(encoding="utf-8") == "{ this is not json"


### PR DESCRIPTION
## Summary

When trusty-* tools are installed, per-project linkage should happen **automatically** when claude-mpm starts a session — not require a manual `claude-mpm setup trusty-memory`. Without memory/search, claude-mpm runs degraded. This brings the startup autodetect migration to full parity with the manual setup, idempotently and with an opt-out, for both duetto and non-duetto users (no code-level branch between them).

The existing `migrate_trusty_autodetect` migration already detected healthy daemons and wired `.mcp.json`. It now **also**:

1. **Creates the per-project memory palace** (core fix) — once `trusty-memory` is healthy, idempotent `GET`/`POST` `/api/v1/palaces` with name = project dir. Registering the MCP server alone is not enough; without a palace every memory call silently no-ops.
2. **Injects the capture/index hooks** — SessionStart/Stop/SubagentStop (memory) and PostToolUse index (search) into `~/.claude/settings.json` (always) and `./.claude/settings.json` (only if it already exists). Idempotent via `_mpm_service` dedup; strips legacy kuzu-memory/mcp-vector-search hooks.
3. **Opt-out** — short-circuits to a full no-op if `CLAUDE_MPM_NO_TRUSTY_AUTO_LINK` is truthy **or** project config `trusty.auto_link: false`.

All palace/hook failures are warning-level and never raise. Absence of trusty-* remains a clean no-op (no HTTP, no settings touched).

## Refactor

The hook-injection logic (`_inject_hooks_to_settings`, `_TRUSTY_HOOK_SPECS`, legacy cleanup, atomic write) is extracted out of `TrustyMixin` into a new **console-free** shared module `services/trusty_hooks.py` (pure functions; reporting via an optional callback). Both the interactive setup path and the startup migration now share one implementation. `handlers/trusty.py` shrinks **918 → 720 lines** (−198); the new shared module is 304 lines.

A typed `TrustyConfig.auto_link` sub-model (default `True`) is added to `UnifiedConfig` so the opt-out is a real config field.

## Tests

20 new/updated unit tests, all HTTP mocked (no live daemon required):

- **Palace**: created when absent (POST issued), not created when present (idempotent), non-fatal on HTTP failure.
- **Opt-out**: env var → full no-op (short-circuits before detection); `trusty.auto_link: false` → no-op; explicit `true` still runs.
- **Absence**: binary missing → no HTTP, no palace, no hook injection, no settings touched.
- **Hooks**: idempotent (second run no-ops via dedup), project settings untouched when absent / updated when present, user settings created, malformed file skipped (never corrupted), and structural **parity** with the historical `TrustyMixin` hook layout.

Raw `ruff format --check`, `ruff check`, and the two new test files all pass; `mypy` adds **zero** new errors (the only remaining errors in `unified_config.py` are pre-existing on `main`).

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)