### PR TITLE
docs(sld): backfill References for all 13 SPEC-HOOKS sections

### DIFF
--- a/docs/specs/hooks.md
+++ b/docs/specs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks & Enforcement Subsystem — Spec-Linked Documentation
 
-**Status:** Active (sections: draft pending backfill)
+**Status:** Active
 **Version:** v1
 **Subsystem:** HOOKS
 
@@ -38,7 +38,7 @@ functions once this spec is reviewed.
 
 ## Bash relay — claude-hook-fast.sh {#SPEC-HOOKS-01~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -100,7 +100,7 @@ itself spawns sub-agents.
 
 ## Python environment resolver — claude-hook-handler.sh {#SPEC-HOOKS-02~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -150,7 +150,7 @@ redundant shell process lingering after the Python handler starts.
 
 ## Hook entry-point router — hook_handler.main {#SPEC-HOOKS-03~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -205,7 +205,7 @@ never block the Claude Code session.
 
 ## Hook installation and idempotent merge — HookInstallerService {#SPEC-HOOKS-04~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -262,7 +262,7 @@ the primary hook command changed from `claude-hook-handler.sh` to `claude-hook`.
 
 ## PreToolUse enforcement pipeline — ToolHandler {#SPEC-HOOKS-05~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -322,7 +322,7 @@ safety gate (context overflow blocks all tools unconditionally).
 
 ## PostToolUse observability pipeline — ToolHandler {#SPEC-HOOKS-06~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -372,7 +372,7 @@ sequences.
 
 ## Stop lifecycle handler {#SPEC-HOOKS-07~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -425,7 +425,7 @@ the session closes, not the first action on the next prompt.
 
 ## UserPromptSubmit handler {#SPEC-HOOKS-08~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -478,7 +478,7 @@ between the main hook handler process and the message-check process.
 
 ## SubagentStop/Start handler and processor {#SPEC-HOOKS-09~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -535,7 +535,7 @@ include explicit type information.
 
 ## Event services — duplicate detector, state manager, connection manager {#SPEC-HOOKS-10~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -601,7 +601,7 @@ hook subprocess.
 
 ## Context circuit breaker {#SPEC-HOOKS-11~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -649,7 +649,7 @@ false permits merely allow one more tool call before the overflow.
 
 ## Model tier enforcement {#SPEC-HOOKS-12~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -711,7 +711,7 @@ invocations.
 
 ## Permission gate {#SPEC-HOOKS-13~1}
 
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 

--- a/src/claude_mpm/hooks/claude_hooks/handlers/stop_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/stop_handler.py
@@ -12,6 +12,8 @@ field on real Claude Code Stop events (confirmed by hook log inspection:
 ``Received event with keys: ['hook_event_name']``).  Token usage is obtained
 by parsing the transcript JSONL at
 ``~/.claude/projects/{cwd_encoded}/{session_id}.jsonl``.
