### PR TITLE
feat: manifest config system — CLI (init/validate/show) [PR3/4]

### DIFF
--- a/docs/specs/manifest.md
+++ b/docs/specs/manifest.md
@@ -25,6 +25,7 @@ Design source of truth: `docs/design/manifest-config-system.md`
 | SPEC-MANIFEST-02~1 | [Deep-merge semantics including setup.services union](#deep-merge-semantics-including-setupservices-union-spec-manifest-021) | `claude_mpm.manifest.merger` |
 | SPEC-MANIFEST-03~1 | [Schema validation contract](#schema-validation-contract-spec-manifest-031) | `claude_mpm.manifest.schema` |
 | SPEC-MANIFEST-04~1 | [Preset resolution — four-step resolution order](#preset-resolution--four-step-resolution-order-spec-manifest-041) | `claude_mpm.manifest.resolver`, `claude_mpm.manifest.presets` |
+| SPEC-MANIFEST-05~1 | [CLI surface contract — manifest init/validate/show](#cli-surface-contract--manifest-initvalidateshow-spec-manifest-051) | `claude_mpm.cli.commands.manifest_commands`, `claude_mpm.cli.parsers.manifest_parser` |
 
 ---
 
@@ -291,3 +292,102 @@ Design source of truth: `docs/design/manifest-config-system.md`
 |--------|------|
 | `claude_mpm.manifest.resolver` | `resolve_preset`, `PresetResolutionError`; implements the four-step resolution order |
 | `claude_mpm.manifest.presets` | `load_builtin_preset`; loads bundled `default.json`, `minimal.json`, `enterprise.json` via `importlib.resources` |
+
+---
+
+## CLI surface contract — manifest init/validate/show {#SPEC-MANIFEST-05~1}
+
+**ID:** SPEC-MANIFEST-05~1
+**Status:** active
+
+### Behavior Contract (WHAT)
+
+The `claude-mpm manifest` command group exposes three subcommands:
+
+#### `manifest init`
+
+- **Inputs:**
+  - Optional `--extends PRESET` — built-in preset name or local path; defaults
+    to `"default"` in interactive mode when omitted.
+  - `--force` / `-f` — overwrite an existing manifest without error.
+  - `--non-interactive` / `--yes` / `-y` — skip all prompts (CI-safe mode).
+  - `--seed-agents`, `--seed-settings`, `--seed-services` — include empty
+    stub sections for the named keys.
+  - `--path PATH` — write the manifest to this exact file path instead of the
+    auto-discovered `<repo-root>/.claude-mpm/manifest.json`.
+
+- **Outputs (success):**  Writes a minimal valid `manifest.json` to disk.
+  Prints the path of the created file to stdout.  Returns exit code 0.
+
+- **Outputs (file already exists, no `--force`):**  Prints an error message to
+  stderr and returns exit code 1.  The existing file is not modified.
+
+- **Postconditions:**  The written file is a valid manifest (passes
+  `validate_manifest()`).
+
+#### `manifest validate`
+
+- **Inputs:**
+  - `--path PATH` — validate a specific file instead of the auto-discovered one.
+
+- **Outputs (dormant — no manifest found):**  Prints a clear "no manifest
+  found (system dormant)" message to stdout and exits **0**.  Absence of a
+  manifest file is not an error.
+
+- **Outputs (valid manifest):**  Prints a success message to stdout and exits
+  **0**.
+
+- **Outputs (invalid manifest or unresolvable preset):**  Prints a CLEAR,
+  ACTIONABLE error message to stderr (including the offending JSON path for
+  schema errors, or the list of sources tried for preset resolution errors)
+  and exits **non-zero (1)**.
+
+- **Exit-code contract:**
+
+  | Condition | Exit code |
+  |-----------|-----------|
+  | No manifest (dormant) | 0 |
+  | Valid manifest | 0 |
+  | Invalid JSON | 1 |
+  | Schema violation | 1 |
+  | Preset unresolvable | 1 |
+
+#### `manifest show`
+
+- **Inputs:**
+  - `--path PATH` — show the resolved config for a specific manifest file.
+
+- **Outputs (dormant — no manifest found):**  Prints "No manifest found
+  (system dormant)." to **stderr** and exits **0**.
+
+- **Outputs (valid manifest):**  Prints the fully-merged effective
+  configuration as pretty-printed JSON to **stdout** and exits **0**.  When
+  `extends` is set to a built-in preset (e.g. `"default"`), the output is the
+  result of `deep_merge(preset, repo)` and contains all keys from both sides.
+
+- **Outputs (invalid manifest or unresolvable preset):**  Prints an error
+  message to stderr and exits **1**.
+
+### Rationale (WHY)
+
+- **Dormant-exit-0 for validate and show:** Returning exit code 0 when no
+  manifest is found preserves the invariant that absence of a manifest is a
+  valid project state, not a failure.  CI scripts that run `manifest validate`
+  on every repo (whether or not they have opted in) must not fail because of
+  this.
+
+- **Non-interactive safety for init:** Providing `--non-interactive` (with
+  `--extends`) allows `manifest init` to be used safely in setup scripts and
+  CI jobs without requiring a TTY.  The flag combination is intentionally
+  explicit to prevent accidental scaffolding in pipelines.
+
+- **stdout vs stderr split for show:** Printing the effective JSON to stdout
+  and all status/error messages to stderr allows `manifest show | jq '...'`
+  to work without filtering noise.
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `claude_mpm.cli.commands.manifest_commands` | `manage_manifest`, `_cmd_init`, `_cmd_validate`, `_cmd_show`; full implementation of all three subcommands |
+| `claude_mpm.cli.parsers.manifest_parser` | `add_manifest_subparser`; registers the `manifest` command group and its subcommands with the argparse tree |

--- a/src/claude_mpm/cli/commands/manifest_commands.py
+++ b/src/claude_mpm/cli/commands/manifest_commands.py
@@ -1,0 +1,541 @@
+"""
+Manifest CLI command group — init, validate, show.
+
+WHAT: Implements the ``claude-mpm manifest`` subcommand group with three
+subcommands:
+
+* ``init``     — scaffold ``.claude-mpm/manifest.json`` interactively or
+  non-interactively.
+* ``validate`` — schema-validate and preset-resolve the manifest; exits
+  non-zero with a clear, actionable error on failure.
+* ``show``     — load, resolve, merge, and pretty-print the effective config
+  as JSON to stdout.
+
+WHY: A dedicated CLI surface lets developers and CI pipelines interact with
+the manifest system without writing Python.  The dormant-exit-0 contract is
+preserved in all three subcommands — absence of ``manifest.json`` is not an
+error condition.
+
+References
+----------
+SPEC-MANIFEST-05~1 : docs/specs/manifest.md#SPEC-MANIFEST-05~1
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+from claude_mpm.manifest.loader import find_manifest, load_manifest
+from claude_mpm.manifest.resolver import PresetResolutionError
+from claude_mpm.manifest.schema import ManifestValidationError, validate_manifest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Built-in preset names offered to the user during ``init``.
+_BUILTIN_PRESETS: list[str] = ["default", "minimal", "enterprise"]
+
+#: Minimum valid manifest structure.
+_MIN_MANIFEST: dict[str, str] = {"version": "1.0"}
+
+
+# ---------------------------------------------------------------------------
+# Helper — discover the repo root
+# ---------------------------------------------------------------------------
+
+
+def _repo_root(start_dir: Path | None = None) -> Path:
+    """Return the directory that should contain ``.claude-mpm/``.
+
+    WHAT: Walks upward from *start_dir* (or cwd) looking for a ``.git``
+    directory.  Falls back to cwd when no git root is found so the command
+    works in non-git directories.
+
+    WHY: The manifest must sit at the project root, not just wherever the
+    user happens to have ``cd``'d to.  Mirroring git-root discovery is the
+    most intuitive behaviour.
+
+    Test: Create a temp dir with a ``.git`` subdirectory, call ``_repo_root``
+    from a nested subdirectory; assert the returned path equals the temp dir
+    root.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    current = (start_dir or Path.cwd()).resolve()
+    while True:
+        if (current / ".git").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            # No git root — fall back to cwd.
+            return (start_dir or Path.cwd()).resolve()
+        current = parent
+
+
+# ---------------------------------------------------------------------------
+# ``manifest init``
+# ---------------------------------------------------------------------------
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    """Implement ``claude-mpm manifest init``.
+
+    WHAT: Writes a minimal ``.claude-mpm/manifest.json`` at the repo root.
+    Supports interactive and non-interactive (``--non-interactive`` /
+    ``--yes``) modes.  Refuses to overwrite an existing ``manifest.json``
+    unless ``--force`` is given.
+
+    WHY: Providing an ``init`` command lowers the barrier to entry — users do
+    not need to know the manifest JSON structure to get started.  CI pipelines
+    can use the non-interactive path to scaffold manifests deterministically.
+
+    Test: Run with ``--non-interactive --extends default`` in a temp dir;
+    assert the file is created and validates against the schema.  Run a second
+    time without ``--force``; assert a non-zero exit code is returned and the
+    file is unchanged.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    # Determine target directory — either --path (parent dir) or repo root.
+    if args.path:
+        manifest_path = Path(args.path).resolve()
+    else:
+        root = _repo_root()
+        manifest_path = root / ".claude-mpm" / "manifest.json"
+
+    # ------------------------------------------------------------------
+    # Guard against overwrite unless --force
+    # ------------------------------------------------------------------
+    if manifest_path.exists() and not args.force:
+        print(
+            f"Error: manifest already exists at {manifest_path}\n"
+            "Use --force to overwrite it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ------------------------------------------------------------------
+    # Determine mode (interactive vs non-interactive)
+    # ------------------------------------------------------------------
+    non_interactive: bool = getattr(args, "non_interactive", False) or getattr(
+        args, "yes", False
+    )
+
+    # ------------------------------------------------------------------
+    # Gather options
+    # ------------------------------------------------------------------
+    extends: str | None = getattr(args, "extends", None)
+    seed_agents: bool = getattr(args, "seed_agents", False)
+    seed_settings: bool = getattr(args, "seed_settings", False)
+    seed_services: bool = getattr(args, "seed_services", False)
+
+    if not non_interactive and sys.stdin.isatty():
+        # Interactive prompting
+        extends, seed_agents, seed_settings, seed_services = _interactive_init_prompt(
+            extends, seed_agents, seed_settings, seed_services
+        )
+    elif not non_interactive and extends is None:
+        # Non-TTY but no flags — silently use defaults (non-interactive safe).
+        pass
+
+    # ------------------------------------------------------------------
+    # Build manifest dict
+    # ------------------------------------------------------------------
+    manifest: dict = {"version": "1.0"}
+
+    if extends and extends.lower() != "none":
+        manifest["extends"] = extends
+
+    if seed_agents:
+        manifest["agents"] = {}
+
+    if seed_settings:
+        manifest["settings"] = {}
+
+    if seed_services:
+        manifest.setdefault("setup", {})["services"] = []
+
+    # Validate before writing (fail fast if we produced something invalid).
+    validate_manifest(manifest)
+
+    # ------------------------------------------------------------------
+    # Write to disk
+    # ------------------------------------------------------------------
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Created {manifest_path}")
+    return 0
+
+
+def _interactive_init_prompt(
+    extends: str | None,
+    seed_agents: bool,
+    seed_settings: bool,
+    seed_services: bool,
+) -> tuple[str | None, bool, bool, bool]:
+    """Prompt the user for ``init`` options interactively.
+
+    WHAT: Asks whether to extend a built-in preset and which empty sections to
+    seed.  Returns updated values of the four option flags.
+
+    WHY: Separating the prompt loop from ``_cmd_init`` keeps the main logic
+    testable without a TTY.
+
+    Test: This function is intentionally not called in non-interactive tests.
+    Verify via manual smoke-test or a test that patches ``input()``.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    preset_choices = _BUILTIN_PRESETS + ["none"]
+    print("Available presets: " + ", ".join(preset_choices))
+
+    if extends is None:
+        raw = input(
+            "Extend a preset? [default/minimal/enterprise/none] (default): "
+        ).strip()
+        extends = raw if raw else "default"
+
+    if extends.lower() == "none":
+        extends = None
+
+    if not seed_agents:
+        raw = input("Seed empty 'agents' section? [y/N] ").strip().lower()
+        seed_agents = raw in ("y", "yes")
+
+    if not seed_settings:
+        raw = input("Seed empty 'settings' section? [y/N] ").strip().lower()
+        seed_settings = raw in ("y", "yes")
+
+    if not seed_services:
+        raw = input("Seed empty 'setup.services' list? [y/N] ").strip().lower()
+        seed_services = raw in ("y", "yes")
+
+    return extends, seed_agents, seed_settings, seed_services
+
+
+# ---------------------------------------------------------------------------
+# Internal helper — load a manifest from an explicit file path
+# ---------------------------------------------------------------------------
+
+
+def _load_from_explicit_path(
+    manifest_path: Path,
+) -> tuple[dict, dict] | None:
+    """Load, validate, and optionally merge a manifest from an explicit file.
+
+    WHAT: Reads *manifest_path*, parses JSON, validates against the schema,
+    and resolves any ``extends`` preset.  Returns a ``(repo, effective)`` tuple
+    on success.  Raises ``ManifestLoadError``, ``ManifestValidationError``, or
+    ``PresetResolutionError`` on failure.  Returns ``None`` if the file does
+    not exist (dormant).
+
+    WHY: ``load_manifest`` discovers files by walking upward from a directory,
+    which does not work when the caller provides an arbitrary explicit path via
+    ``--path``.  This helper gives ``_cmd_validate`` and ``_cmd_show`` a way to
+    load a manifest at any location without the discovery logic.
+
+    Test: Pass a valid manifest path; assert a tuple is returned.
+    Pass a non-existent path; assert ``None`` is returned.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    import json as _json
+
+    from claude_mpm.manifest.loader import ManifestLoadError
+
+    if not manifest_path.exists():
+        return None
+
+    try:
+        raw_text = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestLoadError(manifest_path, f"Could not read file: {exc}") from exc
+
+    try:
+        repo_manifest: dict = _json.loads(raw_text)
+    except _json.JSONDecodeError as exc:
+        raise ManifestLoadError(
+            manifest_path,
+            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+        ) from exc
+
+    if not isinstance(repo_manifest, dict):
+        raise ManifestLoadError(
+            manifest_path,
+            f"Manifest root must be a JSON object, not {type(repo_manifest).__name__}.",
+        )
+
+    validate_manifest(repo_manifest)
+
+    extends: str | None = repo_manifest.get("extends")
+    if extends is not None:
+        from claude_mpm.manifest.merger import deep_merge
+        from claude_mpm.manifest.resolver import resolve_preset
+
+        preset_dict = resolve_preset(extends)
+        effective = deep_merge(preset_dict, repo_manifest)
+        return repo_manifest, effective
+
+    return repo_manifest, repo_manifest
+
+
+# ---------------------------------------------------------------------------
+# ``manifest validate``
+# ---------------------------------------------------------------------------
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    """Implement ``claude-mpm manifest validate``.
+
+    WHAT: Locates the manifest (or uses ``--path``), schema-validates it, and
+    attempts to resolve the ``extends`` preset.  Exits 0 when the manifest is
+    valid or absent (dormant).  Exits non-zero with a CLEAR, actionable message
+    when the manifest is invalid or its preset cannot be resolved.
+
+    WHY: CI pipelines need a zero-friction validate command that follows shell
+    conventions (exit codes) so ``manifest validate`` can be dropped into any
+    CI script.  Dormant is not an error — missing a manifest is a valid
+    project state.
+
+    Test: In a temp dir with no manifest, assert exit 0.  With a valid
+    ``{"version": "1.0"}`` manifest, assert exit 0.  With an invalid manifest,
+    assert exit 1 and a message on stderr.  With ``extends: nonexistent``,
+    assert exit 1 and a message mentioning "preset".
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    from claude_mpm.manifest.loader import ManifestLoadError
+
+    if args.path:
+        # Explicit path provided — load directly without directory walking.
+        manifest_path = Path(args.path).resolve()
+        try:
+            pair = _load_from_explicit_path(manifest_path)
+        except ManifestLoadError as exc:
+            print(
+                f"Error: Failed to load manifest at {exc.path}\n  {exc.message}",
+                file=sys.stderr,
+            )
+            return 1
+        except ManifestValidationError as exc:
+            print(
+                f"Error: Manifest is invalid.\n"
+                f"  Path:    {exc.path}\n"
+                f"  Problem: {exc.message}\n"
+                f"\nFix the field '{exc.path}' in {manifest_path} and re-run.",
+                file=sys.stderr,
+            )
+            return 1
+        except PresetResolutionError as exc:
+            print(
+                f"Error: Cannot resolve preset '{exc.extends}'.\n"
+                f"{exc}\n"
+                f"\nAvailable built-in presets: {', '.join(_BUILTIN_PRESETS)}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if pair is None:
+            print(
+                f"No manifest found at {manifest_path} (system dormant).",
+                file=sys.stdout,
+            )
+            return 0
+
+        print(f"Manifest is valid: {manifest_path}")
+        return 0
+
+    # Auto-discovery path.
+    found = find_manifest(Path.cwd())
+    if found is None:
+        print(
+            "No manifest found (.claude-mpm/manifest.json not found). "
+            "System is dormant.",
+        )
+        return 0
+
+    manifest_path = found
+    start_dir = manifest_path.parent.parent
+
+    # Attempt to load (parse + validate + resolve).
+    try:
+        load_manifest(start_dir)
+    except ManifestLoadError as exc:
+        print(
+            f"Error: Failed to load manifest at {exc.path}\n  {exc.message}",
+            file=sys.stderr,
+        )
+        return 1
+    except ManifestValidationError as exc:
+        print(
+            f"Error: Manifest is invalid.\n"
+            f"  Path:    {exc.path}\n"
+            f"  Problem: {exc.message}\n"
+            f"\nFix the field '{exc.path}' in {manifest_path} and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+    except PresetResolutionError as exc:
+        print(
+            f"Error: Cannot resolve preset '{exc.extends}'.\n"
+            f"{exc}\n"
+            f"\nAvailable built-in presets: {', '.join(_BUILTIN_PRESETS)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Manifest is valid: {manifest_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# ``manifest show``
+# ---------------------------------------------------------------------------
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    """Implement ``claude-mpm manifest show``.
+
+    WHAT: Loads, resolves, and deep-merges the manifest, then pretty-prints the
+    effective configuration as JSON to stdout.  If no manifest is found, prints
+    a dormant message to stderr and exits 0.
+
+    WHY: Developers need a quick way to inspect the fully-resolved config to
+    debug merge issues and understand what is active.  Sending the JSON to
+    stdout (and dormant messages to stderr) lets callers pipe into ``jq`` or
+    other JSON tools without interference.
+
+    Test: In a temp dir with ``{"version": "1.0", "extends": "default"}``,
+    assert exit 0 and that the output is valid JSON containing ``"version"``.
+    In a dormant temp dir, assert exit 0 with no stdout.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    from claude_mpm.manifest.loader import ManifestLoadError
+
+    if args.path:
+        # Explicit path — load directly without directory walking.
+        manifest_path = Path(args.path).resolve()
+        try:
+            pair = _load_from_explicit_path(manifest_path)
+        except ManifestLoadError as exc:
+            print(
+                f"Error: Failed to load manifest at {exc.path}\n  {exc.message}",
+                file=sys.stderr,
+            )
+            return 1
+        except ManifestValidationError as exc:
+            print(
+                f"Error: Manifest is invalid.\n"
+                f"  Path:    {exc.path}\n"
+                f"  Problem: {exc.message}",
+                file=sys.stderr,
+            )
+            return 1
+        except PresetResolutionError as exc:
+            print(
+                f"Error: Cannot resolve preset '{exc.extends}'.\n{exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if pair is None:
+            print("No manifest found (system dormant).", file=sys.stderr)
+            return 0
+
+        _, effective = pair
+        print(json.dumps(effective, indent=2))
+        return 0
+
+    # Auto-discovery path.
+    found = find_manifest(Path.cwd())
+    if found is None:
+        print("No manifest found (system dormant).", file=sys.stderr)
+        return 0
+    start_dir = found.parent.parent
+
+    try:
+        result = load_manifest(start_dir)
+    except ManifestLoadError as exc:
+        print(
+            f"Error: Failed to load manifest at {exc.path}\n  {exc.message}",
+            file=sys.stderr,
+        )
+        return 1
+    except ManifestValidationError as exc:
+        print(
+            f"Error: Manifest is invalid.\n"
+            f"  Path:    {exc.path}\n"
+            f"  Problem: {exc.message}",
+            file=sys.stderr,
+        )
+        return 1
+    except PresetResolutionError as exc:
+        print(
+            f"Error: Cannot resolve preset '{exc.extends}'.\n{exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if result is None:
+        # load_manifest returned None — defensive guard.
+        print("No manifest found (system dormant).", file=sys.stderr)
+        return 0
+
+    print(json.dumps(result.effective, indent=2))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher — called by the executor
+# ---------------------------------------------------------------------------
+
+
+def manage_manifest(args: argparse.Namespace) -> int:
+    """Dispatch ``claude-mpm manifest <subcommand>``.
+
+    WHAT: Routes the ``args.manifest_command`` value to the appropriate
+    handler (``_cmd_init``, ``_cmd_validate``, or ``_cmd_show``).  Prints
+    usage and returns 1 for unknown or missing subcommands.
+
+    WHY: A single entry point keeps executor.py simple — one ``if command ==
+    "manifest"`` branch routes here, and all manifest-specific logic is
+    contained in this module.
+
+    Test: Call with a Namespace whose ``manifest_command`` is ``"validate"``;
+    assert the function delegates to ``_cmd_validate``.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    subcommand: str | None = getattr(args, "manifest_command", None)
+
+    handlers = {
+        "init": _cmd_init,
+        "validate": _cmd_validate,
+        "show": _cmd_show,
+    }
+
+    if subcommand in handlers:
+        return handlers[subcommand](args)
+
+    # No subcommand or unknown — print help hint.
+    print(
+        "Usage: claude-mpm manifest <subcommand> [options]\n"
+        "\n"
+        "Subcommands:\n"
+        "  init       Scaffold .claude-mpm/manifest.json\n"
+        "  validate   Validate manifest against schema and check preset resolution\n"
+        "  show       Print the fully-resolved effective configuration as JSON\n"
+        "\n"
+        "Run 'claude-mpm manifest <subcommand> --help' for details.",
+        file=sys.stderr,
+    )
+    return 1

--- a/src/claude_mpm/cli/executor.py
+++ b/src/claude_mpm/cli/executor.py
@@ -439,6 +439,13 @@ def execute_command(command: str, args) -> int:
     if command == "autotodos":
         return _handle_autotodos(args)
 
+    # Handle manifest command (init / validate / show) with lazy import
+    if command == "manifest":
+        from .commands.manifest_commands import manage_manifest
+
+        result = manage_manifest(args)
+        return result if result is not None else 0
+
     # Handle channels command with lazy import
     if command == "channels":
         from .commands.channels import handle_channels_command
@@ -542,6 +549,7 @@ def execute_command(command: str, args) -> int:
         "ztk",
         "ztk-stats",
         "llmlingua-stats",
+        "manifest",
     ]
 
     suggestion = suggest_similar_commands(command, all_commands)

--- a/src/claude_mpm/cli/parsers/base_parser.py
+++ b/src/claude_mpm/cli/parsers/base_parser.py
@@ -745,6 +745,14 @@ def create_parser(
     except ImportError:
         pass
 
+    # Add manifest command parser (init / validate / show)
+    try:
+        from .manifest_parser import add_manifest_subparser
+
+        add_manifest_subparser(subparsers)
+    except ImportError:
+        pass
+
     # Add channels command parser
     try:
         from ..commands.channels import add_channels_subcommand

--- a/src/claude_mpm/cli/parsers/manifest_parser.py
+++ b/src/claude_mpm/cli/parsers/manifest_parser.py
@@ -1,0 +1,206 @@
+"""
+Manifest command parser for claude-mpm CLI.
+
+WHAT: Registers the ``manifest`` top-level command and its three subcommands
+(``init``, ``validate``, ``show``) with the argparse subparser tree.
+
+WHY: Keeping the parser definition separate from the command implementation
+follows the project's established pattern (one parser module per command
+domain, one commands/ module per implementation) and allows the executor to
+import only the parser at startup, deferring the heavier manifest imports
+until the command actually runs.
+
+References
+----------
+SPEC-MANIFEST-05~1 : docs/specs/manifest.md#SPEC-MANIFEST-05~1
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def add_manifest_subparser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Add the ``manifest`` command and its subcommands to *subparsers*.
+
+    WHAT: Creates ``manifest`` as a top-level command with three second-level
+    subcommands: ``init``, ``validate``, and ``show``.  All three subcommands
+    store their chosen action in ``args.manifest_command`` so the executor and
+    ``manage_manifest`` can dispatch without inspecting ``sys.argv`` directly.
+
+    WHY: Mirroring the ``config`` command's nested-subparser pattern keeps the
+    parser tree consistent and gives ``--help`` output that matches user
+    expectations for a three-verb command group.
+
+    Test: Call ``add_manifest_subparser(subparsers)``; parse
+    ``["manifest", "validate"]`` with the resulting parser; assert
+    ``args.command == "manifest"`` and ``args.manifest_command == "validate"``.
+
+    :spec: SPEC-MANIFEST-05~1
+    """
+    manifest_parser = subparsers.add_parser(
+        "manifest",
+        help="Manage the .claude-mpm/manifest.json configuration file",
+        description=(
+            "Manage the .claude-mpm/manifest.json manifest configuration.\n"
+            "\n"
+            "Available subcommands:\n"
+            "  init       Scaffold .claude-mpm/manifest.json (interactive or non-interactive)\n"
+            "  validate   Validate the manifest against the schema and resolve presets\n"
+            "  show       Print the fully-resolved effective configuration as JSON\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    manifest_subparsers = manifest_parser.add_subparsers(
+        dest="manifest_command",
+        help="Manifest subcommands",
+        metavar="SUBCOMMAND",
+    )
+
+    # ------------------------------------------------------------------
+    # ``manifest init``
+    # ------------------------------------------------------------------
+    init_parser = manifest_subparsers.add_parser(
+        "init",
+        help="Scaffold .claude-mpm/manifest.json",
+        description=(
+            "Interactively scaffold .claude-mpm/manifest.json at the repo root.\n"
+            "\n"
+            "In interactive mode (default when stdin is a TTY), prompts for the\n"
+            "preset to extend and which empty sections to seed.\n"
+            "\n"
+            "Use --non-interactive (or --yes) for scripted / CI usage — combine\n"
+            "with --extends to set the preset name without prompting.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Interactive scaffold\n"
+            "  claude-mpm manifest init\n"
+            "\n"
+            "  # Non-interactive, extend the 'default' preset\n"
+            "  claude-mpm manifest init --non-interactive --extends default\n"
+            "\n"
+            "  # Overwrite an existing manifest\n"
+            "  claude-mpm manifest init --force --extends minimal\n"
+        ),
+    )
+
+    init_parser.add_argument(
+        "--extends",
+        metavar="PRESET",
+        default=None,
+        help=(
+            "Built-in preset to extend (default/minimal/enterprise) or 'none'. "
+            "If omitted in interactive mode, the user is prompted."
+        ),
+    )
+    init_parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        default=False,
+        help="Overwrite an existing manifest.json without confirmation.",
+    )
+    init_parser.add_argument(
+        "--non-interactive",
+        "--yes",
+        "-y",
+        dest="non_interactive",
+        action="store_true",
+        default=False,
+        help="Skip all interactive prompts (CI/script-safe mode).",
+    )
+    init_parser.add_argument(
+        "--seed-agents",
+        action="store_true",
+        default=False,
+        help="Include an empty 'agents' section in the generated manifest.",
+    )
+    init_parser.add_argument(
+        "--seed-settings",
+        action="store_true",
+        default=False,
+        help="Include an empty 'settings' section in the generated manifest.",
+    )
+    init_parser.add_argument(
+        "--seed-services",
+        action="store_true",
+        default=False,
+        help="Include an empty 'setup.services' list in the generated manifest.",
+    )
+    init_parser.add_argument(
+        "--path",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        help=(
+            "Write the manifest to this exact file path instead of the default "
+            "<repo-root>/.claude-mpm/manifest.json."
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # ``manifest validate``
+    # ------------------------------------------------------------------
+    validate_parser = manifest_subparsers.add_parser(
+        "validate",
+        help="Validate the manifest against the schema and resolve the extends preset",
+        description=(
+            "Validate .claude-mpm/manifest.json against the JSON schema and confirm\n"
+            "that the 'extends' preset (if any) can be resolved.\n"
+            "\n"
+            "Exit codes:\n"
+            "  0  Manifest is valid, or no manifest found (system dormant).\n"
+            "  1  Manifest is invalid, or preset cannot be resolved.\n"
+            "\n"
+            "Suitable for CI pipelines.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  claude-mpm manifest validate\n"
+            "  claude-mpm manifest validate --path path/to/manifest.json\n"
+        ),
+    )
+    validate_parser.add_argument(
+        "--path",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        help="Validate a specific manifest file instead of the auto-discovered one.",
+    )
+
+    # ------------------------------------------------------------------
+    # ``manifest show``
+    # ------------------------------------------------------------------
+    show_parser = manifest_subparsers.add_parser(
+        "show",
+        help="Print the fully-resolved effective configuration as JSON",
+        description=(
+            "Load, resolve, and deep-merge the manifest, then print the fully-merged\n"
+            "effective configuration to stdout as pretty-printed JSON.\n"
+            "\n"
+            "If no manifest is found (system dormant), prints a message to stderr\n"
+            "and exits 0.\n"
+            "\n"
+            "Pipe into 'jq' to query specific sections:\n"
+            "  claude-mpm manifest show | jq '.agents'\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  claude-mpm manifest show\n"
+            "  claude-mpm manifest show | jq '.settings'\n"
+            "  claude-mpm manifest show --path path/to/manifest.json\n"
+        ),
+    )
+    show_parser.add_argument(
+        "--path",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        help="Show the resolved config for a specific manifest file.",
+    )

--- a/src/claude_mpm/constants.py
+++ b/src/claude_mpm/constants.py
@@ -48,6 +48,7 @@ class CLICommands(StrEnum):
     SKILLS = "skills"
     OAUTH = "oauth"
     PROVIDER = "provider"
+    MANIFEST = "manifest"
 
     def with_prefix(self, prefix: CLIPrefix = CLIPrefix.MPM) -> str:
         """Get command with prefix."""

--- a/tests/test_manifest_cli.py
+++ b/tests/test_manifest_cli.py
@@ -1,0 +1,579 @@
+"""
+tests/test_manifest_cli.py — Unit tests for the manifest CLI commands.
+
+WHAT: Exercises ``manifest init``, ``manifest validate``, and ``manifest show``
+via argparse end-to-end (parser → executor → handler) using the project's
+subprocess / argparse pattern and direct handler function calls with
+temporary directories.
+
+WHY: The CLI surface is the primary developer and CI touchpoint for the
+manifest subsystem.  Correct exit-code behaviour (especially dormant → exit 0)
+is critical; a regression here could cause CI failures in repos that have not
+opted in to the manifest system.
+
+References
+----------
+SPEC-MANIFEST-05~1 : docs/specs/manifest.md#SPEC-MANIFEST-05~1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — thin wrappers that call the CLI handler functions directly
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    """Return an argparse Namespace pre-populated with sensible defaults."""
+    defaults: dict = {
+        "manifest_command": None,
+        "path": None,
+        "force": False,
+        "extends": None,
+        "non_interactive": True,  # non-interactive by default in tests
+        "yes": False,
+        "seed_agents": False,
+        "seed_settings": False,
+        "seed_services": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _write_manifest(directory: Path, content: dict | str) -> Path:
+    """Write a manifest file into *directory*/.claude-mpm/manifest.json."""
+    manifest_dir = directory / ".claude-mpm"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "manifest.json"
+    if isinstance(content, dict):
+        manifest_path.write_text(json.dumps(content), encoding="utf-8")
+    else:
+        manifest_path.write_text(str(content), encoding="utf-8")
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Import the handlers under test
+# ---------------------------------------------------------------------------
+
+from claude_mpm.cli.commands.manifest_commands import (
+    _cmd_init,
+    _cmd_show,
+    _cmd_validate,
+    manage_manifest,
+)
+
+# ===========================================================================
+# manifest init
+# ===========================================================================
+
+
+class TestManifestInit:
+    """Tests for ``claude-mpm manifest init``."""
+
+    def test_creates_manifest_in_temp_dir(self, tmp_path: Path) -> None:
+        """Non-interactive init writes a valid manifest.json.
+
+        Why: The most common CI use-case — scaffold with no prompts.
+        Test: Assert file exists and is valid JSON with version "1.0".
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        from claude_mpm.manifest.schema import validate_manifest
+
+        manifest_path = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(
+            manifest_command="init",
+            path=manifest_path,
+            non_interactive=True,
+        )
+
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._repo_root",
+            return_value=tmp_path,
+        ):
+            exit_code = _cmd_init(args)
+
+        assert exit_code == 0
+        assert manifest_path.exists()
+        data = json.loads(manifest_path.read_text())
+        assert data["version"] == "1.0"
+        validate_manifest(data)  # Must not raise.
+
+    def test_non_interactive_with_extends(self, tmp_path: Path) -> None:
+        """--extends default writes extends key to the manifest.
+
+        Test: Assert 'extends' == 'default' in written file.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(
+            path=manifest_path,
+            non_interactive=True,
+            extends="default",
+        )
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._repo_root",
+            return_value=tmp_path,
+        ):
+            exit_code = _cmd_init(args)
+
+        assert exit_code == 0
+        data = json.loads(manifest_path.read_text())
+        assert data.get("extends") == "default"
+
+    def test_refuses_overwrite_without_force(self, tmp_path: Path) -> None:
+        """Without --force, a second init on an existing file returns exit 1.
+
+        Test: Create a manifest, run init again, assert exit_code == 1 and
+        the original file is unchanged.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        original_content = {"version": "1.0", "settings": {"my": "value"}}
+        manifest_path = _write_manifest(tmp_path, original_content)
+
+        args = _make_args(
+            path=manifest_path,
+            non_interactive=True,
+            force=False,
+        )
+
+        exit_code = _cmd_init(args)
+
+        assert exit_code == 1
+        # File must be unchanged.
+        data = json.loads(manifest_path.read_text())
+        assert data == original_content
+
+    def test_force_overwrites_existing(self, tmp_path: Path) -> None:
+        """--force overwrites an existing manifest without error.
+
+        Test: Write an original manifest, then init --force --extends minimal;
+        assert exit_code == 0 and file now has extends == 'minimal'.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        original = {"version": "1.0", "settings": {"old": "data"}}
+        manifest_path = _write_manifest(tmp_path, original)
+
+        args = _make_args(
+            path=manifest_path,
+            non_interactive=True,
+            force=True,
+            extends="minimal",
+        )
+        exit_code = _cmd_init(args)
+
+        assert exit_code == 0
+        data = json.loads(manifest_path.read_text())
+        assert data.get("extends") == "minimal"
+        # Old key must be gone.
+        assert "settings" not in data
+
+    def test_output_validates_against_schema(self, tmp_path: Path) -> None:
+        """The written manifest must pass validate_manifest().
+
+        Test: Run init, read the file, call validate_manifest; assert no
+        exception is raised.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        from claude_mpm.manifest.schema import validate_manifest
+
+        manifest_path = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(
+            path=manifest_path,
+            non_interactive=True,
+            extends="default",
+            seed_agents=True,
+            seed_settings=True,
+            seed_services=True,
+        )
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._repo_root",
+            return_value=tmp_path,
+        ):
+            exit_code = _cmd_init(args)
+
+        assert exit_code == 0
+        data = json.loads(manifest_path.read_text())
+        validate_manifest(data)
+
+    def test_seed_flags_add_sections(self, tmp_path: Path) -> None:
+        """Seed flags produce expected empty sections.
+
+        Test: Run init with all seed flags; assert 'agents', 'settings',
+        and 'setup.services' are present.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(
+            path=manifest_path,
+            non_interactive=True,
+            seed_agents=True,
+            seed_settings=True,
+            seed_services=True,
+        )
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._repo_root",
+            return_value=tmp_path,
+        ):
+            exit_code = _cmd_init(args)
+
+        assert exit_code == 0
+        data = json.loads(manifest_path.read_text())
+        assert "agents" in data
+        assert "settings" in data
+        assert "setup" in data
+        assert data["setup"]["services"] == []
+
+
+# ===========================================================================
+# manifest validate
+# ===========================================================================
+
+
+class TestManifestValidate:
+    """Tests for ``claude-mpm manifest validate``."""
+
+    def test_dormant_no_file_exits_zero(self, tmp_path: Path) -> None:
+        """When no manifest exists, validate must exit 0 (system dormant).
+
+        Test: Point --path at a non-existent file; assert exit_code == 0.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        missing = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(path=missing)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 0
+
+    def test_valid_manifest_exits_zero(self, tmp_path: Path) -> None:
+        """A valid manifest.json → exit 0.
+
+        Test: Write {"version": "1.0"}; assert exit_code == 0.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(tmp_path, {"version": "1.0"})
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 0
+
+    def test_valid_manifest_with_extends_exits_zero(self, tmp_path: Path) -> None:
+        """A manifest with a resolvable 'extends' preset → exit 0.
+
+        Test: Write {"version": "1.0", "extends": "default"}; assert exit_code == 0.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(
+            tmp_path, {"version": "1.0", "extends": "default"}
+        )
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 0
+
+    def test_invalid_schema_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        """A manifest failing schema validation → exit 1 + clear message.
+
+        Test: Write {"version": "2.0"} (invalid version); assert exit_code == 1
+        and stderr contains a message.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(tmp_path, {"version": "2.0"})
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        # The error must mention something actionable.
+        assert "Error" in captured.err or "error" in captured.err.lower()
+
+    def test_unresolvable_preset_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        """An unresolvable 'extends' preset → exit 1 + clear message.
+
+        Test: Write {"version": "1.0", "extends": "nonexistent-preset-xyz"};
+        assert exit_code == 1 and stderr mentions "preset".
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(
+            tmp_path,
+            {"version": "1.0", "extends": "nonexistent-preset-xyz-abc"},
+        )
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "preset" in captured.err.lower() or "nonexistent" in captured.err
+
+    def test_invalid_json_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        """A manifest with malformed JSON → exit 1 + clear message.
+
+        Test: Write "not-json"; assert exit_code == 1.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(tmp_path, "not valid json {{{")
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_validate(args)
+
+        assert exit_code == 1
+
+    def test_dormant_auto_discovery_exits_zero(self, tmp_path: Path) -> None:
+        """Auto-discovery in an empty directory → exit 0 (dormant).
+
+        Test: Patch find_manifest to return None (simulates a repo with no
+        manifest file); assert exit_code == 0.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(path=None)
+
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands.find_manifest",
+            return_value=None,
+        ):
+            exit_code = _cmd_validate(args)
+
+        assert exit_code == 0
+
+
+# ===========================================================================
+# manifest show
+# ===========================================================================
+
+
+class TestManifestShow:
+    """Tests for ``claude-mpm manifest show``."""
+
+    def test_dormant_exits_zero(self, tmp_path: Path, capsys) -> None:
+        """No manifest → exit 0, nothing on stdout.
+
+        Test: Call show with --path pointing at a non-existent file; assert
+        exit_code == 0 and stdout is empty.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        missing = tmp_path / ".claude-mpm" / "manifest.json"
+        args = _make_args(path=missing)
+
+        exit_code = _cmd_show(args)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+    def test_show_valid_manifest_prints_json(self, tmp_path: Path, capsys) -> None:
+        """A valid manifest without extends → exit 0, valid JSON on stdout.
+
+        Test: Write {"version": "1.0"}; run show; assert output parses as JSON
+        and contains "version".
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(tmp_path, {"version": "1.0"})
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_show(args)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["version"] == "1.0"
+
+    def test_show_with_extends_default_contains_merged_keys(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """manifest show with extends: default → merged JSON includes preset keys.
+
+        Test: Write {"version": "1.0", "extends": "default"}; run show; assert
+        exit_code == 0 and output parses as JSON.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(
+            tmp_path, {"version": "1.0", "extends": "default"}
+        )
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_show(args)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Must be a non-empty dict.
+        assert isinstance(data, dict)
+        assert data["version"] == "1.0"
+
+    def test_show_invalid_manifest_exits_nonzero(self, tmp_path: Path, capsys) -> None:
+        """An invalid manifest → exit 1.
+
+        Test: Write {"version": "bad"}; run show; assert exit_code == 1.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        manifest_path = _write_manifest(tmp_path, {"version": "bad"})
+        args = _make_args(path=manifest_path)
+
+        exit_code = _cmd_show(args)
+
+        assert exit_code == 1
+
+    def test_show_auto_discovery_dormant(self, tmp_path: Path, capsys) -> None:
+        """Auto-discovery in an empty directory → exit 0, no stdout.
+
+        Test: Patch find_manifest to return None; assert exit_code == 0.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(path=None)
+
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands.find_manifest",
+            return_value=None,
+        ):
+            exit_code = _cmd_show(args)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+
+# ===========================================================================
+# manage_manifest dispatcher
+# ===========================================================================
+
+
+class TestManageManifest:
+    """Tests for the ``manage_manifest`` dispatcher."""
+
+    def test_dispatches_validate(self, tmp_path: Path) -> None:
+        """manage_manifest with manifest_command='validate' calls _cmd_validate.
+
+        Test: Patch _cmd_validate; call manage_manifest; assert the patch was
+        called once.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(
+            manifest_command="validate", path=tmp_path / ".claude-mpm" / "manifest.json"
+        )
+
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._cmd_validate",
+            return_value=0,
+        ) as mock:
+            result = manage_manifest(args)
+
+        mock.assert_called_once_with(args)
+        assert result == 0
+
+    def test_dispatches_show(self, tmp_path: Path) -> None:
+        """manage_manifest with manifest_command='show' calls _cmd_show.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(manifest_command="show", path=None)
+
+        with patch(
+            "claude_mpm.cli.commands.manifest_commands._cmd_show",
+            return_value=0,
+        ) as mock:
+            result = manage_manifest(args)
+
+        mock.assert_called_once_with(args)
+        assert result == 0
+
+    def test_unknown_subcommand_returns_one(self, capsys) -> None:
+        """An unknown subcommand → exit 1.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(manifest_command="nonexistent")
+        result = manage_manifest(args)
+        assert result == 1
+
+    def test_no_subcommand_returns_one(self, capsys) -> None:
+        """No subcommand → exit 1.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        args = _make_args(manifest_command=None)
+        result = manage_manifest(args)
+        assert result == 1
+
+
+# ===========================================================================
+# Parser registration smoke-test
+# ===========================================================================
+
+
+class TestManifestParserRegistration:
+    """Smoke-test that the manifest parser is registered in the main CLI tree."""
+
+    def test_manifest_parser_registered(self) -> None:
+        """create_parser() must produce a parser that accepts 'manifest validate'.
+
+        Test: Parse ['manifest', 'validate'] with the main parser; assert
+        args.command == 'manifest' and args.manifest_command == 'validate'.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        from claude_mpm.cli.parsers.base_parser import create_parser
+
+        parser = create_parser(version="0.0.0")
+        args = parser.parse_args(["manifest", "validate"])
+        assert args.command == "manifest"
+        assert args.manifest_command == "validate"
+
+    def test_manifest_init_flags(self) -> None:
+        """manifest init --non-interactive --extends minimal parses correctly.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        from claude_mpm.cli.parsers.base_parser import create_parser
+
+        parser = create_parser(version="0.0.0")
+        args = parser.parse_args(
+            ["manifest", "init", "--non-interactive", "--extends", "minimal"]
+        )
+        assert args.manifest_command == "init"
+        assert args.non_interactive is True
+        assert args.extends == "minimal"
+
+    def test_manifest_show_path_flag(self) -> None:
+        """manifest show --path /tmp/m.json parses correctly.
+
+        :spec: SPEC-MANIFEST-05~1
+        """
+        from claude_mpm.cli.parsers.base_parser import create_parser
+
+        parser = create_parser(version="0.0.0")
+        args = parser.parse_args(["manifest", "show", "--path", "/tmp/m.json"])
+        assert args.manifest_command == "show"
+        assert args.path == Path("/tmp/m.json")


### PR DESCRIPTION
## Summary

PR3 of 4 for issue #460 (manifest config system).

- Adds `claude-mpm manifest init` — scaffold `.claude-mpm/manifest.json` interactively or non-interactively (`--non-interactive --extends <preset> --force --seed-*`)
- Adds `claude-mpm manifest validate` — schema-validate + preset-resolve; exits 0 for both valid and dormant (no file), exits non-zero with clear, actionable error on invalid manifest or unresolvable preset
- Adds `claude-mpm manifest show` — load, resolve, deep-merge, print effective config as pretty-printed JSON to stdout; dormant exits 0 with message on stderr
- Adds `SPEC-MANIFEST-05~1` to `docs/specs/manifest.md` covering the CLI surface contract (exit-code semantics, dormant-exit-0, stdout/stderr split)
- 25 unit tests covering all three subcommands, the dispatcher, and parser registration
- SLD CI passes (49 tests)

## What's included

- `src/claude_mpm/cli/commands/manifest_commands.py` — full implementation (`_cmd_init`, `_cmd_validate`, `_cmd_show`, `manage_manifest`, `_load_from_explicit_path`)
- `src/claude_mpm/cli/parsers/manifest_parser.py` — argparse parser registration
- `src/claude_mpm/cli/parsers/base_parser.py` — wiring into `create_parser()` factory
- `src/claude_mpm/cli/executor.py` — lazy-import dispatch for `"manifest"` command
- `src/claude_mpm/constants.py` — `CLICommands.MANIFEST`
- `docs/specs/manifest.md` — `SPEC-MANIFEST-05~1` spec section
- `tests/test_manifest_cli.py` — 25 tests

## Deferred (PR4)

- `claude-mpm setup` integration (reads manifest, installs `setup.services`)
- Migration for legacy `.claude-mpm/config.json` → `manifest.json`

## Test plan

- [x] `uv run pytest tests/test_manifest_cli.py -v` — 25/25 pass
- [x] `uv run pytest tests/test_manifest_* -p no:xdist` — 207/207 pass
- [x] `uv run pytest tests/test_spec_traceability.py tests/test_wwl_granularity.py -p no:xdist` — 49/49 pass
- [x] `uv run ruff format . && uv run ruff check --fix .` — clean
- [x] `uv run mypy src/claude_mpm/manifest/ src/claude_mpm/cli/commands/manifest_commands.py src/claude_mpm/cli/parsers/manifest_parser.py` — clean
- [x] Smoke test: `manifest init --non-interactive --extends default`, `manifest validate`, `manifest show` — all work correctly

Part of #460

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)