### PR TITLE
docs(sld): backfill References for all 13 SPEC-AGENTS sections

### DIFF
--- a/docs/specs/agents.md
+++ b/docs/specs/agents.md
@@ -39,7 +39,7 @@ implementing module docstrings once this spec is reviewed.
 ## Agent discovery and registry {#SPEC-AGENTS-01~1}
 
 **ID:** SPEC-AGENTS-01~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -94,7 +94,7 @@ without restarting the process.
 ## AgentLoader public interface {#SPEC-AGENTS-02~1}
 
 **ID:** SPEC-AGENTS-02~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -152,7 +152,7 @@ from user input, the Task tool, and the TodoWrite system. Centralising the casca
 ## Frontmatter validation and auto-correction {#SPEC-AGENTS-03~1}
 
 **ID:** SPEC-AGENTS-03~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -215,7 +215,7 @@ the schema file is missing (e.g., during testing with a partial install).
 ## Agent name normalization {#SPEC-AGENTS-04~1}
 
 **ID:** SPEC-AGENTS-04~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -268,7 +268,7 @@ to prevent user agents from accidentally overriding known-agent display names.
 ## Static capability registry {#SPEC-AGENTS-05~1}
 
 **ID:** SPEC-AGENTS-05~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -308,7 +308,7 @@ operational.
 ## Agent assembly pipeline — subagent path {#SPEC-AGENTS-06~1}
 
 **ID:** SPEC-AGENTS-06~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -376,7 +376,7 @@ debugging deployed files.
 ## PM framework assembly pipeline {#SPEC-AGENTS-07~1}
 
 **ID:** SPEC-AGENTS-07~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -439,7 +439,7 @@ deployed merged file is accidentally used as an override (causing content duplic
 ## BASE template composition {#SPEC-AGENTS-08~1}
 
 **ID:** SPEC-AGENTS-08~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -496,7 +496,7 @@ avoids requiring external repos to rename their base files.
 ## SLD instruction injection hook {#SPEC-AGENTS-09~1}
 
 **ID:** SPEC-AGENTS-09~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -553,7 +553,7 @@ instructions into them would be noise.
 ## Bundled vs. deployed agent sources {#SPEC-AGENTS-10~1}
 
 **ID:** SPEC-AGENTS-10~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -605,7 +605,7 @@ reference or restoration.
 ## AgentDeploymentService — deploy and remove {#SPEC-AGENTS-11~1}
 
 **ID:** SPEC-AGENTS-11~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -667,7 +667,7 @@ at deploy time.
 ## Startup reconciliation and orphan detection {#SPEC-AGENTS-12~1}
 
 **ID:** SPEC-AGENTS-12~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -732,7 +732,7 @@ and must not delete agents the user created independently.
 ## Frontmatter schema {#SPEC-AGENTS-13~1}
 
 **ID:** SPEC-AGENTS-13~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 

--- a/src/claude_mpm/agents/agent_loader.py
+++ b/src/claude_mpm/agents/agent_loader.py
@@ -30,6 +30,10 @@ Usage Examples:
 
     # List all available agents
     agents = list_available_agents()
+
+References
+----------
+SPEC-AGENTS-02~1 : docs/specs/agents.md#SPEC-AGENTS-02~1
 """
 
 import os
@@ -165,6 +169,8 @@ class AgentLoader:
     - Easy testability
     - Minimal complexity
     - Fast, direct file access
+
+    :spec: SPEC-AGENTS-02~1
     """
 
     def __init__(self):

--- a/src/claude_mpm/agents/agents_metadata.py
+++ b/src/claude_mpm/agents/agents_metadata.py
@@ -5,6 +5,10 @@ Agent Metadata Definitions
 
 Preserves AGENT_CONFIG metadata for all agents.
 This metadata is used for agent registration, capability tracking, and performance targets.
+
+References
+----------
+SPEC-AGENTS-05~1 : docs/specs/agents.md#SPEC-AGENTS-05~1
 """
 
 # Documentation Agent Metadata

--- a/src/claude_mpm/agents/frontmatter_validator.py
+++ b/src/claude_mpm/agents/frontmatter_validator.py
@@ -13,6 +13,11 @@ Key Features:
 - Normalizes model names to standard tiers (opus, sonnet, haiku)
 - Fixes tools field when provided as string representation
 - Provides detailed logging of corrections made
+
+References
+----------
+SPEC-AGENTS-03~1 : docs/specs/agents.md#SPEC-AGENTS-03~1
+SPEC-AGENTS-13~1 : docs/specs/agents.md#SPEC-AGENTS-13~1
 """
 
 import json
@@ -51,6 +56,8 @@ class FrontmatterValidator:
     - Model name normalization
     - Tools field parsing and correction
     - Logging of all corrections made
+
+    :spec: SPEC-AGENTS-13~1
     """
 
     # NOTE: Model normalization now handled by ModelTier.normalize()
@@ -156,6 +163,8 @@ class FrontmatterValidator:
 
         Returns:
             ValidationResult with validation status and corrected frontmatter
+
+        :spec: SPEC-AGENTS-03~1
         """
         errors: list[str] = []
         warnings: list[str] = []

--- a/src/claude_mpm/config/sld_config.py
+++ b/src/claude_mpm/config/sld_config.py
@@ -16,6 +16,8 @@ References
 The SLD convention is documented in docs/specs/README.md.
 The skill that engineers use is bundled at
 src/claude_mpm/skills/bundled/universal/spec-linked-docs/SKILL.md.
+
+SPEC-AGENTS-09~1 : docs/specs/agents.md#SPEC-AGENTS-09~1
 """
 
 from __future__ import annotations
@@ -310,6 +312,8 @@ def get_sld_instruction_for_agent(
     ''
     >>> get_sld_instruction_for_agent("research")
     ''
+
+    :spec: SPEC-AGENTS-09~1
     """
     if not is_sld_target_agent_type(agent_type):
         return ""

--- a/src/claude_mpm/core/agent_name_normalizer.py
+++ b/src/claude_mpm/core/agent_name_normalizer.py
@@ -14,6 +14,10 @@ What: Provides :class:`AgentNameNormalizer` with class-level lookups
 ``from_task_format``).  All methods are ``@classmethod`` so no instance is
 required; a module-level singleton ``agent_name_normalizer`` is also
 exported for convenience.