+
+SPEC-HOOKS-07~1 : docs/specs/hooks.md#SPEC-HOOKS-07~1
 """
 
 from datetime import UTC, datetime
@@ -137,6 +139,8 @@ class StopHandler:
         - Captures stop reason and context for analysis
         - Enables tracking of session completion patterns
         - Useful for understanding when and why Claude stops responding
+
+        :spec: SPEC-HOOKS-07~1
         """
         session_id = event.get("session_id", "")
         _stop_debug(

--- a/src/claude_mpm/hooks/claude_hooks/handlers/subagent_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/subagent_handler.py
@@ -3,6 +3,10 @@
 
 Extracted from ``event_handlers.EventHandlers`` as part of the #509 refactor.
 Behavior is preserved verbatim; only the surrounding structure has changed.
+
+References
+----------
+SPEC-HOOKS-09~1 : docs/specs/hooks.md#SPEC-HOOKS-09~1
 """
 
 from datetime import UTC, datetime
@@ -11,7 +15,10 @@ from .base import DEBUG, BaseEventHandler, _log
 
 
 class SubagentHandler:
-    """Handle SubagentStop and SubagentStart events."""
+    """Handle SubagentStop and SubagentStart events.
+
+    :spec: SPEC-HOOKS-09~1
+    """
 
     def __init__(self, base: BaseEventHandler):
         self.base = base

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -3,6 +3,11 @@
 
 Extracted from ``event_handlers.EventHandlers`` as part of the #509 refactor.
 Behavior is preserved verbatim; only the surrounding structure has changed.
+
+References
+----------
+SPEC-HOOKS-05~1 : docs/specs/hooks.md#SPEC-HOOKS-05~1
+SPEC-HOOKS-06~1 : docs/specs/hooks.md#SPEC-HOOKS-06~1
 """
 
 import asyncio
@@ -181,6 +186,8 @@ class ToolHandler:
         - Captures tool parameters for debugging and security analysis
         - Provides context about what Claude is about to do
         - Enables pattern analysis and security monitoring
+
+        :spec: SPEC-HOOKS-05~1
         """
         # Context circuit-breaker: deny tool calls when context >= 95% (issue
         # #420).  Run BEFORE any other PreToolUse work so a critical-context
@@ -492,6 +499,8 @@ class ToolHandler:
         - Captures execution results and success/failure status
         - Provides duration and performance metrics
         - Enables pattern analysis of tool usage and success rates
+
+        :spec: SPEC-HOOKS-06~1
         """
         tool_name = event.get("tool_name", "")
         exit_code = event.get("exit_code", 0)

--- a/src/claude_mpm/hooks/claude_hooks/handlers/user_prompt_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/user_prompt_handler.py
@@ -3,6 +3,10 @@
 
 Extracted from ``event_handlers.EventHandlers`` as part of the #509 refactor.
 Behavior is preserved verbatim; only the surrounding structure has changed.
+
+References
+----------
+SPEC-HOOKS-08~1 : docs/specs/hooks.md#SPEC-HOOKS-08~1
 """
 
 import json
@@ -28,6 +32,8 @@ class UserPromptHandler:
         - Provides full context for debugging and monitoring
         - Captures prompt text, working directory, and session context
         - Enables better filtering and analysis in dashboard
+
+        :spec: SPEC-HOOKS-08~1
         """
         prompt = event.get("prompt", "")
 

--- a/src/claude_mpm/hooks/claude_hooks/hook_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/hook_handler.py
@@ -43,6 +43,10 @@ WHY service-oriented approach:
 
 NOTE: Requires Claude Code version 1.0.92 or higher for proper hook support.
 Earlier versions do not support matcher-based hook configuration.
+
+References
+----------
+SPEC-HOOKS-03~1 : docs/specs/hooks.md#SPEC-HOOKS-03~1
 """
 
 # Suppress RuntimeWarning from frozen runpy (prevents REPL pollution in Claude Code)
@@ -588,6 +592,8 @@ class ClaudeHookHandler:
 
         Returns:
             Modified input for PreToolUse events (v2.0.30+), None otherwise
+
+        :spec: SPEC-HOOKS-03~1
         """
         import time
 

--- a/src/claude_mpm/hooks/claude_hooks/services/connection_manager.py
+++ b/src/claude_mpm/hooks/claude_hooks/services/connection_manager.py
@@ -14,6 +14,10 @@ This service manages:
 - SocketIO connection pool initialization
 - Direct event emission with HTTP fallback
 - Connection cleanup
+
+References
+----------
+SPEC-HOOKS-10~1 : docs/specs/hooks.md#SPEC-HOOKS-10~1
 """
 
 import os
@@ -84,7 +88,10 @@ except ImportError:
 
 
 class ConnectionManagerService:
-    """Manages connections for the Claude hook handler."""
+    """Manages connections for the Claude hook handler.
+
+    :spec: SPEC-HOOKS-10~1
+    """
 
     def __init__(self):
         """Initialize connection management service."""

--- a/src/claude_mpm/hooks/claude_hooks/services/duplicate_detector.py
+++ b/src/claude_mpm/hooks/claude_hooks/services/duplicate_detector.py
@@ -4,6 +4,10 @@ This service manages:
 - Event key generation
 - Duplicate event detection within time windows
 - Recent event tracking
+
+References
+----------
+SPEC-HOOKS-10~1 : docs/specs/hooks.md#SPEC-HOOKS-10~1
 """
 
 import threading
@@ -12,7 +16,10 @@ from collections import deque
 
 
 class DuplicateEventDetector:
-    """Detects and filters duplicate events."""
+    """Detects and filters duplicate events.
+
+    :spec: SPEC-HOOKS-10~1
+    """
 
     def __init__(
         self, max_recent_events: int = 10, duplicate_window_seconds: float = 0.1

--- a/src/claude_mpm/hooks/claude_hooks/services/state_manager.py
+++ b/src/claude_mpm/hooks/claude_hooks/services/state_manager.py
@@ -5,6 +5,10 @@ This service manages:
 - Git branch caching
 - Session state management
 - Cleanup of old entries
+
+References
+----------
+SPEC-HOOKS-10~1 : docs/specs/hooks.md#SPEC-HOOKS-10~1
 """
 
 import os
@@ -41,7 +45,10 @@ DEBUG = os.environ.get("CLAUDE_MPM_HOOK_DEBUG", "false").lower() == "true"
 
 
 class StateManagerService:
-    """Manages state for the Claude hook handler."""
+    """Manages state for the Claude hook handler.
+
+    :spec: SPEC-HOOKS-10~1
+    """
 
     def __init__(self):
         """Initialize state management service."""

--- a/src/claude_mpm/hooks/claude_hooks/services/subagent_processor.py
+++ b/src/claude_mpm/hooks/claude_hooks/services/subagent_processor.py
@@ -5,6 +5,10 @@ This service handles:
 - Structured response extraction
 - Response tracking and correlation
 - Memory field processing
+
+References
+----------
+SPEC-HOOKS-09~1 : docs/specs/hooks.md#SPEC-HOOKS-09~1
 """
 
 import json
@@ -26,7 +30,10 @@ DEBUG = os.environ.get("CLAUDE_MPM_HOOK_DEBUG", "false").lower() == "true"
 
 
 class SubagentResponseProcessor:
-    """Processes subagent responses and extracts structured data."""
+    """Processes subagent responses and extracts structured data.
+
+    :spec: SPEC-HOOKS-09~1
+    """
 
     def __init__(self, state_manager, response_tracking_manager, connection_manager):
         """Initialize the subagent response processor.

--- a/src/claude_mpm/hooks/context_circuit_breaker.py
+++ b/src/claude_mpm/hooks/context_circuit_breaker.py
@@ -21,6 +21,10 @@ If the state file is missing, unreadable, or malformed -- or if the recorded
 empty dict (pass-through).  False denials are far worse than missed denials:
 the worst case for fail-open is the existing behavior; the worst case for
 fail-closed is bricking the session on a stale state file from a prior run.
+
+References
+----------
+SPEC-HOOKS-11~1 : docs/specs/hooks.md#SPEC-HOOKS-11~1
 """
 
 from __future__ import annotations
@@ -75,6 +79,8 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
     Returns a ``hookSpecificOutput``-shaped dict when the breaker fires, and
     an empty dict otherwise.  Callers should treat any non-empty result as
     "emit this and stop processing".
+
+    :spec: SPEC-HOOKS-11~1
     """
     cwd = event.get("cwd", "") or ""
     state = _load_state(cwd)

--- a/src/claude_mpm/hooks/model_tier_hook.py
+++ b/src/claude_mpm/hooks/model_tier_hook.py
@@ -13,6 +13,10 @@ events:
 
 Routing is decided from the ``hook_event_name`` field in the JSON payload so
 that one entrypoint can serve both hook types without changing settings.
+
+References
+----------
+SPEC-HOOKS-12~1 : docs/specs/hooks.md#SPEC-HOOKS-12~1
 """
 
 import json
@@ -263,6 +267,8 @@ def build_model_tier_response(event: dict) -> dict:
     such as ``claude-opus-4-7`` can cause "expected one of sonnet|opus|haiku"
     validation errors on some versions.  We map known dated IDs to their short
     alias before injecting; unknown/custom model IDs are passed through as-is.
+
+    :spec: SPEC-HOOKS-12~1
     """
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})

--- a/src/claude_mpm/hooks/permission_policy.py
+++ b/src/claude_mpm/hooks/permission_policy.py
@@ -22,6 +22,10 @@ Design goals
 The policy intentionally returns simple ``PermissionDecision`` dataclasses
 rather than the wire format. ``model_tier_hook.py`` is responsible for
 rendering the JSON envelope expected by Claude Code.
+
+References
+----------
+SPEC-HOOKS-13~1 : docs/specs/hooks.md#SPEC-HOOKS-13~1
 """
 
 from __future__ import annotations
@@ -134,6 +138,8 @@ def evaluate(event: dict[str, Any]) -> PermissionDecision:
 
     Returns:
         :class:`PermissionDecision` describing the policy outcome.
+
+    :spec: SPEC-HOOKS-13~1
     """
     tool_name = str(event.get("tool_name") or "")
     tool_input = event.get("tool_input") or {}

--- a/src/claude_mpm/scripts/claude-hook-fast.sh
+++ b/src/claude_mpm/scripts/claude-hook-fast.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# References: SPEC-HOOKS-01~1 docs/specs/hooks.md#SPEC-HOOKS-01~1
 # =============================================================================
 # Ultra-fast hook handler for Claude MPM (~15ms vs ~450ms Python)
 #

--- a/src/claude_mpm/scripts/claude-hook-handler.sh
+++ b/src/claude_mpm/scripts/claude-hook-handler.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# References: SPEC-HOOKS-02~1 docs/specs/hooks.md#SPEC-HOOKS-02~1
 #
 # Claude MPM Hook Handler Entry Point Script
 #

--- a/src/claude_mpm/services/hook_installer_service.py
+++ b/src/claude_mpm/services/hook_installer_service.py
@@ -2,6 +2,12 @@
 
 This service manages the automatic installation and removal of Claude Code hooks
 to enable monitor event forwarding via Socket.IO.
+
+References
+----------
+SPEC-HOOKS-01~1 : docs/specs/hooks.md#SPEC-HOOKS-01~1
+SPEC-HOOKS-02~1 : docs/specs/hooks.md#SPEC-HOOKS-02~1
+SPEC-HOOKS-04~1 : docs/specs/hooks.md#SPEC-HOOKS-04~1
 """
 
 import json
@@ -35,6 +41,8 @@ class HookInstallerService:
 
         Returns:
             True if hooks are properly configured, False otherwise.
+
+        :spec: SPEC-HOOKS-04~1
         """
         try:
             if not self.settings_file.exists():
@@ -296,6 +304,8 @@ class HookInstallerService:
 
         Returns:
             True if hooks were installed successfully, False otherwise.
+
+        :spec: SPEC-HOOKS-04~1
         """
         try:
             # Check if already configured


### PR DESCRIPTION
## Summary
- Adds `References` / `:spec:` entries to 13 Python source files + 2 shell script headers implementing SPEC-HOOKS-01~1 through SPEC-HOOKS-13~1
- Promotes all 13 sections in `docs/specs/hooks.md` from `draft (pending backfill)` → `Active`

## Files changed (16 commits, one file each)
- Shell scripts: `claude-hook-fast.sh`, `claude-hook-handler.sh` (header comments)
- Python handlers: `hook_handler.py`, `tool_handler.py`, `stop_handler.py`, `user_prompt_handler.py`, `subagent_handler.py`
- Python services: `hook_installer_service.py`, `subagent_processor.py`, `duplicate_detector.py`, `state_manager.py`, `connection_manager.py`
- Python hooks: `context_circuit_breaker.py`, `model_tier_hook.py`, `permission_policy.py`
- Spec doc: `docs/specs/hooks.md` (13 sections promoted to Active)

## Test plan
- [x] `uv run pytest tests/test_spec_traceability.py -x -q` passes (11 passed)
- [x] `uv run pytest -x -q` passes (only failure is `test_dashboard` — environmental: Playwright Chromium binary not installed)
- [x] `docs/specs/hooks.md` has no remaining `draft (pending backfill)` lines

Closes #624

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)