### PR TITLE
fix: remove clone-specific hook paths and duplicate entries from settings.json (#611)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,18 +10,6 @@
             "command": "claude-hook",
             "timeout": 15,
             "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "claude-hook",
-            "timeout": 60,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Volumes/SSD1/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
-            "_mpm": true
           }
         ]
       }
@@ -34,18 +22,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "claude-hook",
-            "timeout": 60,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Volumes/SSD1/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]
@@ -77,18 +53,6 @@
             "command": "claude-hook",
             "timeout": 15,
             "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "claude-hook",
-            "timeout": 60,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Volumes/SSD1/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
-            "_mpm": true
           }
         ]
       }
@@ -101,18 +65,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "claude-hook",
-            "timeout": 60,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Volumes/SSD1/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]
@@ -139,18 +91,6 @@
             "type": "command",
             "command": "claude-hook",
             "timeout": 15,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "claude-hook",
-            "timeout": 60,
-            "_mpm": true
-          },
-          {
-            "type": "command",
-            "command": "/Volumes/SSD1/Projects/claude-mpm/src/claude_mpm/scripts/claude-hook-handler.sh",
-            "timeout": 60,
             "_mpm": true
           }
         ]


### PR DESCRIPTION
## Problem

The committed `.claude/settings.json` had **three** hook command entries for each of five hook events instead of one:

1. `"claude-hook"` with `timeout: 15`
2. `"claude-hook"` with `timeout: 60` — a byte-identical duplicate that caused the hook to **double-fire**
3. An **absolute path** to `/Volumes/SSD1/.../claude-hook-handler.sh` — clone-specific, wrong for every other contributor, and which caused startup's `_has_stale_hook_paths` to detect the absolute path, force `install_hooks`, and rewrite the file (generating constant churn)

Affected events: **PreToolUse, PostToolUse, Stop, SubagentStop**, and the **first** `UserPromptSubmit` block.

## Fix

Each of the five affected event blocks now contains exactly one entry, matching the existing singleton `SessionStart` / `PermissionRequest` blocks:

```json
{
  "type": "command",
  "command": "claude-hook",
  "timeout": 15,
  "_mpm": true
}
```

This removes both the duplicate timeout-60 entry and the absolute path.

## Left untouched

- `PostToolUseFailure` block (`tool_failure_hook`)
- `SessionStart` block
- `PermissionRequest` block
- The second `UserPromptSubmit` block (`message_check_hook`)
- All other settings (attribution, spinnerVerbs, permissions, etc.)

## Verification

- `python3 -m json.tool .claude/settings.json` → valid JSON
- `grep '"command": "/'` → no matches (no absolute paths remain)
- Net change: 60 lines deleted, 0 added

Closes #611

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)