### PR TITLE
fix(trusty): stdio MCP servers show NOT RUNNING despite being connected

### DIFF
--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -278,6 +278,40 @@ def _mcp_servers_from_file(path: Path) -> frozenset[str]:
     return frozenset(servers.keys())
 
 
+def _is_stdio_configured(service: str) -> bool:
+    """Whether ``service`` is configured as a stdio-type MCP server in any
+    ``.mcp.json``.
+
+    Why: For stdio-type MCP servers, Claude Code manages the process — the
+    HTTP health check is informational only. A stdio-configured service that
+    fails the HTTP probe is still accessible via stdio and should NOT be
+    shown as "not running".
+
+    What: Reads both the project-level and user-level ``.mcp.json`` and
+    returns ``True`` if ``service`` appears with ``"type": "stdio"`` in
+    either. Returns ``False`` on any I/O / parse error (fail-safe).
+
+    Test: ``tests/test_trusty_status_indicators.py`` — see
+    ``TestStdioConfiguredDetection``.
+    """
+    import json
+
+    for path in (
+        Path.cwd() / ".mcp.json",
+        Path.home() / ".claude" / ".mcp.json",
+    ):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            servers = data.get("mcpServers", {})
+            entry = servers.get(service)
+            if isinstance(entry, dict) and entry.get("type") == "stdio":
+                return True
+        except (OSError, json.JSONDecodeError, ValueError, KeyError):
+            pass
+    return False
+
+
 def _is_configured_in_mcp(service: str) -> bool:
     """Whether ``service`` appears in EITHER the project or user-level MCP config.
 
@@ -385,22 +419,33 @@ def get_trusty_status(service: str) -> tuple[str, str]:
         emoji = _SERVICE_EMOJI.get(service, "")
         base_url, host_port = _base_url(service)
 
-        if _cached_health_check(service, base_url):
+        is_healthy = _cached_health_check(service, base_url)
+        is_stdio = _is_stdio_configured(service)
+
+        # stdio-configured services: HTTP health failure ≠ not running.
+        # Claude Code manages the stdio process — if configured, assume connected.
+        if is_healthy or is_stdio:
             if service == "trusty-memory":
                 palace = _palace_name()
-                # #598 option 1: /health only proves the daemon is up — verify
-                # the palace actually exists before claiming it. Fail-safe:
-                # only append "(not created)" on a definitive negative.
-                if _cached_palace_exists(service, base_url, palace):
-                    palace_display = f"palace: {palace}"
+                if is_healthy:
+                    # #598 option 1: /health only proves the daemon is up — verify
+                    # the palace actually exists before claiming it. Fail-safe:
+                    # only append "(not created)" on a definitive negative.
+                    if _cached_palace_exists(service, base_url, palace):
+                        palace_display = f"palace: {palace}"
+                    else:
+                        palace_display = f"palace: {palace} (not created)"
+                    line = f"{emoji} {service}: on   {palace_display}   {host_port}"
                 else:
-                    palace_display = f"palace: {palace} (not created)"
-                line = f"{emoji} {service}: on   {palace_display}   {host_port}"
-            else:
+                    # stdio connected but HTTP unreachable (port informational only)
+                    line = f"{emoji} {service}: on (stdio)   palace: {palace}"
+            elif is_healthy:
                 line = f"{emoji} {service}: on   {host_port}"
+            else:
+                line = f"{emoji} {service}: on (stdio)"
             return ("on", line)
 
-        # /health failed but the service is present (opted in) → not running.
+        # NOT stdio-configured AND health check failed → truly not running.
         hint = _start_hint(service)
         line = f"{emoji} {service}: not running  {hint}"
         state = "configured" if _is_configured_in_mcp(service) else "not_running"

--- a/tests/test_trusty_status_indicators.py
+++ b/tests/test_trusty_status_indicators.py
@@ -21,6 +21,7 @@ import pytest
 from claude_mpm.services.trusty_status import (
     _health_check,
     _is_configured_in_mcp,
+    _is_stdio_configured,
     _palace_exists,
     _palace_name,
     get_trusty_status,
@@ -258,11 +259,12 @@ class TestGetTrustyMemoryStatus:
         assert state == "absent"
         assert line == ""
 
-    def test_configured_not_running_when_in_mcp_but_unhealthy(
+    def test_configured_not_running_when_in_mcp_but_unhealthy_non_stdio(
         self, tmp_path, monkeypatch
     ):
-        """Returns 'configured' state when in mcp.json but health check fails."""
-        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "stdio"}})
+        """Returns 'configured' state when in mcp.json (non-stdio) and health fails."""
+        # Use a non-stdio type so the stdio fast-path does not apply.
+        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "sse", "url": "http://x"}})
         monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
         with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
             with patch(
@@ -274,9 +276,9 @@ class TestGetTrustyMemoryStatus:
         assert "not running" in line
         assert "trusty-memory" in line
 
-    def test_not_running_suggests_start_command(self, tmp_path, monkeypatch):
-        """'not running' hint includes a start command for trusty-memory."""
-        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "stdio"}})
+    def test_not_running_suggests_start_command_non_stdio(self, tmp_path, monkeypatch):
+        """'not running' hint includes a start command for non-stdio trusty-memory."""
+        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "sse", "url": "http://x"}})
         monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
         with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
             with patch(
@@ -374,11 +376,12 @@ class TestGetTrustySearchStatus:
         assert state == "absent"
         assert line == ""
 
-    def test_configured_not_running_when_in_mcp_but_unhealthy(
+    def test_configured_not_running_when_in_mcp_but_unhealthy_non_stdio(
         self, tmp_path, monkeypatch
     ):
-        """Returns 'configured' state when in mcp.json but health check fails."""
-        _write_mcp_json(tmp_path, {"trusty-search": {"type": "stdio"}})
+        """Returns 'configured' state when in mcp.json (non-stdio) and health fails."""
+        # Use a non-stdio type so the stdio fast-path does not apply.
+        _write_mcp_json(tmp_path, {"trusty-search": {"type": "sse", "url": "http://x"}})
         monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
         with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
             with patch(
@@ -404,10 +407,12 @@ class TestGetTrustySearchStatus:
         assert "trusty-search: on" in line
         assert "/ui" not in line  # The new module does NOT show /ui paths
 
-    def test_not_running_suggests_serve_command(self, tmp_path, monkeypatch):
-        """'not running' hint includes 'trusty-search serve'."""
-        _write_mcp_json(tmp_path, {"trusty-search": {"type": "stdio"}})
+    def test_not_running_suggests_serve_command_non_stdio(self, tmp_path, monkeypatch):
+        """'not running' hint includes 'trusty-search serve' for non-stdio services."""
+        # Use sse type so the stdio fast-path does not apply and the hint is shown.
+        _write_mcp_json(tmp_path, {"trusty-search": {"type": "sse", "url": "http://x"}})
         monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
             with patch(
                 "claude_mpm.services.trusty_status._cached_health_check",
@@ -436,6 +441,157 @@ class TestGetTrustySearchStatus:
                 _, line = get_trusty_status("trusty-search")
         # \U0001f50d is the magnifying glass emoji
         assert "\U0001f50d" in line
+
+
+# ===========================================================================
+# _is_stdio_configured + stdio-aware get_trusty_status behaviour
+# ===========================================================================
+
+
+class TestStdioConfiguredDetection:
+    """Tests for _is_stdio_configured and its effect on get_trusty_status."""
+
+    # -----------------------------------------------------------------------
+    # _is_stdio_configured unit tests
+    # -----------------------------------------------------------------------
+
+    def test_returns_true_when_mcp_json_has_stdio_type(self, tmp_path, monkeypatch):
+        """Returns True when .mcp.json has type: stdio for the service."""
+        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        # Point home to tmp_path so the user-level .mcp.json does not interfere.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _is_stdio_configured("trusty-memory") is True
+
+    def test_returns_false_when_type_is_not_stdio(self, tmp_path, monkeypatch):
+        """Returns False when .mcp.json has a non-stdio type for the service."""
+        _write_mcp_json(tmp_path, {"trusty-memory": {"type": "sse", "url": "http://x"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _is_stdio_configured("trusty-memory") is False
+
+    def test_returns_false_when_service_absent_from_mcp_json(
+        self, tmp_path, monkeypatch
+    ):
+        """Returns False when the service does not appear in .mcp.json."""
+        _write_mcp_json(tmp_path, {"other-service": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _is_stdio_configured("trusty-memory") is False
+
+    def test_returns_false_when_no_mcp_json(self, tmp_path, monkeypatch):
+        """Returns False (fail-safe) when no .mcp.json exists."""
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _is_stdio_configured("trusty-memory") is False
+
+    def test_returns_false_on_malformed_mcp_json(self, tmp_path, monkeypatch):
+        """Returns False (fail-safe) when .mcp.json is not valid JSON."""
+        bad = tmp_path / ".mcp.json"
+        bad.write_text("{ not valid json }", encoding="utf-8")
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _is_stdio_configured("trusty-memory") is False
+
+    # -----------------------------------------------------------------------
+    # get_trusty_status integration: stdio + health failure → still "on"
+    # -----------------------------------------------------------------------
+
+    def test_get_trusty_status_returns_on_for_stdio_when_health_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """get_trusty_status returns ('on', ...) for stdio service even when HTTP
+        health check fails — this is the critical regression test for the bug where
+        stdio-type MCP servers were shown as NOT RUNNING."""
+        _write_mcp_json(tmp_path, {"trusty-search": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
+            with patch(
+                "claude_mpm.services.trusty_status._cached_health_check",
+                return_value=False,
+            ):
+                state, line = get_trusty_status("trusty-search")
+        assert state == "on"
+        assert "trusty-search" in line
+
+    def test_get_trusty_status_line_contains_stdio_marker_when_health_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """When health fails but stdio is configured, the display line includes
+        '(stdio)' to indicate how the service is connected."""
+        _write_mcp_json(tmp_path, {"trusty-search": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
+            with patch(
+                "claude_mpm.services.trusty_status._cached_health_check",
+                return_value=False,
+            ):
+                state, line = get_trusty_status("trusty-search")
+        assert state == "on"
+        assert "(stdio)" in line
+
+    def test_get_trusty_status_returns_configured_when_not_stdio_and_health_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """get_trusty_status still returns 'configured' for non-stdio services
+        that fail the health check — the existing behaviour is preserved."""
+        _write_mcp_json(tmp_path, {"trusty-search": {"type": "sse", "url": "http://x"}})
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
+            with patch(
+                "claude_mpm.services.trusty_status._cached_health_check",
+                return_value=False,
+            ):
+                state, line = get_trusty_status("trusty-search")
+        assert state == "configured"
+        assert "not running" in line
+
+    def test_trusty_memory_on_stdio_without_http_includes_palace_info(
+        self, tmp_path, monkeypatch
+    ):
+        """When trusty-memory is stdio-connected but HTTP is unreachable, the
+        display line still includes 'palace:' information derived from cwd."""
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        _write_mcp_json(project_dir, {"trusty-memory": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: project_dir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
+            with patch(
+                "claude_mpm.services.trusty_status._cached_health_check",
+                return_value=False,
+            ):
+                with patch(
+                    "claude_mpm.services.trusty_status._load_config", return_value={}
+                ):
+                    state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "palace:" in line
+        assert "my-project" in line
+
+    def test_trusty_memory_on_stdio_without_http_has_stdio_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """When trusty-memory is stdio-connected and HTTP fails, line has '(stdio)'."""
+        project_dir = tmp_path / "demo"
+        project_dir.mkdir()
+        _write_mcp_json(project_dir, {"trusty-memory": {"type": "stdio"}})
+        monkeypatch.setattr(Path, "cwd", lambda: project_dir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("claude_mpm.services.trusty_status._is_present", return_value=True):
+            with patch(
+                "claude_mpm.services.trusty_status._cached_health_check",
+                return_value=False,
+            ):
+                with patch(
+                    "claude_mpm.services.trusty_status._load_config", return_value={}
+                ):
+                    state, line = get_trusty_status("trusty-memory")
+        assert state == "on"
+        assert "(stdio)" in line
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

trusty-memory (and other trusty services configured as stdio MCP servers) incorrectly showed 'NOT RUNNING' in the PM session prompt even when they were running and actively connected via stdio.

## Root Cause

Status detection relied on HTTP health checks. For stdio-configured MCP servers (which communicate via stdin/stdout), the HTTP probe fails, causing a false 'NOT RUNNING' status.

## Solution

Added `_is_stdio_configured(service)` helper to detect stdio-configured MCP servers. Updated `get_trusty_status()` to return status ('on', ...) for stdio-configured services even when HTTP health checks fail.

## Changes

- **src/claude_mpm/services/trusty_status.py** — add stdio detection helper + update status logic
- **tests/test_trusty_status_indicators.py** — new + updated test cases covering stdio detection (48 tests pass)

## Testing

All tests pass: `uv run pytest tests/test_trusty_status_indicators.py -v`