+
+References
+----------
+SPEC-AGENTS-04~1 : docs/specs/agents.md#SPEC-AGENTS-04~1
 """
 
 from claude_mpm.core.agent_name_registry import (
@@ -159,6 +163,8 @@ class AgentNameNormalizer:
     - Task tool display
     - Agent type identification
     - Color coding
+
+    :spec: SPEC-AGENTS-04~1
     """
 
     # ---------------------------------------------------------------------------

--- a/src/claude_mpm/core/unified_agent_registry.py
+++ b/src/claude_mpm/core/unified_agent_registry.py
@@ -22,6 +22,11 @@ Architecture:
 - AgentTier: Hierarchical precedence system
 - AgentType: Agent classification system
 - Discovery engine with tier-based precedence
+
+References
+----------
+SPEC-AGENTS-01~1 : docs/specs/agents.md#SPEC-AGENTS-01~1
+SPEC-AGENTS-10~1 : docs/specs/agents.md#SPEC-AGENTS-10~1
 """
 
 import contextlib
@@ -130,6 +135,8 @@ class UnifiedAgentRegistry:
 
     This class provides a single, authoritative interface for all agent operations
     in Claude MPM, replacing the multiple duplicate agent registry modules.
+
+    :spec: SPEC-AGENTS-10~1
     """
 
     def __init__(self, cache_enabled: bool = True, cache_ttl: int = 3600):
@@ -223,6 +230,8 @@ class UnifiedAgentRegistry:
 
         Returns:
             Dictionary mapping agent names to their metadata
+
+        :spec: SPEC-AGENTS-01~1
         """
         start_time = time.time()
 

--- a/src/claude_mpm/services/agents/deployment/agent_deployment.py
+++ b/src/claude_mpm/services/agents/deployment/agent_deployment.py
@@ -25,6 +25,11 @@ ROLLBACK PROCEDURES:
 - Use clean_deployment() to remove system agents
 - User-created agents are preserved during cleanup
 - Version tracking allows targeted rollbacks
+
+References
+----------
+SPEC-AGENTS-10~1 : docs/specs/agents.md#SPEC-AGENTS-10~1
+SPEC-AGENTS-11~1 : docs/specs/agents.md#SPEC-AGENTS-11~1
 """
 
 import time
@@ -130,6 +135,8 @@ class AgentDeploymentService(ConfigServiceBase, AgentDeploymentInterface):
     - Python 3.8+ for pathlib and typing features
     - JSON parsing for template files
     - YAML generation capabilities
+
+    :spec: SPEC-AGENTS-10~1
     """
 
     def __init__(
@@ -350,6 +357,8 @@ class AgentDeploymentService(ConfigServiceBase, AgentDeploymentInterface):
             - errors: List of deployment errors
             - total: Total number of agents processed
             - repaired: List of agents with repaired frontmatter
+
+        :spec: SPEC-AGENTS-11~1
         """
         # METRICS: Record deployment start time for performance tracking
         deployment_start_time = time.time()

--- a/src/claude_mpm/services/agents/deployment/agent_template_builder.py
+++ b/src/claude_mpm/services/agents/deployment/agent_template_builder.py
@@ -5,6 +5,12 @@ including YAML and Markdown generation, template merging, and metadata extractio
 
 Extracted from AgentDeploymentService as part of the refactoring to improve
 maintainability and testability.
