### PR TITLE
feat: first-class trusty-review + per-session tool availability gating in mpm

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -60,6 +60,8 @@ Sequence:
 
 If neither memory backend nor code search backend is configured, skip directly to Research delegation.
 
+> **Session availability override:** See the dynamically-injected "## Available Tool Services" block below for THIS session's actual availability — it OVERRIDES the unconditional guidance above; do not call tools listed as NOT available.
+
 ## MCP Context Loading (Optional)
 
 At session start, if the `trusty-memory` MCP server is connected, call `get_prompt_context()` to load project aliases and conventions into working context. This enables automatic abbreviation resolution (e.g. `tga` → `trusty-git-analytics`) without manual context-setting each session.

--- a/src/claude_mpm/cli/startup_display.py
+++ b/src/claude_mpm/cli/startup_display.py
@@ -477,7 +477,7 @@ def display_startup_banner(
         print(ztk_message)
         # Trusty daemon connection status (#598) — suppressed services return
         # an empty line, so only opted-in (binary present) services print.
-        for service in ("trusty-memory", "trusty-search"):
+        for service in ("trusty-memory", "trusty-search", "trusty-review"):
             _, trusty_line = get_trusty_status(service)
             if trusty_line:
                 print(trusty_line)
@@ -714,7 +714,7 @@ def display_startup_banner(
 
     # Trusty daemon connection status (#598) — suppressed services return an
     # empty line, so only opted-in (binary present) services add a row.
-    for service in ("trusty-memory", "trusty-search"):
+    for service in ("trusty-memory", "trusty-search", "trusty-review"):
         _, trusty_line = get_trusty_status(service)
         if trusty_line:
             lines.append(

--- a/src/claude_mpm/commands/mpm-review.md
+++ b/src/claude_mpm/commands/mpm-review.md
@@ -1,0 +1,73 @@
+---
+namespace: mpm/dev
+command: review
+aliases: [mpm-review]
+migration_target: /mpm/dev:review
+category: dev
+description: Run a code review of the current diff or a PR via trusty-review, with graceful fallback
+---
+
+# /mpm-review
+
+Run a first-class code review using the `trusty-review` MCP server, with a
+graceful fallback to the `openrouter-code-reviewer` agent when trusty-review is
+not available this session.
+
+## Usage
+
+```
+/mpm-review                       # review the current `git diff` (working tree)
+/mpm-review <owner>/<repo>#<PR>    # review an open pull request
+```
+
+When no argument is given, the current `git diff` (uncommitted + staged changes)
+is reviewed. When an `<owner>/<repo>#<PR>` argument is given, the named pull
+request is reviewed instead.
+
+## Behavior (follow this sequence)
+
+1. **Probe health.** Call `mcp__trusty-review__review_health`.
+
+2. **If healthy → review via trusty-review:**
+   - **No argument:** capture the current `git diff` and call
+     `mcp__trusty-review__review_diff` with that diff.
+   - **`<owner>/<repo>#<PR>` argument:** call `mcp__trusty-review__review_pr`
+     with the parsed owner, repo, and PR number.
+
+3. **If unhealthy or absent → fall back gracefully.** Do NOT error out. Delegate
+   the review to the existing `openrouter-code-reviewer` agent over the same diff
+   or PR, and note in the output that trusty-review was unavailable so the result
+   came from the fallback reviewer.
+
+4. **Output a structured report** using trusty-review's verdict vocabulary:
+   - `APPROVE` — no blocking issues.
+   - `APPROVE*` — approve with non-blocking nits/suggestions.
+   - `REQUEST_CHANGES` — changes required before merge.
+   - `BLOCK` — must not merge (e.g. compile break, security issue).
+   - `UNKNOWN` — review could not reach a verdict (e.g. insufficient context).
+
+   Include the verdict, a short rationale, and the per-finding details returned
+   by the reviewer.
+
+## Runtime requirements
+
+`trusty-review` is review-on-demand and is auto-wired into `.mcp.json` when the
+`trusty-review` binary is detected (entry: `trusty-review serve --stdio`, env
+`TRUSTY_REVIEW_AUTH_MODE=cli`). For an authoritative review the following must
+be available in the Claude Code process environment:
+
+- **AWS Bedrock credentials** — `trusty-review` runs its LLM pass through
+  Bedrock (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`,
+  plus a region). These are inherited from the environment; they are never
+  written into `.mcp.json`.
+- **trusty-search on `127.0.0.1:7878`** — authoritative review pulls repository
+  context from a real trusty-search index. The default index name (`main`) may
+  not exist for a given project; set `TRUSTY_SEARCH_INDEX` to the project's
+  actual index when needed (it is intentionally NOT hardcoded in the MCP env).
+- **`GITHUB_TOKEN` + `TRUSTY_REVIEW_AUTH_MODE=cli`** — required for
+  `review_pr` so a local GitHub PAT works in serve mode. `GITHUB_TOKEN` is
+  inherited from the environment and is never written into `.mcp.json`.
+
+If trusty-review reports the verdict `UNKNOWN` because it could not reach
+trusty-search or a model, surface that to the user along with the missing
+prerequisite rather than presenting it as a passing review.

--- a/src/claude_mpm/core/framework/formatters/content_formatter.py
+++ b/src/claude_mpm/core/framework/formatters/content_formatter.py
@@ -42,6 +42,7 @@ class ContentFormatter:
         context_section: str,
         inject_output_style: bool = False,
         output_style_content: str | None = None,
+        tool_status_section: str | None = None,
     ) -> str:
         """Format complete framework instructions.
 
@@ -51,6 +52,11 @@ class ContentFormatter:
             context_section: Generated temporal/user context section
             inject_output_style: Whether to inject output style content
             output_style_content: Output style content to inject (if needed)
+            tool_status_section: Optional per-session "Available Tool Services"
+                block (auto-detected trusty-* capabilities). When provided it is
+                appended after ``context_section`` and before the BASE_PM block.
+                Defaults to ``None`` to stay backward-compatible with existing
+                callers.
 
         Returns:
             Formatted framework instructions
@@ -122,6 +128,12 @@ class ContentFormatter:
 
             # Add enhanced temporal and user context for better awareness
             instructions += context_section
+
+            # Add per-session "Available Tool Services" block (auto-detected
+            # trusty-* capabilities). Backward-compatible: only injected when a
+            # caller supplies it; existing callers pass None and see no change.
+            if tool_status_section:
+                instructions += tool_status_section
 
             # Add BASE_PM.md framework requirements AFTER INSTRUCTIONS.md
             if framework_content.get("base_pm_instructions"):

--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -352,6 +352,7 @@ class FrameworkLoader:
         # Generate dynamic sections
         capabilities_section = self._generate_agent_capabilities_section()
         context_section = self.context_generator.generate_temporal_user_context()
+        tool_status_section = self._generate_tool_status_section()
 
         # Format the complete framework
         return self.content_formatter.format_full_framework(
@@ -360,7 +361,120 @@ class FrameworkLoader:
             context_section,
             inject_output_style,
             output_style_content,
+            tool_status_section,
         )
+
+    def _generate_tool_status_section(self) -> str:
+        """Why: The static PM instructions (Context-First Protocol, MEMORY.md)
+        tell the PM to use trusty-memory/trusty-search unconditionally. When
+        those daemons are absent/down this session the PM wastes tool calls and
+        tokens. This injects a per-session capability block so the PM can act on
+        what is ACTUALLY available and degrade gracefully (skip + inform).
+
+        What: Calls ``get_trusty_capabilities()`` and renders a markdown block
+        ``## Available Tool Services (auto-detected at session start)`` — a
+        Service | Status | Impact table plus an explicit NEGATION line per
+        service that is not ON, plus a DEGRADED-MODE note when ALL trusty
+        services are absent/not-running. Always-on but resilient: any failure
+        (or no detected capabilities) returns ``""`` so nothing is injected and
+        startup never breaks.
+
+        Test: ``tests/test_framework_loader_tool_status.py`` — asserts the block
+        is present with the correct NEGATION line when a service is absent, the
+        degraded-mode note when all absent, and an empty string on probe error.
+        """
+        try:
+            from claude_mpm.services.trusty_status import get_trusty_capabilities
+
+            capabilities = get_trusty_capabilities()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.debug(f"Skipping tool status section: {e}")
+            return ""
+
+        if not capabilities:
+            return ""
+
+        # Human-facing labels for each detected state.
+        status_labels = {
+            "on": "ON",
+            "configured": "NOT RUNNING",
+            "not_running": "NOT RUNNING",
+            "absent": "ABSENT",
+        }
+
+        # Per-service Impact text keyed by availability (ON vs everything else).
+        impact_on = {
+            "trusty-memory": (
+                "Context-First Protocol active: query "
+                "`mcp__trusty-memory__memory_recall` first."
+            ),
+            "trusty-search": (
+                "Code search available: use `mcp__trusty-search__search` before "
+                "delegating to Research."
+            ),
+            "trusty-analyze": (
+                "Code analysis available: `mcp__trusty-analyze__*` is usable."
+            ),
+            "trusty-review": ("`/mpm-review` and `mcp__trusty-review__*` are usable."),
+        }
+        impact_off = {
+            "trusty-memory": (
+                "Despite MEMORY.md/Context-First guidance, trusty-memory is NOT "
+                "available this session — SKIP all `mcp__trusty-memory__*` calls "
+                "and memory recall steps."
+            ),
+            "trusty-search": (
+                "trusty-search is NOT available — SKIP code search; delegate "
+                "directly to Research."
+            ),
+            "trusty-analyze": (
+                "trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls."
+            ),
+            "trusty-review": (
+                "code review via trusty-review unavailable; fall back to "
+                "`openrouter-code-reviewer`."
+            ),
+        }
+
+        lines = [
+            "\n\n## Available Tool Services (auto-detected at session start)\n",
+            "This OVERRIDES the unconditional tool guidance elsewhere in these "
+            "instructions. Do NOT call any service listed as NOT available "
+            "below.\n",
+            "| Service | Status | Impact |",
+            "| --- | --- | --- |",
+        ]
+
+        negations: list[str] = []
+        for service in (
+            "trusty-memory",
+            "trusty-search",
+            "trusty-analyze",
+            "trusty-review",
+        ):
+            state = capabilities.get(service, "absent")
+            is_on = state == "on"
+            label = status_labels.get(state, "ABSENT")
+            impact = (impact_on if is_on else impact_off)[service]
+            lines.append(f"| {service} | {label} | {impact} |")
+            if not is_on:
+                negations.append(f"- {impact}")
+
+        if negations:
+            lines.append("\n**Skip the following this session:**\n")
+            lines.extend(negations)
+
+        all_unavailable = all(state != "on" for state in capabilities.values())
+        if all_unavailable:
+            lines.append(
+                "\n**DEGRADED MODE — no trusty services available this session.** "
+                "Skip all memory recall and code search; delegate directly to "
+                "the Research agent. Suggest the user run `claude-mpm setup "
+                "trusty-search` / `claude-mpm setup trusty-memory` to enable "
+                "Context-First tooling."
+            )
+
+        return "\n".join(lines) + "\n"
 
     def _format_minimal_framework(self) -> str:
         """Format minimal framework instructions."""

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -78,6 +78,34 @@ _SERVICES: tuple[dict[str, Any], ...] = (
             "args": [],
         },
     },
+    # trusty-review is review-on-demand: it gets an .mcp.json entry so the
+    # ``mcp__trusty-review__*`` tools and ``/mpm-review`` are wired, but it
+    # has NO per-project palace and NO capture/index hooks (it is not in
+    # ``_TRUSTY_HOOK_SPECS``, so ``inject_trusty_hooks`` is a no-op for it).
+    # It ships no ``http_addr`` discovery file, so detection always resolves
+    # via the hardcoded ``fallback_addr`` (127.0.0.1:7880).
+    #
+    # The ``env`` block carries ONLY non-secret config: ``TRUSTY_REVIEW_AUTH_MODE=cli``
+    # lets a local GitHub PAT work in serve mode (learned from testing). AWS
+    # credentials and ``GITHUB_TOKEN`` are deliberately NOT set here — they are
+    # inherited from the Claude Code process environment. ``TRUSTY_SEARCH_INDEX``
+    # is intentionally omitted: the default ``main`` may not exist for a given
+    # project, so the user sets it explicitly when authoritative review is needed
+    # (documented in ``/mpm-review``).
+    {
+        "name": "trusty-review",
+        "binary": "trusty-review",
+        "addr_file": Path.home() / ".trusty-review" / "http_addr",
+        "fallback_addr": "127.0.0.1:7880",
+        "mcp_entry": {
+            "type": "stdio",
+            "command": "trusty-review",
+            "args": ["serve", "--stdio"],
+            "env": {
+                "TRUSTY_REVIEW_AUTH_MODE": "cli",
+            },
+        },
+    },
 )
 
 

--- a/src/claude_mpm/services/mcp/config_builder.py
+++ b/src/claude_mpm/services/mcp/config_builder.py
@@ -68,6 +68,16 @@ class MCPServiceConfigBuilder:
             "command": "trusty-analyzer",
             "args": ["mcp"],
         },
