### PR TITLE
feat(workflow): bake trusty-review into PR workflow (optional, inference-gated)

### DIFF
--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -82,6 +82,36 @@ Task:
     - Request reviews if needed
 ```
 
+## Code Review (If Available)
+
+After the PR is created and CI passes, the PM checks whether `trusty-review` is available before proceeding to squash-merge.
+
+### Availability Check
+
+Call `mcp__trusty-review__review_health`. Treat trusty-review as **available** if and only if:
+
+- `status == "ok"` AND
+- `reviewer_model` is set (non-empty string)
+
+If the health call throws an exception, returns a non-`ok` status, or returns an empty `reviewer_model`, skip the review step entirely — never block or warn the user about trusty-review being unavailable.
+
+> **Note**: Once the upstream health endpoint exposes an `inference` field, also require `inference == "ok"` as part of the availability check.
+
+### When Available
+
+The PM calls `mcp__trusty-review__review_pr(owner, repo, pr_number)` directly (PM has MCP tool access). Route the verdict as follows:
+
+| Verdict | Action |
+|---------|--------|
+| `APPROVE` or `APPROVE*` | Proceed to squash-merge |
+| `REQUEST_CHANGES` | Delegate findings to Engineer for remediation; re-run CI before merge |
+| `BLOCK` | Do not merge; escalate immediately to the user |
+| `UNKNOWN` or tool error | Fail open — proceed to squash-merge with a note that review was inconclusive |
+
+### When Unavailable
+
+Skip silently. Do not surface any message to the user about trusty-review being down. The PR workflow continues to squash-merge as normal.
+
 ## Common Patterns
 
 ### Single Feature PR

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -315,7 +315,7 @@ Final `git status` before session end.
 
 **[SKILL: mpm-pr-workflow]**
 
-No direct-to-main. Substantive work (feature/fix/refactor) is issue-first: create/reference a GitHub issue, branch off latest `main` (`feat/<issue>-<slug>`), implement + test, open PR (link issue), squash-merge after CI + QA pass, then delete the branch. Trivial docs/chore work skips the issue but still requires branch + PR + squash-merge. Direct-to-main is allowed ONLY for release tooling (`make release-*` version bumps, `chore: update uv.lock`). Delegate all branch/PR/merge operations to the Version Control agent.
+No direct-to-main. Substantive work (feature/fix/refactor) is issue-first: create/reference a GitHub issue, branch off latest `main` (`feat/<issue>-<slug>`), implement + test, open PR (link issue), squash-merge after CI + QA pass, then delete the branch. Trivial docs/chore work skips the issue but still requires branch + PR + squash-merge. Direct-to-main is allowed ONLY for release tooling (`make release-*` version bumps, `chore: update uv.lock`). Delegate all branch/PR/merge operations to the Version Control agent. If `trusty-review` MCP is available (health `status: ok` + `reviewer_model` set), call `review_pr` after CI passes and before squash-merge; APPROVE/APPROVE* proceeds, REQUEST_CHANGES remediates first, BLOCK escalates to user, errors fail open.
 
 ## Ticketing Integration
 


### PR DESCRIPTION
## Summary
- Adds optional `trusty-review` code review step to `mpm-pr-workflow` skill (both project-local and distributed copies)
- Availability gate: call `review_health` first; proceed only if `status == "ok"` and `reviewer_model` is set
- Verdict routing: APPROVE/APPROVE* → merge; REQUEST_CHANGES → remediate; BLOCK → escalate; errors fail open
- Updates `PM_INSTRUCTIONS.md` PR Workflow section with single-sentence summary
- Once `bobmatnyc/trusty-tools#719` ships an `inference` field, the availability check will also require `inference == "ok"`

## Test plan
- [ ] Verify skill content in `plugin/skills/mpm-pr-workflow/SKILL.md`
- [ ] Verify PM_INSTRUCTIONS.md PR Workflow section updated

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)