### PR TITLE
docs(sld): backfill References for all SPEC-INTEGRATIONS sections

### DIFF
--- a/docs/specs/integrations.md
+++ b/docs/specs/integrations.md
@@ -10,9 +10,9 @@ dispatcher with trusty-memory as primary and kuzu-memory as live fallback), the 
 migrations system, and the Dashboard/UI service.
 
 Each section constitutes one governed specification with a stable ID, a behavior contract
-(WHAT), a rationale section (WHY), and an implementing-modules table. All sections carry
-`**Status:** draft (pending backfill)` — the CI UNCOVERED check is therefore exempted
-until implementing modules add matching `References` docstring blocks.
+(WHAT), a rationale section (WHY), and an implementing-modules table. All sections are
+`**Status:** Active`: the implementing modules carry matching `References` docstring blocks,
+so the CI UNCOVERED check is enforced for every section.
 
 ---
 
@@ -37,7 +37,7 @@ until implementing modules add matching `References` docstring blocks.
 ## Trusty service address discovery {#SPEC-INTEGRATIONS-01~1}
 
 **ID:** SPEC-INTEGRATIONS-01~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -83,7 +83,7 @@ the default ports.
 ## Trusty MCP service setup {#SPEC-INTEGRATIONS-02~1}
 
 **ID:** SPEC-INTEGRATIONS-02~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -172,7 +172,7 @@ incorrect and were repaired by migration `fix_trusty_memory_bridge` (v6.5.0).
 ## Trusty autodetect migration {#SPEC-INTEGRATIONS-03~1}
 
 **ID:** SPEC-INTEGRATIONS-03~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -224,7 +224,7 @@ setup wizard wrote with richer configuration.
 ## MCP config builder {#SPEC-INTEGRATIONS-04~1}
 
 **ID:** SPEC-INTEGRATIONS-04~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -295,7 +295,7 @@ static config assumed.
 ## MCP service installer {#SPEC-INTEGRATIONS-05~1}
 
 **ID:** SPEC-INTEGRATIONS-05~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -364,7 +364,7 @@ assumed present. Those services are handled by the interactive `TrustyMixin` set
 ## Memory enrichment — multi-backend dispatcher {#SPEC-INTEGRATIONS-06~1}
 
 **ID:** SPEC-INTEGRATIONS-06~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -438,7 +438,7 @@ is inaccurate — the module was refactored into a multi-backend dispatcher, not
 ## Memory capture — session lifecycle events {#SPEC-INTEGRATIONS-07~1}
 
 **ID:** SPEC-INTEGRATIONS-07~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -499,7 +499,7 @@ startup or shutdown sequences.
 ## Memory enrichment — delegation layer {#SPEC-INTEGRATIONS-08~1}
 
 **ID:** SPEC-INTEGRATIONS-08~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -562,7 +562,7 @@ rather than the raw Claude Code event JSON, enabling more precise memory queries
 ## Migrations system — registry and runner {#SPEC-INTEGRATIONS-09~1}
 
 **ID:** SPEC-INTEGRATIONS-09~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -634,7 +634,7 @@ creates a misleading "pending" count for genuinely clean systems.
 ## Dashboard / UI service application {#SPEC-INTEGRATIONS-10~1}
 
 **ID:** SPEC-INTEGRATIONS-10~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 
