### PR TITLE
feat: manifest config system — preset resolver + built-in presets [PR2/4]

### DIFF
--- a/docs/specs/manifest.md
+++ b/docs/specs/manifest.md
@@ -24,6 +24,7 @@ Design source of truth: `docs/design/manifest-config-system.md`
 | SPEC-MANIFEST-01~1 | [Detection-gated loading — dormant-unless-present contract](#detection-gated-loading--dormant-unless-present-contract-spec-manifest-011) | `claude_mpm.manifest.loader` |
 | SPEC-MANIFEST-02~1 | [Deep-merge semantics including setup.services union](#deep-merge-semantics-including-setupservices-union-spec-manifest-021) | `claude_mpm.manifest.merger` |
 | SPEC-MANIFEST-03~1 | [Schema validation contract](#schema-validation-contract-spec-manifest-031) | `claude_mpm.manifest.schema` |
+| SPEC-MANIFEST-04~1 | [Preset resolution — four-step resolution order](#preset-resolution--four-step-resolution-order-spec-manifest-041) | `claude_mpm.manifest.resolver`, `claude_mpm.manifest.presets` |
 
 ---
 
@@ -215,3 +216,78 @@ Design source of truth: `docs/design/manifest-config-system.md`
 | Module | Role |
 |--------|------|
 | `claude_mpm.manifest.schema` | `MANIFEST_SCHEMA` dict, `validate_manifest`, `ManifestValidationError` |
+
+---
+
+## Preset resolution — four-step resolution order {#SPEC-MANIFEST-04~1}
+
+**ID:** SPEC-MANIFEST-04~1
+**Status:** active
+
+### Behavior Contract (WHAT)
+
+- **Inputs:**
+  - `extends: str` — the value of the `extends` key in a repo manifest.  May be
+    a local path (starts with `./` or `/`), a preset name, or a built-in preset
+    name.
+
+- **Outputs:** A validated manifest dict representing the resolved preset.
+
+- **Resolution order (FIRST MATCH WINS):**
+
+  | Step | Source | Condition / Location |
+  |------|--------|----------------------|
+  | 1 | **Local path** | `extends` starts with `./` or `/`.  Resolved relative to the current working directory for `./`; absolute path used as-is for `/`. |
+  | 2 | **User preset directory** | `~/.claude-mpm/presets/<extends>.json` |
+  | 3 | **Package entry point** | `importlib.metadata.entry_points(group="claude_mpm.presets")` with key `== extends`.  Entry point must be callable; called as `get_manifest() -> dict`. |
+  | 4 | **Built-in presets** | Bundled JSON files in `claude_mpm/manifest/presets/` package; loaded via `importlib.resources` so the package works when installed as a wheel. |
+
+- **Dormant principle:** Resolution is only ever triggered when (a) a manifest
+  file is detected by the loader and (b) that manifest contains a non-empty
+  `extends` key.  Projects without a manifest file are completely unaffected.
+
+- **Validation:** Each resolved preset dict is validated against the manifest
+  JSON schema (SPEC-MANIFEST-03~1) before being returned.  A preset with an
+  invalid shape raises `ManifestValidationError`.
+
+- **Multi-level chains:** If a resolved preset itself contains an `extends` key,
+  that key is ignored for now (multi-level chaining is out of scope for this
+  implementation — see TODO referencing optional feature O1 in `resolver.py`).
+
+- **Error conditions:**
+  - No source matches: raises `PresetResolutionError` with a message listing all
+    sources that were tried.
+  - JSON file present but unreadable / invalid JSON: raises `PresetResolutionError`
+    wrapping the underlying I/O or parse error.
+  - Resolved preset fails schema validation: raises `ManifestValidationError`.
+
+### Rationale (WHY)
+
+- The four-step order mirrors common precedence conventions in tooling (local >
+  user > installed > built-in) so that more specific overrides win over more
+  general ones without surprising the user.
+
+- Local paths allow teams to version-control presets alongside their code without
+  publishing a Python package.
+
+- The user preset directory (`~/.claude-mpm/presets/`) gives individual
+  developers a personal preset slot that does not require any installation step.
+
+- Entry points are the standard Python extension mechanism (pytest plugins,
+  Sphinx extensions, Babel extractors all use the same pattern), so third-party
+  preset authors can publish a `claude-mpm-<name>` pip package and have it
+  auto-discovered without requiring the user to configure any path.
+
+- Built-in presets serve as zero-install defaults and as reference implementations
+  that demonstrate valid manifest structure.
+
+- Loading bundled JSON via `importlib.resources` (not raw `__file__` path joins)
+  is required for correct behavior when the package is installed as a zip-safe
+  wheel.
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `claude_mpm.manifest.resolver` | `resolve_preset`, `PresetResolutionError`; implements the four-step resolution order |
+| `claude_mpm.manifest.presets` | `load_builtin_preset`; loads bundled `default.json`, `minimal.json`, `enterprise.json` via `importlib.resources` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.setuptools.package-data]
-claude_mpm = [ "VERSION", "BUILD_NUMBER", "scripts/*", "scripts/*.sh", "scripts/setup/*", "scripts/setup/*.sh", "commands/*.md", "config/*.yaml", "skills/bundled/**/*.md", "dashboard/*.html", "dashboard/templates/*.html", "dashboard/static/*.css", "dashboard/static/*.js", "dashboard/static/css/*.css", "dashboard/static/js/*.js", "dashboard/static/js/components/*.js", "dashboard/static/svelte-build/**/*", "agents/*.md", "agents/*.json", "agents/*.yaml", "agents/templates/*.json", "agents/templates/*.md", "agents/schema/*.json", "hooks/**/*.py", "hooks/**/*.sh", "hooks/claude_hooks/*", "hooks/claude_hooks/**/*", "templates/*.yaml", "templates/.pre-commit-config.yaml", "templates/claude/**/*", "templates/claude/hooks/scripts/*.sh", "templates/claude/commands/*.md", "bin/ztk", "bin/ztk_LICENSE",]
+claude_mpm = [ "VERSION", "BUILD_NUMBER", "scripts/*", "scripts/*.sh", "scripts/setup/*", "scripts/setup/*.sh", "commands/*.md", "config/*.yaml", "skills/bundled/**/*.md", "dashboard/*.html", "dashboard/templates/*.html", "dashboard/static/*.css", "dashboard/static/*.js", "dashboard/static/css/*.css", "dashboard/static/js/*.js", "dashboard/static/js/components/*.js", "dashboard/static/svelte-build/**/*", "agents/*.md", "agents/*.json", "agents/*.yaml", "agents/templates/*.json", "agents/templates/*.md", "agents/schema/*.json", "hooks/**/*.py", "hooks/**/*.sh", "hooks/claude_hooks/*", "hooks/claude_hooks/**/*", "templates/*.yaml", "templates/.pre-commit-config.yaml", "templates/claude/**/*", "templates/claude/hooks/scripts/*.sh", "templates/claude/commands/*.md", "bin/ztk", "bin/ztk_LICENSE", "manifest/presets/*.json",]
 
 [tool.pytest.ini_options]
 testpaths = [ "tests",]

--- a/src/claude_mpm/manifest/__init__.py
+++ b/src/claude_mpm/manifest/__init__.py
@@ -4,7 +4,8 @@ Manifest configuration subsystem for claude-mpm.
 WHAT: Exposes the public surface of the manifest package:
 ``find_manifest``, ``load_manifest``, ``ManifestResult``,
 ``ManifestLoadError``, ``ManifestValidationError``, ``deep_merge``,
-``validate_manifest``, and ``MANIFEST_SCHEMA``.
+``validate_manifest``, ``MANIFEST_SCHEMA``, ``resolve_preset``, and
+``PresetResolutionError``.
 
 WHY: A single import point lets callers write
 ``from claude_mpm.manifest import load_manifest`` without knowing which
@@ -16,6 +17,7 @@ References
 SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
 SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
 SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+SPEC-MANIFEST-04~1 : docs/specs/manifest.md#SPEC-MANIFEST-04~1
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ from claude_mpm.manifest.loader import (
     load_manifest,
 )
 from claude_mpm.manifest.merger import deep_merge
+from claude_mpm.manifest.resolver import PresetResolutionError, resolve_preset
 from claude_mpm.manifest.schema import (
     MANIFEST_SCHEMA,
     ManifestValidationError,
@@ -38,8 +41,10 @@ __all__ = [
     "ManifestLoadError",
     "ManifestResult",
     "ManifestValidationError",
+    "PresetResolutionError",
     "deep_merge",
     "find_manifest",
     "load_manifest",
+    "resolve_preset",
     "validate_manifest",
 ]

--- a/src/claude_mpm/manifest/loader.py
+++ b/src/claude_mpm/manifest/loader.py
@@ -6,14 +6,16 @@ manifest file by walking up the directory hierarchy, and
 ``load_manifest(start_dir, preset_resolver=None) -> ManifestResult | None`` as
 the primary entry point.  Returns ``None`` immediately when no manifest file is
 found (the "dormant unless detected" contract).  When the file is present,
-parses JSON, validates against the schema, and optionally merges a preset via an
-injectable resolver callable.
+parses JSON, validates against the schema, and merges a preset via the resolver
+when ``extends`` is set.  The ``preset_resolver`` parameter accepts an optional
+callable override for testing; when ``None`` (the default), the built-in
+``resolve_preset`` from ``claude_mpm.manifest.resolver`` is used automatically.
 
 WHY: Returning ``None`` (not an empty default) when no manifest file exists
 keeps the system completely transparent to projects that have not opted in — no
 warnings, no defaults, no changed behaviour.  The injectable ``preset_resolver``
-parameter creates a clean seam so PR2 (preset resolution) can plug in without
-rewriting this module.  Walking upward from ``start_dir`` mirrors ``git`` and
+parameter creates a clean seam for tests to stub the resolver without rewriting
+this module.  Walking upward from ``start_dir`` mirrors ``git`` and
 ``tsconfig.json`` discovery conventions.
 
 References
@@ -21,6 +23,7 @@ References
 SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
 SPEC-MANIFEST-02~1 : docs/specs/manifest.md#SPEC-MANIFEST-02~1
 SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+SPEC-MANIFEST-04~1 : docs/specs/manifest.md#SPEC-MANIFEST-04~1
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from claude_mpm.manifest.merger import deep_merge
+from claude_mpm.manifest.resolver import resolve_preset
 from claude_mpm.manifest.schema import ManifestValidationError, validate_manifest
 
 if TYPE_CHECKING:
@@ -160,23 +164,25 @@ def load_manifest(
     WHAT: Returns ``None`` when no ``.claude-mpm/manifest.json`` is found
     (the dormant-unless-present contract).  When the file is found: parses JSON,
     validates against the schema, and returns a ``ManifestResult``.  If
-    ``extends`` is present AND ``preset_resolver`` is provided, calls the
-    resolver and deep-merges the preset under the repo manifest.
+    ``extends`` is present, resolves the preset via ``preset_resolver`` (or the
+    built-in ``resolve_preset`` when no custom resolver is given) and deep-merges
+    the preset under the repo manifest.
 
     WHY: Single entry point for all manifest-aware code so every caller benefits
     from the same validation and merge semantics.  The injectable
-    ``preset_resolver`` keeps PR1 self-contained while leaving a clean seam for
-    PR2 to plug in real preset resolution without changing this function's
-    signature or callers.
+    ``preset_resolver`` parameter keeps the resolver swappable for tests while
+    defaulting to the real four-step resolver so production callers need no extra
+    plumbing.
 
     Test: In a temp dir without a manifest, assert ``None`` is returned.
     In a temp dir with a valid ``{"version": "1.0"}`` manifest, assert a
     ``ManifestResult`` is returned with ``repo["version"] == "1.0"``.
     With a malformed JSON file, assert ``ManifestLoadError`` is raised.
-    With ``extends`` set and a resolver provided, assert the resolver is called
-    and the result contains merged keys from both preset and repo.
+    With ``extends`` set and no custom resolver, assert the built-in resolver is
+    used and the result contains merged keys from both preset and repo.
 
     :spec: SPEC-MANIFEST-01~1
+    :spec: SPEC-MANIFEST-04~1
 
     Parameters
     ----------
@@ -184,9 +190,9 @@ def load_manifest(
         Directory from which to begin searching for the manifest.
     preset_resolver:
         Optional callable ``(extends_name: str) -> dict`` that returns the
-        preset manifest dict.  When ``None`` and ``extends`` is set in the
-        manifest, the repo manifest is returned unmerged with no error raised
-        (PR2 will supply the real resolver).
+        preset manifest dict.  When ``None`` (the default) and ``extends`` is
+        set, the built-in ``resolve_preset`` from
+        ``claude_mpm.manifest.resolver`` is used automatically.
 
     Returns
     -------
@@ -200,6 +206,8 @@ def load_manifest(
         When the manifest file exists but contains invalid JSON or cannot be read.
     ManifestValidationError
         When the manifest file contains valid JSON but fails schema validation.
+    PresetResolutionError
+        When ``extends`` is set and no preset source matches.
     """
     # -- DORMANT CHECK (must be first) ---------------------------------------
     manifest_path = find_manifest(start_dir)
@@ -233,12 +241,14 @@ def load_manifest(
     # -- VALIDATE -------------------------------------------------------------
     validate_manifest(repo_manifest)
 
-    # -- PRESET RESOLUTION (injectable seam) ----------------------------------
+    # -- PRESET RESOLUTION ----------------------------------------------------
     extends: str | None = repo_manifest.get("extends")
 
-    if extends is not None and preset_resolver is not None:
-        # PR2 plugs in here: resolve and merge the preset.
-        preset_dict = preset_resolver(extends)
+    if extends is not None:
+        # Use the injectable resolver when provided (allows test stubs),
+        # otherwise fall back to the real built-in four-step resolver.
+        _resolver = preset_resolver if preset_resolver is not None else resolve_preset
+        preset_dict = _resolver(extends)
         effective = deep_merge(preset_dict, repo_manifest)
         return ManifestResult(
             repo=repo_manifest,
@@ -247,8 +257,7 @@ def load_manifest(
             preset_merged=True,
         )
 
-    # No resolver (or no extends) → return the raw repo manifest unmerged.
-    # Callers that need preset resolution should provide a preset_resolver.
+    # No extends → return the raw repo manifest unmerged.
     return ManifestResult(
         repo=repo_manifest,
         effective=repo_manifest,

--- a/src/claude_mpm/manifest/presets/__init__.py
+++ b/src/claude_mpm/manifest/presets/__init__.py
@@ -1,0 +1,76 @@
+"""
+Manifest configuration subsystem — built-in preset accessor.
+
+WHAT: Provides ``load_builtin_preset(name: str) -> dict | None`` that reads
+the bundled JSON preset files (``default.json``, ``minimal.json``,
+``enterprise.json``) via ``importlib.resources``.  Returns ``None`` when the
+name does not match any bundled preset.
+
+WHY: Using ``importlib.resources`` (not raw ``__file__`` path joins) ensures
+the presets are loaded correctly when the package is installed as a zip-safe
+wheel, where ``__file__`` paths may not exist as real filesystem entries.
+The accessor is a separate module so the resolver can import it without
+circular dependencies, and callers can load built-in presets directly
+without going through the full resolution chain.
+
+References
+----------
+SPEC-MANIFEST-04~1 : docs/specs/manifest.md#SPEC-MANIFEST-04~1
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+
+# ---------------------------------------------------------------------------
+# Known built-in preset names (lower-case, no extension).
+# ---------------------------------------------------------------------------
+
+_BUILTIN_NAMES: frozenset[str] = frozenset({"default", "minimal", "enterprise"})
+
+__all__ = ["BUILTIN_PRESET_NAMES", "load_builtin_preset"]
+
+#: The set of built-in preset names shipped with this package.
+BUILTIN_PRESET_NAMES: frozenset[str] = _BUILTIN_NAMES
+
+
+def load_builtin_preset(name: str) -> dict | None:
+    """Load and return the built-in preset *name* as a dict, or ``None``.
+
+    WHAT: Reads ``<name>.json`` from the ``claude_mpm.manifest.presets``
+    package directory using ``importlib.resources``.  Returns ``None`` if
+    *name* is not in the set of known built-in presets.
+
+    WHY: Centralises built-in preset loading in one place.  Using
+    ``importlib.resources`` (not ``__file__``) guarantees correct behavior
+    when the package is installed as a zip-safe wheel where the JSON files may
+    not be accessible as real filesystem paths.
+
+    Test: Call ``load_builtin_preset("default")``; assert the result is a
+    ``dict`` with ``"version"`` key ``"1.0"``.  Call
+    ``load_builtin_preset("unknown")``; assert ``None`` is returned.
+
+    :spec: SPEC-MANIFEST-04~1
+
+    Parameters
+    ----------
+    name:
+        The built-in preset name (e.g. ``"default"``, ``"minimal"``,
+        ``"enterprise"``).  Case-sensitive.
+
+    Returns
+    -------
+    dict | None
+        The parsed preset dict, or ``None`` if *name* is unknown.
+    """
+    if name not in _BUILTIN_NAMES:
+        return None
+
+    # importlib.resources.files() works with installed wheels and editable
+    # installs alike.  The package anchor is this module's own package.
+    package_ref = importlib.resources.files(__name__)
+    preset_file = package_ref.joinpath(f"{name}.json")
+    text = preset_file.read_text(encoding="utf-8")
+    result: dict = json.loads(text)
+    return result

--- a/src/claude_mpm/manifest/presets/default.json
+++ b/src/claude_mpm/manifest/presets/default.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "agents": {
+    "engineer": {
+      "model": "claude-sonnet-4-5",
+      "resource_tier": "tier2",
+      "max_tokens": 8192
+    },
+    "qa": {
+      "model": "claude-haiku-4-5",
+      "resource_tier": "tier1",
+      "max_tokens": 4096
+    },
+    "planner": {
+      "model": "claude-opus-4-7",
+      "resource_tier": "tier3",
+      "max_tokens": 16384
+    },
+    "reviewer": {
+      "model": "claude-haiku-4-5",
+      "resource_tier": "tier1",
+      "max_tokens": 4096
+    }
+  },
+  "settings": {
+    "permissions": {
+      "additionalDirectories": []
+    }
+  },
+  "setup": {
+    "services": ["kuzu-memory", "mcp-ticketer"]
+  }
+}

--- a/src/claude_mpm/manifest/presets/enterprise.json
+++ b/src/claude_mpm/manifest/presets/enterprise.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "agents": {
+    "engineer": {
+      "model": "claude-sonnet-4-5",
+      "resource_tier": "tier2",
+      "max_tokens": 8192
+    },
+    "qa": {
+      "model": "claude-haiku-4-5",
+      "resource_tier": "tier1",
+      "max_tokens": 4096
+    },
+    "planner": {
+      "model": "claude-sonnet-4-5",
+      "resource_tier": "tier2",
+      "max_tokens": 8192
+    }
+  },
+  "hooks": {
+    "PreToolUse": ["claude-mpm audit-hook pre"],
+    "Stop": ["claude-mpm audit-hook stop"]
+  },
+  "settings": {
+    "permissions": {
+      "additionalDirectories": []
+    },
+    "model": "claude-haiku-4-5"
+  },
+  "setup": {
+    "services": ["kuzu-memory"]
+  }
+}

--- a/src/claude_mpm/manifest/presets/minimal.json
+++ b/src/claude_mpm/manifest/presets/minimal.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0",
+  "settings": {}
+}

--- a/src/claude_mpm/manifest/resolver.py
+++ b/src/claude_mpm/manifest/resolver.py
@@ -1,0 +1,264 @@
+"""
+Manifest configuration subsystem — preset resolver.
+
+WHAT: Provides ``resolve_preset(extends: str) -> dict`` that resolves a preset
+name or path from a repo manifest's ``extends`` field by trying four sources in
+priority order (FIRST MATCH WINS):
+
+1. **Local path** — if *extends* starts with ``./`` or ``/``, load that JSON
+   file.  Relative paths (``./``) are resolved against the current working
+   directory.
+2. **User preset directory** — ``~/.claude-mpm/presets/<name>.json``.
+3. **Package entry point** — ``importlib.metadata.entry_points(group=
+   "claude_mpm.presets")`` with key equal to *name*.  The entry point must be
+   callable and return ``dict``.
+4. **Built-in presets** — JSON files bundled inside this package
+   (``default``, ``minimal``, ``enterprise``), loaded via
+   ``claude_mpm.manifest.presets.load_builtin_preset``.
+
+Each resolved dict is schema-validated before being returned.  If no source
+matches, a ``PresetResolutionError`` is raised listing all sources tried.
+
+WHY: Separating resolution from loading keeps the loader module simple and
+testable.  The injectable seam in ``loader.py`` (``preset_resolver`` parameter)
+allows tests to stub the resolver without touching the loader.  The four-step
+order mirrors common tooling conventions (local > user > installed > built-in)
+so that more specific overrides always win over more general ones.
+
+References
+----------
+SPEC-MANIFEST-04~1 : docs/specs/manifest.md#SPEC-MANIFEST-04~1
+SPEC-MANIFEST-03~1 : docs/specs/manifest.md#SPEC-MANIFEST-03~1
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+
+from claude_mpm.manifest.presets import load_builtin_preset
+from claude_mpm.manifest.schema import validate_manifest
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+
+class PresetResolutionError(LookupError):
+    """Raised when a preset name cannot be resolved from any source.
+
+    WHAT: Carries a human-readable ``message`` attribute listing all resolution
+    sources that were tried, so the user can diagnose the problem.
+
+    WHY: A distinct exception type allows callers to distinguish "preset not
+    found" from other ``LookupError`` / ``KeyError`` exceptions that might arise
+    elsewhere in the system.
+
+    :spec: SPEC-MANIFEST-04~1
+    """
+
+    def __init__(self, extends: str, tried: list[str]) -> None:
+        self.extends = extends
+        self.tried = tried
+        tried_str = "\n  - ".join(tried)
+        super().__init__(
+            f"Could not resolve preset '{extends}'. Sources tried:\n  - {tried_str}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+__all__ = ["PresetResolutionError", "resolve_preset"]
+
+
+def resolve_preset(extends: str) -> dict:
+    """Resolve the preset identified by *extends* and return its manifest dict.
+
+    WHAT: Tries four resolution sources in order — local path, user preset
+    directory, package entry point, built-in presets — and returns the first
+    match.  The resolved dict is schema-validated before being returned.
+
+    WHY: Centralising all resolution logic here keeps the loader simple and
+    every caller benefits from the same validation and error reporting.  The
+    four-step order mirrors common tooling conventions (local > user > installed
+    > built-in).
+
+    Test: Pass ``"default"``; assert a dict with ``version == "1.0"`` is
+    returned.  Pass an unknown name; assert ``PresetResolutionError`` is raised
+    listing all sources tried.  Pass a ``./path.json`` pointing to a valid JSON
+    file; assert that file is loaded.
+
+    :spec: SPEC-MANIFEST-04~1
+
+    Parameters
+    ----------
+    extends:
+        The value of the ``extends`` field from the repo manifest.  May be a
+        local path (starts with ``./`` or ``/``), a user-preset name, an entry-
+        point key, or a built-in preset name.
+
+    Returns
+    -------
+    dict
+        The resolved and schema-validated preset manifest dict.
+
+    Raises
+    ------
+    PresetResolutionError
+        When no resolution source produces a match.
+    ManifestValidationError
+        When a resolved preset fails schema validation.
+    """
+    tried: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Step 1: Local path
+    # ------------------------------------------------------------------
+    if extends.startswith("./") or extends.startswith("/"):
+        source_label = f"local path: {extends}"
+        tried.append(source_label)
+        preset_path = (
+            Path(extends).resolve()
+            if extends.startswith("/")
+            else (Path.cwd() / extends).resolve()
+        )
+        if preset_path.is_file():
+            return _load_and_validate_json(preset_path, source_label)
+        # Local path given but file not found → fail immediately with a clear
+        # message rather than falling through to other sources, since the
+        # user was explicit about wanting this exact file.
+        raise PresetResolutionError(extends, tried)
+
+    # ------------------------------------------------------------------
+    # Step 2: User preset directory
+    # ------------------------------------------------------------------
+    user_preset_path = Path.home() / ".claude-mpm" / "presets" / f"{extends}.json"
+    source_label = f"user preset directory: {user_preset_path}"
+    tried.append(source_label)
+    if user_preset_path.is_file():
+        return _load_and_validate_json(user_preset_path, source_label)
+
+    # ------------------------------------------------------------------
+    # Step 3: Package entry point
+    # ------------------------------------------------------------------
+    source_label = f"entry point group 'claude_mpm.presets', key '{extends}'"
+    tried.append(source_label)
+    ep_result = _try_entry_point(extends)
+    if ep_result is not None:
+        _validate_preset(ep_result, source_label)
+        return ep_result
+
+    # ------------------------------------------------------------------
+    # Step 4: Built-in presets
+    # ------------------------------------------------------------------
+    source_label = f"built-in preset: '{extends}'"
+    tried.append(source_label)
+    builtin = load_builtin_preset(extends)
+    if builtin is not None:
+        _validate_preset(builtin, source_label)
+        return builtin
+
+    # Nothing matched.
+    raise PresetResolutionError(extends, tried)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_and_validate_json(path: Path, source_label: str) -> dict:
+    """Read *path* as JSON, validate as a manifest, and return the dict.
+
+    WHAT: Reads the file, parses JSON, and calls ``validate_manifest``.
+    Wraps I/O or JSON parse errors in ``PresetResolutionError``.
+
+    WHY: Centralises the read-parse-validate triple so all file-based sources
+    share the same error handling path.
+
+    :spec: SPEC-MANIFEST-04~1
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PresetResolutionError(
+            str(path), [f"{source_label}: could not read file: {exc}"]
+        ) from exc
+
+    try:
+        data: dict = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PresetResolutionError(
+            str(path),
+            [
+                f"{source_label}: invalid JSON at line {exc.lineno},"
+                f" column {exc.colno}: {exc.msg}"
+            ],
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise PresetResolutionError(
+            str(path),
+            [f"{source_label}: preset root must be a JSON object"],
+        )
+
+    _validate_preset(data, source_label)
+    return data
+
+
+def _validate_preset(data: dict, source_label: str) -> None:
+    """Validate *data* against the manifest schema.
+
+    WHAT: Calls ``validate_manifest``; if it raises, wraps the error message
+    with the source label for better diagnostics.
+
+    WHY: All preset sources must produce a valid manifest dict.  Centralising
+    validation here prevents callers from forgetting to validate.
+
+    NOTE: Multi-level extends chains (a preset that itself has ``extends``) are
+    OUT OF SCOPE for this implementation — optional feature O1, deferred.  If
+    the resolved preset contains an ``extends`` key, it is ignored here.
+    TODO(O1): When multi-level chaining is implemented, recurse into
+    ``resolve_preset(data["extends"])`` here and deep-merge before returning.
+
+    :spec: SPEC-MANIFEST-04~1
+    """
+    # May raise ManifestValidationError; let it propagate — the caller asked
+    # for a valid preset, so an invalid shape is a hard error.
+    validate_manifest(data)
+
+
+def _try_entry_point(name: str) -> dict | None:
+    """Attempt to resolve *name* from the ``claude_mpm.presets`` entry-point group.
+
+    WHAT: Uses ``importlib.metadata.entry_points`` to enumerate all registered
+    ``claude_mpm.presets`` entry points, finds the one whose key matches *name*,
+    loads and calls it as ``get_manifest() -> dict``, and returns the result.
+    Returns ``None`` if no matching entry point is found.
+
+    WHY: Entry points are the standard Python extension mechanism for
+    auto-discoverable plugins.  Third-party preset packages (e.g.
+    ``claude-mpm-duetto``) register under this group so no path configuration
+    is needed.
+
+    :spec: SPEC-MANIFEST-04~1
+    """
+    try:
+        eps = importlib.metadata.entry_points(group="claude_mpm.presets")
+    except Exception:
+        return None
+
+    for ep in eps:
+        if ep.name == name:
+            try:
+                func = ep.load()
+                result = func()
+                if isinstance(result, dict):
+                    return result
+            except Exception:
+                pass
+
+    return None

--- a/tests/test_manifest_loader.py
+++ b/tests/test_manifest_loader.py
@@ -151,8 +151,9 @@ class TestValidManifestLoaded:
         assert result is not None
         assert result.effective == result.repo
 
-    def test_preset_merged_is_false_when_no_resolver(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, {"version": "1.0", "extends": "default"})
+    def test_preset_merged_is_false_when_no_extends(self, tmp_path: Path) -> None:
+        """When extends is absent, no preset is merged and preset_merged is False."""
+        _write_manifest(tmp_path, {"version": "1.0"})
         result = load_manifest(tmp_path)
         assert result is not None
         assert result.preset_merged is False
@@ -279,15 +280,43 @@ class TestInjectablePresetResolver:
         # effective should have merged data
         assert "y" in result.effective.get("agents", {})
 
-    def test_no_resolver_and_extends_present_returns_unmerged(
-        self, tmp_path: Path
-    ) -> None:
-        """Without a resolver, extends is noted but no merge happens."""
-        _write_manifest(tmp_path, {"version": "1.0", "extends": "some-preset"})
-        result = load_manifest(tmp_path, preset_resolver=None)
+    def test_no_custom_resolver_uses_builtin_resolver(self, tmp_path: Path) -> None:
+        """When preset_resolver=None and extends is set, the built-in resolver is used.
+
+        PR2 changed the behavior from PR1: passing preset_resolver=None no longer
+        skips preset resolution; instead the built-in four-step resolver is invoked
+        automatically.  Tests that need to skip resolution should use a stub that
+        returns an empty dict or raises, rather than relying on preset_resolver=None.
+        """
+        from claude_mpm.manifest.resolver import PresetResolutionError
+
+        # A known built-in preset: resolution should succeed and merge the preset.
+        _write_manifest(
+            tmp_path / "with_builtin", {"version": "1.0", "extends": "minimal"}
+        )
+        (tmp_path / "with_builtin").mkdir(exist_ok=True)
+        import json
+
+        preset_dir = tmp_path / "with_builtin" / ".claude-mpm"
+        preset_dir.mkdir(parents=True, exist_ok=True)
+        (preset_dir / "manifest.json").write_text(
+            json.dumps({"version": "1.0", "extends": "minimal"}), encoding="utf-8"
+        )
+        result = load_manifest(tmp_path / "with_builtin", preset_resolver=None)
         assert result is not None
-        assert result.preset_merged is False
-        assert result.effective == result.repo
+        assert result.preset_merged is True
+
+        # An unknown preset name: should raise PresetResolutionError.
+        unknown_dir = tmp_path / "with_unknown"
+        unknown_dir.mkdir()
+        preset_dir2 = unknown_dir / ".claude-mpm"
+        preset_dir2.mkdir()
+        (preset_dir2 / "manifest.json").write_text(
+            json.dumps({"version": "1.0", "extends": "totally-unknown-preset-xyz"}),
+            encoding="utf-8",
+        )
+        with pytest.raises(PresetResolutionError):
+            load_manifest(unknown_dir, preset_resolver=None)
 
     def test_resolver_not_called_when_extends_absent(self, tmp_path: Path) -> None:
         _write_manifest(tmp_path, {"version": "1.0"})

--- a/tests/test_manifest_resolver.py
+++ b/tests/test_manifest_resolver.py
@@ -1,0 +1,479 @@
+"""
+tests/test_manifest_resolver.py — Unit and integration tests for the preset resolver.
+
+WHAT: Exercises ``resolve_preset``, ``PresetResolutionError``,
+``load_builtin_preset``, and the end-to-end integration of
+``load_manifest`` with real preset resolution.
+
+WHY: Preset resolution is the primary new behaviour in PR2.  Correct
+resolution ORDER (local > user > entry-point > built-in) and correct
+error messages when nothing matches are the most important properties to
+verify.  Integration tests confirm the loader + resolver data path works
+end-to-end.
+
+References
+----------
+SPEC-MANIFEST-04~1 : docs/specs/manifest.md#SPEC-MANIFEST-04~1
+SPEC-MANIFEST-01~1 : docs/specs/manifest.md#SPEC-MANIFEST-01~1
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_mpm.manifest.loader import load_manifest
+from claude_mpm.manifest.presets import BUILTIN_PRESET_NAMES, load_builtin_preset
+from claude_mpm.manifest.resolver import PresetResolutionError, resolve_preset
+from claude_mpm.manifest.schema import ManifestValidationError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(directory: Path, content: Any) -> Path:
+    """Write a manifest file into *directory*/.claude-mpm/manifest.json."""
+    manifest_dir = directory / ".claude-mpm"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "manifest.json"
+    if isinstance(content, dict):
+        manifest_path.write_text(json.dumps(content), encoding="utf-8")
+    else:
+        manifest_path.write_text(str(content), encoding="utf-8")
+    return manifest_path
+
+
+def _write_preset_file(path: Path, content: dict) -> None:
+    """Write a preset JSON file at *path* (creates parent dirs)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(content), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_builtin_preset
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBuiltinPreset:
+    """Tests for the built-in preset accessor module."""
+
+    def test_default_returns_dict(self) -> None:
+        result = load_builtin_preset("default")
+        assert isinstance(result, dict)
+
+    def test_minimal_returns_dict(self) -> None:
+        result = load_builtin_preset("minimal")
+        assert isinstance(result, dict)
+
+    def test_enterprise_returns_dict(self) -> None:
+        result = load_builtin_preset("enterprise")
+        assert isinstance(result, dict)
+
+    def test_unknown_returns_none(self) -> None:
+        assert load_builtin_preset("does-not-exist") is None
+        assert load_builtin_preset("") is None
+        assert load_builtin_preset("DEFAULT") is None  # case-sensitive
+
+    def test_each_builtin_has_version(self) -> None:
+        for name in BUILTIN_PRESET_NAMES:
+            preset = load_builtin_preset(name)
+            assert preset is not None
+            assert preset.get("version") == "1.0", f"{name} missing version"
+
+    def test_builtin_preset_names_coverage(self) -> None:
+        """Sanity-check the frozenset covers all three expected names."""
+        assert "default" in BUILTIN_PRESET_NAMES
+        assert "minimal" in BUILTIN_PRESET_NAMES
+        assert "enterprise" in BUILTIN_PRESET_NAMES
+
+    def test_importlib_resources_path(self) -> None:
+        """Verify load_builtin_preset works via importlib.resources (wheel-safe)."""
+        # This test verifies the correct loading mechanism is used by checking
+        # the result is valid JSON with the expected structure.
+        result = load_builtin_preset("default")
+        assert result is not None
+        assert isinstance(result, dict)
+        assert result["version"] == "1.0"
+
+    def test_default_has_agents(self) -> None:
+        result = load_builtin_preset("default")
+        assert result is not None
+        assert "agents" in result
+        assert isinstance(result["agents"], dict)
+
+    def test_enterprise_has_hooks(self) -> None:
+        result = load_builtin_preset("enterprise")
+        assert result is not None
+        assert "hooks" in result
+        hooks = result["hooks"]
+        assert "PreToolUse" in hooks
+        assert "Stop" in hooks
+
+    def test_minimal_is_minimal(self) -> None:
+        """Minimal preset should have only version and (optionally) settings."""
+        result = load_builtin_preset("minimal")
+        assert result is not None
+        assert "version" in result
+        # Should NOT have agents or hooks
+        assert "agents" not in result
+        assert "hooks" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: each built-in preset schema-validates
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinPresetSchemaValidation:
+    """Verifies each built-in preset passes the manifest schema."""
+
+    @pytest.mark.parametrize("name", list(BUILTIN_PRESET_NAMES))
+    def test_builtin_validates(self, name: str) -> None:
+        from claude_mpm.manifest.schema import validate_manifest
+
+        preset = load_builtin_preset(name)
+        assert preset is not None
+        # Should NOT raise
+        validate_manifest(preset)
+
+
+# ---------------------------------------------------------------------------
+# Tests: PresetResolutionError
+# ---------------------------------------------------------------------------
+
+
+class TestPresetResolutionError:
+    """Tests for the PresetResolutionError exception."""
+
+    def test_has_extends_and_tried(self) -> None:
+        err = PresetResolutionError("my-preset", ["source1", "source2"])
+        assert err.extends == "my-preset"
+        assert err.tried == ["source1", "source2"]
+
+    def test_message_includes_sources(self) -> None:
+        err = PresetResolutionError("my-preset", ["source1", "source2"])
+        msg = str(err)
+        assert "my-preset" in msg
+        assert "source1" in msg
+        assert "source2" in msg
+
+    def test_is_lookup_error(self) -> None:
+        err = PresetResolutionError("x", [])
+        assert isinstance(err, LookupError)
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve_preset — resolution ORDER
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePresetOrder:
+    """Verify FIRST MATCH WINS in the four-step resolution order."""
+
+    # ------------------------------------------------------------------
+    # Step 4: built-in wins when nothing else matches
+    # ------------------------------------------------------------------
+
+    def test_builtin_default_resolves(self) -> None:
+        result = resolve_preset("default")
+        assert isinstance(result, dict)
+        assert result.get("version") == "1.0"
+
+    def test_builtin_minimal_resolves(self) -> None:
+        result = resolve_preset("minimal")
+        assert isinstance(result, dict)
+
+    def test_builtin_enterprise_resolves(self) -> None:
+        result = resolve_preset("enterprise")
+        assert isinstance(result, dict)
+
+    def test_unknown_raises_preset_resolution_error(self) -> None:
+        with pytest.raises(PresetResolutionError) as exc_info:
+            resolve_preset("no-such-preset-xyz-123")
+        err = exc_info.value
+        assert "no-such-preset-xyz-123" in str(err)
+        # All four sources should be listed
+        assert len(err.tried) >= 3  # user-dir, entry-point, built-in
+
+    def test_error_lists_all_sources_tried(self) -> None:
+        with pytest.raises(PresetResolutionError) as exc_info:
+            resolve_preset("totally-unknown-preset")
+        tried_text = "\n".join(exc_info.value.tried)
+        assert "user preset directory" in tried_text
+        assert "entry point" in tried_text
+        assert "built-in" in tried_text
+
+    # ------------------------------------------------------------------
+    # Step 1: local path beats everything
+    # ------------------------------------------------------------------
+
+    def test_local_absolute_path_wins(self, tmp_path: Path) -> None:
+        preset_file = tmp_path / "my-preset.json"
+        _write_preset_file(
+            preset_file, {"version": "1.0", "settings": {"key": "local"}}
+        )
+        result = resolve_preset(str(preset_file))
+        assert result["settings"]["key"] == "local"
+
+    def test_local_relative_path_wins_over_builtin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        preset_file = tmp_path / "my-preset.json"
+        _write_preset_file(
+            preset_file, {"version": "1.0", "settings": {"key": "local-rel"}}
+        )
+        monkeypatch.chdir(tmp_path)
+        result = resolve_preset("./my-preset.json")
+        assert result["settings"]["key"] == "local-rel"
+
+    def test_local_path_not_found_raises_immediately(self, tmp_path: Path) -> None:
+        """When a local path is explicit, fail immediately if file missing."""
+        with pytest.raises(PresetResolutionError) as exc_info:
+            resolve_preset(str(tmp_path / "nonexistent.json"))
+        assert "local path" in " ".join(exc_info.value.tried)
+
+    def test_local_relative_path_not_found_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(PresetResolutionError):
+            resolve_preset("./no-such-file.json")
+
+    # ------------------------------------------------------------------
+    # Step 2: user preset dir beats entry-point and built-in
+    # ------------------------------------------------------------------
+
+    def test_user_preset_dir_beats_builtin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user_preset_dir = tmp_path / ".claude-mpm" / "presets"
+        user_preset_dir.mkdir(parents=True)
+        preset_file = user_preset_dir / "default.json"
+        # Override the built-in "default" with a custom one
+        preset_file.write_text(
+            json.dumps({"version": "1.0", "settings": {"override": "from-user-dir"}}),
+            encoding="utf-8",
+        )
+        # Patch Path.home() to point to tmp_path
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        result = resolve_preset("default")
+        assert result["settings"]["override"] == "from-user-dir"
+
+    def test_user_preset_dir_beats_entry_point(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User dir is checked before entry points."""
+        user_preset_dir = tmp_path / ".claude-mpm" / "presets"
+        user_preset_dir.mkdir(parents=True)
+        preset_file = user_preset_dir / "acme.json"
+        preset_file.write_text(
+            json.dumps({"version": "1.0", "settings": {"src": "user-dir"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        # Register a mock entry point for "acme" that would return different data
+        mock_ep = MagicMock()
+        mock_ep.name = "acme"
+        mock_ep.load.return_value = lambda: {
+            "version": "1.0",
+            "settings": {"src": "entry-point"},
+        }
+
+        with patch.object(importlib.metadata, "entry_points", return_value=[mock_ep]):
+            result = resolve_preset("acme")
+
+        # User dir should win
+        assert result["settings"]["src"] == "user-dir"
+
+    # ------------------------------------------------------------------
+    # Step 3: entry point beats built-in
+    # ------------------------------------------------------------------
+
+    def test_entry_point_beats_builtin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Entry points are checked before built-in presets."""
+        # Patch home so no user preset dir file exists for "default"
+        monkeypatch.setattr(
+            Path, "home", classmethod(lambda cls: Path("/nonexistent-tmp-home"))
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "default"
+        mock_ep.load.return_value = lambda: {
+            "version": "1.0",
+            "settings": {"src": "entry-point"},
+        }
+
+        with patch.object(importlib.metadata, "entry_points", return_value=[mock_ep]):
+            result = resolve_preset("default")
+
+        assert result["settings"]["src"] == "entry-point"
+
+    def test_entry_point_for_unknown_builtin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An entry point for a non-built-in name is found before failing."""
+        monkeypatch.setattr(
+            Path, "home", classmethod(lambda cls: Path("/nonexistent-tmp-home"))
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "acme-corp"
+        mock_ep.load.return_value = lambda: {
+            "version": "1.0",
+            "settings": {"company": "acme"},
+        }
+
+        with patch.object(importlib.metadata, "entry_points", return_value=[mock_ep]):
+            result = resolve_preset("acme-corp")
+
+        assert result["settings"]["company"] == "acme"
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve_preset — validation
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePresetValidation:
+    """Ensure resolved presets are schema-validated."""
+
+    def test_invalid_local_preset_raises_validation_error(self, tmp_path: Path) -> None:
+        """A local preset with an invalid shape raises ManifestValidationError."""
+        preset_file = tmp_path / "bad.json"
+        # Missing required "version" key → schema violation
+        preset_file.write_text(json.dumps({"agents": {}}), encoding="utf-8")
+        with pytest.raises(ManifestValidationError):
+            resolve_preset(str(preset_file))
+
+    def test_invalid_entry_point_preset_raises_validation_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            Path, "home", classmethod(lambda cls: Path("/nonexistent-tmp-home"))
+        )
+        mock_ep = MagicMock()
+        mock_ep.name = "bad-preset"
+        mock_ep.load.return_value = lambda: {"no_version": True}
+
+        with patch.object(importlib.metadata, "entry_points", return_value=[mock_ep]):
+            with pytest.raises(ManifestValidationError):
+                resolve_preset("bad-preset")
+
+
+# ---------------------------------------------------------------------------
+# Tests: multi-level extends chains (deferred, O1)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiLevelExtendsDeferral:
+    """Confirm that a preset's own extends key is ignored (O1 deferred)."""
+
+    def test_preset_with_extends_key_is_returned_without_recursion(
+        self, tmp_path: Path
+    ) -> None:
+        """A preset that itself has 'extends' should be returned as-is (no recursion)."""
+        preset_file = tmp_path / "chained.json"
+        preset_file.write_text(
+            json.dumps({"version": "1.0", "extends": "default", "settings": {"x": 1}}),
+            encoding="utf-8",
+        )
+        # Should not raise, should not recurse
+        result = resolve_preset(str(preset_file))
+        assert result["settings"]["x"] == 1
+        assert result["extends"] == "default"  # key preserved but not resolved
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: load_manifest + real resolver
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifestIntegration:
+    """End-to-end tests: load_manifest with the built-in resolver."""
+
+    def test_extends_minimal_merges_correctly(self, tmp_path: Path) -> None:
+        """A manifest with extends=minimal resolves and merges correctly."""
+        _write_manifest(
+            tmp_path,
+            {
+                "version": "1.0",
+                "extends": "minimal",
+                "settings": {"project": "my-proj"},
+            },
+        )
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.preset_merged is True
+        assert result.effective["settings"]["project"] == "my-proj"
+        assert result.effective["version"] == "1.0"
+
+    def test_extends_default_merges_preset_agents(self, tmp_path: Path) -> None:
+        """Extending 'default' pulls in the preset's agent definitions."""
+        _write_manifest(
+            tmp_path,
+            {
+                "version": "1.0",
+                "extends": "default",
+            },
+        )
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.preset_merged is True
+        # The default preset defines agents
+        assert "agents" in result.effective
+        assert "engineer" in result.effective["agents"]
+
+    def test_repo_wins_over_preset_on_scalar(self, tmp_path: Path) -> None:
+        """Repo manifest scalar values override the preset's values."""
+        _write_manifest(
+            tmp_path,
+            {
+                "version": "1.0",
+                "extends": "default",
+                "agents": {"engineer": {"model": "custom-model"}},
+            },
+        )
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.effective["agents"]["engineer"]["model"] == "custom-model"
+
+    def test_preset_resolver_override_still_works(self, tmp_path: Path) -> None:
+        """Injectable preset_resolver param still overrides the built-in resolver."""
+        stub_preset = {"version": "1.0", "settings": {"from": "stub"}}
+        _write_manifest(
+            tmp_path,
+            {"version": "1.0", "extends": "anything"},
+        )
+        result = load_manifest(tmp_path, preset_resolver=lambda _: stub_preset)
+        assert result is not None
+        assert result.effective["settings"]["from"] == "stub"
+
+    def test_no_extends_no_preset_merged(self, tmp_path: Path) -> None:
+        """Without extends, preset_merged is False and effective == repo."""
+        _write_manifest(tmp_path, {"version": "1.0", "settings": {"k": "v"}})
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.preset_merged is False
+        assert result.effective == result.repo
+
+    def test_unknown_preset_raises(self, tmp_path: Path) -> None:
+        """load_manifest with an unknown extends raises PresetResolutionError."""
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "no-such-preset-xyz"})
+        with pytest.raises(PresetResolutionError):
+            load_manifest(tmp_path)
+
+    def test_extends_enterprise_has_hooks(self, tmp_path: Path) -> None:
+        """Extending enterprise preset provides audit hooks."""
+        _write_manifest(tmp_path, {"version": "1.0", "extends": "enterprise"})
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert result.preset_merged is True
+        assert "hooks" in result.effective
+        assert "PreToolUse" in result.effective["hooks"]


### PR DESCRIPTION
## Summary

PR 2 of 4 for the manifest config system (issue #460). Builds on the loader/schema/merger core landed in PR1 (#613) and delivers the preset resolver and three built-in presets.

**What's in this PR:**
- `src/claude_mpm/manifest/resolver.py` — `resolve_preset(extends)` with 4-step resolution order (local path → user preset dir → package entry point → built-in). Raises `PresetResolutionError` listing all sources tried when nothing matches. Each resolved dict is schema-validated.
- `src/claude_mpm/manifest/presets/` — `default.json`, `minimal.json`, `enterprise.json` bundled presets; `__init__.py` exposes `load_builtin_preset(name)` via `importlib.resources` (wheel-safe).
- `loader.py` updated: when `extends` is set and no custom `preset_resolver` is passed, the built-in `resolve_preset` is invoked automatically. The injectable seam is preserved — tests can still pass a stub resolver.
- `__init__.py` re-exports `resolve_preset` and `PresetResolutionError`.
- `pyproject.toml` — `manifest/presets/*.json` added to `package-data` so the files ship in the wheel.
- `docs/specs/manifest.md` — new `SPEC-MANIFEST-04~1` section with resolution order, dormant principle, and implementing modules table.
- 39 new unit + integration tests covering all resolution paths, schema validation, error messages, and the full `load_manifest → resolve_preset` data path.

**What's deferred:**
- CLI commands (`manifest show` / `manifest validate` / `manifest init`) → PR3
- `claude-mpm setup` integration + legacy config migration → PR4
- Multi-level `extends` chaining (optional feature O1) → deferred, clearly marked TODO in `resolver.py`

## Test plan

- [x] `uv run pytest tests/test_manifest_resolver.py tests/test_manifest_loader.py tests/test_manifest_merger.py tests/test_manifest_schema.py -v` — 133/133 pass
- [x] `uv run pytest tests/test_spec_traceability.py tests/test_wwl_granularity.py -p no:xdist -v` — 49/49 pass (SLD CI)
- [x] `uv run mypy src/claude_mpm/manifest/` — no issues
- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed

Part of #460

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)