### PR TITLE
fix: size context circuit-breaker window dynamically per model (#642)

### DIFF
--- a/docs/specs/hooks.md
+++ b/docs/specs/hooks.md
@@ -607,36 +607,75 @@ hook subprocess.
 
 - **Inputs:** A `PreToolUse` hook event dict containing `session_id` and `cwd`.
 
-- **Outputs:** Non-empty dict `{"hookSpecificOutput": {"permissionDecision": "deny", ...}}`
-  when the breaker fires; empty dict `{}` when the breaker does not fire (pass-through).
+- **Outputs (post-#642 fix):**
+  - **At/above threshold, non-allowlisted tool:**
+    `{"permissionDecision": "allow", "permissionDecisionReason": "<warning text>"}`.
+    `"allow"` is the only documented non-blocking `permissionDecision` value.
+    `"warn"` is **not** a documented Claude Code value and is never emitted.
+    The warning text is always surfaced in `permissionDecisionReason`.
+    The session remains fully usable — this is an allow-with-warning, not a block.
+  - **Read-only / recovery tool (always, regardless of threshold):**
+    `{}` (unconditional pass-through, no warning).
+  - **Breaker disabled, threshold not reached, or fail-open:**
+    `{}` (pass-through).
 
-- **State source:** Reads `<cwd>/.claude-mpm/state/context-usage.json`. This file is
-  written by `ContextUsageTracker` in the `PostToolUse` handler.
+- **Dynamic context window (post-#642 fix):** The context-window ceiling is resolved
+  per model from `model_context_window.resolve_context_window()`.  1 M-context models
+  (Opus 4.x, Sonnet 4.5+) use a 1 M budget; older 200 K models use the 200 K default.
+  This prevents false-positive fires on large-context models.
 
-- **Threshold:** `CRITICAL_THRESHOLD = 95.0` (percent). Fires when
-  `state["percentage"] >= 95.0`.
+- **Percentage clamped at 100:** `percentage_used` values stored by older tracker
+  versions (which used a 200 K budget against a 1 M model) can exceed 100.  All
+  computed percentages are clamped to `[0, 100]` before evaluation.
+
+- **State source:** Reads `<cwd>/.claude-mpm/state/context-usage.json`. Written by
+  `ContextUsageTracker` on each Stop event.
+
+- **Threshold:** `CRITICAL_THRESHOLD = 95.0` (percent). Fires when the computed
+  percentage `>= 95.0`.  When raw token counts (`cumulative_input_tokens` +
+  `cumulative_output_tokens`) are present they are preferred over the stored
+  `percentage_used`; the dynamic model window is used for the recomputation.
+
+- **Always-allowed tools (`ALWAYS_ALLOWED_TOOLS`):** Read-only and recovery tools
+  (`Read`, `Grep`, `Glob`, `LS`, `NotebookRead`, `WebSearch`, `WebFetch`,
+  `mpm-resume`, `mpm-session-pause`, `mpm-compact`, `TodoRead`, `TodoWrite`,
+  `exit_plan_mode`) are **always** returned as `{}` (unconditional pass-through) even
+  when the threshold is exceeded.  This ensures a session at threshold can still
+  self-recover via `/compact` or `/mpm-resume`.
 
 - **Session-ID guard:** Only fires when `state["session_id"]` matches the current
   session ID (from event payload or `CLAUDE_SESSION_ID` env var). A stale state file
-  from a prior session does not trigger a block.
+  from a prior session does not trigger a warning.
 
-- **Fail-open cases:** Returns empty dict (no block) if the state file is missing,
-  unreadable, malformed JSON, or if the session IDs do not match. Returns empty dict
-  if the percentage is below the threshold.
+- **Disable switch:** The breaker can be fully bypassed via:
+  - Environment variable: `CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1` (or `true` / `yes` / `on`).
+  - Config key: `{"context_circuit_breaker": {"disabled": true}}` in
+    `.claude/settings.json`, `.claude/settings.local.json`, or `~/.claude/settings.json`.
+  The disable instructions are included in every warning message.
 
-- **`main()` entrypoint:** Wraps `evaluate()` in the `hookSpecificOutput` envelope
-  for standalone invocation. Not currently wired as a standalone hook in settings.json.
+- **Fail-open cases:** Returns `{}` (pass-through) if the state file is missing,
+  unreadable, malformed JSON, or if the session IDs do not match. Returns `{}` if the
+  percentage is below the threshold. Fail-open is intentional: a missed warning is far
+  less harmful than a false block that makes the session unrecoverable.
+
+- **`main()` entrypoint:** Wraps `evaluate()` in the `hookSpecificOutput` envelope for
+  standalone invocation.  Emits `{"hookSpecificOutput": {"permissionDecision": "allow",
+  "permissionDecisionReason": "..."}}` when the breaker fires; `{"continue": true}`
+  otherwise.
 
 - **Error conditions:** All file I/O failures are caught and treated as fail-open.
 
 ### Rationale (WHY)
 
-Prevents context window overflow that would cause Claude Code to silently drop earlier
-conversation context. The 95% threshold matches `ContextUsageTracker.THRESHOLDS["critical"]`
-to maintain a single source of truth for the critical threshold. Fail-open is
-intentional: false denials (blocking a session due to a stale or missing state file)
-are worse than false permits, because false denials require manual intervention while
-false permits merely allow one more tool call before the overflow.
+The pre-#642 breaker hard-blocked every tool call once tokens exceeded 95 % of a
+hardcoded 200 K ceiling.  On models with 1 M context windows (Opus 4.x, Sonnet 4.5+)
+this fired almost immediately and made sessions completely unrecoverable — even
+recovery tools like `/compact` were blocked.
+
+The fix makes the breaker warn-only (never hard-block), resolves the context-window
+dynamically per model, and always allows read-only / recovery tools through.  The
+`permissionDecision` value is `"allow"` (a documented Claude Code PreToolUse value) so
+the harness can surface the warning to the user while still proceeding.
 
 ### Implementing Modules
 
@@ -644,6 +683,7 @@ false permits merely allow one more tool call before the overflow.
 |-------------|----------|------|
 | `src/claude_mpm/hooks/context_circuit_breaker.py` | `evaluate` | Circuit breaker decision logic |
 | `src/claude_mpm/hooks/context_circuit_breaker.py` | `main` | Standalone entrypoint |
+| `src/claude_mpm/hooks/model_context_window.py` | `resolve_context_window` | Per-model context-window resolution |
 
 ---
 

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -189,11 +189,18 @@ class ToolHandler:
 
         :spec: SPEC-HOOKS-05~1
         """
-        # Context circuit-breaker: warn (not hard-block) when context >= 95%
-        # (issue #420, fixed in #642).  Read-only/recovery tools always pass
-        # through unconditionally.  Failures here must fail open — the breaker
-        # module already swallows errors internally, but we wrap the import too
-        # in case the module itself is unavailable.
+        # Context circuit-breaker: allow-with-warning (not hard-block) when
+        # context >= 95% (issue #420, fixed in #642).  Read-only/recovery
+        # tools always pass through unconditionally.  Failures here must fail
+        # open — the breaker module already swallows errors internally, but we
+        # wrap the import too in case the module itself is unavailable.
+        #
+        # IMPORTANT: a "deny" short-circuits immediately (only a legacy/future
+        # path — post-#642 the breaker never denies).  An "allow" + reason is a
+        # non-blocking warning: we stash the reason and let the rest of the
+        # pipeline run (model-tier injection / ztk rewriting) so Agent tool
+        # calls at high context still receive tier routing.  The warning is
+        # attached to the final response before returning.
         try:
             from claude_mpm.hooks import context_circuit_breaker
 
@@ -201,16 +208,21 @@ class ToolHandler:
         except Exception:
             cb_decision = {}
         cb_decision_type = cb_decision.get("permissionDecision")
-        if cb_decision_type in ("deny", "warn"):
+        _cb_warning_reason: str = ""
+        if cb_decision_type == "deny":
+            # Hard block — legacy path only; breaker post-#642 never denies.
             return {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
-                    "permissionDecision": cb_decision_type,
+                    "permissionDecision": "deny",
                     "permissionDecisionReason": cb_decision.get(
                         "permissionDecisionReason", ""
                     ),
                 }
             }
+        if cb_decision_type == "allow":
+            # Allow-with-warning: stash reason, continue pipeline.
+            _cb_warning_reason = cb_decision.get("permissionDecisionReason", "")
 
         # Model-tier injection (Agent calls) and ztk rewriting (Bash calls).
         # These were previously handled by the pretooluse_dispatcher subprocess;
@@ -224,6 +236,8 @@ class ToolHandler:
         # Both functions are fail-open: they return {"continue": True} on any
         # error or non-matching input, so we only short-circuit when there is
         # actual work to do (model injection or ztk rewrite).
+        # When a circuit-breaker warning is pending we attach it to the
+        # response before returning so it is not silently dropped.
         _tool_name_early = event.get("tool_name", "")
         if _tool_name_early == "Agent":
             try:
@@ -232,9 +246,13 @@ class ToolHandler:
                 _tier_response = build_model_tier_response(event)
                 if _tier_response.get("hookSpecificOutput"):
                     # Model was injected; return immediately so the modified
-                    # tool_input reaches Claude Code.  Dashboard observability
-                    # for this call is intentionally skipped (low-value for
-                    # model-routing events; keeps the hot path fast).
+                    # tool_input reaches Claude Code.  Attach warning if any.
+                    if _cb_warning_reason:
+                        _hso = _tier_response["hookSpecificOutput"]
+                        if isinstance(_hso, dict) and not _hso.get(
+                            "permissionDecisionReason"
+                        ):
+                            _hso["permissionDecisionReason"] = _cb_warning_reason
                     return _tier_response
             except Exception as _e:
                 if DEBUG:
@@ -246,6 +264,12 @@ class ToolHandler:
                 _ztk_response = build_ztk_response(event)
                 if _ztk_response.get("hookSpecificOutput"):
                     # ztk rewrote the command; return the modified tool_input.
+                    if _cb_warning_reason:
+                        _hso = _ztk_response["hookSpecificOutput"]
+                        if isinstance(_hso, dict) and not _hso.get(
+                            "permissionDecisionReason"
+                        ):
+                            _hso["permissionDecisionReason"] = _cb_warning_reason
                     return _ztk_response
             except Exception as _e:
                 if DEBUG:
@@ -333,8 +357,18 @@ class ToolHandler:
                     f"  - Emitted todo_updated event with {len(tool_params['todos'])} todos for session {session_id[:8]}..."
                 )
 
-        # Normal path: no input modification, no deny -- caller treats this
-        # as a plain "continue" (see hook_handler._route_event return logic).
+        # Normal path: no input modification, no deny.
+        # If the circuit breaker fired an allow-with-warning and this is not
+        # an Agent/Bash call (those attach it above), surface the warning now.
+        if _cb_warning_reason:
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": _cb_warning_reason,
+                }
+            }
+        # Caller treats None as a plain "continue" (see hook_handler._route_event).
         return None
 
     def _handle_task_delegation(

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -189,23 +189,23 @@ class ToolHandler:
 
         :spec: SPEC-HOOKS-05~1
         """
-        # Context circuit-breaker: deny tool calls when context >= 95% (issue
-        # #420).  Run BEFORE any other PreToolUse work so a critical-context
-        # session aborts cleanly instead of doing extra observability work
-        # that pushes us further over the limit.  Failures here must fail
-        # open -- the breaker module already swallows errors internally, but
-        # we wrap the import too in case the module itself is unavailable.
+        # Context circuit-breaker: warn (not hard-block) when context >= 95%
+        # (issue #420, fixed in #642).  Read-only/recovery tools always pass
+        # through unconditionally.  Failures here must fail open — the breaker
+        # module already swallows errors internally, but we wrap the import too
+        # in case the module itself is unavailable.
         try:
             from claude_mpm.hooks import context_circuit_breaker
 
             cb_decision = context_circuit_breaker.evaluate(event)
         except Exception:
             cb_decision = {}
-        if cb_decision.get("permissionDecision") == "deny":
+        cb_decision_type = cb_decision.get("permissionDecision")
+        if cb_decision_type in ("deny", "warn"):
             return {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
+                    "permissionDecision": cb_decision_type,
                     "permissionDecisionReason": cb_decision.get(
                         "permissionDecisionReason", ""
                     ),

--- a/src/claude_mpm/hooks/context_circuit_breaker.py
+++ b/src/claude_mpm/hooks/context_circuit_breaker.py
@@ -17,9 +17,11 @@ almost immediately and made sessions completely unrecoverable.  The fix:
 2. **Percentage clamped at 100** — ``percentage_used`` read from the state file
    can exceed 100 when a prior version wrote it with the wrong budget; we cap
    it before evaluation so display values are always sane.
-3. **Warn instead of hard-block** — the breaker no longer returns
-   ``permissionDecision: deny`` for regular tool calls.  It emits a warning
-   annotation and passes through, preserving session usability.
+3. **Allow-with-warning instead of hard-block** — the breaker no longer
+   returns ``permissionDecision: deny`` for regular tool calls.  It emits
+   ``permissionDecision: "allow"`` (the only documented non-blocking value)
+   with the warning text in ``permissionDecisionReason``, preserving session
+   usability.  "warn" is not a documented PreToolUse value and was removed.
 4. **Always allow read-only / recovery tools** — the tools listed in
    ``ALWAYS_ALLOWED_TOOLS`` pass through unconditionally, even if the threshold
    is exceeded and warnings are suppressed for them.
@@ -233,9 +235,12 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
     """Evaluate the breaker against the current event.
 
     Returns a ``hookSpecificOutput``-shaped dict when the breaker fires a
-    *warning*, and an empty dict otherwise.  A warning no longer results in a
-    ``deny`` decision — it is surfaced as a ``permissionDecision: warn`` so
-    the harness can show the message while still allowing the tool call.
+    *warning*, and an empty dict otherwise.  At/above threshold the decision
+    is ``permissionDecision: "allow"`` (a documented PreToolUse value) with
+    the warning text in ``permissionDecisionReason``.  This is the only
+    non-empty decision this function can emit — "deny" and "warn" are never
+    returned (the former was the pre-#642 behavior; the latter is not a
+    documented Claude Code value and could be treated as an error).
 
     Read-only and recovery tools (``ALWAYS_ALLOWED_TOOLS``) are never warned
     against and always return an empty dict (unconditional pass-through).
@@ -278,9 +283,12 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
         f"To disable this warning: set {_DISABLE_ENV_VAR}=1 or add "
         f'"{_CONFIG_KEY}": {{"disabled": true}} to .claude/settings.json.'
     )
-    # Return a warning, NOT a deny — the session remains usable.
+    # Return allow-with-warning — "allow" is a documented PreToolUse value;
+    # "warn" is NOT documented and risks being treated as deny/error.
+    # The warning text is carried in permissionDecisionReason so the harness
+    # can surface it while still letting the tool call proceed.
     return {
-        "permissionDecision": "warn",
+        "permissionDecision": "allow",
         "permissionDecisionReason": reason,
     }
 
@@ -305,11 +313,13 @@ def main() -> None:
     decision = evaluate(event)
     decision_type = decision.get("permissionDecision")
 
-    if decision_type in ("deny", "warn"):
+    # evaluate() only ever returns "allow" (allow-with-warning) or nothing ({}
+    # → pass-through).  "deny" and "warn" are never emitted post-#642 fix.
+    if decision_type == "allow":
         payload = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
-                "permissionDecision": decision_type,
+                "permissionDecision": "allow",
                 "permissionDecisionReason": decision.get(
                     "permissionDecisionReason", ""
                 ),

--- a/src/claude_mpm/hooks/context_circuit_breaker.py
+++ b/src/claude_mpm/hooks/context_circuit_breaker.py
@@ -1,30 +1,54 @@
-"""PreToolUse circuit-breaker: deny tool calls when context >= CRITICAL threshold.
+"""PreToolUse context circuit breaker — warn (not hard-block) when context nears full.
 
-When the running session's context window is at or above the critical threshold
-(>=95%), every additional tool call risks pushing the conversation past the
-hard limit and dropping prior context.  This hook returns a ``deny`` decision
-so the harness blocks the call and surfaces a wrap-up message to the user.
+WHAT: Reads cumulative context-usage state from the per-session state file and
+emits a *warning* annotation when the session's context exceeds a critical
+threshold.  Read-only and recovery tools are always allowed through, so a
+session that has hit the threshold can still self-recover via /compact, Read,
+Grep, or /mpm-resume.
+
+WHY: Prior to this fix (issue #642) the breaker hard-blocked every tool call
+once the token count exceeded 95 % of a *hardcoded* 200 K ceiling.  On models
+with 1 M context windows (Opus 4.x, large-context Sonnet 4.5+) this fired
+almost immediately and made sessions completely unrecoverable.  The fix:
+
+1. **Dynamic context window** — the ceiling is resolved from the active model id
+   (via :mod:`claude_mpm.hooks.model_context_window`) so 1 M-context models are
+   never compared against a 200 K budget.
+2. **Percentage clamped at 100** — ``percentage_used`` read from the state file
+   can exceed 100 when a prior version wrote it with the wrong budget; we cap
+   it before evaluation so display values are always sane.
+3. **Warn instead of hard-block** — the breaker no longer returns
+   ``permissionDecision: deny`` for regular tool calls.  It emits a warning
+   annotation and passes through, preserving session usability.
+4. **Always allow read-only / recovery tools** — the tools listed in
+   ``ALWAYS_ALLOWED_TOOLS`` pass through unconditionally, even if the threshold
+   is exceeded and warnings are suppressed for them.
+5. **Disable switch** — set the ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1`` env
+   var or the ``context_circuit_breaker.disabled`` config key to fully bypass
+   this module.  The disable instructions are included in the warning message.
 
 State source
 ------------
 The cumulative context-usage state is written by
 :class:`claude_mpm.services.infrastructure.context_usage_tracker.ContextUsageTracker`
-to ``<cwd>/.claude-mpm/state/context-usage.json``.  That same file is read by
-:mod:`claude_mpm.hooks.claude_hooks.auto_pause_handler` and is the only
-cross-process source of context state available to the hook subprocess (the
-SDK-mode ``MonitorAgent`` keeps its tracker in-memory only).
+to ``<cwd>/.claude-mpm/state/context-usage.json``.
 
 Fail-open policy
 ----------------
-If the state file is missing, unreadable, or malformed -- or if the recorded
-``session_id`` doesn't match the current session -- the breaker returns an
-empty dict (pass-through).  False denials are far worse than missed denials:
-the worst case for fail-open is the existing behavior; the worst case for
-fail-closed is bricking the session on a stale state file from a prior run.
+If the state file is missing, unreadable, or malformed the breaker returns an
+empty dict (pass-through).  False positives (blocking a session unnecessarily)
+are far worse than a missed warning.
+
+Disable switch
+--------------
+Set ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1`` (or ``true`` / ``yes``) in the
+environment **or** add ``"context_circuit_breaker": {"disabled": true}`` to
+``.claude/settings.json`` to fully disable this module.
 
 References
 ----------
 SPEC-HOOKS-11~1 : docs/specs/hooks.md#SPEC-HOOKS-11~1
+GitHub issue #642
 """
 
 from __future__ import annotations
@@ -34,17 +58,108 @@ import os
 from pathlib import Path
 from typing import Any
 
-# Critical threshold (percentage).  Mirrors
-# ``ContextUsageTracker.THRESHOLDS["critical"]`` (0.95 -> 95%).
+from claude_mpm.hooks.model_context_window import (
+    resolve_context_window,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Threshold (percentage) above which the warning fires.
+# Mirrors ``ContextUsageTracker.THRESHOLDS["critical"]`` (0.95 → 95 %).
 CRITICAL_THRESHOLD: float = 95.0
 
+# Tools that are always allowed through — even above the critical threshold.
+# These are read-only / recovery / navigation tools that a user needs to be
+# able to run in order to self-recover from a full context window.
+ALWAYS_ALLOWED_TOOLS: frozenset[str] = frozenset(
+    {
+        # Read-only file tools
+        "Read",
+        "Glob",
+        "Grep",
+        "LS",
+        "NotebookRead",
+        # Web retrieval (needed to fetch docs during recovery)
+        "WebSearch",
+        "WebFetch",
+        # Session management / recovery skills
+        "mpm-resume",
+        "mpm-session-pause",
+        "mpm-compact",
+        # Claude Code built-ins
+        "TodoRead",
+        "TodoWrite",
+        "exit_plan_mode",
+    }
+)
+
 _STATE_FILE_RELATIVE = Path(".claude-mpm") / "state" / "context-usage.json"
+
+# Environment variable name for the disable switch.
+_DISABLE_ENV_VAR = "CLAUDE_MPM_DISABLE_CONTEXT_BREAKER"
+
+# Config key path inside .claude/settings.json for the disable switch.
+# JSON path: {"context_circuit_breaker": {"disabled": true}}
+_CONFIG_KEY = "context_circuit_breaker"
+_CONFIG_DISABLED_FIELD = "disabled"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_disabled(cwd: str) -> bool:
+    """Return True if the circuit breaker has been explicitly disabled.
+
+    Checks, in order:
+    1. ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER`` env var (any truthy value).
+    2. ``context_circuit_breaker.disabled`` in .claude/settings.json.
+    3. ``context_circuit_breaker.disabled`` in ~/.claude/settings.json.
+    """
+    env_val = os.environ.get(_DISABLE_ENV_VAR, "").strip().lower()
+    if env_val in ("1", "true", "yes", "on"):
+        return True
+
+    # Check project and global settings files.
+    settings_candidates: list[Path] = []
+    if cwd:
+        settings_candidates.extend(
+            [
+                Path(cwd) / ".claude" / "settings.local.json",
+                Path(cwd) / ".claude" / "settings.json",
+            ]
+        )
+    settings_candidates.append(Path.home() / ".claude" / "settings.json")
+
+    for settings_path in settings_candidates:
+        try:
+            if not settings_path.is_file():
+                continue
+            with settings_path.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            cb_config = data.get(_CONFIG_KEY)
+            if isinstance(cb_config, dict):
+                disabled_val = cb_config.get(_CONFIG_DISABLED_FIELD, False)
+                if disabled_val is True or str(disabled_val).lower() in (
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                ):
+                    return True
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+
+    return False
 
 
 def _load_state(cwd: str) -> dict[str, Any] | None:
     """Read context-usage state from disk.
 
-    Returns ``None`` when the file is missing, unreadable, or malformed --
+    Returns ``None`` when the file is missing, unreadable, or malformed —
     the breaker treats all of those cases as fail-open.
     """
     if not cwd:
@@ -73,33 +188,84 @@ def _current_session_id(event: dict[str, Any]) -> str | None:
     return None
 
 
+def _compute_percentage(state: dict[str, Any]) -> float | None:
+    """Compute context usage percentage from state, clamped to [0, 100].
+
+    The ``percentage_used`` field may have been written by an older version of
+    the tracker that used a hardcoded 200 K budget against a 1 M-context model.
+    That can produce values well above 100.  We clamp the displayed value and,
+    more importantly, recompute from raw token counts when the active model's
+    real window is larger than the stored budget.
+
+    Returns ``None`` when the percentage cannot be determined (fail-open).
+    """
+    # Prefer recomputing from raw tokens if available, using the real window.
+    cumulative_input = state.get("cumulative_input_tokens")
+    cumulative_output = state.get("cumulative_output_tokens")
+
+    if isinstance(cumulative_input, (int, float)) and isinstance(
+        cumulative_output, (int, float)
+    ):
+        total_tokens = float(cumulative_input) + float(cumulative_output)
+        # Resolve context window for the active model.
+        context_window = resolve_context_window()
+        raw_pct = (total_tokens / context_window) * 100.0
+        return min(raw_pct, 100.0)
+
+    # Fall back to the stored percentage_used field.
+    percentage_raw = state.get("percentage_used")
+    if percentage_raw is None:
+        return None
+    try:
+        percentage = float(percentage_raw)
+    except (TypeError, ValueError):
+        return None
+    # Clamp to [0, 100] regardless of what was stored.
+    return min(max(percentage, 0.0), 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 def evaluate(event: dict[str, Any]) -> dict[str, Any]:
     """Evaluate the breaker against the current event.
 
-    Returns a ``hookSpecificOutput``-shaped dict when the breaker fires, and
-    an empty dict otherwise.  Callers should treat any non-empty result as
-    "emit this and stop processing".
+    Returns a ``hookSpecificOutput``-shaped dict when the breaker fires a
+    *warning*, and an empty dict otherwise.  A warning no longer results in a
+    ``deny`` decision — it is surfaced as a ``permissionDecision: warn`` so
+    the harness can show the message while still allowing the tool call.
+
+    Read-only and recovery tools (``ALWAYS_ALLOWED_TOOLS``) are never warned
+    against and always return an empty dict (unconditional pass-through).
 
     :spec: SPEC-HOOKS-11~1
     """
     cwd = event.get("cwd", "") or ""
+
+    # Unconditional allow for read-only / recovery tools.
+    tool_name = str(event.get("tool_name") or "")
+    if tool_name in ALWAYS_ALLOWED_TOOLS:
+        return {}
+
+    # Disable switch check.
+    if _is_disabled(cwd):
+        return {}
+
     state = _load_state(cwd)
     if state is None:
         return {}
 
-    # Session-ID guard: only block when the persisted state belongs to the
-    # current session.  Stale state from a prior run must not deny live work.
+    # Session-ID guard: only warn when the persisted state belongs to the
+    # current session.  Stale state from a prior run must not affect live work.
     current_sid = _current_session_id(event)
     state_sid = state.get("session_id")
     if current_sid is not None and state_sid and state_sid != current_sid:
         return {}
 
-    percentage_raw = state.get("percentage_used")
-    if percentage_raw is None:
-        return {}
-    try:
-        percentage = float(percentage_raw)
-    except (TypeError, ValueError):
+    percentage = _compute_percentage(state)
+    if percentage is None:
         return {}
 
     if percentage < CRITICAL_THRESHOLD:
@@ -107,11 +273,14 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
 
     pct_display = round(percentage)
     reason = (
-        f"Context at {pct_display}% — session paused to prevent data loss. "
-        "Use /mpm-resume or start a new session."
+        f"Context at {pct_display}% — approaching session limit. "
+        "Consider running /compact or starting a new session via /mpm-resume. "
+        f"To disable this warning: set {_DISABLE_ENV_VAR}=1 or add "
+        f'"{_CONFIG_KEY}": {{"disabled": true}} to .claude/settings.json.'
     )
+    # Return a warning, NOT a deny — the session remains usable.
     return {
-        "permissionDecision": "deny",
+        "permissionDecision": "warn",
         "permissionDecisionReason": reason,
     }
 
@@ -120,9 +289,8 @@ def main() -> None:
     """Entry point when invoked as ``python3 -m claude_mpm.hooks.context_circuit_breaker``.
 
     Reads a hook event from stdin, evaluates the breaker, and emits either a
-    deny decision wrapped in ``hookSpecificOutput`` or a pass-through
-    ``{"continue": true}`` payload.  Any failure short-circuits to pass-through
-    (fail-open).
+    warning annotation or a pass-through ``{"continue": true}`` payload.
+    Any failure short-circuits to pass-through (fail-open).
     """
     import sys
 
@@ -135,11 +303,13 @@ def main() -> None:
         return
 
     decision = evaluate(event)
-    if decision.get("permissionDecision") == "deny":
+    decision_type = decision.get("permissionDecision")
+
+    if decision_type in ("deny", "warn"):
         payload = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
+                "permissionDecision": decision_type,
                 "permissionDecisionReason": decision.get(
                     "permissionDecisionReason", ""
                 ),

--- a/src/claude_mpm/hooks/model_context_window.py
+++ b/src/claude_mpm/hooks/model_context_window.py
@@ -112,8 +112,13 @@ def resolve_context_window(model_id: str | None = None) -> int:
         return CONTEXT_WINDOW_MAP[lower]
 
     # 2. Prefix match — handles dated variants like "claude-opus-4-6-20260101".
+    # Require a delimiter boundary ("-") after the prefix so that a future
+    # "claude-sonnet-4-50" does not accidentally match "claude-sonnet-4-5"
+    # (1 M window).  We match only when lower == prefix (already handled above
+    # by the exact-match branch, kept here as a safety net) or when the next
+    # character after the prefix is "-".
     for prefix, window in CONTEXT_WINDOW_MAP.items():
-        if lower.startswith(prefix):
+        if lower == prefix or lower.startswith(prefix + "-"):
             return window
 
     # 3. Unknown model — return conservative default.

--- a/src/claude_mpm/hooks/model_context_window.py
+++ b/src/claude_mpm/hooks/model_context_window.py
@@ -1,0 +1,157 @@
+"""Model-to-context-window resolution for the context circuit breaker.
+
+WHAT: Maps active model identifiers to their real context-window sizes so the
+circuit breaker computes context usage as a fraction of the *actual* window
+rather than a hardcoded 200 K default.
+
+WHY: Claude Opus 4.x and selected Sonnet 4.x variants ship with a 1 M-token
+context window.  Dividing cumulative token counts by a hardcoded 200_000 ceiling
+causes those models to report > 100 % usage almost immediately, which fires the
+circuit breaker on every tool call — including recovery tools — and makes the
+session unrecoverable (GitHub issue #642).
+
+Model-ID resolution order
+-------------------------
+1. ``ANTHROPIC_MODEL`` environment variable (set by claude-mpm or user).
+2. Project ``.claude/settings.local.json`` → ``model`` key.
+3. Project ``.claude/settings.json`` → ``model`` key.
+4. Global ``~/.claude/settings.json`` → ``model`` key.
+5. Conservative default: ``DEFAULT_CONTEXT_WINDOW`` (200_000).
+
+The resolution is intentionally cheap: no heavy imports, no I/O beyond a
+small JSON settings read.  It is called from the PreToolUse hot path.
+
+Extending the map
+-----------------
+Add entries to ``CONTEXT_WINDOW_MAP`` using the *model id prefix* as the key
+(everything before the date suffix / patch version).  Exact ids are matched
+first; prefix matching handles versioned variants automatically.
+
+    CONTEXT_WINDOW_MAP["claude-new-model-X-Y"] = 2_000_000
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Context-window map
+# ---------------------------------------------------------------------------
+
+# Default for unknown / legacy models (conservative so the breaker can still
+# fire on genuine 200K models even when the model is not in the map).
+DEFAULT_CONTEXT_WINDOW: Final[int] = 200_000
+
+# 1 M-token context window (Opus 4.x and large-context Sonnet variants).
+_1M: Final[int] = 1_000_000
+
+# Map of model-id prefix -> context window in tokens.
+# Keys are lowercase, no trailing date/version suffix.
+# Ordering: more-specific keys must come before generic ones — Python dicts
+# are insertion-ordered (Python 3.7+), and the resolver iterates top-to-bottom.
+CONTEXT_WINDOW_MAP: dict[str, int] = {
+    # -----------------------------------------------------------------------
+    # Opus 4.x — 1 M context window
+    # -----------------------------------------------------------------------
+    "claude-opus-4": _1M,
+    # -----------------------------------------------------------------------
+    # Sonnet 4.x — 1 M context window for 4.5+ variants
+    # -----------------------------------------------------------------------
+    "claude-sonnet-4-5": _1M,
+    "claude-sonnet-4-6": _1M,
+    "claude-sonnet-4-7": _1M,
+    # Sonnet 4.0 / 4.1 / 4.4 remain at 200 K
+    "claude-sonnet-4": DEFAULT_CONTEXT_WINDOW,
+    # -----------------------------------------------------------------------
+    # Haiku 4.x — 200 K context window (may be updated as announced)
+    # -----------------------------------------------------------------------
+    "claude-haiku-4": DEFAULT_CONTEXT_WINDOW,
+    # -----------------------------------------------------------------------
+    # Claude 3.x — 200 K context window
+    # -----------------------------------------------------------------------
+    "claude-3-7-sonnet": DEFAULT_CONTEXT_WINDOW,
+    "claude-3-5-sonnet": DEFAULT_CONTEXT_WINDOW,
+    "claude-3-5-haiku": DEFAULT_CONTEXT_WINDOW,
+    "claude-3-opus": DEFAULT_CONTEXT_WINDOW,
+    "claude-3-sonnet": DEFAULT_CONTEXT_WINDOW,
+    "claude-3-haiku": DEFAULT_CONTEXT_WINDOW,
+    # -----------------------------------------------------------------------
+    # Short aliases (used in settings.json / ANTHROPIC_MODEL)
+    # -----------------------------------------------------------------------
+    "opus": _1M,  # bare alias assumed to refer to the latest Opus (1 M)
+    "sonnet": DEFAULT_CONTEXT_WINDOW,
+    "haiku": DEFAULT_CONTEXT_WINDOW,
+}
+
+
+def resolve_context_window(model_id: str | None = None) -> int:
+    """Return the context-window size (in tokens) for *model_id*.
+
+    Falls back to ``DEFAULT_CONTEXT_WINDOW`` when the model is unknown.
+
+    Args:
+        model_id: Raw model identifier (e.g. ``"claude-opus-4-6-20260101"``).
+            Pass ``None`` to trigger env-var / settings-file resolution.
+
+    Returns:
+        Integer token count for the model's context window.
+    """
+    if model_id is None:
+        model_id = _detect_active_model()
+
+    if not model_id:
+        return DEFAULT_CONTEXT_WINDOW
+
+    lower = model_id.lower().strip()
+
+    # 1. Exact match (fastest path for known identifiers).
+    if lower in CONTEXT_WINDOW_MAP:
+        return CONTEXT_WINDOW_MAP[lower]
+
+    # 2. Prefix match — handles dated variants like "claude-opus-4-6-20260101".
+    for prefix, window in CONTEXT_WINDOW_MAP.items():
+        if lower.startswith(prefix):
+            return window
+
+    # 3. Unknown model — return conservative default.
+    return DEFAULT_CONTEXT_WINDOW
+
+
+def _detect_active_model() -> str | None:
+    """Probe env vars and Claude settings files for the active model id.
+
+    Returns the first non-empty model string found, or ``None`` when nothing
+    is configured.
+    """
+    # 1. ANTHROPIC_MODEL env var (highest priority — set by claude-mpm config).
+    env_model = os.environ.get("ANTHROPIC_MODEL", "").strip()
+    if env_model:
+        return env_model
+
+    # 2. CLAUDE_MODEL env var (secondary env-based override).
+    env_model2 = os.environ.get("CLAUDE_MODEL", "").strip()
+    if env_model2:
+        return env_model2
+
+    # 3-5. Claude settings files (project-local first, then global).
+    cwd = os.environ.get("CLAUDE_HOOK_CWD", "") or str(Path.cwd())
+    settings_paths = [
+        Path(cwd) / ".claude" / "settings.local.json",
+        Path(cwd) / ".claude" / "settings.json",
+        Path.home() / ".claude" / "settings.json",
+    ]
+    for settings_path in settings_paths:
+        try:
+            if settings_path.is_file():
+                with settings_path.open(encoding="utf-8") as fh:
+                    data = json.load(fh)
+                model_val = str(data.get("model", "")).strip()
+                if model_val:
+                    return model_val
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+
+    return None

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -21,13 +21,15 @@ Processing order
 ----------------
 1. Parse the event from stdin.  On any failure, emit pass-through (fail-open).
 2. Route ``PermissionRequest`` events to the permission policy engine.
-3. For ``PreToolUse``: run the context circuit breaker FIRST.  It now emits
-   warnings rather than hard denials; read-only/recovery tools always pass
-   through.  If it denies (legacy path), stop immediately.
+3. For ``PreToolUse``: run the context circuit breaker.  It now emits
+   ``permissionDecision: "allow"`` with a warning reason (not a hard block).
+   A non-blocking allow-with-warning must NOT interrupt the dispatch pipeline —
+   model-tier injection / ztk rewriting must still run.  Only an actual
+   ``permissionDecision: "deny"`` short-circuits immediately.
 4. Branch on ``tool_name``:
-   * ``Agent`` -> model tier injection.
-   * ``Bash``  -> ztk rewrite.
-   * anything else -> ``{"continue": true}``.
+   * ``Agent`` -> model tier injection (warning attached if present).
+   * ``Bash``  -> ztk rewrite (warning attached if present).
+   * anything else -> pass-through (with allow+reason if breaker fired).
 
 Fail-open policy
 ----------------
@@ -49,25 +51,54 @@ def _passthrough() -> dict[str, Any]:
     return {"continue": True}
 
 
-def _circuit_breaker_response(decision: dict[str, Any]) -> dict[str, Any]:
-    """Wrap a circuit-breaker decision in the PreToolUse wire format.
+def _circuit_breaker_deny_response(decision: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a circuit-breaker *deny* decision in the PreToolUse wire format.
 
-    Supports both ``deny`` (blocks the call) and ``warn`` (shows a message
-    but allows the call through).
+    Only called when ``permissionDecision`` is ``"deny"``.  Allow-with-warning
+    decisions (``"allow"``) do NOT short-circuit; they continue through the
+    dispatch pipeline so model-tier injection / ztk rewriting still runs.
     """
-    decision_type = decision.get("permissionDecision", "deny")
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": decision_type,
+            "permissionDecision": "deny",
             "permissionDecisionReason": decision.get("permissionDecisionReason", ""),
         }
     }
 
 
-# Keep the old name as an alias for backward compatibility with any external
-# callers that imported it directly (unlikely but safe to preserve).
-_circuit_breaker_deny_response = _circuit_breaker_response
+def _merge_warning_into_response(
+    response: dict[str, Any], warning_reason: str
+) -> dict[str, Any]:
+    """Attach a circuit-breaker warning reason to an existing hook response.
+
+    The warning is carried in ``permissionDecisionReason`` inside
+    ``hookSpecificOutput``.  If the response already has a
+    ``hookSpecificOutput`` dict we inject there; otherwise we build a minimal
+    allow-with-reason envelope so the harness can surface the message.
+    """
+    if not warning_reason:
+        return response
+
+    hso = response.get("hookSpecificOutput")
+    if isinstance(hso, dict):
+        # Existing hookSpecificOutput: inject reason if not already set.
+        if not hso.get("permissionDecisionReason"):
+            hso["permissionDecisionReason"] = warning_reason
+        # Ensure the decision is at least allow if none is set.
+        if not hso.get("permissionDecision"):
+            hso["permissionDecision"] = "allow"
+        return response
+
+    # No hookSpecificOutput yet: build a minimal allow-with-reason wrapper,
+    # preserving any top-level keys the caller already set (e.g. "continue").
+    merged = dict(response)
+    merged["hookSpecificOutput"] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "permissionDecisionReason": warning_reason,
+    }
+    return merged
 
 
 def dispatch(event: dict[str, Any]) -> dict[str, Any]:
@@ -87,23 +118,33 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
         if hook_event == "PermissionRequest":
             return model_tier_hook.build_permission_request_response(event)
 
-        # Context circuit breaker runs first.  It now emits warnings (not hard
-        # denials) for critical context levels, and always passes read-only /
-        # recovery tools through unconditionally (issue #642).
+        # Context circuit breaker runs first.  It emits either:
+        #   - "deny" → hard block (short-circuit immediately).
+        #   - "allow" + reason → allow-with-warning (do NOT short-circuit;
+        #     model-tier injection / ztk rewriting must still run so Agent
+        #     calls at high context still get tier routing).
+        #   - {} → no-op pass-through.
         breaker_decision = context_circuit_breaker.evaluate(event)
         decision_type = breaker_decision.get("permissionDecision")
-        if decision_type in ("deny", "warn"):
-            # deny → block the call; warn → show message but allow the call.
-            return _circuit_breaker_response(breaker_decision)
+        warning_reason: str = ""
+        if decision_type == "deny":
+            # Hard block — only legacy path; breaker post-#642 never denies.
+            return _circuit_breaker_deny_response(breaker_decision)
+        if decision_type == "allow":
+            # Allow-with-warning: stash the reason, continue the pipeline.
+            warning_reason = breaker_decision.get("permissionDecisionReason", "")
 
         # Branch on the tool being invoked.
         tool_name = event.get("tool_name", "")
         if tool_name == "Agent":
-            return model_tier_hook.build_model_tier_response(event)
+            response = model_tier_hook.build_model_tier_response(event)
+            return _merge_warning_into_response(response, warning_reason)
         if tool_name == "Bash":
-            return ztk_hook.build_ztk_response(event)
+            response = ztk_hook.build_ztk_response(event)
+            return _merge_warning_into_response(response, warning_reason)
 
-        return _passthrough()
+        base = _passthrough()
+        return _merge_warning_into_response(base, warning_reason)
     except Exception:
         # Fail-open: a hook crash must never block a tool call.
         return _passthrough()

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -6,7 +6,8 @@ every PreToolUse event:
 
 * ``model_tier_hook``       — injects a model tier into ``Agent`` tool calls.
 * ``ztk_hook``              — rewrites ``Bash`` commands through ztk compression.
-* ``context_circuit_breaker`` — denies all tool calls when context >= 95%.
+* ``context_circuit_breaker`` — warns (not hard-blocks) when context >= 95%;
+  read-only/recovery tools are always allowed through (issue #642).
 * ``claude-hook``           — the full handler (dashboard, memory, auto-pause).
 
 Spawning four Python interpreters per tool call adds significant latency.  This
@@ -20,9 +21,9 @@ Processing order
 ----------------
 1. Parse the event from stdin.  On any failure, emit pass-through (fail-open).
 2. Route ``PermissionRequest`` events to the permission policy engine.
-3. For ``PreToolUse``: run the context circuit breaker FIRST.  If it denies,
-   emit the deny response immediately and stop — no point rewriting a call
-   that is about to be blocked.
+3. For ``PreToolUse``: run the context circuit breaker FIRST.  It now emits
+   warnings rather than hard denials; read-only/recovery tools always pass
+   through.  If it denies (legacy path), stop immediately.
 4. Branch on ``tool_name``:
    * ``Agent`` -> model tier injection.
    * ``Bash``  -> ztk rewrite.
@@ -48,15 +49,25 @@ def _passthrough() -> dict[str, Any]:
     return {"continue": True}
 
 
-def _circuit_breaker_deny_response(decision: dict[str, Any]) -> dict[str, Any]:
-    """Wrap a circuit-breaker deny decision in the PreToolUse wire format."""
+def _circuit_breaker_response(decision: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a circuit-breaker decision in the PreToolUse wire format.
+
+    Supports both ``deny`` (blocks the call) and ``warn`` (shows a message
+    but allows the call through).
+    """
+    decision_type = decision.get("permissionDecision", "deny")
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
+            "permissionDecision": decision_type,
             "permissionDecisionReason": decision.get("permissionDecisionReason", ""),
         }
     }
+
+
+# Keep the old name as an alias for backward compatibility with any external
+# callers that imported it directly (unlikely but safe to preserve).
+_circuit_breaker_deny_response = _circuit_breaker_response
 
 
 def dispatch(event: dict[str, Any]) -> dict[str, Any]:
@@ -76,11 +87,14 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
         if hook_event == "PermissionRequest":
             return model_tier_hook.build_permission_request_response(event)
 
-        # Context circuit breaker runs first: if context is critical, deny the
-        # call outright before doing any model/ztk rewriting.
+        # Context circuit breaker runs first.  It now emits warnings (not hard
+        # denials) for critical context levels, and always passes read-only /
+        # recovery tools through unconditionally (issue #642).
         breaker_decision = context_circuit_breaker.evaluate(event)
-        if breaker_decision.get("permissionDecision") == "deny":
-            return _circuit_breaker_deny_response(breaker_decision)
+        decision_type = breaker_decision.get("permissionDecision")
+        if decision_type in ("deny", "warn"):
+            # deny → block the call; warn → show message but allow the call.
+            return _circuit_breaker_response(breaker_decision)
 
         # Branch on the tool being invoked.
         tool_name = event.get("tool_name", "")

--- a/tests/unit/hooks/test_context_circuit_breaker.py
+++ b/tests/unit/hooks/test_context_circuit_breaker.py
@@ -1,16 +1,35 @@
-"""Unit tests for the PreToolUse context circuit-breaker (issue #420)."""
+"""Unit tests for the PreToolUse context circuit-breaker (issue #420, #642).
+
+Coverage requirements (issue #642):
+(a) Correct context-window resolution for a 1 M-context model vs a 200 K model.
+(b) Percentage clamped at 100 when raw tokens exceed the window.
+(c) Read-only / recovery tools are allowed through even when threshold is exceeded.
+(d) The CLAUDE_MPM_DISABLE_CONTEXT_BREAKER disable switch fully bypasses the breaker.
+"""
 
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
 
 from claude_mpm.hooks import context_circuit_breaker
+from claude_mpm.hooks.model_context_window import (
+    CONTEXT_WINDOW_MAP,
+    DEFAULT_CONTEXT_WINDOW,
+    resolve_context_window,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -25,17 +44,298 @@ def _write_state(cwd: Path, state: dict) -> None:
     state_file.write_text(json.dumps(state), encoding="utf-8")
 
 
-def _event(cwd: Path, session_id: str = "sess-current") -> dict:
+def _event(
+    cwd: Path,
+    session_id: str = "sess-current",
+    tool_name: str = "Edit",
+) -> dict:
     return {
         "cwd": str(cwd),
         "session_id": session_id,
-        "tool_name": "Edit",
+        "tool_name": tool_name,
         "tool_input": {},
     }
 
 
 # ---------------------------------------------------------------------------
-# Threshold behavior
+# (a) Context-window resolution: 1 M-context vs 200 K models
+# ---------------------------------------------------------------------------
+
+
+class TestModelContextWindowResolution:
+    """Verify that the model→window map returns correct values."""
+
+    def test_opus_4_resolves_to_1m(self) -> None:
+        window = resolve_context_window("claude-opus-4")
+        assert window == 1_000_000
+
+    def test_opus_4_with_version_suffix_resolves_to_1m(self) -> None:
+        window = resolve_context_window("claude-opus-4-6-20260101")
+        assert window == 1_000_000
+
+    def test_opus_4_6_resolves_to_1m(self) -> None:
+        window = resolve_context_window("claude-opus-4-6")
+        assert window == 1_000_000
+
+    def test_sonnet_4_5_resolves_to_1m(self) -> None:
+        window = resolve_context_window("claude-sonnet-4-5")
+        assert window == 1_000_000
+
+    def test_sonnet_4_5_with_date_resolves_to_1m(self) -> None:
+        window = resolve_context_window("claude-sonnet-4-5-20250601")
+        assert window == 1_000_000
+
+    def test_sonnet_4_0_resolves_to_200k(self) -> None:
+        # Sonnet 4.0 is a 200 K model.
+        window = resolve_context_window("claude-sonnet-4-0")
+        assert window == DEFAULT_CONTEXT_WINDOW
+
+    def test_haiku_resolves_to_200k(self) -> None:
+        window = resolve_context_window("claude-haiku-4")
+        assert window == DEFAULT_CONTEXT_WINDOW
+
+    def test_sonnet_3_5_resolves_to_200k(self) -> None:
+        window = resolve_context_window("claude-3-5-sonnet-20241022")
+        assert window == DEFAULT_CONTEXT_WINDOW
+
+    def test_unknown_model_returns_default(self) -> None:
+        window = resolve_context_window("gpt-4-turbo")
+        assert window == DEFAULT_CONTEXT_WINDOW
+
+    def test_none_model_returns_default_without_env(self) -> None:
+        """When no model is set in env or settings, default is returned."""
+        # Patch _detect_active_model to return None, simulating no configured model.
+        with mock.patch(
+            "claude_mpm.hooks.model_context_window._detect_active_model",
+            return_value=None,
+        ):
+            window = resolve_context_window(None)
+        assert window == DEFAULT_CONTEXT_WINDOW
+
+    def test_anthropic_model_env_var_is_used(self) -> None:
+        """ANTHROPIC_MODEL env var drives resolve_context_window(None)."""
+        with mock.patch.dict(
+            os.environ, {"ANTHROPIC_MODEL": "claude-opus-4-6"}, clear=False
+        ):
+            window = resolve_context_window(None)
+        assert window == 1_000_000
+
+    def test_claude_model_env_var_is_used_as_fallback(self) -> None:
+        """CLAUDE_MODEL env var is used when ANTHROPIC_MODEL is absent."""
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_MODEL"}
+        env["CLAUDE_MODEL"] = "claude-opus-4"
+        with mock.patch.dict(os.environ, env, clear=True):
+            window = resolve_context_window(None)
+        assert window == 1_000_000
+
+    def test_map_has_1m_entries_for_opus_4(self) -> None:
+        """Sanity check: CONTEXT_WINDOW_MAP contains 1 M entries for Opus 4.x."""
+        opus_entries = {k: v for k, v in CONTEXT_WINDOW_MAP.items() if "opus-4" in k}
+        assert all(v == 1_000_000 for v in opus_entries.values()), opus_entries
+
+
+# ---------------------------------------------------------------------------
+# (b) Percentage clamped at 100
+# ---------------------------------------------------------------------------
+
+
+class TestPercentageClamping:
+    """Verify that percentage_used > 100 is clamped before evaluation."""
+
+    def test_percentage_above_100_is_clamped_to_100(self, project_cwd: Path) -> None:
+        """When stored percentage_used > 100, it is clamped to 100 (not >100)."""
+        # Use raw token counts that exceed the 200 K window significantly.
+        # With a 200 K model and 250 K tokens, raw_pct = 125 % → clamped to 100.
+        _write_state(
+            project_cwd,
+            {
+                "session_id": "sess-current",
+                "cumulative_input_tokens": 230_000,
+                "cumulative_output_tokens": 20_000,
+                "percentage_used": 125.0,
+            },
+        )
+        with mock.patch.dict(
+            os.environ, {"ANTHROPIC_MODEL": "claude-sonnet-4-0"}, clear=False
+        ):
+            decision = context_circuit_breaker.evaluate(_event(project_cwd))
+        # Should fire the warning (clamped 100 >= 95).
+        assert decision.get("permissionDecision") == "warn"
+        # The displayed percentage must be at most 100.
+        reason = decision.get("permissionDecisionReason", "")
+        # The reason embeds the percentage; it should not say > 100.
+        assert "101" not in reason
+        assert "125" not in reason
+
+    def test_stored_percentage_125_clamped_to_100_in_fallback(
+        self, project_cwd: Path
+    ) -> None:
+        """When only percentage_used is stored (no raw tokens), clamp to 100."""
+        _write_state(
+            project_cwd,
+            {
+                "session_id": "sess-current",
+                # No cumulative_input_tokens / cumulative_output_tokens.
+                "percentage_used": 125.0,
+            },
+        )
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ANTHROPIC_MODEL", None)
+            os.environ.pop("CLAUDE_MODEL", None)
+            decision = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert decision.get("permissionDecision") == "warn"
+        reason = decision.get("permissionDecisionReason", "")
+        assert "125" not in reason
+        assert "101" not in reason
+
+
+# ---------------------------------------------------------------------------
+# (c) Read-only / recovery tools pass through even above threshold
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysAllowedTools:
+    """Tools in ALWAYS_ALLOWED_TOOLS are never blocked or warned."""
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "Read",
+            "Grep",
+            "Glob",
+            "LS",
+            "NotebookRead",
+            "WebSearch",
+            "WebFetch",
+            "TodoRead",
+            "TodoWrite",
+            "exit_plan_mode",
+        ],
+    )
+    def test_read_only_tool_passes_above_threshold(
+        self, project_cwd: Path, tool: str
+    ) -> None:
+        """Read-only / recovery tools are always allowed, even at 99 %."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        event = _event(project_cwd, tool_name=tool)
+        result = context_circuit_breaker.evaluate(event)
+        assert result == {}, f"Expected pass-through for {tool!r}, got {result!r}"
+
+    def test_always_allowed_tools_constant_is_not_empty(self) -> None:
+        """Sanity: the constant contains the expected recovery tools."""
+        required = {"Read", "Grep", "Glob"}
+        assert required.issubset(context_circuit_breaker.ALWAYS_ALLOWED_TOOLS)
+
+    def test_edit_is_not_always_allowed(self, project_cwd: Path) -> None:
+        """Edit tool is NOT in the always-allowed set and CAN be warned."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        event = _event(project_cwd, tool_name="Edit")
+        result = context_circuit_breaker.evaluate(event)
+        # Should fire a warning for Edit at 99 %.
+        assert result.get("permissionDecision") == "warn"
+
+
+# ---------------------------------------------------------------------------
+# (d) Disable switch
+# ---------------------------------------------------------------------------
+
+
+class TestDisableSwitch:
+    """CLAUDE_MPM_DISABLE_CONTEXT_BREAKER bypasses the breaker entirely."""
+
+    def test_env_var_disables_breaker(self, project_cwd: Path) -> None:
+        """Setting CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1 bypasses the breaker."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_DISABLE_CONTEXT_BREAKER": "1"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result == {}
+
+    def test_env_var_true_disables_breaker(self, project_cwd: Path) -> None:
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_DISABLE_CONTEXT_BREAKER": "true"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result == {}
+
+    def test_env_var_yes_disables_breaker(self, project_cwd: Path) -> None:
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_DISABLE_CONTEXT_BREAKER": "yes"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result == {}
+
+    def test_env_var_0_does_not_disable(self, project_cwd: Path) -> None:
+        """CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=0 should NOT disable the breaker."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        # Remove the env var first to ensure clean state, then set to "0".
+        env = dict(os.environ.items())
+        env["CLAUDE_MPM_DISABLE_CONTEXT_BREAKER"] = "0"
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result.get("permissionDecision") == "warn"
+
+    def test_config_file_disabled_key_disables_breaker(self, project_cwd: Path) -> None:
+        """context_circuit_breaker.disabled: true in settings.json disables breaker."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        # Write a .claude/settings.json with the disable key.
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"disabled": True}}),
+            encoding="utf-8",
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_DISABLE_CONTEXT_BREAKER": ""},  # ensure env is off
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result == {}
+
+    def test_disable_switch_name_in_warning_message(self, project_cwd: Path) -> None:
+        """The warning message must mention the disable env var."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        result = context_circuit_breaker.evaluate(_event(project_cwd))
+        reason = result.get("permissionDecisionReason", "")
+        assert "CLAUDE_MPM_DISABLE_CONTEXT_BREAKER" in reason
+
+
+# ---------------------------------------------------------------------------
+# Existing threshold / fail-open behavior (regression tests)
 # ---------------------------------------------------------------------------
 
 
@@ -55,43 +355,35 @@ def test_just_below_threshold_passes_through(project_cwd: Path) -> None:
     assert context_circuit_breaker.evaluate(_event(project_cwd)) == {}
 
 
-def test_at_exactly_95_denies(project_cwd: Path) -> None:
+def test_at_exactly_95_warns(project_cwd: Path) -> None:
     _write_state(
         project_cwd,
         {"session_id": "sess-current", "percentage_used": 95.0},
     )
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    assert decision.get("permissionDecision") == "deny"
+    # Post-#642: at threshold the decision is "warn", not "deny".
+    assert decision.get("permissionDecision") == "warn"
     assert "95%" in decision.get("permissionDecisionReason", "")
 
 
-def test_above_95_denies_with_percentage_in_reason(project_cwd: Path) -> None:
+def test_above_95_warns_with_percentage_in_reason(project_cwd: Path) -> None:
     _write_state(
         project_cwd,
         {"session_id": "sess-current", "percentage_used": 97.4},
     )
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    assert decision.get("permissionDecision") == "deny"
+    assert decision.get("permissionDecision") == "warn"
     reason = decision.get("permissionDecisionReason", "")
-    # 97.4% rounds to 97 for display.
+    # 97.4 % rounds to 97 for display.
     assert "97%" in reason
-    assert "/mpm-resume" in reason
-
-
-# ---------------------------------------------------------------------------
-# Fail-open paths
-# ---------------------------------------------------------------------------
 
 
 def test_state_file_missing_fails_open(tmp_path: Path) -> None:
-    # No .claude-mpm directory at all -- breaker must pass through.
     event = _event(tmp_path)
     assert context_circuit_breaker.evaluate(event) == {}
 
 
 def test_session_id_mismatch_fails_open(project_cwd: Path) -> None:
-    # State recorded under a different session -- this is stale data from a
-    # prior run and must NOT block the live session.
     _write_state(
         project_cwd,
         {"session_id": "sess-OLD", "percentage_used": 99.0},
@@ -131,11 +423,69 @@ def test_no_cwd_fails_open() -> None:
     assert context_circuit_breaker.evaluate({"tool_name": "Edit"}) == {}
 
 
-def test_state_session_id_missing_still_blocks(project_cwd: Path) -> None:
-    # If the state file omits session_id, we can't validate -- but the
-    # breaker must still trip on critical context: missing session_id in the
-    # state is treated as "no mismatch" (don't fail open just because the
-    # writer hasn't recorded a session yet).
+def test_state_session_id_missing_still_warns(project_cwd: Path) -> None:
+    """Missing session_id in state → no mismatch → breaker fires (warn, not deny)."""
     _write_state(project_cwd, {"percentage_used": 96.0})
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    assert decision.get("permissionDecision") == "deny"
+    assert decision.get("permissionDecision") == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Dynamic window recomputation from raw tokens
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicWindowFromRawTokens:
+    """Verify that raw token counts are recomputed against the real model window."""
+
+    def test_1m_model_with_250k_tokens_does_not_fire(self, project_cwd: Path) -> None:
+        """250 K tokens on a 1 M-context model = 25 % — well below 95 %."""
+        _write_state(
+            project_cwd,
+            {
+                "session_id": "sess-current",
+                "cumulative_input_tokens": 230_000,
+                "cumulative_output_tokens": 20_000,
+                "percentage_used": 125.0,  # stale/wrong value from 200 K budget
+            },
+        )
+        with mock.patch.dict(
+            os.environ, {"ANTHROPIC_MODEL": "claude-opus-4-6"}, clear=False
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 250 K / 1 M = 25 % → no warning.
+        assert result == {}
+
+    def test_200k_model_at_190k_tokens_fires(self, project_cwd: Path) -> None:
+        """190 K tokens on a 200 K model = 95 % → warning fires."""
+        _write_state(
+            project_cwd,
+            {
+                "session_id": "sess-current",
+                "cumulative_input_tokens": 180_000,
+                "cumulative_output_tokens": 10_000,
+                "percentage_used": 95.0,
+            },
+        )
+        with mock.patch.dict(
+            os.environ, {"ANTHROPIC_MODEL": "claude-sonnet-4-0"}, clear=False
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result.get("permissionDecision") == "warn"
+
+    def test_1m_model_at_960k_tokens_fires(self, project_cwd: Path) -> None:
+        """960 K tokens on a 1 M model = 96 % → warning fires."""
+        _write_state(
+            project_cwd,
+            {
+                "session_id": "sess-current",
+                "cumulative_input_tokens": 900_000,
+                "cumulative_output_tokens": 60_000,
+                "percentage_used": 98.0,
+            },
+        )
+        with mock.patch.dict(
+            os.environ, {"ANTHROPIC_MODEL": "claude-opus-4-6"}, clear=False
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result.get("permissionDecision") == "warn"

--- a/tests/unit/hooks/test_context_circuit_breaker.py
+++ b/tests/unit/hooks/test_context_circuit_breaker.py
@@ -160,7 +160,8 @@ class TestPercentageClamping:
         ):
             decision = context_circuit_breaker.evaluate(_event(project_cwd))
         # Should fire the warning (clamped 100 >= 95).
-        assert decision.get("permissionDecision") == "warn"
+        # Post-#642: decision is "allow" (documented value) not "warn" (undocumented).
+        assert decision.get("permissionDecision") == "allow"
         # The displayed percentage must be at most 100.
         reason = decision.get("permissionDecisionReason", "")
         # The reason embeds the percentage; it should not say > 100.
@@ -170,7 +171,12 @@ class TestPercentageClamping:
     def test_stored_percentage_125_clamped_to_100_in_fallback(
         self, project_cwd: Path
     ) -> None:
-        """When only percentage_used is stored (no raw tokens), clamp to 100."""
+        """When only percentage_used is stored (no raw tokens), clamp to 100.
+
+        _detect_active_model is mocked to return None so this test is fully
+        deterministic regardless of what .claude/settings.json exists in the
+        repo (e.g. claude-sonnet-4-6 = 1 M would swallow 125 % as 12.5 %).
+        """
         _write_state(
             project_cwd,
             {
@@ -179,11 +185,13 @@ class TestPercentageClamping:
                 "percentage_used": 125.0,
             },
         )
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("ANTHROPIC_MODEL", None)
-            os.environ.pop("CLAUDE_MODEL", None)
+        with mock.patch(
+            "claude_mpm.hooks.model_context_window._detect_active_model",
+            return_value=None,
+        ):
             decision = context_circuit_breaker.evaluate(_event(project_cwd))
-        assert decision.get("permissionDecision") == "warn"
+        # "allow" is the documented PreToolUse value for allow-with-warning.
+        assert decision.get("permissionDecision") == "allow"
         reason = decision.get("permissionDecisionReason", "")
         assert "125" not in reason
         assert "101" not in reason
@@ -230,15 +238,25 @@ class TestAlwaysAllowedTools:
         assert required.issubset(context_circuit_breaker.ALWAYS_ALLOWED_TOOLS)
 
     def test_edit_is_not_always_allowed(self, project_cwd: Path) -> None:
-        """Edit tool is NOT in the always-allowed set and CAN be warned."""
+        """Edit is NOT in the always-allowed set: fires allow-with-warning at threshold.
+
+        Critically: a non-allowlisted tool at/above threshold must be ALLOWED
+        (permissionDecision == "allow"), never denied — the invariant of issue #642.
+        """
         _write_state(
             project_cwd,
             {"session_id": "sess-current", "percentage_used": 99.0},
         )
         event = _event(project_cwd, tool_name="Edit")
         result = context_circuit_breaker.evaluate(event)
-        # Should fire a warning for Edit at 99 %.
-        assert result.get("permissionDecision") == "warn"
+        # Must be "allow" (documented value) with a reason — never "deny" or "warn".
+        assert result.get("permissionDecision") == "allow", (
+            "Non-allowlisted tool at threshold must be ALLOWED-with-warning, not "
+            f"blocked.  Got: {result.get('permissionDecision')!r}"
+        )
+        assert result.get("permissionDecisionReason"), (
+            "Warning reason must be non-empty"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +318,8 @@ class TestDisableSwitch:
         env["CLAUDE_MPM_DISABLE_CONTEXT_BREAKER"] = "0"
         with mock.patch.dict(os.environ, env, clear=True):
             result = context_circuit_breaker.evaluate(_event(project_cwd))
-        assert result.get("permissionDecision") == "warn"
+        # "allow" is the documented value; "warn" is not valid.
+        assert result.get("permissionDecision") == "allow"
 
     def test_config_file_disabled_key_disables_breaker(self, project_cwd: Path) -> None:
         """context_circuit_breaker.disabled: true in settings.json disables breaker."""
@@ -355,24 +374,27 @@ def test_just_below_threshold_passes_through(project_cwd: Path) -> None:
     assert context_circuit_breaker.evaluate(_event(project_cwd)) == {}
 
 
-def test_at_exactly_95_warns(project_cwd: Path) -> None:
+def test_at_exactly_95_fires_allow_with_warning(project_cwd: Path) -> None:
     _write_state(
         project_cwd,
         {"session_id": "sess-current", "percentage_used": 95.0},
     )
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    # Post-#642: at threshold the decision is "warn", not "deny".
-    assert decision.get("permissionDecision") == "warn"
+    # Post-#642: at threshold the decision is "allow" (documented) + reason text.
+    # "warn" is not a documented PreToolUse value and was replaced.
+    assert decision.get("permissionDecision") == "allow"
     assert "95%" in decision.get("permissionDecisionReason", "")
 
 
-def test_above_95_warns_with_percentage_in_reason(project_cwd: Path) -> None:
+def test_above_95_allows_with_warning_and_percentage_in_reason(
+    project_cwd: Path,
+) -> None:
     _write_state(
         project_cwd,
         {"session_id": "sess-current", "percentage_used": 97.4},
     )
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    assert decision.get("permissionDecision") == "warn"
+    assert decision.get("permissionDecision") == "allow"
     reason = decision.get("permissionDecisionReason", "")
     # 97.4 % rounds to 97 for display.
     assert "97%" in reason
@@ -423,11 +445,13 @@ def test_no_cwd_fails_open() -> None:
     assert context_circuit_breaker.evaluate({"tool_name": "Edit"}) == {}
 
 
-def test_state_session_id_missing_still_warns(project_cwd: Path) -> None:
-    """Missing session_id in state → no mismatch → breaker fires (warn, not deny)."""
+def test_state_session_id_missing_still_fires_allow_with_warning(
+    project_cwd: Path,
+) -> None:
+    """Missing session_id in state → no mismatch → breaker fires allow-with-warning."""
     _write_state(project_cwd, {"percentage_used": 96.0})
     decision = context_circuit_breaker.evaluate(_event(project_cwd))
-    assert decision.get("permissionDecision") == "warn"
+    assert decision.get("permissionDecision") == "allow"
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +481,7 @@ class TestDynamicWindowFromRawTokens:
         assert result == {}
 
     def test_200k_model_at_190k_tokens_fires(self, project_cwd: Path) -> None:
-        """190 K tokens on a 200 K model = 95 % → warning fires."""
+        """190 K tokens on a 200 K model = 95 % → allow-with-warning fires."""
         _write_state(
             project_cwd,
             {
@@ -471,10 +495,10 @@ class TestDynamicWindowFromRawTokens:
             os.environ, {"ANTHROPIC_MODEL": "claude-sonnet-4-0"}, clear=False
         ):
             result = context_circuit_breaker.evaluate(_event(project_cwd))
-        assert result.get("permissionDecision") == "warn"
+        assert result.get("permissionDecision") == "allow"
 
     def test_1m_model_at_960k_tokens_fires(self, project_cwd: Path) -> None:
-        """960 K tokens on a 1 M model = 96 % → warning fires."""
+        """960 K tokens on a 1 M model = 96 % → allow-with-warning fires."""
         _write_state(
             project_cwd,
             {
@@ -488,4 +512,114 @@ class TestDynamicWindowFromRawTokens:
             os.environ, {"ANTHROPIC_MODEL": "claude-opus-4-6"}, clear=False
         ):
             result = context_circuit_breaker.evaluate(_event(project_cwd))
-        assert result.get("permissionDecision") == "warn"
+        assert result.get("permissionDecision") == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Protocol-safety: only documented permissionDecision values are emitted
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolSafeOutput:
+    """The breaker must only emit documented permissionDecision values.
+
+    The Claude Code PreToolUse protocol accepts exactly three values:
+    "allow", "deny", "ask".  "warn" is not documented and risks being
+    treated as deny/error, reproducing the original bug #642.
+    """
+
+    _DOCUMENTED_VALUES = frozenset({"allow", "deny", "ask"})
+
+    def test_threshold_exceeded_emits_allow_not_warn(self, project_cwd: Path) -> None:
+        """At/above threshold: permissionDecision must be a documented value."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        result = context_circuit_breaker.evaluate(_event(project_cwd))
+        decision = result.get("permissionDecision")
+        assert decision in self._DOCUMENTED_VALUES, (
+            f"permissionDecision {decision!r} is not a documented Claude Code "
+            f"PreToolUse value.  Valid values: {sorted(self._DOCUMENTED_VALUES)}"
+        )
+        # Specifically: must be "allow" (never "deny" — that would hard-block).
+        assert decision == "allow"
+
+    def test_threshold_exceeded_has_reason_text(self, project_cwd: Path) -> None:
+        """The warning text is carried in permissionDecisionReason."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        result = context_circuit_breaker.evaluate(_event(project_cwd))
+        reason = result.get("permissionDecisionReason", "")
+        assert reason, "permissionDecisionReason must be non-empty when threshold fires"
+        assert "compact" in reason.lower() or "context" in reason.lower(), (
+            "Warning reason should mention context management options"
+        )
+
+    def test_non_allowlisted_tool_at_threshold_is_allowed_not_denied(
+        self, project_cwd: Path
+    ) -> None:
+        """Non-allowlisted tools (Bash, Edit, Write) at/above threshold must be ALLOWED.
+
+        This is the core invariant of issue #642: the breaker must NEVER
+        hard-block tool calls.  A session at threshold must remain usable.
+        """
+        for tool in ("Bash", "Edit", "Write", "MultiEdit", "Task"):
+            _write_state(
+                project_cwd,
+                {"session_id": "sess-current", "percentage_used": 99.0},
+            )
+            result = context_circuit_breaker.evaluate(
+                _event(project_cwd, tool_name=tool)
+            )
+            decision = result.get("permissionDecision")
+            assert decision != "deny", (
+                f"Tool {tool!r} at threshold was DENIED — reproduces bug #642. "
+                "The breaker must allow-with-warning, never hard-block."
+            )
+            assert decision == "allow", (
+                f"Tool {tool!r} at threshold: expected 'allow', got {decision!r}"
+            )
+
+    def test_evaluate_never_returns_warn_string(self, project_cwd: Path) -> None:
+        """evaluate() must never return permissionDecision == 'warn' (undocumented)."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result.get("permissionDecision") != "warn", (
+            "'warn' is not a documented PreToolUse permissionDecision value "
+            "and was removed in the #642 fix."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Prefix-match boundary fix
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixMatchBoundary:
+    """Verify that prefix matching requires a delimiter boundary."""
+
+    def test_sonnet_4_5_does_not_match_hypothetical_4_50(self) -> None:
+        """claude-sonnet-4-50 must NOT match the claude-sonnet-4-5 (1 M) prefix."""
+        window = resolve_context_window("claude-sonnet-4-50")
+        # claude-sonnet-4-50 is not in the map; fallback to DEFAULT (200 K).
+        # It must NOT inherit the 1 M window from the "claude-sonnet-4-5" entry.
+        assert window == DEFAULT_CONTEXT_WINDOW, (
+            f"claude-sonnet-4-50 matched claude-sonnet-4-5 (1 M) prefix — "
+            f"boundary check failed.  Got {window}"
+        )
+
+    def test_sonnet_4_5_with_date_still_resolves_to_1m(self) -> None:
+        """claude-sonnet-4-5-20251201 (genuine date variant) still resolves 1 M."""
+        window = resolve_context_window("claude-sonnet-4-5-20251201")
+        assert window == 1_000_000
+
+    def test_sonnet_4_6_with_date_still_resolves_to_1m(self) -> None:
+        """claude-sonnet-4-6-20260101 (genuine date variant) still resolves 1 M."""
+        window = resolve_context_window("claude-sonnet-4-6-20260101")
+        assert window == 1_000_000


### PR DESCRIPTION
## Summary

The auto-pause context circuit breaker divided token usage by a hardcoded ~200K window, overshooting 100% on 1M-context models (Opus 4.x) and hard-blocking every tool call, making sessions unrecoverable.

## What Changed

- **New `model_context_window.py`** resolves context window dynamically per active model (Opus 4.x / 1M Sonnet variants → 1,000,000; others → 200,000) with boundary-safe prefix matching for dated model IDs.
- **`percentage_used` clamped at 100.**
- **Read-only/recovery tools always allowed** (Read, Grep, Glob, LS, recall/compact/pause, etc.) — allowed through before any threshold or state check.
- **Breaker degrades to allow-with-warning** (documented `permissionDecision: "allow"` + `permissionDecisionReason`) instead of hard block — no protocol-invalid `"warn"` value; non-allowlisted tools at threshold are allowed-with-warning, never denied.
- **Warn path no longer short-circuits dispatch**, so model-tier injection for Agent calls is preserved.
- **Disable switch**: `CLAUDE_MPM_DISABLE_CONTEXT_BREAKER` env var + `context_circuit_breaker.disabled` config key, surfaced in the warning message.
- **SPEC-HOOKS-11** in `docs/specs/hooks.md` updated to match.

## Testing

55 unit tests pass in `tests/unit/hooks/test_context_circuit_breaker.py`.

## Review

Passed independent adversarial code review (BLOCK → APPROVE after fixes).

Closes #642

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)