### PR TITLE
docs(skills): correct nonexistent /mpm-pause references to /mpm-session-pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2995,7 +2995,7 @@
 
 ### Feat
 
-- **skills**: add /mpm-pause skill for chat-accessible session saving
+- **skills**: add /mpm-session-pause skill for chat-accessible session saving
 
 ### Fix
 
@@ -5298,7 +5298,7 @@ Use direct MCP server integrations (mcp-ticketer, mcp-vector-search, etc.) inste
 
 ### Feat
 
-- **skills**: add /mpm-pause skill for chat-accessible session saving
+- **skills**: add /mpm-session-pause skill for chat-accessible session saving
 
 ### Fix
 

--- a/plugin/skills/mpm-session-pause/SKILL.md
+++ b/plugin/skills/mpm-session-pause/SKILL.md
@@ -7,7 +7,7 @@ category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 ---
 
-# /mpm-pause
+# /mpm-session-pause
 
 Pause the current session and save all work state for later resume.
 
@@ -23,14 +23,14 @@ When invoked, this skill:
 ## Usage
 
 ```
-/mpm-pause [optional message describing current work]
+/mpm-session-pause [optional message describing current work]
 ```
 
 **Examples:**
 ```
-/mpm-pause
-/mpm-pause Working on authentication refactor, about to test login flow
-/mpm-pause Need to context switch to urgent bug fix
+/mpm-session-pause
+/mpm-session-pause Working on authentication refactor, about to test login flow
+/mpm-session-pause Need to context switch to urgent bug fix
 ```
 
 ## Implementation
@@ -54,7 +54,7 @@ except ImportError:
     raise SystemExit(1)
 
 # Optional: Get message from user's command
-# If user provided message after /mpm-pause, extract it
+# If user provided message after /mpm-session-pause, extract it
 # Otherwise, message = None
 
 # Create session pause manager
@@ -150,22 +150,22 @@ should not be committed. No git commit is created by the pause operation.
 
 **Context switching:**
 ```
-/mpm-pause Switching to urgent production bug
+/mpm-session-pause Switching to urgent production bug
 ```
 
 **End of work session:**
 ```
-/mpm-pause Completed API refactor, ready for testing tomorrow
+/mpm-session-pause Completed API refactor, ready for testing tomorrow
 ```
 
 **Before major changes:**
 ```
-/mpm-pause Saving state before attempting risky refactor
+/mpm-session-pause Saving state before attempting risky refactor
 ```
 
 **When approaching context limit:**
 ```
-/mpm-pause Hit 150k tokens, starting fresh session
+/mpm-session-pause Hit 150k tokens, starting fresh session
 ```
 
 ## Related Commands

--- a/plugin/skills/mpm-session-resume/SKILL.md
+++ b/plugin/skills/mpm-session-resume/SKILL.md
@@ -149,7 +149,7 @@ else:
     if session_count == 0:
         print("No paused sessions found for this project in .claude-mpm/sessions/")
         print("")
-        print("To create a paused session, use: /mpm-pause")
+        print("To create a paused session, use: /mpm-session-pause")
     elif session_count > 1:
         # Show numbered list so the user can pick.
         print(helper.format_session_list())
@@ -168,7 +168,7 @@ else:
         if session_data is None:
             print("No paused sessions found for this project in .claude-mpm/sessions/")
             print("")
-            print("To create a paused session, use: /mpm-pause")
+            print("To create a paused session, use: /mpm-session-pause")
         else:
             session_id = session_data.get("session_id", "unknown")
             file_path = session_data.get("file_path")
@@ -228,7 +228,7 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 
 ## Related Commands
 
-- `/mpm-pause` - Pause current session and save state
+- `/mpm-session-pause` - Pause current session and save state
 - `/mpm-init resume` - Alternative resume entry point
 
 See `docs/features/session-auto-resume.md` for auto-pause behavior.