@@ -711,7 +711,7 @@ as cleanly as the inline form, and the WebSocket requires direct access to `app.
 ## Dashboard / UI service daemon lifecycle {#SPEC-INTEGRATIONS-11~1}
 
 **ID:** SPEC-INTEGRATIONS-11~1
-**Status:** draft (pending backfill)
+**Status:** Active
 
 ### Behavior Contract (WHAT)
 

--- a/src/claude_mpm/cli/commands/setup/handlers/trusty.py
+++ b/src/claude_mpm/cli/commands/setup/handlers/trusty.py
@@ -5,6 +5,11 @@ Each `_setup_trusty_*` follows the same shape:
 2. Ensure the long-running daemon is up (launchd plist).
 3. Register the project / palace / etc.
 4. Write the ``.mcp.json`` entry (with rollback on failure).
+
+References
+----------
+SPEC-INTEGRATIONS-01~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-01~1
+SPEC-INTEGRATIONS-02~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-02~1
 """
 
 from __future__ import annotations
@@ -22,7 +27,10 @@ from ..mcp_config import _mcp_config_transaction
 
 
 class TrustyMixin:
-    """Mixin: trusty-search / trusty-memory / trusty-analyzer setup."""
+    """Mixin: trusty-search / trusty-memory / trusty-analyzer setup.
+
+    :spec: SPEC-INTEGRATIONS-01~1
+    """
 
     # ------------------------------------------------------------------
     # Declare methods provided by McpConfigMixin at runtime via MRO.
@@ -338,6 +346,8 @@ class TrustyMixin:
            ``127.0.0.1:7878``); install launchd plist if down.
         3. Register/index current project.
         4. Write ``.mcp.json`` entry pointing at ``trusty-search serve``.
+
+        :spec: SPEC-INTEGRATIONS-02~1
         """
         console.print("\n[bold cyan]Trusty Search MCP Setup[/bold cyan]")
         console.print(
@@ -463,6 +473,8 @@ class TrustyMixin:
         verify (a) the palace appears via GET /api/v1/palaces, (b) .mcp.json
         contains the trusty-memory entry, and (c) settings.json contains the
         SessionStart hook entry tagged with ``_mpm_service: trusty-memory``.
+
+        :spec: SPEC-INTEGRATIONS-02~1
 
         Steps:
         1. Install via cargo (or cargo-binstall) if missing.
@@ -649,6 +661,8 @@ class TrustyMixin:
         1. Install via cargo (from git) if missing.
         2. Ensure daemon is running on http://127.0.0.1:7879 (launchd plist).
         3. Write ``.mcp.json`` entry pointing at ``trusty-analyzer mcp``.
+
+        :spec: SPEC-INTEGRATIONS-02~1
         """
         console.print("\n[bold cyan]Trusty Analyzer MCP Setup[/bold cyan]")
         console.print(

--- a/src/claude_mpm/hooks/kuzu_enrichment_hook.py
+++ b/src/claude_mpm/hooks/kuzu_enrichment_hook.py
@@ -15,6 +15,10 @@ DESIGN DECISIONS:
 - Reuses KuzuMemoryHook's retrieval methods for consistency
 - Injects memories as a dedicated section in agent context
 - Falls back gracefully if kuzu-memory is not available
+
+References
+----------
+SPEC-INTEGRATIONS-08~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-08~1
 """
 
 import logging
@@ -35,6 +39,8 @@ class KuzuEnrichmentHook(PreDelegationHook):
     2. Retrieves relevant memories from kuzu-memory
     3. Injects memories into agent context
     4. Formats memories for optimal agent understanding
+
+    :spec: SPEC-INTEGRATIONS-08~1
     """
 
     def __init__(self):

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -23,6 +23,11 @@ Design goals
 
 Invocation: ``python3 -m claude_mpm.hooks.memory_capture`` from
 ``.claude/settings.json`` (PostToolUse, Stop, SubagentStop, SessionStart).
+
+References
+----------
+SPEC-INTEGRATIONS-06~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-06~1
+SPEC-INTEGRATIONS-07~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-07~1
 """
 
 from __future__ import annotations
@@ -687,6 +692,8 @@ def handle_user_prompt_submit(
         immediately (recall result is the user-visible value).
       * Inject recalled context as ``additionalContext`` via
         ``hookSpecificOutput`` when there are any results.
+
+    :spec: SPEC-INTEGRATIONS-06~1
     """
     result: dict[str, Any] = {"continue": True}
 
@@ -778,7 +785,10 @@ def _read_event() -> dict[str, Any] | None:
 
 
 def main() -> None:
-    """Read one Claude Code hook event from stdin and dispatch to backend."""
+    """Read one Claude Code hook event from stdin and dispatch to backend.
+
+    :spec: SPEC-INTEGRATIONS-07~1
+    """
     event = _read_event()
     if event is None:
         _emit_continue()

--- a/src/claude_mpm/hooks/memory_integration_hook.py
+++ b/src/claude_mpm/hooks/memory_integration_hook.py
@@ -10,6 +10,10 @@ agent outputs because:
 - The format is clear and unambiguous
 - It's more reliable than pattern matching
 - Agents can add multiple learnings in a single response
+
+References
+----------
+SPEC-INTEGRATIONS-08~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-08~1
 """
 
 import re
@@ -68,6 +72,8 @@ class MemoryPreDelegationHook(PreDelegationHook):
 
     DESIGN DECISION: Memory is injected as a clearly formatted section in the context
     to ensure agents understand it's their accumulated knowledge, not current task info.
+
+    :spec: SPEC-INTEGRATIONS-08~1
     """
 
     def __init__(self, config: Config = None):
@@ -231,6 +237,8 @@ class MemoryPostDelegationHook(PostDelegationHook):
     Type: mistake
     Content: Never hardcode configuration values
     #
+
+    :spec: SPEC-INTEGRATIONS-08~1
     """
 
     def __init__(self, config: Config = None):

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -27,6 +27,10 @@ fail whenever the daemons picked different ports. We mirror the discovery
 logic used by the ``claude-mpm setup trusty-*`` handlers: read the addr file
 when present, fall back to the legacy port only when the file is missing or
 unreadable.
+
+References
+----------
+SPEC-INTEGRATIONS-03~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-03~1
 """
 
 from __future__ import annotations
@@ -298,6 +302,8 @@ def run_migration(project_dir: Path | None = None) -> bool:
         False if everything was already configured, no daemons were detected,
         or auto-link is opted out. Never raises on the absence/opt-out path —
         only propagates exceptions from disk writes.
+
+    :spec: SPEC-INTEGRATIONS-03~1
     """
     project_dir = project_dir or Path.cwd()
     mcp_path = project_dir / ".mcp.json"

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -3,6 +3,10 @@ Migration registry for version-based migrations.
 
 Migrations are registered by version and run automatically on first startup
 of that version. Each migration runs once and is tracked in state file.
+
+References
+----------
+SPEC-INTEGRATIONS-09~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-09~1
 """
 
 from collections.abc import Callable

--- a/src/claude_mpm/migrations/runner.py
+++ b/src/claude_mpm/migrations/runner.py
@@ -3,6 +3,10 @@ Migration runner for version-based migrations.
 
 Tracks completed migrations and runs pending ones on startup.
 State is stored in ~/.claude-mpm/migrations.json
+
+References
+----------
+SPEC-INTEGRATIONS-09~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-09~1
 """
 
 import json
@@ -90,6 +94,8 @@ def run_pending_migrations(current_version: str | None = None) -> int:
 
     Returns:
         Number of migrations run
+
+    :spec: SPEC-INTEGRATIONS-09~1
     """
     pending = get_pending_migrations()
 

--- a/src/claude_mpm/services/mcp/config_builder.py
+++ b/src/claude_mpm/services/mcp/config_builder.py
@@ -6,6 +6,10 @@ Generates MCP service configurations, preferring static known-good configs
 and falling back to runtime detection (pipx run, uvx, direct binaries).
 
 Extracted from MCPConfigManager as part of god-class decomposition (#507).
+
+References
+----------
+SPEC-INTEGRATIONS-04~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-04~1
 """
 
 from __future__ import annotations
@@ -25,6 +29,8 @@ class MCPServiceConfigBuilder:
     """Build MCP service configuration dicts from static templates or detection.
 
     Depends on an :class:`MCPServiceLocator` for executable discovery.
+
+    :spec: SPEC-INTEGRATIONS-04~1
     """
 
     # Static known-good MCP service configurations.
@@ -332,6 +338,8 @@ class MCPServiceConfigBuilder:
 
         Returns:
             Service configuration dict or None if service not found
+
+        :spec: SPEC-INTEGRATIONS-04~1
         """
         static_config = self.get_static_service_config(service_name)
         if static_config:

--- a/src/claude_mpm/services/mcp/service_installer.py
+++ b/src/claude_mpm/services/mcp/service_installer.py
@@ -6,6 +6,10 @@ Installs missing MCP services via pipx (preferred) with fallbacks to
 uvx and ``pip install --user``.
 
 Extracted from MCPConfigManager as part of god-class decomposition (#507).
+
+References
+----------
+SPEC-INTEGRATIONS-05~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-05~1
 """
 
 from __future__ import annotations
@@ -23,7 +27,10 @@ if TYPE_CHECKING:
 
 
 class MCPServiceInstaller:
-    """Install missing MCP services across supported package managers."""
+    """Install missing MCP services across supported package managers.
+
+    :spec: SPEC-INTEGRATIONS-05~1
+    """
 
     # Standard MCP services that should use pipx
     PIPX_SERVICES = {
@@ -65,6 +72,8 @@ class MCPServiceInstaller:
 
         Returns:
             Tuple of (success, message)
+
+        :spec: SPEC-INTEGRATIONS-05~1
         """
         missing = []
         for service_name in self.PIPX_SERVICES:

--- a/src/claude_mpm/services/ui_service/app.py
+++ b/src/claude_mpm/services/ui_service/app.py
@@ -3,6 +3,10 @@
 Creates the FastAPI app, registers all routers, configures CORS and
 WebSocket endpoints, and manages the ProcessManager lifecycle via the
 lifespan context manager.
+
+References
+----------
+SPEC-INTEGRATIONS-10~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-10~1
 """
 
 import json
@@ -58,6 +62,8 @@ def create_app(service_config: UIServiceConfig | None = None) -> FastAPI:
 
     Returns:
         Fully configured FastAPI application instance.
+
+    :spec: SPEC-INTEGRATIONS-10~1
     """
     cfg = service_config or UIServiceConfig.from_env()
 

--- a/src/claude_mpm/services/ui_service/serve_daemon.py
+++ b/src/claude_mpm/services/ui_service/serve_daemon.py
@@ -17,6 +17,10 @@ DESIGN DECISIONS:
   loop via asyncio.gather(uvicorn_serve, channel_hub.start()).
 - The /health endpoint (already in app.py) is augmented here to return the
   expected service identifier so DaemonManager.is_our_service() works.
+
+References
+----------
+SPEC-INTEGRATIONS-11~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-11~1
 """
 
 from __future__ import annotations
@@ -67,6 +71,8 @@ class ServeDaemon:
         daemon_mode: True → launch as detached background process.
         channels: Optional list of channel adapter names to enable.
         project_root: Default working directory for new sessions.
+
+    :spec: SPEC-INTEGRATIONS-11~1
     """
 
     def __init__(
@@ -231,6 +237,8 @@ class _ServeDaemonManager(DaemonManager):
         python -m claude_mpm.cli serve start --background --port N --host H
 
     instead of the monitor start command baked into the base class.
+
+    :spec: SPEC-INTEGRATIONS-11~1
     """
 
     def __init__(


### PR DESCRIPTION
Closes #630

## Summary
Adds References/:spec: entries to 11 Python source files implementing SPEC-INTEGRATIONS-01~1 through SPEC-INTEGRATIONS-11~1. Promotes all sections in docs/specs/integrations.md to Active.

## Test plan
- [ ] uv run pytest tests/test_spec_traceability.py passes
- [ ] uv run pytest -x -q passes

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)