### PR TITLE
docs(sld): backfill References for all SPEC-SESSIONS sections

### DIFF
--- a/docs/specs/sessions.md
+++ b/docs/specs/sessions.md
@@ -10,9 +10,9 @@ interactive SDK session entry point, the event and hook buses, Socket.IO relay
 implementations, and the monitor agent watchdog.
 
 Each section constitutes one governed specification with a stable ID, a behavior contract
-(WHAT), a rationale section (WHY), and an implementing-modules table. All sections carry
-`**Status:** draft (pending backfill)` — the UNCOVERED check is therefore waived until
-code `References` blocks are added in a subsequent backfill phase.
+(WHAT), a rationale section (WHY), and an implementing-modules table. All sections are
+`**Status:** Active`: the implementing modules carry `References` / `:spec:` blocks
+linking back to these sections, so the UNCOVERED check is enforced.
 
 ---
 
@@ -39,7 +39,7 @@ code `References` blocks are added in a subsequent backfill phase.
 ## Services SessionManager — singleton token tracker {#SPEC-SESSIONS-01~1}
 
 **ID:** SPEC-SESSIONS-01~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -106,7 +106,7 @@ field is hardcoded to `"claude-sonnet-4.5"`, which is stale relative to the acti
 ## Core SessionManager — subprocess-reuse registry {#SPEC-SESSIONS-02~1}
 
 **ID:** SPEC-SESSIONS-02~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -164,7 +164,7 @@ is not suitable for this purpose.
 ## SessionManagementService — session orchestration layer {#SPEC-SESSIONS-03~1}
 
 **ID:** SPEC-SESSIONS-03~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -229,7 +229,7 @@ out of scope for this extraction.
 ## SDK runtime — SDKAgentRunner in-process executor {#SPEC-SESSIONS-04~1}
 
 **ID:** SPEC-SESSIONS-04~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 > **Note:** `SDKAgentRunner` is **fully implemented** but is designated **frozen /
 > unsupported** by project decision (epic #355 closed). The implementation must not be
@@ -309,7 +309,7 @@ capabilities will be added to `SDKAgentRunner` under the project decision to lea
 ## CLI runtime — CLIAgentRunner subprocess executor {#SPEC-SESSIONS-05~1}
 
 **ID:** SPEC-SESSIONS-05~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -376,7 +376,7 @@ The docstrings are stale and should be corrected in a future cleanup.
 ## AgentRuntime ABC, config dataclasses, and factory {#SPEC-SESSIONS-06~1}
 
 **ID:** SPEC-SESSIONS-06~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -432,7 +432,7 @@ fallback is always available regardless of SDK package installation.
 ## Runtime bridge and config resolution {#SPEC-SESSIONS-07~1}
 
 **ID:** SPEC-SESSIONS-07~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -489,7 +489,7 @@ docstring says it only accepts `"exec"` or `"subprocess"`.
 ## Interactive SDK session — _launch_sdk_mode {#SPEC-SESSIONS-08~1}
 
 **ID:** SPEC-SESSIONS-08~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 > **Correctness note:** Prior research documents (`sdk-runtime-current-state-2026-05-04.md`,
 > line 82) claimed `_launch_sdk_mode()` "DOES NOT EXIST." This was incorrect. The
@@ -566,7 +566,7 @@ monitor runs.
 ## SessionStateTracker — SDK session state store {#SPEC-SESSIONS-09~1}
 
 **ID:** SPEC-SESSIONS-09~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -622,7 +622,7 @@ automatically as new ones arrive, with no manual cleanup required.
 ## HookEventBus — cross-process injection queue {#SPEC-SESSIONS-10~1}
 
 **ID:** SPEC-SESSIONS-10~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -680,7 +680,7 @@ streaming. They are not connected.
 ## EventBus — in-process pyee event emitter {#SPEC-SESSIONS-11~1}
 
 **ID:** SPEC-SESSIONS-11~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -739,7 +739,7 @@ processing across the codebase.
 ## Socket.IO relays — DirectSocketIORelay (live) and SocketIORelay (frozen) {#SPEC-SESSIONS-12~1}
 
 **ID:** SPEC-SESSIONS-12~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -796,7 +796,7 @@ direct `sio.emit()` path.
 ## MonitorAgent — session watchdog daemon {#SPEC-SESSIONS-13~1}
 
 **ID:** SPEC-SESSIONS-13~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 

--- a/src/claude_mpm/core/interactive_session.py
+++ b/src/claude_mpm/core/interactive_session.py
@@ -8,6 +8,10 @@ This module uses protocol-based dependency injection to break circular imports.
 Instead of importing ClaudeRunner directly, it uses ClaudeRunnerProtocol which
 defines the interface it needs. This allows ClaudeRunner to create instances
 of InteractiveSession without circular dependency issues.
+
+References
+----------
+SPEC-SESSIONS-08~1 : docs/specs/sessions.md#SPEC-SESSIONS-08~1
 """
 
 from __future__ import annotations
@@ -67,6 +71,8 @@ class InteractiveSession:
     DESIGN DECISION: Uses composition over inheritance - takes ClaudeRunner as
     dependency rather than inheriting from it. This maintains loose coupling
     and makes testing easier while preserving all original functionality.
+
+    :spec: SPEC-SESSIONS-08~1
     """
 
     def __init__(self, runner: ClaudeRunnerProtocol):

--- a/src/claude_mpm/core/session_manager.py
+++ b/src/claude_mpm/core/session_manager.py
@@ -1,4 +1,9 @@
-"""Session ID management for Claude subprocess optimization."""
+"""Session ID management for Claude subprocess optimization.
+
+References
+----------
+SPEC-SESSIONS-02~1 : docs/specs/sessions.md#SPEC-SESSIONS-02~1
+"""
 
 import gzip
 import json
@@ -14,7 +19,10 @@ logger = get_logger(__name__)
 
 
 class SessionManager:
-    """Manages session IDs for Claude subprocess reuse."""
+    """Manages session IDs for Claude subprocess reuse.
+
+    :spec: SPEC-SESSIONS-02~1
+    """
 
     def __init__(self, session_dir: Path | None = None):
         """Initialize session manager.

--- a/src/claude_mpm/services/agents/agent_runtime.py
+++ b/src/claude_mpm/services/agents/agent_runtime.py
@@ -11,6 +11,10 @@ Usage::
 
     runtime = create_runtime("sdk", AgentConfig(system_prompt="You are helpful."))
     result = await runtime.run("Explain dependency injection.")
+
+References
+----------
+SPEC-SESSIONS-06~1 : docs/specs/sessions.md#SPEC-SESSIONS-06~1
 """
 
 from __future__ import annotations
@@ -117,6 +121,8 @@ class AgentRuntime(ABC):
     Every concrete runtime (CLI subprocess, SDK in-process, etc.) must
     implement these methods so that higher-level MPM orchestration code
     can remain backend-agnostic.
+
+    :spec: SPEC-SESSIONS-06~1
     """
 
     @abstractmethod

--- a/src/claude_mpm/services/agents/cli_runtime.py
+++ b/src/claude_mpm/services/agents/cli_runtime.py
@@ -2,6 +2,10 @@
 
 Wraps the existing ClaudeAdapter subprocess execution to implement
 the AgentRuntime ABC, providing a drop-in alternative to SDKAgentRunner.
+
+References
+----------
+SPEC-SESSIONS-05~1 : docs/specs/sessions.md#SPEC-SESSIONS-05~1
 """
 
 from __future__ import annotations
@@ -31,6 +35,8 @@ class CLIAgentRunner(AgentRuntime):
     Wraps :class:`~claude_mpm.adapters.cli_adapters.ClaudeAdapter` to
     implement the :class:`AgentRuntime` ABC, allowing the factory and
     runtime-config layer to treat CLI and SDK backends interchangeably.
+
+    :spec: SPEC-SESSIONS-05~1
     """
 
     def __init__(

--- a/src/claude_mpm/services/agents/hook_event_bus.py
+++ b/src/claude_mpm/services/agents/hook_event_bus.py
@@ -2,6 +2,10 @@
 
 Sidecar agents write messages to a JSON-lines file.
 The PreToolUse hook reads and consumes them on each tool call.
+
+References
+----------
+SPEC-SESSIONS-10~1 : docs/specs/sessions.md#SPEC-SESSIONS-10~1
 """
 
 from __future__ import annotations
@@ -65,6 +69,8 @@ class HookEventBus:
     messages, formats them as a systemMessage, then truncates the file.
 
     Uses file locking to handle concurrent writes from multiple sidecar agents.
+
+    :spec: SPEC-SESSIONS-10~1
     """
 
     def __init__(self, queue_path: str | Path | None = None) -> None:

--- a/src/claude_mpm/services/agents/monitor_agent.py
+++ b/src/claude_mpm/services/agents/monitor_agent.py
@@ -7,6 +7,10 @@ Responsibilities:
 - Context pressure warnings at configurable thresholds
 - Session duration warnings
 - Idle/stuck detection when in processing state
+
+References
+----------
+SPEC-SESSIONS-13~1 : docs/specs/sessions.md#SPEC-SESSIONS-13~1
 """
 
 from __future__ import annotations
@@ -59,6 +63,8 @@ class MonitorAgent:
 
     The monitor is created and owned by ``_launch_sdk_mode()`` -- it is
     not a global singleton.
+
+    :spec: SPEC-SESSIONS-13~1
     """
 
     def __init__(self, config: MonitorConfig | None = None) -> None:

--- a/src/claude_mpm/services/agents/runtime_bridge.py
+++ b/src/claude_mpm/services/agents/runtime_bridge.py
@@ -4,6 +4,10 @@ Provides a unified entry point that routes to SDK or CLI based on config.
 This module is intentionally lightweight -- it delegates all heavy lifting
 to :mod:`~claude_mpm.services.agents.agent_runtime` and
 :mod:`~claude_mpm.services.agents.runtime_config`.
+
+References
+----------
+SPEC-SESSIONS-07~1 : docs/specs/sessions.md#SPEC-SESSIONS-07~1
 """
 
 from __future__ import annotations
@@ -28,6 +32,8 @@ async def execute_agent_prompt(
 
     Returns a dict with keys: ``text``, ``session_id``, ``cost_usd``,
     ``num_turns``, ``duration_ms``, ``is_error``, ``tool_calls``, ``runtime``.
+
+    :spec: SPEC-SESSIONS-07~1
     """
     from claude_mpm.services.agents.agent_runtime import AgentConfig
     from claude_mpm.services.agents.runtime_config import get_runtime, get_runtime_type

--- a/src/claude_mpm/services/agents/runtime_config.py
+++ b/src/claude_mpm/services/agents/runtime_config.py
@@ -6,6 +6,10 @@ Determines which AgentRuntime backend to use based on:
 
 The config-file path (``configuration.yaml``) is intentionally omitted for now
 since the unified config system can layer this on top later.
+
+References
+----------
+SPEC-SESSIONS-07~1 : docs/specs/sessions.md#SPEC-SESSIONS-07~1
 """
 
 from __future__ import annotations
@@ -28,6 +32,8 @@ def get_runtime_type() -> str:
     1. ``CLAUDE_MPM_RUNTIME`` environment variable (``"sdk"`` or ``"cli"``).
     2. Auto-detect: ``"sdk"`` if ``claude_agent_sdk`` is importable,
        otherwise ``"cli"``.
+
+    :spec: SPEC-SESSIONS-07~1
     """
     env_runtime = os.environ.get("CLAUDE_MPM_RUNTIME", "").strip().lower()
     if env_runtime in ("sdk", "cli"):

--- a/src/claude_mpm/services/agents/sdk_runtime.py
+++ b/src/claude_mpm/services/agents/sdk_runtime.py
@@ -33,6 +33,10 @@ Usage:
     async with runner.interruptible() as session:
         r = await session.query("Do something long-running.")
         await session.interrupt()  # cancel if needed
+
+References
+----------
+SPEC-SESSIONS-04~1 : docs/specs/sessions.md#SPEC-SESSIONS-04~1
 """
 
 from __future__ import annotations
@@ -144,6 +148,8 @@ class SDKAgentRunner(AgentRuntime):
     * ``run_with_hooks()`` - persistent session via ``ClaudeSDKClient`` with
       optional ``can_use_tool`` callback for tool interception.
     * ``inject()`` - multi-turn conversation using ``ClaudeSDKClient``.
+
+    :spec: SPEC-SESSIONS-04~1
     """
 
     def __init__(

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -2,6 +2,10 @@
 
 Updated by _launch_sdk_mode() as it processes messages.
 Read by MessageEndpoint HTTP handlers (/session, /activity).
+
+References
+----------
+SPEC-SESSIONS-09~1 : docs/specs/sessions.md#SPEC-SESSIONS-09~1
 """
 
 from __future__ import annotations
@@ -59,6 +63,8 @@ class SessionStateTracker:
     All writes happen from the asyncio REPL thread.
     All reads happen from the HTTP server thread.
     Uses a lock for thread safety.
+
+    :spec: SPEC-SESSIONS-09~1
     """
 
     def __init__(self, max_events: int = 100) -> None:

--- a/src/claude_mpm/services/event_bus/direct_relay.py
+++ b/src/claude_mpm/services/event_bus/direct_relay.py
@@ -12,6 +12,10 @@ Claude sends hook events with these REQUIRED fields:
 - timestamp: ISO format timestamp
 
 DO NOT use "event" or "type" fields - use "hook_event_name" instead!
+
+References
+----------
+SPEC-SESSIONS-12~1 : docs/specs/sessions.md#SPEC-SESSIONS-12~1
 """
 
 import logging
@@ -31,6 +35,8 @@ class DirectSocketIORelay:
     WHY: The original SocketIORelay creates a client connection back to the server,
     which causes events to not reach the dashboard properly. This direct relay
     uses the server's broadcaster directly for proper event emission.
+
+    :spec: SPEC-SESSIONS-12~1
     """
 
     def __init__(self, server_instance):

--- a/src/claude_mpm/services/event_bus/event_bus.py
+++ b/src/claude_mpm/services/event_bus/event_bus.py
@@ -6,6 +6,10 @@ WHY pyee over alternatives:
 - Simple EventEmitter pattern familiar to developers
 - Thread-safe for multi-threaded environments
 - Efficient event dispatch with minimal overhead
+
+References
+----------
+SPEC-SESSIONS-11~1 : docs/specs/sessions.md#SPEC-SESSIONS-11~1
 """
 
 import asyncio
@@ -32,6 +36,8 @@ class EventBus:
     - Prevents duplicate event processing
     - Simplifies configuration and management
     - Thread-safe initialization with proper locking
+
+    :spec: SPEC-SESSIONS-11~1
     """
 
     _instance: Optional["EventBus"] = None

--- a/src/claude_mpm/services/event_bus/relay.py
+++ b/src/claude_mpm/services/event_bus/relay.py
@@ -6,6 +6,10 @@ WHY separate relay component:
 - Enables graceful degradation when Socket.IO unavailable
 - Simplifies testing by mocking just the relay
 - Supports batching and retry logic in one place
+
+References
+----------
+SPEC-SESSIONS-12~1 : docs/specs/sessions.md#SPEC-SESSIONS-12~1
 """
 
 import os
@@ -42,6 +46,8 @@ class SocketIORelay:
     - Provides single point for Socket.IO configuration
     - Enables event batching and optimization
     - Simplifies debugging with centralized logging
+
+    :spec: SPEC-SESSIONS-12~1
     """
 
     def __init__(self, port: int | None = None):

--- a/src/claude_mpm/services/session_management_service.py
+++ b/src/claude_mpm/services/session_management_service.py
@@ -13,6 +13,10 @@ Extracted from ClaudeRunner to follow Single Responsibility Principle.
 DEPENDENCY INJECTION:
 This service uses protocol-based dependency injection to avoid circular imports.
 It accepts a ClaudeRunnerProtocol instead of importing ClaudeRunner directly.
+
+References
+----------
+SPEC-SESSIONS-03~1 : docs/specs/sessions.md#SPEC-SESSIONS-03~1
 """
 
 import time
@@ -33,7 +37,10 @@ else:
 
 
 class SessionManagementService(BaseService, SessionManagementInterface):
-    """Service for managing Claude session orchestration."""
+    """Service for managing Claude session orchestration.
+
+    :spec: SPEC-SESSIONS-03~1
+    """
 
     def __init__(self, runner: Optional["ClaudeRunnerProtocol"] = None):
         """Initialize the session management service.

--- a/src/claude_mpm/services/session_manager.py
+++ b/src/claude_mpm/services/session_manager.py
@@ -12,6 +12,10 @@ Extended with:
 - Resume log generation on session end
 - Context metrics persistence
 - Automatic resume log injection on session startup
+
+References
+----------
+SPEC-SESSIONS-01~1 : docs/specs/sessions.md#SPEC-SESSIONS-01~1
 """
 
 import os
@@ -33,6 +37,8 @@ class SessionManager:
     duplicate session IDs across different components.
 
     Uses double-checked locking pattern for thread-safe singleton initialization.
+
+    :spec: SPEC-SESSIONS-01~1
     """
 
     _instance: Optional["SessionManager"] = None


### PR DESCRIPTION
Closes #628

## Summary
Adds References/:spec: entries to 15 Python source files implementing SPEC-SESSIONS-01~1 through SPEC-SESSIONS-13~1. Promotes all sections in docs/specs/sessions.md to Active.

## Test plan
- [x] uv run pytest tests/test_spec_traceability.py passes (11 passed)
- [x] uv run pytest -x -q passes (6652 passed; the single failure is the Playwright dashboard test, which fails only because the Chromium browser binary is not installed in this environment — unrelated to these docs-only changes)

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)