--- a/src/claude_mpm/services/cli/session_resume_helper.py
+++ b/src/claude_mpm/services/cli/session_resume_helper.py
@@ -645,7 +645,7 @@ class SessionResumeHelper:
         if not sessions:
             return (
                 "No saved sessions found in .claude-mpm/sessions/\n"
-                "\nTo create a session use: /mpm-pause"
+                "\nTo create a session use: /mpm-session-pause"
             )
 
         lines: list[str] = [
@@ -724,7 +724,7 @@ class SessionResumeHelper:
         if not sessions:
             return None, (
                 "No saved sessions found in .claude-mpm/sessions/\n"
-                "\nTo create a session use: /mpm-pause"
+                "\nTo create a session use: /mpm-session-pause"
             )
 
         # Try integer index when the selector looks like a small positive

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
@@ -8,7 +8,7 @@ tags: [mpm-command, session, pm-recommended]
 effort: medium
 ---
 
-# /mpm-pause
+# /mpm-session-pause
 
 Pause the current session and save all work state for later resume.
 
@@ -24,14 +24,14 @@ When invoked, this skill:
 ## Usage
 
 ```
-/mpm-pause [optional message describing current work]
+/mpm-session-pause [optional message describing current work]
 ```
 
 **Examples:**
 ```
-/mpm-pause
-/mpm-pause Working on authentication refactor, about to test login flow
-/mpm-pause Need to context switch to urgent bug fix
+/mpm-session-pause
+/mpm-session-pause Working on authentication refactor, about to test login flow
+/mpm-session-pause Need to context switch to urgent bug fix
 ```
 
 ## Implementation
@@ -55,7 +55,7 @@ except ImportError:
     raise SystemExit(1)
 
 # Optional: Get message from user's command
-# If user provided message after /mpm-pause, extract it
+# If user provided message after /mpm-session-pause, extract it
 # Otherwise, message = None
 
 # Create session pause manager
@@ -151,22 +151,22 @@ should not be committed. No git commit is created by the pause operation.
 
 **Context switching:**
 ```
-/mpm-pause Switching to urgent production bug
+/mpm-session-pause Switching to urgent production bug
 ```
 
 **End of work session:**
 ```
-/mpm-pause Completed API refactor, ready for testing tomorrow
+/mpm-session-pause Completed API refactor, ready for testing tomorrow
 ```
 
 **Before major changes:**
 ```
-/mpm-pause Saving state before attempting risky refactor
+/mpm-session-pause Saving state before attempting risky refactor
 ```
 
 **When approaching context limit:**
 ```
-/mpm-pause Hit 150k tokens, starting fresh session
+/mpm-session-pause Hit 150k tokens, starting fresh session
 ```
 
 ## Related Commands

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -155,7 +155,7 @@ else:
     if session_count == 0:
         print("No paused sessions found for this project in .claude-mpm/sessions/")
         print("")
-        print("To create a paused session, use: /mpm-pause")
+        print("To create a paused session, use: /mpm-session-pause")
     elif session_count > 1:
         # Show numbered list so the user can pick.
         print(helper.format_session_list())
@@ -174,7 +174,7 @@ else:
         if session_data is None:
             print("No paused sessions found for this project in .claude-mpm/sessions/")
             print("")
-            print("To create a paused session, use: /mpm-pause")
+            print("To create a paused session, use: /mpm-session-pause")
         else:
             session_id = session_data.get("session_id", "unknown")
             file_path = session_data.get("file_path")
@@ -234,7 +234,7 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 
 ## Related Commands
 
-- `/mpm-pause` - Pause current session and save state
+- `/mpm-session-pause` - Pause current session and save state
 - `/mpm-init resume` - Alternative resume entry point
 
 See `docs/features/session-auto-resume.md` for auto-pause behavior.

--- a/tests/test_session_resume_selection.py
+++ b/tests/test_session_resume_selection.py
@@ -56,7 +56,7 @@ class TestFormatSessionList:
         helper = SessionResumeHelper(project_path=tmp_path)
         result = helper.format_session_list()
         assert "No saved sessions" in result
-        assert "/mpm-pause" in result
+        assert "/mpm-session-pause" in result
 
     def test_single_session_appears_as_index_1(self, tmp_path: Path) -> None:
         sessions_dir = tmp_path / ".claude-mpm" / "sessions"


### PR DESCRIPTION
## Problem

The session pause/resume skill documentation (and a couple of helper output strings) referenced a slash command **`/mpm-pause`** that **does not exist**. The actual command shipped by this package is **`/mpm-session-pause`** — matching the skill's frontmatter `name: mpm-session-pause` and its directory. Users following the docs would invoke a nonexistent command.

## Fix

Replaced every bare `/mpm-pause` reference with `/mpm-session-pause`. This is a pure, word-boundary-safe string correction (`/mpm-session-pause` does not contain the `/mpm-pause` substring, so the replacement is idempotent and never produces `session-session-pause`). Frontmatter `name:` fields, the `/mpm-session-resume` command, and all Python identifiers were left untouched.

### Affected files (31 replacements)
- `src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md` — H1 title `# /mpm-pause` → `# /mpm-session-pause` + usage examples (10 occ)
- `src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md` — help output + related-commands (3 occ)
- `plugin/skills/mpm-session-pause/SKILL.md` — duplicated plugin copy, H1 + usage (10 occ)
- `plugin/skills/mpm-session-resume/SKILL.md` — duplicated plugin copy (3 occ)
- `src/claude_mpm/services/cli/session_resume_helper.py` — two user-facing "To create a session use:" help strings (2 occ)
- `tests/test_session_resume_selection.py` — assertion updated in lockstep with the helper output it validates (1 occ)
- `CHANGELOG.md` — two historical "add /mpm-pause skill" entries corrected to the real command name (2 occ)

### Verification
- `grep -rn "/mpm-pause"` (excluding correct `/mpm-session-pause`): **0 bare occurrences remain**
- `grep -rn "session-session-pause"`: **0 malformed strings**
- Frontmatter `name: mpm-session-pause` lines confirmed unchanged.

## Note

This supersedes the mis-filed issue **bobmatnyc/claude-mpm-skills#22** — that issue was opened against `claude-mpm-skills`, which has **zero** `/mpm-pause` matches. The buggy references actually live here in `claude-mpm` (the package that ships these skills). Issue #22 will be cross-referenced and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)