+        # Review-on-demand MCP server. ``env`` carries ONLY non-secret config:
+        # TRUSTY_REVIEW_AUTH_MODE=cli lets a local GitHub PAT work in serve mode.
+        # AWS creds / GITHUB_TOKEN are inherited from the Claude Code process
+        # environment and must NOT be hardcoded here.
+        "trusty-review": {
+            "type": "stdio",
+            "command": "trusty-review",
+            "args": ["serve", "--stdio"],
+            "env": {"TRUSTY_REVIEW_AUTH_MODE": "cli"},
+        },
     }
 
     def __init__(

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -48,15 +48,19 @@ from typing import Any
 _HEALTH_TIMEOUT_S = 0.2
 
 # Default ports when the http_addr discovery file is missing/unreadable.
+# trusty-review has no http_addr discovery file of its own, so it ALWAYS falls
+# back to this default port (127.0.0.1:7880) for its /health probe.
 _DEFAULT_PORTS: dict[str, int] = {
     "trusty-memory": 7070,
     "trusty-search": 7878,
+    "trusty-review": 7880,
 }
 
 # Display emoji per service.
 _SERVICE_EMOJI: dict[str, str] = {
     "trusty-memory": "🧠",
     "trusty-search": "🔍",
+    "trusty-review": "📝",
 }
 
 # Cache: { http_addr_file_path: (mtime, is_healthy) }. Keyed by the discovery
@@ -295,6 +299,10 @@ def _start_hint(service: str) -> str:
     """The ``(start: ...)`` hint shown when a service is not running."""
     if service == "trusty-memory":
         return "(start: trusty-memory ...)"
+    if service == "trusty-analyze":
+        return "(start: trusty-analyze serve)"
+    if service == "trusty-review":
+        return "(start: trusty-review serve)"
     return "(start: trusty-search serve)"
 
 
@@ -361,3 +369,43 @@ def get_trusty_status(service: str) -> tuple[str, str]:
     except Exception:
         # Fail-safe: never break the banner over a status probe.
         return ("absent", "")
+
+
+# Services whose per-session capability is reported to the PM prompt. Order is
+# stable so the injected table renders deterministically.
+_CAPABILITY_SERVICES: tuple[str, ...] = (
+    "trusty-memory",
+    "trusty-search",
+    "trusty-analyze",
+    "trusty-review",
+)
+
+
+def get_trusty_capabilities() -> dict[str, str]:
+    """Why: The PM prompt instructs unconditional use of trusty-* tools, but
+    those daemons may be absent/down this session — wasting tool calls/tokens.
+    This is the single source of truth for per-session tool availability fed
+    into the prompt so the PM can degrade gracefully (skip + inform).
+
+    What: Returns ``{service: state}`` for ``trusty-memory``, ``trusty-search``,
+    ``trusty-analyze`` and ``trusty-review`` where ``state`` is one of
+    ``"on"`` / ``"configured"`` / ``"not_running"`` / ``"absent"``, computed
+    via :func:`get_trusty_status` (filesystem presence + cached ≤200ms
+    ``/health`` probes). Cheap and cached; ``trusty-review`` has no
+    ``http_addr`` file so it probes ``127.0.0.1:7880/health``. Per service it
+    is wrapped in try/except so a single bad probe never poisons the map, and
+    the whole call NEVER raises or blocks startup (any top-level failure yields
+    an all-``"absent"`` map).
+
+    Test: ``tests/test_trusty_status.py`` — verifies correct states for
+    all-on / mixed / all-absent combinations and that a probe that raises is
+    reported as ``"absent"`` rather than propagating.
+    """
+    capabilities: dict[str, str] = {}
+    for service in _CAPABILITY_SERVICES:
+        try:
+            state, _line = get_trusty_status(service)
+        except Exception:
+            state = "absent"
+        capabilities[service] = state
+    return capabilities

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -486,3 +486,90 @@ def test_no_hooks_or_palace_when_binaries_missing(
     assert palace_calls == []
     assert hook_calls == []
     assert not (project_dir / ".mcp.json").exists()
+
+
+# --------------------------------------------------------------------------
+# trusty-review (review-on-demand): MCP entry only, no palace, no hooks.
+# --------------------------------------------------------------------------
+
+
+def _service_descriptor(name: str) -> dict[str, object]:
+    """Return the _SERVICES descriptor with the given name (asserts presence)."""
+    for svc in mod._SERVICES:
+        if svc["name"] == name:
+            return svc
+    raise AssertionError(f"{name} not found in _SERVICES")
+
+
+def test_trusty_review_registered_in_services() -> None:
+    """trusty-review is a known autodetect service with the stdio serve entry."""
+    svc = _service_descriptor("trusty-review")
+    assert svc["binary"] == "trusty-review"
+    assert svc["fallback_addr"] == "127.0.0.1:7880"
+    assert svc["mcp_entry"] == {
+        "type": "stdio",
+        "command": "trusty-review",
+        "args": ["serve", "--stdio"],
+        "env": {"TRUSTY_REVIEW_AUTH_MODE": "cli"},
+    }
+
+
+def test_trusty_review_env_holds_no_secrets() -> None:
+    """The auto-wired env must NEVER carry AWS keys / GITHUB_TOKEN — those are
+    inherited from the Claude Code process environment, not written to disk."""
+    env = _service_descriptor("trusty-review")["mcp_entry"]["env"]
+    forbidden = {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "GITHUB_TOKEN",
+        "TRUSTY_SEARCH_INDEX",
+    }
+    assert forbidden.isdisjoint(env.keys())
+    assert env == {"TRUSTY_REVIEW_AUTH_MODE": "cli"}
+
+
+def test_trusty_review_wired_without_palace_or_hooks(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Healthy trusty-review → .mcp.json entry written, but NO palace created
+    and NO trusty-review hooks injected (it has no _TRUSTY_HOOK_SPECS entry)."""
+    from claude_mpm.services import trusty_hooks
+
+    palace_calls: list[object] = []
+    hook_services: list[object] = []
+
+    monkeypatch.setattr(mod, "_ensure_palace", lambda *a, **k: palace_calls.append(a))
+    monkeypatch.setattr(
+        trusty_hooks,
+        "inject_trusty_hooks",
+        lambda services, **k: hook_services.append(list(services)) or False,
+    )
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-review"})),
+        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
+        patch.object(mod, "_http_health_check", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    servers = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]
+    assert servers["trusty-review"] == {
+        "type": "stdio",
+        "command": "trusty-review",
+        "args": ["serve", "--stdio"],
+        "env": {"TRUSTY_REVIEW_AUTH_MODE": "cli"},
+    }
+    # No palace was created for trusty-review (palace is memory-only).
+    assert palace_calls == []
+    # inject_trusty_hooks is called with trusty-review, but it has no hook spec
+    # so nothing is actually injected for it.
+    assert hook_services == [["trusty-review"]]
+
+
+def test_trusty_review_has_no_hook_spec() -> None:
+    """trusty-review must not declare any capture/index hooks."""
+    from claude_mpm.services.trusty_hooks import _TRUSTY_HOOK_SPECS
+
+    assert "trusty-review" not in _TRUSTY_HOOK_SPECS

--- a/tests/test_framework_loader_tool_status.py
+++ b/tests/test_framework_loader_tool_status.py
@@ -1,0 +1,186 @@
+"""Tests for FrameworkLoader._generate_tool_status_section (issue #606).
+
+Why: The per-session "Available Tool Services" block is the runtime override
+that stops the PM from calling trusty-* tools that are absent/down this
+session. These tests pin its contract: the table renders with the correct
+NEGATION lines per unavailable service, a DEGRADED-MODE note appears when all
+services are unavailable, and the block injects nothing (empty string) on any
+probe error so framework assembly never breaks.
+
+What: Exercises ``_generate_tool_status_section`` against mocked
+``get_trusty_capabilities`` return values, plus a backward-compat check that
+``ContentFormatter.format_full_framework`` ignores a ``None``
+``tool_status_section``.
+
+Test: ``uv run pytest tests/test_framework_loader_tool_status.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from claude_mpm.core.framework_loader import FrameworkLoader
+from claude_mpm.services import trusty_status
+
+
+def _render(monkeypatch, capabilities) -> str:
+    """Invoke the section generator with a stubbed capabilities probe.
+
+    ``capabilities`` may be a dict (returned verbatim) or an Exception instance
+    (raised) to exercise the fail-safe path. The method only touches
+    ``self.logger``, so we bind it to a minimal stub to avoid heavy init.
+    """
+
+    def _fake_caps():
+        if isinstance(capabilities, Exception):
+            raise capabilities
+        return capabilities
+
+    monkeypatch.setattr(trusty_status, "get_trusty_capabilities", _fake_caps)
+    stub = SimpleNamespace(logger=logging.getLogger("test_tool_status"))
+    return FrameworkLoader._generate_tool_status_section(stub)
+
+
+HEADER = "## Available Tool Services (auto-detected at session start)"
+
+
+class TestToolStatusSection:
+    def test_all_on_renders_table_no_negations_no_degraded(self, monkeypatch):
+        """Every service ON → header + table, no skip list, no degraded note."""
+        block = _render(
+            monkeypatch,
+            {
+                "trusty-memory": "on",
+                "trusty-search": "on",
+                "trusty-analyze": "on",
+                "trusty-review": "on",
+            },
+        )
+        assert HEADER in block
+        assert "| Service | Status | Impact |" in block
+        # All four rows render with the ON status label.
+        assert block.count("| ON |") == 4
+        assert "| trusty-memory | ON |" in block
+        assert "| trusty-review | ON |" in block
+        # No service is unavailable → no skip list and no negations.
+        assert "Skip the following this session" not in block
+        assert "is NOT" not in block
+        assert "DEGRADED MODE" not in block
+
+    def test_memory_absent_has_explicit_negation(self, monkeypatch):
+        """An absent service gets an explicit NOT-available negation line."""
+        block = _render(
+            monkeypatch,
+            {
+                "trusty-memory": "absent",
+                "trusty-search": "on",
+                "trusty-analyze": "on",
+                "trusty-review": "on",
+            },
+        )
+        assert "| trusty-memory | ABSENT |" in block
+        assert "trusty-memory is NOT" in block
+        assert "SKIP all `mcp__trusty-memory__*` calls" in block
+        assert "Skip the following this session" in block
+        # Not all unavailable → no degraded-mode banner.
+        assert "DEGRADED MODE" not in block
+
+    def test_not_running_labeled_not_running(self, monkeypatch):
+        """``configured`` and ``not_running`` both render as NOT RUNNING."""
+        block = _render(
+            monkeypatch,
+            {
+                "trusty-memory": "configured",
+                "trusty-search": "not_running",
+                "trusty-analyze": "on",
+                "trusty-review": "on",
+            },
+        )
+        assert "| trusty-memory | NOT RUNNING |" in block
+        assert "| trusty-search | NOT RUNNING |" in block
+
+    def test_all_absent_emits_degraded_mode(self, monkeypatch):
+        """All services unavailable → DEGRADED MODE note present."""
+        block = _render(
+            monkeypatch,
+            {
+                "trusty-memory": "absent",
+                "trusty-search": "absent",
+                "trusty-analyze": "absent",
+                "trusty-review": "absent",
+            },
+        )
+        assert HEADER in block
+        assert "DEGRADED MODE" in block
+        assert "delegate directly to" in block
+        # Each service still gets its negation line.
+        assert "trusty-memory is NOT" in block
+        assert "trusty-search is NOT" in block
+
+    def test_probe_error_injects_nothing(self, monkeypatch):
+        """A raising probe yields an empty string (nothing injected)."""
+        block = _render(monkeypatch, RuntimeError("probe exploded"))
+        assert block == ""
+
+    def test_empty_capabilities_injects_nothing(self, monkeypatch):
+        """An empty capabilities map yields an empty string."""
+        block = _render(monkeypatch, {})
+        assert block == ""
+
+
+class TestContentFormatterBackwardCompat:
+    def test_none_tool_status_section_is_noop(self):
+        """format_full_framework must stay backward-compatible: passing
+        tool_status_section=None injects nothing and does not raise."""
+        from claude_mpm.core.framework.formatters.content_formatter import (
+            ContentFormatter,
+        )
+
+        formatter = ContentFormatter()
+        framework_content = {"framework_instructions": "# Base instructions\n"}
+        with_none = formatter.format_full_framework(
+            framework_content,
+            "CAPS",
+            "CTX",
+            False,
+            None,
+            None,
+        )
+        without_arg = formatter.format_full_framework(
+            framework_content,
+            "CAPS",
+            "CTX",
+            False,
+            None,
+        )
+        assert with_none == without_arg
+        assert "Available Tool Services" not in with_none
+
+    def test_tool_status_section_appended_when_provided(self):
+        """When a block is supplied it appears in the assembled output."""
+        from claude_mpm.core.framework.formatters.content_formatter import (
+            ContentFormatter,
+        )
+
+        formatter = ContentFormatter()
+        block = "\n\n## Available Tool Services (auto-detected at session start)\n"
+        out = formatter.format_full_framework(
+            {"framework_instructions": "# Base instructions\n"},
+            "CAPS",
+            "CTX",
+            False,
+            None,
+            block,
+        )
+        assert "Available Tool Services" in out
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_trusty_review_wiring.py
+++ b/tests/test_trusty_review_wiring.py
@@ -1,0 +1,112 @@
+"""Tests for first-class trusty-review wiring in mpm (Feature B).
+
+Why: trusty-review is the review-on-demand MCP server backing ``/mpm-review``.
+These tests pin the three wiring surfaces that make it first-class: its
+``STATIC_MCP_CONFIGS`` entry, its presence in the per-session capability map
+(``get_trusty_capabilities``), and the bundled ``mpm-review.md`` command file
+that the command-deployment glob picks up. They also guard the security
+invariant that NO secrets are baked into the static MCP env.
+
+What: Asserts the static config entry shape (stdio ``serve --stdio`` + non-secret
+``env``), that ``get_trusty_capabilities`` reports trusty-review, and that
+``src/claude_mpm/commands/mpm-review.md`` exists with valid frontmatter and the
+expected behavioral sections.
+
+Test: ``uv run pytest tests/test_trusty_review_wiring.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from claude_mpm.services.mcp.config_builder import MCPServiceConfigBuilder
+
+
+class TestStaticMcpConfig:
+    def test_trusty_review_present(self):
+        """trusty-review is a known static MCP config."""
+        configs = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS
+        assert "trusty-review" in configs
+
+    def test_trusty_review_entry_shape(self):
+        """Entry is the stdio serve --stdio form with the cli auth-mode env."""
+        entry = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS["trusty-review"]
+        assert entry == {
+            "type": "stdio",
+            "command": "trusty-review",
+            "args": ["serve", "--stdio"],
+            "env": {"TRUSTY_REVIEW_AUTH_MODE": "cli"},
+        }
+
+    def test_trusty_review_env_holds_no_secrets(self):
+        """No AWS keys / GITHUB_TOKEN / search index baked into the static env."""
+        env = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS["trusty-review"]["env"]
+        forbidden = {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "GITHUB_TOKEN",
+            "TRUSTY_SEARCH_INDEX",
+        }
+        assert forbidden.isdisjoint(env.keys())
+
+
+class TestCapabilityDetection:
+    def test_trusty_review_reported_in_capabilities(self, monkeypatch):
+        """get_trusty_capabilities always reports trusty-review's state."""
+        from claude_mpm.services import trusty_status
+
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = trusty_status.get_trusty_capabilities()
+        assert "trusty-review" in caps
+        assert caps["trusty-review"] == "absent"
+
+
+class TestMpmReviewCommand:
+    COMMAND_PATH = (
+        Path(__file__).parent.parent
+        / "src"
+        / "claude_mpm"
+        / "commands"
+        / "mpm-review.md"
+    )
+
+    def test_command_file_exists(self):
+        """The bundled command file the deploy glob picks up must exist."""
+        assert self.COMMAND_PATH.is_file()
+
+    def test_command_frontmatter_well_formed(self):
+        """Frontmatter is a YAML block with the expected command metadata."""
+        import yaml
+
+        text = self.COMMAND_PATH.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        _, frontmatter, _body = text.split("---\n", 2)
+        meta = yaml.safe_load(frontmatter)
+        assert meta["command"] == "review"
+        assert "mpm-review" in meta["aliases"]
+        assert isinstance(meta.get("description"), str) and meta["description"]
+
+    def test_command_body_documents_health_probe_and_fallback(self):
+        """Body must describe the health probe, the trusty-review tools, the
+        fallback agent, and the verdict vocabulary."""
+        body = self.COMMAND_PATH.read_text(encoding="utf-8")
+        assert "mcp__trusty-review__review_health" in body
+        assert "mcp__trusty-review__review_diff" in body
+        assert "mcp__trusty-review__review_pr" in body
+        assert "openrouter-code-reviewer" in body
+        for verdict in ("APPROVE", "REQUEST_CHANGES", "BLOCK", "UNKNOWN"):
+            assert verdict in body
+
+    def test_command_body_documents_runtime_requirements(self):
+        """Body must call out the Bedrock / trusty-search / GITHUB_TOKEN needs."""
+        body = self.COMMAND_PATH.read_text(encoding="utf-8")
+        assert "Bedrock" in body
+        assert "7878" in body  # trusty-search default port
+        assert "GITHUB_TOKEN" in body
+        assert "TRUSTY_REVIEW_AUTH_MODE=cli" in body

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -30,7 +30,9 @@ import pytest
 
 from src.claude_mpm.services import trusty_status
 from src.claude_mpm.services.trusty_status import (
+    _CAPABILITY_SERVICES,
     _HEALTH_TIMEOUT_S,
+    get_trusty_capabilities,
     get_trusty_status,
 )
 
@@ -677,3 +679,82 @@ class TestGetStatusPalaceVerification:
         state, line = get_trusty_status("trusty-search")
         assert state == "on"
         assert "palace" not in line
+
+
+class TestGetTrustyCapabilities:
+    """get_trusty_capabilities() — the per-session source of truth fed to the
+    PM prompt. Covers all-on / mixed / all-absent state combinations and the
+    never-raises contract (a probe that raises is reported as ``absent``)."""
+
+    def test_returns_all_four_capability_services(self, monkeypatch):
+        """The map always covers exactly the four reported services."""
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = get_trusty_capabilities()
+        assert set(caps) == set(_CAPABILITY_SERVICES)
+        assert set(caps) == {
+            "trusty-memory",
+            "trusty-search",
+            "trusty-analyze",
+            "trusty-review",
+        }
+
+    def test_all_on(self, monkeypatch):
+        """Every service healthy → every state is ``on``."""
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda s: ("on", f"{s}: on")
+        )
+        caps = get_trusty_capabilities()
+        assert all(state == "on" for state in caps.values())
+
+    def test_all_absent(self, monkeypatch):
+        """No service opted in → every state is ``absent``."""
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = get_trusty_capabilities()
+        assert all(state == "absent" for state in caps.values())
+
+    def test_mixed_states_preserved_per_service(self, monkeypatch):
+        """Each service's distinct state is preserved verbatim in the map."""
+        states = {
+            "trusty-memory": ("on", "x"),
+            "trusty-search": ("not_running", "x"),
+            "trusty-analyze": ("configured", "x"),
+            "trusty-review": ("absent", ""),
+        }
+        monkeypatch.setattr(trusty_status, "get_trusty_status", lambda s: states[s])
+        caps = get_trusty_capabilities()
+        assert caps == {
+            "trusty-memory": "on",
+            "trusty-search": "not_running",
+            "trusty-analyze": "configured",
+            "trusty-review": "absent",
+        }
+
+    def test_single_probe_raising_yields_absent_not_propagated(self, monkeypatch):
+        """A per-service probe that raises is reported as ``absent`` for THAT
+        service only; the others still resolve. The call never propagates."""
+
+        def _maybe_boom(service):
+            if service == "trusty-search":
+                raise RuntimeError("probe blew up")
+            return ("on", f"{service}: on")
+
+        monkeypatch.setattr(trusty_status, "get_trusty_status", _maybe_boom)
+        caps = get_trusty_capabilities()
+        assert caps["trusty-search"] == "absent"
+        assert caps["trusty-memory"] == "on"
+        assert caps["trusty-analyze"] == "on"
+        assert caps["trusty-review"] == "on"
+
+    def test_never_raises_overall(self, monkeypatch):
+        """Even if every probe raises, the call returns an all-``absent`` map."""
+
+        def _always_boom(_service):
+            raise RuntimeError("everything is on fire")
+
+        monkeypatch.setattr(trusty_status, "get_trusty_status", _always_boom)
+        caps = get_trusty_capabilities()
+        assert caps == dict.fromkeys(_CAPABILITY_SERVICES, "absent")


### PR DESCRIPTION
Combines two features that both touch `src/claude_mpm/services/trusty_status.py`, so they ship in one branch/PR.

Closes #606
Closes #609

## Feature C (#606) — predicate mpm usage on available tools

The static PM instructions tell the PM to use `trusty-memory` / `trusty-search` unconditionally; when those daemons are absent/down a session wastes tool calls and tokens. This injects a per-session capability block the PM acts on.

- **`trusty_status.py`** (cherry-picked): `get_trusty_capabilities()` — single source of truth returning `{service: state}` for trusty-memory/search/analyze/review via the existing `get_trusty_status()` internals (filesystem presence + cached ≤200ms `/health` probes). Never raises; registers trusty-review on port 7880.
- **`content_formatter.py`** (cherry-picked): optional `tool_status_section` param on `format_full_framework`, appended after `context_section`. Backward-compatible (defaults to `None`).
- **`framework_loader.py`**: `_generate_tool_status_section()` wired into `_format_full_framework()`. Renders `## Available Tool Services (auto-detected at session start)` — a Service|Status|Impact table with explicit NEGATION lines per unavailable service and a DEGRADED-MODE note when all are absent. Fail-safe: any probe error injects nothing.
- **`PM_INSTRUCTIONS.md`**: short pointer after the Context-First Protocol noting the injected block OVERRIDES the unconditional guidance.

### Rendered block — all services ON

```
## Available Tool Services (auto-detected at session start)

This OVERRIDES the unconditional tool guidance elsewhere in these instructions. Do NOT call any service listed as NOT available below.

| Service | Status | Impact |
| --- | --- | --- |
| trusty-memory | ON | Context-First Protocol active: query `mcp__trusty-memory__memory_recall` first. |
| trusty-search | ON | Code search available: use `mcp__trusty-search__search` before delegating to Research. |
| trusty-analyze | ON | Code analysis available: `mcp__trusty-analyze__*` is usable. |
| trusty-review | ON | `/mpm-review` and `mcp__trusty-review__*` are usable. |
```

### Rendered block — all services ABSENT

```
## Available Tool Services (auto-detected at session start)

This OVERRIDES the unconditional tool guidance elsewhere in these instructions. Do NOT call any service listed as NOT available below.

| Service | Status | Impact |
| --- | --- | --- |
| trusty-memory | ABSENT | Despite MEMORY.md/Context-First guidance, trusty-memory is NOT available this session — SKIP all `mcp__trusty-memory__*` calls and memory recall steps. |
| trusty-search | ABSENT | trusty-search is NOT available — SKIP code search; delegate directly to Research. |
| trusty-analyze | ABSENT | trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls. |
| trusty-review | ABSENT | code review via trusty-review unavailable; fall back to `openrouter-code-reviewer`. |

**Skip the following this session:**

- Despite MEMORY.md/Context-First guidance, trusty-memory is NOT available this session — SKIP all `mcp__trusty-memory__*` calls and memory recall steps.
- trusty-search is NOT available — SKIP code search; delegate directly to Research.
- trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls.
- code review via trusty-review unavailable; fall back to `openrouter-code-reviewer`.

**DEGRADED MODE — no trusty services available this session.** Skip all memory recall and code search; delegate directly to the Research agent. Suggest the user run `claude-mpm setup trusty-search` / `claude-mpm setup trusty-memory` to enable Context-First tooling.
```

## Feature B (#609) — first-class trusty-review code review

- **`migrate_trusty_autodetect.py`**: trusty-review `_SERVICES` descriptor — binary `trusty-review`, fallback `127.0.0.1:7880`, stdio MCP entry `serve --stdio`. **No palace, no hooks** (no `_TRUSTY_HOOK_SPECS` entry → `inject_trusty_hooks` is a no-op for it). `env` holds ONLY `TRUSTY_REVIEW_AUTH_MODE=cli`; AWS keys / `GITHUB_TOKEN` inherited from the process environment, never written to disk; `TRUSTY_SEARCH_INDEX` intentionally omitted.
- **`config_builder.py`**: same stdio entry added to `STATIC_MCP_CONFIGS`.
- **`startup_display.py`**: trusty-review added to both banner loops (suppressed when not opted in).
- **`mpm-review.md`**: new bundled `/mpm-review` command (picked up by the command-deploy `*.md` glob). Probes `review_health` → `review_diff` (current git diff) or `review_pr` (`owner/repo#PR`) → falls back to `openrouter-code-reviewer` when unavailable. Output uses trusty-review's verdict vocabulary (APPROVE / APPROVE* / REQUEST_CHANGES / BLOCK / UNKNOWN). Documents Bedrock / trusty-search:7878 / `GITHUB_TOKEN` runtime needs.

## Commits (one file per commit)

| Commit | File |
| --- | --- |
| feat: get_trusty_capabilities() source of truth (cherry-pick) | trusty_status.py |
| feat: optional tool_status_section param (cherry-pick) | content_formatter.py |
| feat: inject Available Tool Services block | framework_loader.py |
| docs: point Context-First at override block | PM_INSTRUCTIONS.md |
| test: get_trusty_capabilities combinations | test_trusty_status.py |
| test: tool status section + formatter compat | test_framework_loader_tool_status.py |
| feat: auto-detect/wire trusty-review (no palace/hooks) | migrate_trusty_autodetect.py |
| feat: trusty-review STATIC_MCP_CONFIGS | config_builder.py |
| feat: trusty-review in startup banner | startup_display.py |
| feat: /mpm-review bundled command | mpm-review.md |
| test: trusty-review autodetect wiring | test_trusty_autodetect.py |
| test: trusty-review static config / capabilities / command | test_trusty_review_wiring.py |

## Verification

- `uv run pytest tests/test_trusty_status.py tests/test_framework_loader_tool_status.py tests/test_trusty_review_wiring.py tests/migrations/test_trusty_autodetect.py -n auto` → **84 passed**.
- `ruff format --check` and `ruff check` → clean on all touched Python files.
- `mypy` introduces **zero new errors** (the 25 reported are pre-existing baseline errors in `framework_loader.py` / `startup_display.py:747`, also present on `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)