### PR TITLE
feat: manifest config system — core (schema, merger, loader) [PR1/4]

### DIFF
--- a/docs/specs/manifest.md
+++ b/docs/specs/manifest.md
@@ -1,0 +1,217 @@
+# Manifest Configuration Subsystem — Spec-Linked Documentation
+
+**Status:** Active (sections: draft pending backfill)
+**Version:** v1
+**Subsystem:** MANIFEST
+
+This document covers the core behavioral contracts for the claude-mpm manifest
+configuration system.  Each section constitutes one governed specification with a
+stable ID, a behavior contract (WHAT), a rationale section (WHY), and an
+implementing-modules table.
+
+The IDs below use the `{#SPEC-MANIFEST-NN~1}` anchor form that the traceability
+checker recognizes as a declaration.  Engineer agents add matching
+`References: SPEC-MANIFEST-NN~1` entries to the docstrings of implementing modules.
+
+Design source of truth: `docs/design/manifest-config-system.md`
+
+---
+
+## Table of Contents
+
+| ID | Section | Implementing module(s) |
+|----|---------|------------------------|
+| SPEC-MANIFEST-01~1 | [Detection-gated loading — dormant-unless-present contract](#detection-gated-loading--dormant-unless-present-contract-spec-manifest-011) | `claude_mpm.manifest.loader` |
+| SPEC-MANIFEST-02~1 | [Deep-merge semantics including setup.services union](#deep-merge-semantics-including-setupservices-union-spec-manifest-021) | `claude_mpm.manifest.merger` |
+| SPEC-MANIFEST-03~1 | [Schema validation contract](#schema-validation-contract-spec-manifest-031) | `claude_mpm.manifest.schema` |
+
+---
+
+## Detection-gated loading — dormant-unless-present contract {#SPEC-MANIFEST-01~1}
+
+**ID:** SPEC-MANIFEST-01~1
+**Status:** draft (pending backfill)
+
+### Behavior Contract (WHAT)
+
+- **Inputs:**
+  - `start_dir: Path | str` — a directory path from which to search upward for
+    `.claude-mpm/manifest.json`.
+  - Optional `preset_resolver: Callable[[str], dict] | None` — injectable callable
+    used to resolve the `extends` preset name to a raw manifest dict.
+
+- **Outputs:**
+  - `find_manifest(start_dir) -> Path | None` — returns the absolute path to the
+    manifest file if one is found at `<repo-root>/.claude-mpm/manifest.json`;
+    returns `None` if no such file exists anywhere in the directory hierarchy.
+  - `load_manifest(start_dir, preset_resolver=None) -> ManifestResult | None` —
+    returns `None` (sentinel "no manifest") when no manifest file is found.
+    Returns a `ManifestResult` when the file exists.  Never raises due to absence
+    of the manifest file.
+
+- **Preconditions:** `start_dir` must be a readable directory.
+
+- **Postconditions (file absent):** The function returns `None`.  No logging, no
+  warnings, no defaults applied, no state mutated.  Existing system behavior is
+  completely unchanged.
+
+- **Postconditions (file present):**
+  1. The file is read and parsed as JSON.  A `ManifestLoadError` is raised on
+     malformed JSON with a clear, actionable message.
+  2. The parsed dict is validated against the manifest JSON schema (SPEC-MANIFEST-03~1).
+     A `ManifestValidationError` is raised with the offending key and violated
+     constraint when validation fails.
+  3. If `extends` is absent or `preset_resolver` is `None`, a `ManifestResult` is
+     returned with the raw repo manifest (no preset merged).
+  4. If `extends` is present AND `preset_resolver` is provided, the resolver is
+     called with the `extends` string and its return value is deep-merged under
+     the repo manifest via the merger (SPEC-MANIFEST-02~1).  The resulting merged
+     dict is stored in `ManifestResult.effective`.
+
+- **Error conditions:**
+  - Missing file: returns `None` (not an error).
+  - Malformed JSON: raises `ManifestLoadError`.
+  - Schema violation: raises `ManifestValidationError`.
+  - Resolver failure: propagates the resolver's exception unchanged.
+
+### Rationale (WHY)
+
+- The "dormant unless detected" contract is the foundational design constraint
+  for this subsystem.  Many projects using claude-mpm do not have a manifest.
+  If the loader applied defaults or emitted warnings on every startup without a
+  file, it would break the experience for the majority of users who have not
+  opted in.  Returning `None` (not an empty dict, not a default manifest) makes
+  the absent case unambiguously distinguishable from "manifest present but empty".
+
+- The injectable `preset_resolver` parameter creates a clean seam for PR2
+  (preset resolution) without requiring the loader to be rewritten.  PR1 callers
+  that do not yet have a resolver simply omit it; the loader degrades gracefully.
+
+- Searching upward from `start_dir` (rather than requiring an absolute path)
+  mirrors `git` and `tsconfig.json` discovery conventions, allowing `load_manifest`
+  to be called from any subdirectory of a project.
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `claude_mpm.manifest.loader` | Full implementation: `find_manifest`, `load_manifest`, `ManifestResult` |
+
+---
+
+## Deep-merge semantics including setup.services union {#SPEC-MANIFEST-02~1}
+
+**ID:** SPEC-MANIFEST-02~1
+**Status:** draft (pending backfill)
+
+### Behavior Contract (WHAT)
+
+- **Inputs:**
+  - `preset: dict` — the resolved preset manifest dict (may be empty).
+  - `repo: dict` — the repo-level manifest dict (may be empty).
+
+- **Outputs:** A new dict `effective` representing the merged configuration.
+  Neither `preset` nor `repo` is mutated.
+
+- **Merge rules (applied recursively):**
+
+  | Location | Rule |
+  |----------|------|
+  | Scalar values | `repo` wins; if `repo` omits the key, `preset` value is used. |
+  | Object values (`agents`, `settings`, `hooks`, and any nested dicts) | Deep merge; for any key present in both, `repo` wins at the leaf level via recursive application of these rules. |
+  | `setup.services` array | Union of `preset["setup"]["services"]` and `repo["setup"]["services"]`, deduplicated, preserving insertion order (preset entries first, then repo-only extras). |
+  | All other arrays | `repo` replaces `preset` entirely when `repo` specifies the key.  If `repo` omits the key, `preset` value is used. |
+
+- **Preconditions:** Both `preset` and `repo` must be valid Python dicts.  Values
+  may be of any JSON-compatible type.
+
+- **Postconditions:**
+  - The returned dict contains all keys from `preset` that are not overridden by `repo`.
+  - All keys from `repo` appear in the result with their `repo` values (or merged
+    sub-dicts where the rule requires deep merge).
+  - `effective["setup"]["services"]` (when both sides supply the key) is the
+    deduplicated union preserving preset-first insertion order.
+  - All other array keys in `effective` come from `repo` when `repo` sets them.
+
+- **Error conditions:** Raises `TypeError` if either argument is not a `dict`.
+
+### Rationale (WHY)
+
+- The split between "object deep-merge" and "array replace" is deliberate.
+  Objects (agents, settings) represent named configurations where partial overrides
+  are the common case (e.g. override one agent's model without restating all its
+  other fields).  Arrays outside `setup.services` represent ordered command lists
+  (hook arrays) where a partial override would produce unpredictable behavior.
+  Replacing the entire array gives the repo author full control.
+
+- `setup.services` is the single exception to the array-replace rule because the
+  expected semantics is "run the preset's services AND the repo's services".
+  A union merge with deduplication matches how most users will think about it:
+  "I want the company standard services PLUS my project-specific ones."
+
+- Pure-function design (no I/O, no global state) makes the merger independently
+  testable and usable in any context where the caller has already loaded the dicts.
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `claude_mpm.manifest.merger` | Full implementation: `deep_merge` pure function |
+
+---
+
+## Schema validation contract {#SPEC-MANIFEST-03~1}
+
+**ID:** SPEC-MANIFEST-03~1
+**Status:** draft (pending backfill)
+
+### Behavior Contract (WHAT)
+
+- **Inputs:** `data: dict` — a parsed manifest dict to validate.
+
+- **Outputs:** `None` on success (no return value).
+
+- **Schema structure (JSON Schema draft-07):**
+
+  | Key | Type | Required | Constraint |
+  |-----|------|----------|------------|
+  | `version` | string | yes | Enum: `["1.0"]` |
+  | `extends` | string | no | Min length 1 |
+  | `agents` | object | no | Values are objects |
+  | `hooks` | object | no | Values are arrays of strings |
+  | `settings` | object | no | Arbitrary key-value pairs |
+  | `setup` | object | no | Contains optional `services` (array of strings) |
+
+- **Additional properties:** Allowed at the top level (the schema does not set
+  `additionalProperties: false`).  This matches the design doc's intent of an
+  extensible format where future top-level keys can be added without breaking
+  existing validators.
+
+- **Error conditions:** Raises `ManifestValidationError` when `data` fails
+  validation.  The error message includes the offending JSON path and the
+  schema constraint that was violated.  The exception carries `path` (a
+  dot-separated string) and `message` (human-readable description) attributes.
+
+### Rationale (WHY)
+
+- JSON Schema draft-07 is used (rather than Pydantic or a hand-written
+  validator) because `jsonschema` is already a transitive dependency of the
+  claude-mpm stack and adds zero new installation cost.  The schema dict lives
+  in Python source so it is importable, testable, and diffable via normal code
+  review tooling.
+
+- Allowing additional properties at the top level makes the schema forward-compatible:
+  an older version of claude-mpm can load a manifest written for a newer version
+  without validation errors, provided the known fields are valid.  Individual
+  subsections (e.g. `setup`) may be stricter if their semantics require it.
+
+- `ManifestValidationError` is a distinct exception type (not a generic
+  `ValueError`) so callers can catch it precisely and present actionable error
+  messages without catching unrelated `ValueError` exceptions from other parts of
+  the system.
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `claude_mpm.manifest.schema` | `MANIFEST_SCHEMA` dict, `validate_manifest`, `ManifestValidationError` |

--- a/src/claude_mpm/manifest/__init__.py
+++ b/src/claude_mpm/manifest/__init__.py
@@ -1,0 +1,45 @@
+"""
+Manifest configuration subsystem for claude-mpm.
+
+WHAT: Exposes the public surface of the manifest package:
+``find_manifest``, ``load_manifest``, ``ManifestResult``,
+``ManifestLoadError``, ``ManifestValidationError``, ``deep_merge``,
+``validate_manifest``, and ``MANIFEST_SCHEMA``.
+
+WHY: A single import point lets callers write
+``from claude_mpm.manifest import load_manifest`` without knowing which
+sub-module owns each symbol.  Internal module structure can change without
+breaking external callers.
+
+References
+----------
+SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
+SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
+SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+"""
+
+from __future__ import annotations
+
+from claude_mpm.manifest.loader import (
+    ManifestLoadError,
+    ManifestResult,
+    find_manifest,
+    load_manifest,
+)
+from claude_mpm.manifest.merger import deep_merge
+from claude_mpm.manifest.schema import (
+    MANIFEST_SCHEMA,
+    ManifestValidationError,
+    validate_manifest,
+)
+
+__all__ = [
+    "MANIFEST_SCHEMA",
+    "ManifestLoadError",
+    "ManifestResult",
+    "ManifestValidationError",
+    "deep_merge",
+    "find_manifest",
+    "load_manifest",
+    "validate_manifest",
+]

--- a/src/claude_mpm/manifest/loader.py
+++ b/src/claude_mpm/manifest/loader.py
@@ -1,0 +1,257 @@
+"""
+Manifest configuration subsystem — detection-gated loader.
+
+WHAT: Provides ``find_manifest(start_dir) -> Path | None`` to locate the
+manifest file by walking up the directory hierarchy, and
+``load_manifest(start_dir, preset_resolver=None) -> ManifestResult | None`` as
+the primary entry point.  Returns ``None`` immediately when no manifest file is
+found (the "dormant unless detected" contract).  When the file is present,
+parses JSON, validates against the schema, and optionally merges a preset via an
+injectable resolver callable.
+
+WHY: Returning ``None`` (not an empty default) when no manifest file exists
+keeps the system completely transparent to projects that have not opted in — no
+warnings, no defaults, no changed behaviour.  The injectable ``preset_resolver``
+parameter creates a clean seam so PR2 (preset resolution) can plug in without
+rewriting this module.  Walking upward from ``start_dir`` mirrors ``git`` and
+``tsconfig.json`` discovery conventions.
+
+References
+----------
+SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
+SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
+SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from claude_mpm.manifest.merger import deep_merge
+from claude_mpm.manifest.schema import ManifestValidationError, validate_manifest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# ---------------------------------------------------------------------------
+# Public exceptions
+# ---------------------------------------------------------------------------
+
+
+class ManifestLoadError(OSError):
+    """Raised when a manifest file exists but cannot be read or parsed.
+
+    WHAT: Wraps lower-level ``json.JSONDecodeError`` or ``OSError`` exceptions
+    and provides a human-readable ``message`` attribute pointing to the file
+    and the problem.
+
+    WHY: A distinct exception type allows callers (CLI, setup) to distinguish
+    "file not found" (returns ``None``) from "file found but broken" (raises
+    ``ManifestLoadError``), without catching broad ``Exception`` or ``OSError``.
+
+    :spec: SPEC-MANIFEST-01~1
+    """
+
+    def __init__(self, path: Path, message: str) -> None:
+        self.path = path
+        self.message = message
+        super().__init__(f"Failed to load manifest at '{path}': {message}")
+
+
+# Re-export so callers can import everything from the loader.
+__all__ = [
+    "ManifestLoadError",
+    "ManifestResult",
+    "ManifestValidationError",
+    "find_manifest",
+    "load_manifest",
+]
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ManifestResult:
+    """Immutable result object returned by ``load_manifest`` on success.
+
+    WHAT: Carries the raw repo manifest dict, the effective (merged) config dict
+    (equal to ``repo`` when no preset was resolved), the absolute path to the
+    manifest file, and a flag indicating whether a preset was merged.
+
+    WHY: A dataclass (not a plain dict) lets callers pattern-match on the result
+    type, use type checkers, and access fields by name without magic string keys.
+    ``frozen=True`` prevents accidental mutation by callers.
+
+    :spec: SPEC-MANIFEST-01~1
+    """
+
+    #: The raw repo-level manifest as parsed from disk.
+    repo: dict
+    #: The merged effective config.  Equals ``repo`` when no preset was applied.
+    effective: dict
+    #: Absolute path to the manifest file that was loaded.
+    path: Path
+    #: True when a preset was resolved and merged into ``effective``.
+    preset_merged: bool = field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+#: Relative path from a repo root to the manifest file.
+_MANIFEST_RELATIVE = Path(".claude-mpm") / "manifest.json"
+
+
+def find_manifest(start_dir: Path | str) -> Path | None:
+    """Locate the manifest file by walking up from *start_dir*.
+
+    WHAT: Searches *start_dir* and each ancestor directory for
+    ``.claude-mpm/manifest.json``.  Returns the absolute ``Path`` to the first
+    match, or ``None`` if no manifest is found anywhere in the hierarchy.
+
+    WHY: Walking upward mirrors ``git`` and ``tsconfig.json`` conventions so
+    that ``load_manifest`` can be called from any sub-directory of a project.
+
+    Test: Create a temp dir with ``.claude-mpm/manifest.json``, call
+    ``find_manifest`` from a sub-directory; assert the returned path points to
+    the manifest file.  Call from a directory with no manifest; assert ``None``.
+
+    :spec: SPEC-MANIFEST-01~1
+
+    Parameters
+    ----------
+    start_dir:
+        The directory from which to start searching.
+
+    Returns
+    -------
+    Path | None
+        Absolute path to the manifest, or ``None`` if not found.
+    """
+    current = Path(start_dir).resolve()
+    while True:
+        candidate = current / _MANIFEST_RELATIVE
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            # Reached the filesystem root without finding a manifest.
+            return None
+        current = parent
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(
+    start_dir: Path | str,
+    preset_resolver: Callable[[str], dict] | None = None,
+) -> ManifestResult | None:
+    """Load, validate, and optionally merge the manifest for the given project.
+
+    WHAT: Returns ``None`` when no ``.claude-mpm/manifest.json`` is found
+    (the dormant-unless-present contract).  When the file is found: parses JSON,
+    validates against the schema, and returns a ``ManifestResult``.  If
+    ``extends`` is present AND ``preset_resolver`` is provided, calls the
+    resolver and deep-merges the preset under the repo manifest.
+
+    WHY: Single entry point for all manifest-aware code so every caller benefits
+    from the same validation and merge semantics.  The injectable
+    ``preset_resolver`` keeps PR1 self-contained while leaving a clean seam for
+    PR2 to plug in real preset resolution without changing this function's
+    signature or callers.
+
+    Test: In a temp dir without a manifest, assert ``None`` is returned.
+    In a temp dir with a valid ``{"version": "1.0"}`` manifest, assert a
+    ``ManifestResult`` is returned with ``repo["version"] == "1.0"``.
+    With a malformed JSON file, assert ``ManifestLoadError`` is raised.
+    With ``extends`` set and a resolver provided, assert the resolver is called
+    and the result contains merged keys from both preset and repo.
+
+    :spec: SPEC-MANIFEST-01~1
+
+    Parameters
+    ----------
+    start_dir:
+        Directory from which to begin searching for the manifest.
+    preset_resolver:
+        Optional callable ``(extends_name: str) -> dict`` that returns the
+        preset manifest dict.  When ``None`` and ``extends`` is set in the
+        manifest, the repo manifest is returned unmerged with no error raised
+        (PR2 will supply the real resolver).
+
+    Returns
+    -------
+    ManifestResult | None
+        ``None`` when no manifest file is found.
+        ``ManifestResult`` when a valid manifest is loaded.
+
+    Raises
+    ------
+    ManifestLoadError
+        When the manifest file exists but contains invalid JSON or cannot be read.
+    ManifestValidationError
+        When the manifest file contains valid JSON but fails schema validation.
+    """
+    # -- DORMANT CHECK (must be first) ---------------------------------------
+    manifest_path = find_manifest(start_dir)
+    if manifest_path is None:
+        # No manifest present → system remains completely dormant.
+        return None
+
+    # -- PARSE ----------------------------------------------------------------
+    try:
+        raw_text = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestLoadError(
+            manifest_path,
+            f"Could not read file: {exc}",
+        ) from exc
+
+    try:
+        repo_manifest: dict = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ManifestLoadError(
+            manifest_path,
+            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+        ) from exc
+
+    if not isinstance(repo_manifest, dict):
+        raise ManifestLoadError(
+            manifest_path,
+            f"Manifest root must be a JSON object, not {type(repo_manifest).__name__}.",
+        )
+
+    # -- VALIDATE -------------------------------------------------------------
+    validate_manifest(repo_manifest)
+
+    # -- PRESET RESOLUTION (injectable seam) ----------------------------------
+    extends: str | None = repo_manifest.get("extends")
+
+    if extends is not None and preset_resolver is not None:
+        # PR2 plugs in here: resolve and merge the preset.
+        preset_dict = preset_resolver(extends)
+        effective = deep_merge(preset_dict, repo_manifest)
+        return ManifestResult(
+            repo=repo_manifest,
+            effective=effective,
+            path=manifest_path,
+            preset_merged=True,
+        )
+
+    # No resolver (or no extends) → return the raw repo manifest unmerged.
+    # Callers that need preset resolution should provide a preset_resolver.
+    return ManifestResult(
+        repo=repo_manifest,
+        effective=repo_manifest,
+        path=manifest_path,
+        preset_merged=False,
+    )

--- a/src/claude_mpm/manifest/merger.py
+++ b/src/claude_mpm/manifest/merger.py
@@ -1,0 +1,173 @@
+"""
+Manifest configuration subsystem — deep-merge implementation.
+
+WHAT: Provides ``deep_merge(preset, repo) -> dict``, a pure function that
+merges a preset manifest dict with a repo manifest dict according to the rules
+defined in ``docs/design/manifest-config-system.md``: scalars and objects are
+deep-merged with repo winning at the leaf level; ``setup.services`` arrays are
+union-merged (preset-first, deduplicated, insertion-order-preserving); all other
+arrays are replaced by the repo value when present.
+
+WHY: Isolating merge logic in a pure, I/O-free function makes it independently
+testable without any filesystem or network setup.  The caller (loader, CLI, or
+future resolver) owns the I/O; this module owns only the merge semantics.
+Separating ``setup.services`` from the general array-replace rule is explicit
+in the design doc and must be implemented exactly here — not scattered across
+callers — to guarantee consistent behaviour.
+
+References
+----------
+SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
+"""
+
+from __future__ import annotations
+
+import copy
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def deep_merge(preset: dict, repo: dict) -> dict:
+    """Merge *preset* and *repo* manifest dicts into an effective config dict.
+
+    WHAT: Returns a new dict produced by recursively merging *repo* on top of
+    *preset* using the rules below.  Neither input is mutated.
+
+    Rules:
+    - Scalars: *repo* wins; absent keys fall back to *preset*.
+    - Objects (dicts): recursive deep merge; *repo* wins at each leaf.
+    - ``setup.services`` array: union of both arrays, deduplicated,
+      preserving insertion order (preset entries first, then repo-only extras).
+    - All other arrays: *repo* replaces *preset* entirely when *repo* specifies
+      the key; *preset* value used when *repo* omits the key.
+
+    WHY: Centralises all merge semantics in one callable so every code path
+    (loader, CLI, future migration) produces identical results.
+
+    Test: Call with ``preset={"agents": {"eng": {"model": "haiku", "color":
+    "green"}}, "setup": {"services": ["svc-a"]}}`` and
+    ``repo={"agents": {"eng": {"model": "sonnet"}}, "setup":
+    {"services": ["svc-b"]}}``; assert ``result["agents"]["eng"]`` equals
+    ``{"model": "sonnet", "color": "green"}`` and
+    ``result["setup"]["services"]`` equals ``["svc-a", "svc-b"]``.
+
+    :spec: SPEC-MANIFEST-02~1
+
+    Parameters
+    ----------
+    preset:
+        The resolved preset manifest dict.  May be empty.
+    repo:
+        The repo-level manifest dict.  May be empty.
+
+    Returns
+    -------
+    dict
+        The merged effective configuration.
+
+    Raises
+    ------
+    TypeError
+        If either argument is not a ``dict``.
+    """
+    if not isinstance(preset, dict):
+        raise TypeError(f"preset must be a dict, got {type(preset).__name__}")
+    if not isinstance(repo, dict):
+        raise TypeError(f"repo must be a dict, got {type(repo).__name__}")
+
+    # Start with a deep copy of the preset so we never mutate the input.
+    result = copy.deepcopy(preset)
+    _merge_into(result, repo, path=())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge_into(target: dict, source: dict, path: tuple[str, ...]) -> None:
+    """Recursively merge *source* into *target* in-place.
+
+    WHAT: Iterates over every key in *source* and merges it into *target*
+    in-place using the three-way dispatch: (1) dicts on both sides recurse;
+    (2) arrays on both sides trigger the ``setup.services`` union check or the
+    default array-replace rule; (3) all other cases copy the source value into
+    target (repo wins).
+
+    WHY: Separating the workhorse from ``deep_merge``'s entry-point allows
+    ``deep_merge`` to own the initial deep-copy and type-checking while this
+    function focuses purely on the recursive merge logic.  The *path* tuple
+    is the minimum bookkeeping needed to identify the ``setup.services``
+    special case without coupling the merge rules to the manifest schema.
+
+    :spec: SPEC-MANIFEST-02~1
+    """
+    for key, source_value in source.items():
+        if key not in target:
+            # Key exists only in repo → copy it wholesale.
+            target[key] = copy.deepcopy(source_value)
+            continue
+
+        target_value = target[key]
+
+        # Both sides have this key — apply merge rules.
+        if isinstance(target_value, dict) and isinstance(source_value, dict):
+            # Both are objects → recurse.
+            _merge_into(target_value, source_value, path + (key,))
+        elif isinstance(target_value, list) and isinstance(source_value, list):
+            # Both are arrays → check for the setup.services special case.
+            if path == ("setup",) and key == "services":
+                # Union merge: preset-first, then repo-only extras, deduplicated.
+                target[key] = _union_merge(target_value, source_value)
+            elif path == () and key == "setup":
+                # Should not reach here (setup is a dict, not a list), but be safe.
+                target[key] = copy.deepcopy(source_value)
+            else:
+                # All other arrays: repo replaces preset.
+                target[key] = copy.deepcopy(source_value)
+        else:
+            # Scalar or type mismatch → repo wins.
+            target[key] = copy.deepcopy(source_value)
+
+
+def _union_merge(preset_list: list, repo_list: list) -> list:
+    """Return the ordered union of *preset_list* and *repo_list*.
+
+    WHAT: Produces a new list containing all elements of *preset_list* first,
+    followed by elements of *repo_list* that were not already present in
+    *preset_list*.  Preserves insertion order; deduplicates by value.
+
+    WHY: The ``setup.services`` union rule exists so that repo authors can add
+    project-specific services without losing the preset's baseline services.
+    Preset-first ordering ensures the preset's services are installed before
+    any repo-specific additions.
+
+    Test: Call with ``["a", "b"]`` and ``["b", "c"]``; assert result is
+    ``["a", "b", "c"]``.
+
+    Parameters
+    ----------
+    preset_list:
+        Entries from the preset (appear first in the result).
+    repo_list:
+        Entries from the repo (only novel entries appended).
+
+    Returns
+    -------
+    list
+        Deduplicated union with preset entries first.
+    """
+    seen: set = set()
+    result: list = []
+    for item in preset_list:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    for item in repo_list:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result

--- a/src/claude_mpm/manifest/schema.py
+++ b/src/claude_mpm/manifest/schema.py
@@ -1,0 +1,172 @@
+"""
+Manifest configuration subsystem — JSON schema and validation.
+
+WHAT: Provides the canonical JSON Schema (draft-07) dict for manifest v1.0 and
+a ``validate_manifest`` function that raises a clear, actionable
+``ManifestValidationError`` when a manifest dict violates the schema.  Pure
+module; performs no I/O.
+
+WHY: Centralising the schema in one importable Python dict gives the loader,
+the CLI, and test fixtures a single source of truth.  Using ``jsonschema``
+(already a transitive dependency) avoids adding new installation cost.
+Allowing additional top-level properties keeps the format forward-compatible:
+older versions of claude-mpm can load manifests written for newer versions
+without validation failures, provided the known fields are valid.
+
+References
+----------
+SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+"""
+
+from __future__ import annotations
+
+import jsonschema  # type: ignore[import-untyped]
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+
+class ManifestValidationError(ValueError):
+    """Raised when a manifest dict fails JSON-schema validation.
+
+    WHAT: Wraps a ``jsonschema.ValidationError`` and exposes ``path`` (the
+    dot-separated JSON pointer to the offending key) and ``message`` (a
+    human-readable description of the constraint that was violated).
+
+    WHY: A distinct exception type lets callers catch manifest validation
+    failures precisely, without accidentally swallowing unrelated ``ValueError``
+    exceptions from other parts of the system.
+
+    :spec: SPEC-MANIFEST-03~1
+    """
+
+    def __init__(self, path: str, message: str) -> None:
+        self.path = path
+        self.message = message
+        super().__init__(f"Manifest validation error at '{path}': {message}")
+
+
+# ---------------------------------------------------------------------------
+# Schema definition
+# ---------------------------------------------------------------------------
+
+#: JSON Schema draft-07 for manifest v1.0.
+#:
+#: Top-level keys:
+#:   version  (required, enum ["1.0"])
+#:   extends  (optional string, min length 1)
+#:   agents   (optional object whose values are objects)
+#:   hooks    (optional object whose values are arrays of strings)
+#:   settings (optional free-form object)
+#:   setup    (optional object with optional "services" string-array)
+#:
+#: Additional top-level properties are allowed so that future keys do not
+#: break validation on older claude-mpm installations.
+MANIFEST_SCHEMA: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "claude-mpm manifest",
+    "description": "Repo-level manifest configuration for claude-mpm.",
+    "type": "object",
+    "required": ["version"],
+    "additionalProperties": True,
+    "properties": {
+        "version": {
+            "type": "string",
+            "enum": ["1.0"],
+            "description": "Schema version. Currently only '1.0' is valid.",
+        },
+        "extends": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name or path of the preset to extend. "
+                "See docs/design/manifest-config-system.md for resolution order."
+            ),
+        },
+        "agents": {
+            "type": "object",
+            "description": (
+                "Agent overrides keyed by agent name. "
+                "Values are partial agent-config objects deep-merged onto the preset."
+            ),
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": True,
+            },
+        },
+        "hooks": {
+            "type": "object",
+            "description": (
+                "Hook event definitions. Keys are event names "
+                "(e.g. 'PreToolUse'), values are arrays of command strings."
+            ),
+            "additionalProperties": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "settings": {
+            "type": "object",
+            "description": "Arbitrary settings deep-merged into the resolved configuration.",
+            "additionalProperties": True,
+        },
+        "setup": {
+            "type": "object",
+            "description": "Automated setup directives run by 'claude-mpm setup'.",
+            "additionalProperties": True,
+            "properties": {
+                "services": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "MCP service names to install. "
+                        "Union-merged with preset services."
+                    ),
+                },
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Validation helper
+# ---------------------------------------------------------------------------
+
+
+def validate_manifest(data: dict) -> None:
+    """Validate *data* against the manifest JSON schema.
+
+    WHAT: Accepts a parsed manifest dict and raises ``ManifestValidationError``
+    if it violates the schema.  Returns ``None`` on success.
+
+    WHY: Providing a single validation entry point means every caller (loader,
+    CLI, tests) uses the same schema and the same error type, preventing
+    inconsistent validation behaviour across the codebase.
+
+    Test: Pass a minimal ``{"version": "1.0"}``; assert no exception is raised.
+    Pass ``{}``; assert ``ManifestValidationError`` is raised with ``path``
+    containing ``"version"``.
+
+    :spec: SPEC-MANIFEST-03~1
+
+    Parameters
+    ----------
+    data:
+        A parsed manifest dict to validate.
+
+    Raises
+    ------
+    ManifestValidationError
+        When *data* fails schema validation.  The exception carries ``path``
+        (dot-separated JSON path to the offending key) and ``message``
+        (human-readable description of the violated constraint).
+    """
+    try:
+        jsonschema.validate(data, MANIFEST_SCHEMA)
+    except jsonschema.ValidationError as exc:
+        # Build a dot-separated path string from the deque of path components.
+        path_parts = list(exc.absolute_path)
+        path_str = ".".join(str(p) for p in path_parts) if path_parts else "<root>"
+        raise ManifestValidationError(path=path_str, message=exc.message) from exc

--- a/tests/test_manifest_loader.py
+++ b/tests/test_manifest_loader.py
@@ -1,0 +1,310 @@
+"""
+tests/test_manifest_loader.py — Unit tests for the detection-gated manifest loader.
+
+WHAT: Exercises ``find_manifest``, ``load_manifest``, ``ManifestResult``, and
+``ManifestLoadError`` across four key scenarios: (1) dormant path (no file),
+(2) valid file loaded and validated, (3) malformed JSON raises ManifestLoadError,
+(4) injectable preset_resolver is called when ``extends`` is present.
+
+WHY: The loader is the entry point for all manifest-aware code.  Correct
+dormant behaviour (returning None with no side effects) is the most critical
+property to test because a regression here would silently change the behaviour
+of all projects that have not opted in to the manifest system.
+
+References
+----------
+SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 — used as a value at runtime in _write_manifest
+from typing import Any
+
+import pytest
+
+from claude_mpm.manifest.loader import (
+    ManifestLoadError,
+    ManifestResult,
+    find_manifest,
+    load_manifest,
+)
+from claude_mpm.manifest.schema import ManifestValidationError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(directory: Path, content: Any) -> Path:
+    """Write a manifest file (as JSON string or raw string) into *directory*."""
+    manifest_dir = directory / ".claude-mpm"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "manifest.json"
+    if isinstance(content, dict):
+        manifest_path.write_text(json.dumps(content), encoding="utf-8")
+    else:
+        # Allow raw invalid strings for error-path tests.
+        manifest_path.write_text(str(content), encoding="utf-8")
+    return manifest_path
+
+
+# ===========================================================================
+# find_manifest
+# ===========================================================================
+
+
+class TestFindManifest:
+    """``find_manifest`` locates the manifest by walking upward."""
+
+    def test_returns_none_when_no_manifest(self, tmp_path: Path) -> None:
+        assert find_manifest(tmp_path) is None
+
+    def test_finds_manifest_in_same_directory(self, tmp_path: Path) -> None:
+        expected = _write_manifest(tmp_path, {"version": "1.0"})
+        result = find_manifest(tmp_path)
+        assert result == expected
+
+    def test_finds_manifest_in_parent_directory(self, tmp_path: Path) -> None:
+        expected = _write_manifest(tmp_path, {"version": "1.0"})
+        subdir = tmp_path / "src" / "mymodule"
+        subdir.mkdir(parents=True)
+        result = find_manifest(subdir)
+        assert result == expected
+
+    def test_finds_nearest_manifest(self, tmp_path: Path) -> None:
+        """When manifests exist at multiple levels, the nearest one wins."""
+        parent_manifest = _write_manifest(tmp_path, {"version": "1.0"})
+        child_dir = tmp_path / "child"
+        child_dir.mkdir()
+        child_manifest = _write_manifest(child_dir, {"version": "1.0"})
+        result = find_manifest(child_dir)
+        assert result == child_manifest
+        assert result != parent_manifest
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0"})
+        result = find_manifest(str(tmp_path))
+        assert result is not None
+
+    def test_returns_absolute_path(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0"})
+        result = find_manifest(tmp_path)
+        assert result is not None
+        assert result.is_absolute()
+
+
+# ===========================================================================
+# Dormant path (no manifest file)
+# ===========================================================================
+
+
+class TestDormantPath:
+    """When no manifest file exists, load_manifest must return None silently."""
+
+    def test_returns_none_when_no_file(self, tmp_path: Path) -> None:
+        result = load_manifest(tmp_path)
+        assert result is None
+
+    def test_no_exception_when_no_file(self, tmp_path: Path) -> None:
+        """Must not raise any exception for the absent case."""
+        try:
+            load_manifest(tmp_path)
+        except Exception as exc:
+            pytest.fail(f"load_manifest raised unexpectedly: {exc}")
+
+    def test_returns_none_from_subdirectory_with_no_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        subdir = tmp_path / "deep" / "nested"
+        subdir.mkdir(parents=True)
+        result = load_manifest(subdir)
+        assert result is None
+
+
+# ===========================================================================
+# Valid manifest loaded and validated
+# ===========================================================================
+
+
+class TestValidManifestLoaded:
+    """When a valid manifest is found, a ManifestResult is returned."""
+
+    def test_returns_manifest_result(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0"})
+        result = load_manifest(tmp_path)
+        assert isinstance(result, ManifestResult)
+
+    def test_repo_contains_parsed_manifest(self, tmp_path: Path) -> None:
+        manifest = {"version": "1.0", "setup": {"services": ["svc-a"]}}
+        _write_manifest(tmp_path, manifest)
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.repo["version"] == "1.0"
+        assert result.repo["setup"]["services"] == ["svc-a"]
+
+    def test_effective_equals_repo_when_no_resolver(self, tmp_path: Path) -> None:
+        manifest = {"version": "1.0"}
+        _write_manifest(tmp_path, manifest)
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.effective == result.repo
+
+    def test_preset_merged_is_false_when_no_resolver(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "default"})
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.preset_merged is False
+
+    def test_path_attribute_points_to_file(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path, {"version": "1.0"})
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.path == manifest_path
+
+    def test_loads_from_subdirectory(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0"})
+        subdir = tmp_path / "src"
+        subdir.mkdir()
+        result = load_manifest(subdir)
+        assert result is not None
+        assert result.repo["version"] == "1.0"
+
+
+# ===========================================================================
+# Error paths
+# ===========================================================================
+
+
+class TestErrorPaths:
+    """Clear errors raised for malformed files and schema violations."""
+
+    def test_malformed_json_raises_manifest_load_error(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, "{not valid json")
+        with pytest.raises(ManifestLoadError) as exc_info:
+            load_manifest(tmp_path)
+        err = exc_info.value
+        assert hasattr(err, "path")
+        assert hasattr(err, "message")
+
+    def test_manifest_load_error_message_is_human_readable(
+        self, tmp_path: Path
+    ) -> None:
+        _write_manifest(tmp_path, "{bad json")
+        with pytest.raises(ManifestLoadError) as exc_info:
+            load_manifest(tmp_path)
+        assert len(str(exc_info.value)) > 10
+
+    def test_schema_violation_raises_manifest_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        # Missing required "version" field.
+        _write_manifest(tmp_path, {"extends": "default"})
+        with pytest.raises(ManifestValidationError):
+            load_manifest(tmp_path)
+
+    def test_wrong_version_raises_manifest_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        _write_manifest(tmp_path, {"version": "99.0"})
+        with pytest.raises(ManifestValidationError):
+            load_manifest(tmp_path)
+
+    def test_manifest_root_not_object_raises_load_error(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, '["not", "an", "object"]')
+        with pytest.raises(ManifestLoadError):
+            load_manifest(tmp_path)
+
+
+# ===========================================================================
+# Injectable preset resolver
+# ===========================================================================
+
+
+class TestInjectablePresetResolver:
+    """preset_resolver is called when extends is present and resolver provided."""
+
+    def test_resolver_called_with_extends_value(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "mypreset"})
+        calls: list[str] = []
+
+        def resolver(name: str) -> dict:
+            calls.append(name)
+            return {}
+
+        load_manifest(tmp_path, preset_resolver=resolver)
+        assert calls == ["mypreset"]
+
+    def test_resolver_result_merged_into_effective(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            {
+                "version": "1.0",
+                "extends": "preset-x",
+                "agents": {"eng": {"model": "sonnet"}},
+            },
+        )
+        preset_data = {
+            "agents": {"eng": {"model": "haiku", "color": "green"}},
+            "setup": {"services": ["preset-svc"]},
+        }
+
+        result = load_manifest(tmp_path, preset_resolver=lambda _: preset_data)
+        assert result is not None
+        assert result.preset_merged is True
+        # repo wins for model
+        assert result.effective["agents"]["eng"]["model"] == "sonnet"
+        # preset fills color
+        assert result.effective["agents"]["eng"]["color"] == "green"
+        # setup.services from preset appears in effective
+        assert "preset-svc" in result.effective["setup"]["services"]
+
+    def test_preset_merged_true_when_resolver_provided(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "any"})
+        result = load_manifest(tmp_path, preset_resolver=lambda _: {})
+        assert result is not None
+        assert result.preset_merged is True
+
+    def test_repo_unchanged_when_resolver_provided(self, tmp_path: Path) -> None:
+        """result.repo must always be the raw file content, never the merged dict."""
+        _write_manifest(
+            tmp_path, {"version": "1.0", "extends": "p", "agents": {"x": {}}}
+        )
+        preset_data = {"agents": {"y": {"model": "haiku"}}}
+        result = load_manifest(tmp_path, preset_resolver=lambda _: preset_data)
+        assert result is not None
+        # repo should not have been mutated by the merge
+        assert "y" not in result.repo.get("agents", {})
+        # effective should have merged data
+        assert "y" in result.effective.get("agents", {})
+
+    def test_no_resolver_and_extends_present_returns_unmerged(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a resolver, extends is noted but no merge happens."""
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "some-preset"})
+        result = load_manifest(tmp_path, preset_resolver=None)
+        assert result is not None
+        assert result.preset_merged is False
+        assert result.effective == result.repo
+
+    def test_resolver_not_called_when_extends_absent(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0"})
+        calls: list[str] = []
+
+        def resolver(name: str) -> dict:
+            calls.append(name)
+            return {}
+
+        load_manifest(tmp_path, preset_resolver=resolver)
+        assert calls == []
+
+    def test_resolver_exception_propagates(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "bad-preset"})
+
+        def failing_resolver(name: str) -> dict:
+            raise RuntimeError("preset not found")
+
+        with pytest.raises(RuntimeError, match="preset not found"):
+            load_manifest(tmp_path, preset_resolver=failing_resolver)

--- a/tests/test_manifest_merger.py
+++ b/tests/test_manifest_merger.py
@@ -1,0 +1,364 @@
+"""
+tests/test_manifest_merger.py — Unit tests for the manifest deep-merge module.
+
+WHAT: Exercises all merge rules defined in SPEC-MANIFEST-02~1: scalar override,
+nested object merge, ``setup.services`` union+dedup+order, other-array
+replacement, and edge cases (empty preset, empty repo, deep conflicts).
+
+WHY: The merger is the most test-critical module in the manifest subsystem
+because incorrect merge semantics silently produce wrong effective configs that
+are hard to diagnose in production.  Exhaustive unit tests provide the safety
+net that makes future changes safe.
+
+References
+----------
+SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from claude_mpm.manifest.merger import _union_merge, deep_merge
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def merge(preset: dict, repo: dict) -> dict:
+    """Thin wrapper so tests read as ``merge(preset, repo)``."""
+    return deep_merge(preset, repo)
+
+
+# ===========================================================================
+# Scalar override
+# ===========================================================================
+
+
+class TestScalarOverride:
+    """repo wins for scalar values; absent keys fall back to preset."""
+
+    def test_repo_scalar_wins_over_preset(self) -> None:
+        result = merge({"version": "1.0"}, {"version": "2.0"})
+        assert result["version"] == "2.0"
+
+    def test_preset_scalar_used_when_repo_absent(self) -> None:
+        result = merge({"version": "1.0"}, {})
+        assert result["version"] == "1.0"
+
+    def test_repo_adds_new_scalar_key(self) -> None:
+        result = merge({}, {"extra": "value"})
+        assert result["extra"] == "value"
+
+    def test_repo_none_wins_over_preset_string(self) -> None:
+        # None is a valid scalar — repo wins.
+        result = merge({"key": "value"}, {"key": None})
+        assert result["key"] is None
+
+    def test_preset_not_mutated(self) -> None:
+        preset = {"x": 1}
+        repo = {"x": 2}
+        original_preset = copy.deepcopy(preset)
+        merge(preset, repo)
+        assert preset == original_preset
+
+    def test_repo_not_mutated(self) -> None:
+        preset = {"x": 1}
+        repo = {"x": 2}
+        original_repo = copy.deepcopy(repo)
+        merge(preset, repo)
+        assert repo == original_repo
+
+
+# ===========================================================================
+# Nested object merge
+# ===========================================================================
+
+
+class TestNestedObjectMerge:
+    """Objects are recursively deep-merged; repo wins at the leaf level."""
+
+    def test_nested_key_merge(self) -> None:
+        preset = {"agents": {"engineer": {"model": "haiku", "color": "green"}}}
+        repo = {"agents": {"engineer": {"model": "sonnet"}}}
+        result = merge(preset, repo)
+        assert result["agents"]["engineer"]["model"] == "sonnet"
+        assert result["agents"]["engineer"]["color"] == "green"
+
+    def test_repo_adds_new_agent(self) -> None:
+        preset = {"agents": {"engineer": {"model": "haiku"}}}
+        repo = {"agents": {"reviewer": {"model": "opus"}}}
+        result = merge(preset, repo)
+        assert "engineer" in result["agents"]
+        assert result["agents"]["reviewer"]["model"] == "opus"
+
+    def test_deeply_nested_conflict(self) -> None:
+        preset = {"settings": {"permissions": {"additionalDirectories": ["~/shared"]}}}
+        repo = {"settings": {"permissions": {"mode": "strict"}}}
+        result = merge(preset, repo)
+        perms = result["settings"]["permissions"]
+        assert perms["additionalDirectories"] == ["~/shared"]
+        assert perms["mode"] == "strict"
+
+    def test_three_level_nesting(self) -> None:
+        preset = {"a": {"b": {"c": 1, "d": 2}}}
+        repo = {"a": {"b": {"c": 99}}}
+        result = merge(preset, repo)
+        assert result["a"]["b"]["c"] == 99
+        assert result["a"]["b"]["d"] == 2
+
+    def test_object_vs_scalar_type_mismatch_repo_wins(self) -> None:
+        """When preset has dict and repo has scalar, repo wins."""
+        preset = {"key": {"nested": "value"}}
+        repo = {"key": "flat_value"}
+        result = merge(preset, repo)
+        assert result["key"] == "flat_value"
+
+    def test_scalar_vs_object_type_mismatch_repo_wins(self) -> None:
+        """When preset has scalar and repo has dict, repo wins."""
+        preset = {"key": "flat_value"}
+        repo = {"key": {"nested": "value"}}
+        result = merge(preset, repo)
+        assert result["key"] == {"nested": "value"}
+
+
+# ===========================================================================
+# setup.services union merge
+# ===========================================================================
+
+
+class TestSetupServicesUnion:
+    """setup.services is union-merged: preset first, then repo-only extras."""
+
+    def test_union_merges_disjoint_lists(self) -> None:
+        preset = {"setup": {"services": ["kuzu-memory"]}}
+        repo = {"setup": {"services": ["mcp-ticketer"]}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["kuzu-memory", "mcp-ticketer"]
+
+    def test_union_deduplicates_shared_entries(self) -> None:
+        preset = {"setup": {"services": ["kuzu-memory", "shared-svc"]}}
+        repo = {"setup": {"services": ["shared-svc", "mcp-ticketer"]}}
+        result = merge(preset, repo)
+        services = result["setup"]["services"]
+        assert services == ["kuzu-memory", "shared-svc", "mcp-ticketer"]
+
+    def test_union_preserves_preset_first_order(self) -> None:
+        preset = {"setup": {"services": ["a", "b"]}}
+        repo = {"setup": {"services": ["c", "a"]}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["a", "b", "c"]
+
+    def test_empty_preset_services_uses_repo_only(self) -> None:
+        preset = {"setup": {"services": []}}
+        repo = {"setup": {"services": ["svc-x"]}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["svc-x"]
+
+    def test_empty_repo_services_uses_preset_only(self) -> None:
+        preset = {"setup": {"services": ["svc-x"]}}
+        repo = {"setup": {"services": []}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["svc-x"]
+
+    def test_preset_services_absent_uses_repo(self) -> None:
+        preset = {"setup": {}}
+        repo = {"setup": {"services": ["svc-x"]}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["svc-x"]
+
+    def test_repo_services_absent_uses_preset(self) -> None:
+        preset = {"setup": {"services": ["svc-x"]}}
+        repo = {"setup": {}}
+        result = merge(preset, repo)
+        assert result["setup"]["services"] == ["svc-x"]
+
+    def test_no_setup_key_in_either(self) -> None:
+        preset = {"version": "1.0"}
+        repo = {"version": "1.0"}
+        result = merge(preset, repo)
+        assert "setup" not in result
+
+    def test_design_doc_example(self) -> None:
+        """Verbatim example from docs/design/manifest-config-system.md."""
+        preset = {
+            "agents": {"engineer": {"model": "haiku", "color": "green"}},
+            "setup": {"services": ["kuzu-memory"]},
+        }
+        repo = {
+            "extends": "acme",
+            "agents": {"engineer": {"model": "sonnet"}},
+            "setup": {"services": ["mcp-ticketer"]},
+        }
+        result = merge(preset, repo)
+        assert result["agents"]["engineer"]["model"] == "sonnet"
+        assert result["agents"]["engineer"]["color"] == "green"
+        assert result["setup"]["services"] == ["kuzu-memory", "mcp-ticketer"]
+
+
+# ===========================================================================
+# Other-array replacement
+# ===========================================================================
+
+
+class TestOtherArrayReplacement:
+    """All arrays except setup.services are replaced by repo when repo sets them."""
+
+    def test_hooks_array_replaced_not_merged(self) -> None:
+        preset = {"hooks": {"PreToolUse": ["./preset-hook.sh"]}}
+        repo = {"hooks": {"PreToolUse": ["./my-hook.sh"]}}
+        result = merge(preset, repo)
+        assert result["hooks"]["PreToolUse"] == ["./my-hook.sh"]
+
+    def test_hooks_absent_in_repo_uses_preset(self) -> None:
+        preset = {"hooks": {"Stop": ["./cleanup.sh"]}}
+        repo = {}
+        result = merge(preset, repo)
+        assert result["hooks"]["Stop"] == ["./cleanup.sh"]
+
+    def test_hooks_repo_adds_new_event(self) -> None:
+        preset = {"hooks": {"PreToolUse": ["./preset.sh"]}}
+        repo = {"hooks": {"Stop": ["./stop.sh"]}}
+        result = merge(preset, repo)
+        assert result["hooks"]["PreToolUse"] == ["./preset.sh"]
+        assert result["hooks"]["Stop"] == ["./stop.sh"]
+
+    def test_arbitrary_nested_array_replaced(self) -> None:
+        preset = {"settings": {"allowed": ["x", "y"]}}
+        repo = {"settings": {"allowed": ["z"]}}
+        result = merge(preset, repo)
+        assert result["settings"]["allowed"] == ["z"]
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Empty inputs, single-side inputs, type errors."""
+
+    def test_empty_preset_returns_repo(self) -> None:
+        repo = {"version": "1.0", "extends": "default"}
+        result = merge({}, repo)
+        assert result == repo
+
+    def test_empty_repo_returns_preset(self) -> None:
+        preset = {"version": "1.0", "agents": {"eng": {"model": "haiku"}}}
+        result = merge(preset, {})
+        assert result == preset
+
+    def test_both_empty(self) -> None:
+        assert merge({}, {}) == {}
+
+    def test_non_dict_preset_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="preset must be a dict"):
+            deep_merge("not-a-dict", {})  # type: ignore[arg-type]
+
+    def test_non_dict_repo_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="repo must be a dict"):
+            deep_merge({}, ["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_result_is_independent_copy(self) -> None:
+        """Mutating the result must not affect preset or repo."""
+        preset = {"agents": {"eng": {"model": "haiku"}}}
+        repo = {"agents": {"eng": {"color": "blue"}}}
+        result = merge(preset, repo)
+        result["agents"]["eng"]["model"] = "MUTATED"
+        assert preset["agents"]["eng"]["model"] == "haiku"
+
+    def test_large_nested_config(self) -> None:
+        """Realistic full-manifest merge."""
+        preset = {
+            "version": "1.0",
+            "agents": {
+                "engineer": {"model": "haiku", "color": "green", "max_tokens": 4096},
+                "reviewer": {"model": "haiku"},
+            },
+            "hooks": {
+                "PreToolUse": ["./preset-pre.sh"],
+                "Stop": ["./preset-stop.sh"],
+            },
+            "settings": {
+                "permissions": {"additionalDirectories": ["~/shared"]},
+                "model": "claude-haiku-4-5",
+            },
+            "setup": {"services": ["kuzu-memory", "mcp-ticketer"]},
+        }
+        repo = {
+            "version": "1.0",
+            "extends": "acme",
+            "agents": {
+                "engineer": {"model": "sonnet", "color": "blue"},
+                "data-analyst": {"model": "sonnet"},
+            },
+            "hooks": {
+                "PreToolUse": ["./repo-pre.sh"],
+            },
+            "settings": {
+                "permissions": {"mode": "strict"},
+            },
+            "setup": {"services": ["duetto-mcp"]},
+        }
+        result = merge(preset, repo)
+
+        # version: repo wins
+        assert result["version"] == "1.0"
+
+        # agents: deep merge
+        assert result["agents"]["engineer"]["model"] == "sonnet"
+        assert result["agents"]["engineer"]["color"] == "blue"
+        assert result["agents"]["engineer"]["max_tokens"] == 4096
+        assert result["agents"]["reviewer"]["model"] == "haiku"
+        assert result["agents"]["data-analyst"]["model"] == "sonnet"
+
+        # hooks: PreToolUse replaced, Stop kept from preset
+        assert result["hooks"]["PreToolUse"] == ["./repo-pre.sh"]
+        assert result["hooks"]["Stop"] == ["./preset-stop.sh"]
+
+        # settings: deep merge
+        assert result["settings"]["permissions"]["additionalDirectories"] == [
+            "~/shared"
+        ]
+        assert result["settings"]["permissions"]["mode"] == "strict"
+        assert result["settings"]["model"] == "claude-haiku-4-5"
+
+        # setup.services: union
+        assert result["setup"]["services"] == [
+            "kuzu-memory",
+            "mcp-ticketer",
+            "duetto-mcp",
+        ]
+
+
+# ===========================================================================
+# _union_merge unit tests
+# ===========================================================================
+
+
+class TestUnionMerge:
+    """Direct tests for the _union_merge helper."""
+
+    def test_disjoint_lists(self) -> None:
+        assert _union_merge(["a", "b"], ["c", "d"]) == ["a", "b", "c", "d"]
+
+    def test_overlapping_lists(self) -> None:
+        assert _union_merge(["a", "b"], ["b", "c"]) == ["a", "b", "c"]
+
+    def test_preset_first_order(self) -> None:
+        assert _union_merge(["x"], ["y", "x"]) == ["x", "y"]
+
+    def test_both_empty(self) -> None:
+        assert _union_merge([], []) == []
+
+    def test_empty_preset(self) -> None:
+        assert _union_merge([], ["a", "b"]) == ["a", "b"]
+
+    def test_empty_repo(self) -> None:
+        assert _union_merge(["a", "b"], []) == ["a", "b"]
+
+    def test_all_duplicates(self) -> None:
+        assert _union_merge(["x", "y"], ["x", "y"]) == ["x", "y"]

--- a/tests/test_manifest_schema.py
+++ b/tests/test_manifest_schema.py
@@ -1,0 +1,227 @@
+"""
+tests/test_manifest_schema.py — Unit tests for the manifest JSON schema module.
+
+WHAT: Exercises ``validate_manifest`` against the canonical schema, confirming
+that valid minimal and full manifests pass validation and that invalid manifests
+raise ``ManifestValidationError`` with informative messages.
+
+WHY: The schema is the contract boundary.  These tests pin the exact validation
+behaviour so changes to the schema produce explicit test failures, not silent
+regressions.
+
+References
+----------
+SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_mpm.manifest.schema import (
+    MANIFEST_SCHEMA,
+    ManifestValidationError,
+    validate_manifest,
+)
+
+# ===========================================================================
+# Valid manifests
+# ===========================================================================
+
+
+class TestValidManifests:
+    """Manifests that must pass validation without raising."""
+
+    def test_minimal_manifest_passes(self) -> None:
+        validate_manifest({"version": "1.0"})
+
+    def test_full_manifest_passes(self) -> None:
+        validate_manifest(
+            {
+                "version": "1.0",
+                "extends": "default",
+                "agents": {
+                    "engineer": {"model": "sonnet", "color": "blue"},
+                },
+                "hooks": {
+                    "PreToolUse": ["./hooks/pre.sh"],
+                    "Stop": ["./hooks/stop.sh"],
+                },
+                "settings": {
+                    "permissions": {"additionalDirectories": ["~/shared"]},
+                },
+                "setup": {
+                    "services": ["kuzu-memory", "mcp-ticketer"],
+                },
+            }
+        )
+
+    def test_manifest_with_only_extends(self) -> None:
+        validate_manifest({"version": "1.0", "extends": "enterprise"})
+
+    def test_manifest_with_only_agents(self) -> None:
+        validate_manifest({"version": "1.0", "agents": {}})
+
+    def test_manifest_with_empty_setup(self) -> None:
+        validate_manifest({"version": "1.0", "setup": {}})
+
+    def test_manifest_with_empty_services_array(self) -> None:
+        validate_manifest({"version": "1.0", "setup": {"services": []}})
+
+    def test_unknown_top_level_key_is_allowed(self) -> None:
+        """additionalProperties is True — unknown keys must not fail validation."""
+        validate_manifest({"version": "1.0", "future_key": "some-value"})
+
+    def test_agent_with_arbitrary_fields(self) -> None:
+        """Agent objects accept arbitrary fields (MPM-proprietary + native)."""
+        validate_manifest(
+            {
+                "version": "1.0",
+                "agents": {
+                    "eng": {
+                        "model": "sonnet",
+                        "resource_tier": "tier2",
+                        "max_tokens": 8192,
+                        "custom_field": True,
+                    }
+                },
+            }
+        )
+
+
+# ===========================================================================
+# Invalid manifests — required fields
+# ===========================================================================
+
+
+class TestMissingRequiredFields:
+    """Manifests missing required fields must raise ManifestValidationError."""
+
+    def test_missing_version_fails(self) -> None:
+        with pytest.raises(ManifestValidationError) as exc_info:
+            validate_manifest({})
+        err = exc_info.value
+        assert "version" in err.message or "version" in err.path
+
+    def test_empty_dict_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({})
+
+
+# ===========================================================================
+# Invalid manifests — wrong version
+# ===========================================================================
+
+
+class TestWrongVersion:
+    """Only version '1.0' is valid."""
+
+    def test_wrong_version_string_fails(self) -> None:
+        with pytest.raises(ManifestValidationError) as exc_info:
+            validate_manifest({"version": "2.0"})
+        err = exc_info.value
+        assert "version" in err.path or "2.0" in err.message
+
+    def test_integer_version_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": 1})
+
+    def test_null_version_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": None})
+
+    def test_empty_version_string_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": ""})
+
+
+# ===========================================================================
+# Invalid manifests — malformed sub-structures
+# ===========================================================================
+
+
+class TestMalformedSubStructures:
+    """Schema violations in nested keys must raise ManifestValidationError."""
+
+    def test_setup_services_not_array_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "setup": {"services": "not-an-array"}})
+
+    def test_setup_services_array_of_non_strings_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "setup": {"services": [1, 2, 3]}})
+
+    def test_agents_value_not_object_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "agents": {"eng": "not-an-object"}})
+
+    def test_hooks_value_not_array_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest(
+                {"version": "1.0", "hooks": {"PreToolUse": "not-an-array"}}
+            )
+
+    def test_hooks_array_of_non_strings_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "hooks": {"PreToolUse": [42]}})
+
+    def test_extends_empty_string_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "extends": ""})
+
+    def test_extends_not_string_fails(self) -> None:
+        with pytest.raises(ManifestValidationError):
+            validate_manifest({"version": "1.0", "extends": 123})
+
+
+# ===========================================================================
+# ManifestValidationError attributes
+# ===========================================================================
+
+
+class TestManifestValidationErrorAttributes:
+    """The exception must carry path and message attributes."""
+
+    def test_error_has_path_attribute(self) -> None:
+        with pytest.raises(ManifestValidationError) as exc_info:
+            validate_manifest({})
+        err = exc_info.value
+        assert hasattr(err, "path")
+        assert isinstance(err.path, str)
+
+    def test_error_has_message_attribute(self) -> None:
+        with pytest.raises(ManifestValidationError) as exc_info:
+            validate_manifest({})
+        err = exc_info.value
+        assert hasattr(err, "message")
+        assert isinstance(err.message, str)
+        assert len(err.message) > 0
+
+    def test_error_str_contains_path_and_message(self) -> None:
+        with pytest.raises(ManifestValidationError) as exc_info:
+            validate_manifest({"version": "2.0"})
+        err = exc_info.value
+        assert err.path in str(err)
+
+
+# ===========================================================================
+# Schema dict structure
+# ===========================================================================
+
+
+class TestSchemaDict:
+    """MANIFEST_SCHEMA itself must be well-formed."""
+
+    def test_schema_is_dict(self) -> None:
+        assert isinstance(MANIFEST_SCHEMA, dict)
+
+    def test_schema_has_required_key(self) -> None:
+        assert "required" in MANIFEST_SCHEMA
+        assert "version" in MANIFEST_SCHEMA["required"]
+
+    def test_schema_allows_additional_properties(self) -> None:
+        assert MANIFEST_SCHEMA.get("additionalProperties") is True
+
+    def test_schema_has_version_enum(self) -> None:
+        version_schema = MANIFEST_SCHEMA["properties"]["version"]
+        assert "1.0" in version_schema["enum"]


