### PR TITLE
docs(sld): backfill References for all SPEC-SKILLS sections

### DIFF
--- a/docs/specs/skills.md
+++ b/docs/specs/skills.md
@@ -7,9 +7,9 @@
 This document specifies the observable behavior of the seven coherent areas that
 together constitute the claude-mpm Skills subsystem.  Each section carries a stable
 spec ID, a behavior contract (WHAT), a rationale (WHY), and an implementing-modules
-table.  All sections are currently in **draft (pending backfill)** status; they
-describe actual, verified behavior grounded in direct code inspection against
-`src/claude_mpm/skills/` and the research document
+table.  All sections are **Active**, with References backfilled into their
+implementing modules; they describe actual, verified behavior grounded in direct
+code inspection against `src/claude_mpm/skills/` and the research document
 `docs/specs/research/02-agents-skills.md`.
 
 The **Known Drift** section at the end documents inoperative or misaligned
@@ -34,7 +34,7 @@ behavior discovered during research.
 ## SkillsRegistry — flat-file skill discovery {#SPEC-SKILLS-01~1}
 
 **ID:** SPEC-SKILLS-01~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -96,7 +96,7 @@ skill overrides without modifying the package.
 ## SkillsService — directory-based skill discovery {#SPEC-SKILLS-02~1}
 
 **ID:** SPEC-SKILLS-02~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -168,7 +168,7 @@ creating a hard dependency on it.
 ## SkillDiscoveryService — remote/cache skill discovery {#SPEC-SKILLS-03~1}
 
 **ID:** SPEC-SKILLS-03~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -231,7 +231,7 @@ compatibility with skill repositories that predated the directory-based
 ## Skill frontmatter schema and required keys {#SPEC-SKILLS-04~1}
 
 **ID:** SPEC-SKILLS-04~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -296,7 +296,7 @@ intentional design decision.
 ## Bundled skills layout {#SPEC-SKILLS-05~1}
 
 **ID:** SPEC-SKILLS-05~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -360,7 +360,7 @@ the category name without embedding it in every `SKILL.md` frontmatter.
 ## SkillManager — agent-to-skill mapping {#SPEC-SKILLS-06~1}
 
 **ID:** SPEC-SKILLS-06~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -423,7 +423,7 @@ distinct from `SkillsRegistry` (used for skill metadata lookup) and `SkillsServi
 ## AgentSkillsInjector — graceful-noop behavior {#SPEC-SKILLS-07~1}
 
 **ID:** SPEC-SKILLS-07~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 

--- a/src/claude_mpm/cli/commands/skill_source.py
+++ b/src/claude_mpm/cli/commands/skill_source.py
@@ -7,6 +7,10 @@ enable, disable, and show commands with user-friendly output.
 DESIGN DECISION: Uses SkillSourceConfiguration for persistent storage and
 GitSkillSourceManager for Git operations. Provides clear, emoji-enhanced feedback
 for better UX. Handles errors gracefully with actionable messages.
+
+References
+----------
+SPEC-SKILLS-03~1 : docs/specs/skills.md#SPEC-SKILLS-03~1
 """
 
 import json

--- a/src/claude_mpm/services/skills/git_skill_source_manager.py
+++ b/src/claude_mpm/services/skills/git_skill_source_manager.py
@@ -14,6 +14,10 @@ Trade-offs:
 - Code Reuse: Leverage proven sync infrastructure
 - Maintainability: Single source of truth for Git operations
 - Flexibility: Easy to extend with skills-specific features
+
+References
+----------
+SPEC-SKILLS-03~1 : docs/specs/skills.md#SPEC-SKILLS-03~1
 """
 
 import os
@@ -100,6 +104,8 @@ class GitSkillSourceManager:
         >>> manager = GitSkillSourceManager(config)
         >>> results = manager.sync_all_sources()
         >>> skills = manager.get_all_skills()
+
+    :spec: SPEC-SKILLS-03~1
     """
 
     def __init__(

--- a/src/claude_mpm/services/skills/skill_discovery_service.py
+++ b/src/claude_mpm/services/skills/skill_discovery_service.py
@@ -32,6 +32,11 @@ Example Skill File:
     - Code quality and style
     - Security vulnerabilities
     ...
+
+References
+----------
+SPEC-SKILLS-03~1 : docs/specs/skills.md#SPEC-SKILLS-03~1
+SPEC-SKILLS-04~1 : docs/specs/skills.md#SPEC-SKILLS-04~1
 """
 
 import re
@@ -99,6 +104,8 @@ class SkillDiscoveryService:
         >>> skills = service.discover_skills()
         >>> for skill in skills:
         ...     print(f"{skill['name']}: {skill['description']}")
+
+    :spec: SPEC-SKILLS-03~1
     """
 
     def __init__(self, skills_dir: Path):

--- a/src/claude_mpm/skills/agent_skills_injector.py
+++ b/src/claude_mpm/skills/agent_skills_injector.py
@@ -11,8 +11,12 @@ Design Principles:
 - Generate clean YAML frontmatter
 - Inject skills docs after frontmatter
 
-References:
+Related docs:
 - Design: docs/design/claude-mpm-skills-integration-design.md (lines 632-711)
+
+References
+----------
+SPEC-SKILLS-07~1 : docs/specs/skills.md#SPEC-SKILLS-07~1
 """
 
 import json
@@ -49,6 +53,8 @@ class AgentSkillsInjector(LoggerMixin):
         >>> # Generate frontmatter
         >>> frontmatter = injector.generate_frontmatter_with_skills(template)
         >>> print(frontmatter)  # ---\nname: engineer\nskills:\n  - ...\n---
+
+    :spec: SPEC-SKILLS-07~1
     """
 
     def __init__(self, skills_service: SkillsService) -> None:

--- a/src/claude_mpm/skills/bundled/__init__.py
+++ b/src/claude_mpm/skills/bundled/__init__.py
@@ -3,4 +3,8 @@ Bundled skills shipped with Claude MPM.
 
 These skills provide reusable patterns and practices that eliminate
 redundancy across agent templates.
+
+References
+----------
+SPEC-SKILLS-05~1 : docs/specs/skills.md#SPEC-SKILLS-05~1
 """

--- a/src/claude_mpm/skills/registry.py
+++ b/src/claude_mpm/skills/registry.py
@@ -1,4 +1,10 @@
-"""Skills registry - manages bundled and discovered skills."""
+"""Skills registry - manages bundled and discovered skills.
+
+References
+----------
+SPEC-SKILLS-01~1 : docs/specs/skills.md#SPEC-SKILLS-01~1
+SPEC-SKILLS-04~1 : docs/specs/skills.md#SPEC-SKILLS-04~1
+"""
 
 import re
 from dataclasses import dataclass
@@ -154,7 +160,10 @@ def validate_agentskills_spec(skill: Skill) -> tuple[bool, list[str]]:
 
 
 class SkillsRegistry:
-    """Registry for managing skills across all tiers."""
+    """Registry for managing skills across all tiers.
+
+    :spec: SPEC-SKILLS-01~1
+    """
 
     def __init__(self):
         """Initialize the skills registry."""

--- a/src/claude_mpm/skills/skill_manager.py
+++ b/src/claude_mpm/skills/skill_manager.py
@@ -1,4 +1,9 @@
-"""Skills manager - integrates skills with agents."""
+"""Skills manager - integrates skills with agents.
+
+References
+----------
+SPEC-SKILLS-06~1 : docs/specs/skills.md#SPEC-SKILLS-06~1
+"""
 
 import json
 from pathlib import Path
@@ -15,7 +20,10 @@ logger = get_logger(__name__)
 
 
 class SkillManager:
-    """Manages skills and their integration with agents."""
+    """Manages skills and their integration with agents.
+
+    :spec: SPEC-SKILLS-06~1
+    """
 
     def __init__(self):
         """Initialize the skill manager."""

--- a/src/claude_mpm/skills/skills_service.py
+++ b/src/claude_mpm/skills/skills_service.py
@@ -11,9 +11,13 @@ Design:
 - Supports version checking and updates
 - Graceful degradation (warn but continue on errors)
 
-References:
+Related docs:
 - Design: docs/design/claude-mpm-skills-integration-design.md
 - Spec: docs/design/SKILL-MD-FORMAT-SPECIFICATION.md
+
+References
+----------
+SPEC-SKILLS-02~1 : docs/specs/skills.md#SPEC-SKILLS-02~1
 """
 
 import re
@@ -47,6 +51,8 @@ class SkillsService(LoggerMixin):
         >>>
         >>> skills = service.get_skills_for_agent('engineer')
         >>> print(f"Engineer has {len(skills)} skills")
+
+    :spec: SPEC-SKILLS-02~1
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Closes #626

## Summary
Adds References/:spec: entries to 8 Python source files implementing SPEC-SKILLS-01~1 through SPEC-SKILLS-07~1. Promotes all sections in docs/specs/skills.md to Active.

## Test plan
- [x] uv run pytest tests/test_spec_traceability.py passes (11 passed)
- [x] uv run pytest -x -q passes (only failure is pre-existing Playwright browser-binary env issue in test_dashboard, unrelated to docs changes)

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)