+
+References
+----------
+SPEC-AGENTS-06~1 : docs/specs/agents.md#SPEC-AGENTS-06~1
+SPEC-AGENTS-08~1 : docs/specs/agents.md#SPEC-AGENTS-08~1
+SPEC-AGENTS-09~1 : docs/specs/agents.md#SPEC-AGENTS-09~1
 """
 
 import json
@@ -224,6 +230,8 @@ class AgentTemplateBuilder:
                 repo/engineering/BASE-AGENT.md,
                 repo/BASE-AGENT.md
             ]
+
+        :spec: SPEC-AGENTS-08~1
         """
         base_templates = []
         current_dir = agent_file.parent
@@ -470,6 +478,9 @@ class AgentTemplateBuilder:
             json.JSONDecodeError: If template JSON is invalid
             yaml.YAMLError: If template YAML is invalid
             ValueError: If template format is unsupported or malformed
+
+        :spec: SPEC-AGENTS-06~1
+        :spec: SPEC-AGENTS-09~1
         """
         if not template_path.exists():
             raise FileNotFoundError(f"Template file not found: {template_path}")

--- a/src/claude_mpm/services/agents/deployment/startup_reconciliation.py
+++ b/src/claude_mpm/services/agents/deployment/startup_reconciliation.py
@@ -11,6 +11,10 @@ Usage:
 
     # In your startup code
     perform_startup_reconciliation()
+
+References
+----------
+SPEC-AGENTS-12~1 : docs/specs/agents.md#SPEC-AGENTS-12~1
 """
 
 from pathlib import Path
@@ -65,6 +69,8 @@ def _detect_and_remove_orphaned_agents(
 
     Returns:
         List of removed agent filenames
+
+    :spec: SPEC-AGENTS-12~1
     """
     from claude_mpm.core.unified_paths import get_path_manager
     from claude_mpm.utils.agent_provenance import is_mpm_managed_agent
@@ -268,6 +274,8 @@ def perform_startup_reconciliation(
 
     Returns:
         Tuple of (agent_result, skill_result)
+
+    :spec: SPEC-AGENTS-12~1
     """
     project_path = project_path or Path.cwd()
 

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -2,6 +2,10 @@
 
 This module handles deployment of system instructions and framework files.
 Extracted from AgentDeploymentService to reduce complexity and improve maintainability.
+
+References
+----------
+SPEC-AGENTS-07~1 : docs/specs/agents.md#SPEC-AGENTS-07~1
 """
 
 import logging
@@ -192,6 +196,8 @@ class SystemInstructionsDeployer:
             target_dir: Target directory for deployment (not used - always uses project .claude-mpm)
             force_rebuild: Force rebuild even if exists
             results: Results dictionary to update
+
+        :spec: SPEC-AGENTS-07~1
         """
         # Initialize before try so it's always bound for deploy_templates below
         claude_mpm_dir = self.working_directory / ".claude-mpm"


### PR DESCRIPTION
## Summary
- Adds `References` / `:spec:` entries to 10 Python source files implementing SPEC-AGENTS-01~1 through SPEC-AGENTS-13~1
- Promotes all 13 sections in `docs/specs/agents.md` from `draft (pending backfill)` → `Active`

## Files changed
- `src/claude_mpm/core/unified_agent_registry.py` (SPEC-AGENTS-01~1, 10~1)
- `src/claude_mpm/agents/agent_loader.py` (SPEC-AGENTS-02~1)
- `src/claude_mpm/agents/frontmatter_validator.py` (SPEC-AGENTS-03~1, 13~1)
- `src/claude_mpm/core/agent_name_normalizer.py` (SPEC-AGENTS-04~1)
- `src/claude_mpm/agents/agents_metadata.py` (SPEC-AGENTS-05~1)
- `src/claude_mpm/services/agents/deployment/agent_template_builder.py` (SPEC-AGENTS-06~1, 08~1, 09~1)
- `src/claude_mpm/services/agents/deployment/system_instructions_deployer.py` (SPEC-AGENTS-07~1)
- `src/claude_mpm/config/sld_config.py` (SPEC-AGENTS-09~1)
- `src/claude_mpm/services/agents/deployment/agent_deployment.py` (SPEC-AGENTS-10~1, 11~1)
- `src/claude_mpm/services/agents/deployment/startup_reconciliation.py` (SPEC-AGENTS-12~1)
- `docs/specs/agents.md` (13 sections promoted to Active)

## Test plan
- [x] `uv run pytest tests/test_spec_traceability.py -p no:xdist` passes (11 passed)
- [x] `docs/specs/agents.md` has no remaining `draft (pending backfill)` lines
- [x] Full suite: 1 pre-existing unrelated failure (`test_non_conforming_names_preserved`, agent name mapping — also fails on `main`); all else green

Closes #621

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)