### PR DESCRIPTION
## Summary

This is PR1 of 4 implementing the JSON manifest configuration system for claude-mpm (issue #460). It delivers the foundational core layer that all subsequent PRs build on.

**Included in this PR:**
- `docs/specs/manifest.md` — New SLD spec with three governed sections (SPEC-MANIFEST-01~1 detection-gated loading, SPEC-MANIFEST-02~1 deep-merge semantics, SPEC-MANIFEST-03~1 schema validation)
- `src/claude_mpm/manifest/schema.py` — JSON Schema draft-07 for manifest v1.0 + `validate_manifest()` + `ManifestValidationError`
- `src/claude_mpm/manifest/merger.py` — `deep_merge(preset, repo)` pure function implementing all merge rules exactly per the design doc
- `src/claude_mpm/manifest/loader.py` + `__init__.py` — Detection-gated loader: `find_manifest()` + `load_manifest()` with injectable `preset_resolver` seam
- `tests/test_manifest_merger.py` + `test_manifest_schema.py` + `test_manifest_loader.py` — 94 unit tests, all passing

**Key design decision honored:** The loader is completely dormant when `.claude-mpm/manifest.json` does not exist — returns `None`, no warnings, no defaults, no changed behavior for projects that haven't opted in.

**Deferred to PR2:** `resolver.py` + built-in presets (`default.json`, `minimal.json`, `enterprise.json`). The seam is the `preset_resolver: Callable[[str], dict] | None = None` parameter on `load_manifest()`.

**Deferred to PR3:** `manifest_commands.py` CLI (`init`, `validate`, `show` subcommands).

**Deferred to PR4:** `setup.py` integration + legacy config migration.

## Test plan

- [x] `uv run pytest tests/test_manifest_merger.py tests/test_manifest_schema.py tests/test_manifest_loader.py -v` → 94 passed
- [x] `uv run pytest tests/test_spec_traceability.py tests/test_wwl_granularity.py -p no:xdist -v` → 49 passed (SLD CI clean)
- [x] `uv run ruff format . && uv run ruff check .` → clean
- [x] `uv run mypy src/claude_mpm/manifest/` → Success: no issues found in 4 source files

Part of #460

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)