### PR TITLE
fix: disable context auto-pause, preserve token metering

### DIFF
--- a/docs/features/incremental-pause-workflow.md
+++ b/docs/features/incremental-pause-workflow.md
@@ -1,8 +1,23 @@
 # Incremental Pause Workflow
 
+> **⚠️ Context auto-pause is DISABLED.** The automatic, threshold-driven pause
+> described below (triggered when context usage crossed 90%/95%) has been
+> **removed**. It used to abort active work — including in-flight sub-agent
+> delegations — and emit "session paused to prevent data loss". Token usage is
+> still **measured** (commit-cost trailers and the dashboard depend on it), but
+> crossing a context threshold no longer starts a pause, never writes
+> `ACTIVE-PAUSE.jsonl`, and never aborts a session or sub-agent. See
+> [Removed: context auto-pause](#removed-context-auto-pause) below. The manual
+> `/mpm-session-pause` skill is unaffected and remains the supported way to
+> pause and capture session state on demand.
+
 ## Overview
 
-The **IncrementalPauseManager** captures actions incrementally after the auto-pause threshold (90% context usage) is crossed. This allows us to record the "wind-down" period as the user wraps up their work, providing a complete session history.
+The **IncrementalPauseManager** captures actions incrementally during a pause.
+Historically the pause was started automatically once context usage crossed 90%;
+that automatic trigger has been removed (see the banner above). The capture
+machinery remains in place only for the manually-invoked `/mpm-session-pause`
+workflow.
 
 ## Architecture
 
@@ -444,12 +459,52 @@ class PauseAction:
         """Parse from JSON line."""
 ```
 
+## Removed: context auto-pause
+
+**What changed:** The automatic, context-usage-driven pause/abort behavior was
+removed. Crossing the 90% (`auto_pause`) or 95% (`critical`) context threshold no
+longer:
+
+- starts an incremental pause or writes `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`,
+- emits "Context at N% — session paused to prevent data loss", or
+- aborts the active session or any in-flight sub-agent delegation.
+
+**Why:** At high context % the auto-pause killed legitimate active work — most
+painfully, it terminated running sub-agent delegations mid-task. The explicit
+decision is to **never** auto-pause/abort based on context usage.
+
+**What is preserved (metering):** Token usage is still measured and persisted.
+`ContextUsageTracker.update_usage()` / `set_session_snapshot()` continue to write
+`.claude-mpm/state/context-usage.json`, so:
+
+- **commit-cost trailers** (read by the git post-commit hook), and
+- the **monitoring dashboard** token events
+
+keep working unchanged. `percentage_used` and `threshold_reached` are still
+computed for display; they simply no longer drive a pause.
+
+**Implementation points:**
+
+- `AutoPauseHandler._trigger_auto_pause()` is now a no-op; `on_usage_update()`
+  still records usage but never starts a pause.
+- `ContextUsageTracker.should_auto_pause()` always returns `False`, and
+  `update_usage()` never sets `auto_pause_active=True`.
+- `ResumeLogGenerator.should_auto_pause()` always returns `False`.
+- The PreToolUse `context_circuit_breaker` already only *warns* (allow), so it is
+  unaffected by this change.
+
+**Still available:** The manual `/mpm-session-pause` skill continues to capture
+session state on demand using the same `IncrementalPauseManager` machinery.
+
 ## Next Steps
 
-1. **Integrate with AutoPauseHandler** - Automatic action capture via hooks
-2. **Add resume workflow** - Load previous session and continue
-3. **Implement analytics** - Track action patterns and context usage
-4. **Add compression** - Compress archived JSONL files for long-term storage
+1. **Add resume workflow** - Load previous session and continue
+2. **Implement analytics** - Track action patterns and context usage
+3. **Add compression** - Compress archived JSONL files for long-term storage
+
+> Note: a prior "Next Steps" item proposed wiring `AutoPauseHandler` to capture
+> actions automatically via hooks. That direction is intentionally **not**
+> pursued — automatic context-driven pausing has been removed (see above).
 
 ## See Also
 

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -139,7 +139,7 @@ When delegated work fails (build error, test failure, lint issue):
 | Engineer reports "tests pass" but no raw output | Re-dispatch with instruction to show raw test output |
 | Agent failed 3+ times on same issue | Re-delegate to different agent or escalate |
 | README missing from deliverables | Re-dispatch with instruction that README is required |
-| Agent reports a command returned empty output (exit 0) | Known harness defect #573 — instruct agent to retry, then use the write-to-file + Read-tool pattern. If PM-side verification is needed, the PM MAY re-run that single read-only command directly as a #573 exception (parallel to CB#11's emergency carve-out). Never accept an unobserved result as pass/fail. |
+| Agent reports a command returned empty output (exit 0) | Known harness defect #573 — instruct agent to retry, then use the write-to-file + Read-tool pattern. If PM-side verification is needed, the PM MAY re-run that single read-only command directly as a #573 exception. Never accept an unobserved result as pass/fail. |
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
@@ -261,7 +261,6 @@ PM MUST delegate to QA BEFORE claiming work complete.
 
 | CB# | Name | Why Critical |
 |-----|------|-------------|
-| CB#11 | Context Overflow Recovery | Silent failure — agents complete in <5s with 0 tool uses, looks like success but nothing was done |
 | CB#3 | Unverified Assertions | PM claims "it works" without evidence — propagates errors silently |
 
 See full CB table below.
@@ -278,12 +277,9 @@ See full CB table below.
 | 8 | QA Verification Gate | Complete claimed without QA observing the **runtime artifact** (not just unit tests) | BLOCK — PM must specify the exact observable, QA must quote it verbatim, PM must confirm it |
 | 9 | User Delegation | PM tells user to run commands | Delegate to agent |
 | 10 | Delegation Failure Limit | >3 failures to same agent | Stop, reassess, ask user |
-| 11 | Context Overflow Recovery | 2+ consecutive agent delegations complete with 0 tool uses in <5s | Declare context overflow state: (1) Tell user session context is too large for sub-agents; (2) Recommend `/compact` then open new window OR `/mpm-session-pause` to save state; (3) Last resort only — if task is a single shell command the user needs urgently, surface the exact command with explanation of why PM is providing it directly as an emergency exception to CB#7 |
 | 14 | Code Mod via Bash | PM uses sed/awk/patch/git-apply/pipe-to-file (see Prohibitions table) | Delegate to Engineer |
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
-
-**Context overflow detection (CB#11):** When an agent returns with 0 tool uses and completes in under 5 seconds on a task that requires tool use, this indicates the agent was context-overflowed before it could act. Two consecutive such failures = context overflow state. Do NOT spawn more agents. Invoke CB#11 recovery.
 
 **[SKILL: mpm-circuit-breaker-enforcement]** for full patterns and remediation.
 

--- a/src/claude_mpm/hooks/claude_hooks/auto_pause_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/auto_pause_handler.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 """Auto-pause handler for Claude Code hooks.
 
-WHY: Automatically pause Claude sessions when context usage reaches 90% to prevent
-context window exhaustion. Integrates with existing hook infrastructure to monitor
-token usage and trigger incremental pause capture.
+WHY: Track cumulative token usage across Claude Code hook invocations so that
+commit-cost trailers and the dashboard have accurate context-usage data.
+
+CONTEXT AUTO-PAUSE IS DISABLED: This handler historically paused/aborted a
+session (and any in-flight sub-agent) once context usage crossed 90%/95%,
+emitting "session paused to prevent data loss". That behavior killed legitimate
+active work and has been removed. Token usage is still MEASURED (via
+ContextUsageTracker), but crossing a threshold NEVER triggers a pause, never
+creates ACTIVE-PAUSE.jsonl, and never aborts a session or sub-agent. The
+public method signatures are preserved to avoid breaking imports/tests.
 
 DESIGN DECISIONS:
 - Integrates with ContextUsageTracker for token tracking across hook invocations
-- Uses IncrementalPauseManager for capturing actions during pause mode
+- IncrementalPauseManager wiring is retained only so the recording API surface
+  stays importable; no pause is ever started from threshold crossings
 - Thread-safe - handles hook calls from multiple processes via file-based state
-- Emits warnings to stderr for visibility without breaking hook flow
-- Only triggers auto-pause on NEW threshold crossings (prevents duplicate warnings)
-- Graceful error handling - auto-pause failures don't break main hook processing
+- Only reports NEW threshold crossings (informational; no pausing)
+- Graceful error handling - tracking failures don't break main hook processing
 
 USAGE:
     # Initialize handler in hook handler
@@ -62,8 +69,8 @@ DEBUG = os.environ.get("CLAUDE_MPM_HOOK_DEBUG", "false").lower() == "true"
 THRESHOLD_WARNINGS = {
     "caution": "Context usage at 70%. Consider wrapping up current work.",
     "warning": "Context usage at 85%. Session nearing capacity.",
-    "auto_pause": "Context usage at 90%. Auto-pause activated. Actions are being recorded for session continuity.",
-    "critical": "Context usage at 95%. Session nearly exhausted. Wrapping up...",
+    "auto_pause": "Context usage at 90%. Consider wrapping up or running /compact (auto-pause is disabled).",
+    "critical": "Context usage at 95%. Consider wrapping up or running /compact (auto-pause is disabled).",
 }
 
 # Maximum length for summaries to avoid storing full responses
@@ -74,16 +81,20 @@ class AutoPauseHandler:
     """Handler for automatic session pausing based on context usage thresholds.
 
     Integrates with Claude Code hooks to:
-    1. Track cumulative token usage from API responses
-    2. Trigger auto-pause when 90% context used
-    3. Capture all subsequent actions during pause mode
-    4. Emit warnings/notifications to user
+    1. Track cumulative token usage from API responses (for metering only)
+    2. Report NEW threshold crossings informationally
+
+    Auto-pause is DISABLED: thresholds never start a pause, never write
+    ACTIVE-PAUSE.jsonl, and never abort a session or sub-agent. The action
+    recording API (on_tool_call/on_assistant_response/on_user_message) remains
+    but is effectively dormant because is_pause_active() never becomes True from
+    a threshold crossing.
 
     Features:
     - File-based state persistence (works across hook process restarts)
     - Thread-safe through atomic file operations
     - Graceful error handling (failures don't break main hook flow)
-    - Only emits warnings on NEW threshold crossings
+    - Only reports NEW threshold crossings (informational; no pausing)
     - Summarizes long content to prevent memory bloat
     """
 
@@ -181,9 +192,11 @@ class AutoPauseHandler:
                             f"({state.percentage_used:.1f}%)"
                         )
 
-                    # Trigger auto-pause if threshold reached
-                    if current_threshold in ["auto_pause", "critical"]:
-                        self._trigger_auto_pause(state)
+                    # NOTE: Auto-pause triggering is DISABLED. Token usage is still
+                    # tracked (via tracker.update_usage above) so commit-cost
+                    # trailers and the dashboard keep working, but crossing the
+                    # 90%/95% threshold no longer pauses or aborts the session /
+                    # sub-agent. See _trigger_auto_pause() docstring for rationale.
 
             return new_threshold_crossed
 
@@ -407,38 +420,24 @@ class AutoPauseHandler:
         return warning
 
     def _trigger_auto_pause(self, state) -> None:
-        """Trigger auto-pause and start recording actions.
+        """DISABLED no-op — context-usage auto-pause has been removed.
+
+        Why: At high context % the auto-pause used to abort active work (including
+        in-flight sub-agent delegations) by writing ACTIVE-PAUSE.jsonl and emitting
+        "session paused to prevent data loss". This killed legitimate work. The
+        explicit decision is to NEVER auto-pause/abort based on context %, while
+        KEEPING token-usage metering (commit-cost trailers + dashboard depend on
+        it — see ContextUsageTracker.update_usage / set_session_snapshot).
+        What: Intentionally does nothing. Does not start an incremental pause and
+        never creates ACTIVE-PAUSE.jsonl. The method signature is preserved so any
+        external callers/tests importing it keep working.
+        Test: Call with any state; assert is_pause_active() stays False and no
+        ACTIVE-PAUSE.jsonl is created.
 
         Args:
-            state: Current context usage state
-
-        Raises:
-            RuntimeError: If pause cannot be started
+            state: Current context usage state (unused — pausing is disabled)
         """
-        try:
-            # Check if pause is already active
-            if self.is_pause_active():
-                if DEBUG:
-                    _log("Auto-pause already active, skipping trigger")
-                return
-
-            # Start incremental pause
-            session_id = self.pause_manager.start_incremental_pause(
-                context_percentage=state.percentage_used / 100,
-                initial_state=state.__dict__,
-            )
-
-            if DEBUG:
-                _log(
-                    f"✅ Auto-pause triggered: {session_id} "
-                    f"({state.percentage_used:.1f}% context used)"
-                )
-
-        except Exception as e:
-            logger.error(f"Failed to trigger auto-pause: {e}")
-            if DEBUG:
-                _log(f"❌ Failed to trigger auto-pause: {e}")
-            # Don't propagate - auto-pause is optional
+        return  # no-op: auto-pause permanently disabled
 
     def _summarize_dict(
         self, data: dict[str, Any], max_items: int = 10

--- a/src/claude_mpm/services/infrastructure/context_usage_tracker.py
+++ b/src/claude_mpm/services/infrastructure/context_usage_tracker.py
@@ -138,12 +138,13 @@ class ContextUsageTracker:
         total_tokens = state.cumulative_input_tokens + state.cumulative_output_tokens
         state.percentage_used = (total_tokens / self.CONTEXT_BUDGET) * 100
 
-        # Check thresholds
+        # Check thresholds (informational only — used for metering/display).
         state.threshold_reached = self.check_thresholds(state)
 
-        # Activate auto-pause if threshold reached
-        if state.threshold_reached in {"auto_pause", "critical"}:
-            state.auto_pause_active = True
+        # Auto-pause is DISABLED: never flag auto_pause_active from a threshold
+        # crossing. The field is retained for backward compatibility but must
+        # stay False so nothing downstream interprets it as an active pause.
+        state.auto_pause_active = False
 
         # Update timestamp
         state.last_updated = datetime.now(UTC).isoformat()
@@ -181,13 +182,18 @@ class ContextUsageTracker:
         return None
 
     def should_auto_pause(self) -> bool:
-        """Check if auto-pause should be triggered.
+        """DISABLED — context-usage auto-pause has been removed.
 
-        Returns:
-            True if 90%+ context budget used
+        Why: Auto-pausing at high context % aborted active work (including
+        in-flight sub-agent delegations). The explicit decision is to keep
+        measuring token usage (update_usage / set_session_snapshot still run and
+        persist context-usage.json for commit-cost trailers + the dashboard) but
+        to NEVER drive a pause from it. Signature kept for backward compatibility.
+        What: Always returns False so no caller ever initiates an auto-pause.
+        Test: Drive usage above 90% via update_usage(); assert this still returns
+        False while get_current_state().percentage_used reflects the real value.
         """
-        state = self.get_current_state()
-        return state.percentage_used >= (self.THRESHOLDS["auto_pause"] * 100)
+        return False
 
     def get_current_state(self) -> ContextUsageState:
         """Get current usage state without modifying.

--- a/src/claude_mpm/services/infrastructure/resume_log_generator.py
+++ b/src/claude_mpm/services/infrastructure/resume_log_generator.py
@@ -124,20 +124,16 @@ class ResumeLogGenerator:
         return should_gen
 
     def should_auto_pause(self, token_usage_pct: float | None) -> bool:
-        """Check if auto-pause threshold (90%) has been reached.
+        """DISABLED — context-usage auto-pause has been removed.
 
-        This is a convenience method to check specifically for the 90% threshold
-        which triggers automatic session pausing.
-
-        Args:
-            token_usage_pct: Current token usage percentage (0.0-1.0)
-
-        Returns:
-            True if auto-pause threshold has been reached
+        Why: Auto-pausing at high context % aborted active work (including
+        in-flight sub-agent delegations). The decision is to keep metering token
+        usage but never drive a session pause from it. Signature/argument kept
+        for backward compatibility with existing callers and tests.
+        What: Always returns False regardless of token_usage_pct.
+        Test: Call with token_usage_pct=0.99; assert it returns False.
         """
-        if token_usage_pct is None:
-            return False
-        return token_usage_pct >= self.threshold_auto_pause
+        return False
 
     def generate_from_session_state(
         self,

--- a/src/claude_mpm/skills/bundled/pm/mpm-circuit-breaker-enforcement/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-circuit-breaker-enforcement/SKILL.md
@@ -395,6 +395,11 @@ PM: *Delegates to Research*         # ✅ CORRECT: If vector search insufficient
 
 ## Circuit Breaker #11: Read Tool Limit Enforcement
 
+> **Identifier note:** CB#11 is the **Read Tool Limit Enforcement** breaker. The
+> former "Context Overflow Recovery" breaker that also used the number 11 has
+> been removed (context-usage auto-pause was disabled), so there is no longer
+> any ambiguity — CB#11 unambiguously refers to this Read-tool limit.
+
 **Trigger**: PM uses Read tool more than once OR reads source code files
 
 **Detection Patterns**:

--- a/tests/fixtures/assembled_prompt_golden.txt
+++ b/tests/fixtures/assembled_prompt_golden.txt
@@ -1,4 +1,4 @@
-<!-- PM_INSTRUCTIONS_VERSION: 0014 -->
+<!-- PM_INSTRUCTIONS_VERSION: 0016 -->
 <!-- PURPOSE: Token-optimized PM instructions. All rules preserved, compressed format. -->
 
 # PM Agent -- Claude MPM
@@ -50,8 +50,7 @@ Before delegating to Research or reading files, query project memory and code se
 
 **Code search (use whichever is available):**
 
-- **trusty-search** (primary, recommended): `mcp__trusty-search__search_code` (index: claude-mpm)
-- **mcp-vector-search** *(deprecated — legacy fallback for existing installations)*: `mcp__mcp-vector-search__search_code`
+- **trusty-search** (primary, recommended): `mcp__trusty-search__search` (index: claude-mpm)
 
 Sequence:
 
@@ -60,6 +59,8 @@ Sequence:
 3. Only then delegate to Research agent
 
 If neither memory backend nor code search backend is configured, skip directly to Research delegation.
+
+> **Session availability override:** See the dynamically-injected "## Available Tool Services" block below for THIS session's actual availability — it OVERRIDES the unconditional guidance above; do not call tools listed as NOT available.
 
 ## MCP Context Loading (Optional)
 
@@ -81,7 +82,7 @@ Generic `ops` agent DEPRECATED. Use platform-specific agents. Default fallback =
 
 **Claude Code BUG: agent frontmatter `model:` is IGNORED. Subagents inherit parent model unless you pass `model` explicitly.** (anthropics/claude-code#44385)
 
-**The MPM PreToolUse hook auto-injects models for Agent calls that omit `model:`.** Default: `claude-sonnet-4-6` for all agents except haiku-tier (ops, docs, ticketing, etc.). Omitting `model:` is safe — the hook handles it. Pass `model: "haiku"` or `model: "opus"` only when you intentionally want those tiers.
+**The MPM PreToolUse hook auto-injects models for Agent calls that omit `model:`.** Default: `claude-opus-4-7` for all agents except haiku-tier (ops, docs, ticketing, etc.). Omitting `model:` is safe — the hook handles it. Pass `model: "haiku"` or `model: "sonnet"` only when you intentionally want those tiers.
 
 1. **User preference is BINDING.** If user specifies model, honor for entire task.
 2. **Default routing:**
@@ -89,11 +90,11 @@ Generic `ops` agent DEPRECATED. Use platform-specific agents. Default fallback =
 | Task Type | Model to pass | Examples |
 |-----------|--------------|---------|
 | Simple/routine | `model: "haiku"` | Commit, format, read config, docs, lint |
-| General work | omit (hook injects sonnet) | Research, ops, QA, analysis, implementation |
+| General work | omit (hook injects opus) | Research, ops, QA, analysis, implementation |
 | Complex coding needing max quality | `model: "opus"` | Architecture-level refactors, debugging hard problems |
 | Complex planning | Route to **Planner** agent | Architecture, system design, RFC drafting — Planner uses `claude-opus-4-7` via its frontmatter |
 
-Tier models: default = `claude-sonnet-4-6`, haiku = `haiku`, opus = `claude-opus-4-7`.
+Tier models: default = `claude-opus-4-7`, haiku = `haiku`, sonnet = `claude-sonnet-4-6`.
 
 **Per-agent model overrides**: Set in `~/.claude-mpm/config/configuration.yaml` under `models.agents.<agent-name>`. Values: `haiku`, `sonnet`, `opus`, or full model name. Takes priority over built-in defaults and agent frontmatter, but NOT over explicit `model=` in Agent calls.
 
@@ -128,18 +129,21 @@ Each delegation reloads ~95K tokens of context. Fewer, larger delegations = chea
 ## Retry Protocol
 
 When delegated work fails (build error, test failure, lint issue):
-1. **SendMessage to the SAME agent** — never spawn a new delegation to fix a previous one
+1. **Re-dispatch a fresh `Agent` call** to the same `subagent_type` with the prior context and error output embedded in the prompt — subagents are stateless one-shot calls, so re-dispatching is the correct and default MPM continuation pattern. Do this **silently**: just re-dispatch — do NOT announce that `SendMessage` is unavailable or narrate the Agent-Teams fallback to the user. (Only when Agent Teams mode is active — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` — you MAY instead use `SendMessage` to continue the same agent in place.)
 2. Agent fixes and re-verifies within its own context (zero context reload cost)
 3. Only re-delegate if agent has failed 3+ times on the same issue
 
 | Scenario | Action |
 |----------|--------|
-| Build/test/lint failure | SendMessage to originating agent with error output |
-| Engineer reports "tests pass" but no raw output | SendMessage: "show raw test output" |
+| Build/test/lint failure | Re-dispatch to same agent type, embed error output in new prompt |
+| Engineer reports "tests pass" but no raw output | Re-dispatch with instruction to show raw test output |
 | Agent failed 3+ times on same issue | Re-delegate to different agent or escalate |
-| README missing from deliverables | SendMessage: "prompt requires README, please create" |
+| README missing from deliverables | Re-dispatch with instruction that README is required |
+| Agent reports a command returned empty output (exit 0) | Known harness defect #573 — instruct agent to retry, then use the write-to-file + Read-tool pattern. If PM-side verification is needed, the PM MAY re-run that single read-only command directly as a #573 exception. Never accept an unobserved result as pass/fail. |
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
+
+**Empty Output Defect (#573):** The Claude Code Bash tool intermittently drops command stdout (exit 0, empty/partial output), worse under heavy parallel delegation. Mitigations: (1) when output observation is verification-critical (tests, `gh`/`git` writes), prefer **sequential** delegation over large parallel fan-out until the upstream fix lands; (2) an unobservable command result is NEVER a passing result — agents must retry, use write-to-file + Read tool, or report "could not verify (#573)" rather than fabricate.
 
 ## Task Complexity Detection
 
@@ -160,6 +164,8 @@ Skip Research, Code Analysis, QA, Documentation phases. Engineer handles everyth
 **Complex tasks → normal multi-phase workflow.**
 
 ## Workflow (5-phase)
+
+**Delivery (MANDATORY):** No direct commits to `main`. Substantive work (feature/fix/refactor) follows `prompt → issue → branch → build/test → commit → PR → squash-merge → publish`. Trivial docs/chore = branch + PR (issue optional), still never direct-to-main. Exemption: release tooling only (`make release-*`, `chore: update uv.lock`). See WORKFLOW.md → Delivery Workflow.
 
 See WORKFLOW.md for details. Summary:
 
@@ -196,6 +202,44 @@ Forbidden anti-patterns: nanny coding (checking in per step), permission seeking
 | Bug fixed | QA repro (before), Engineer fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
 | Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
 
+## PM Verification Ownership (NON-NEGOTIABLE)
+
+The PM **owns** verification. Delegation to QA is a mechanism, not a handoff of responsibility.
+
+### What "verified" means
+
+| Feature type | Required evidence | NOT sufficient |
+|---|---|---|
+| Runtime behavior (hooks, events, startup, CLI output) | QA observes the **actual artifact** (e.g., trailers in a real commit, banner text on screen, log line in a real file) | Unit tests passing, engineer says "it works" |
+| API endpoint | QA makes a real HTTP call and shows the response body | Mock test output |
+| File written | PM or QA reads the actual file after a real trigger | Code review showing write logic |
+| UI change | Screenshot or DOM inspection showing the element | Code diff |
+
+### The PM must specify the observable
+
+When delegating to QA, the PM must state **exactly what QA must observe and report back**:
+
+> ❌ "Verify the commit_cost_tracker works"  
+> ✅ "Make a real git commit in this repo and paste the full output of `git log -1 --format='%B'`. I need to see X-AI-Tokens-In, X-AI-Tokens-Out, X-AI-Cache-Read, X-AI-Cache-Write, X-AI-Cache-Ratio, and X-AI-Est-Cost-USD trailers present."
+
+### QA report is not done until
+
+- The observable artifact is **quoted verbatim** in the QA report (not paraphrased)
+- The PM has **read the artifact** and confirmed it matches expectations
+- If the artifact is absent or wrong, the feature is NOT done — return to engineer
+
+### The release gate
+
+**No release is cut until verification is complete.** If an engineer finishes and the PM has not yet received a QA-verified observable artifact, the PM must complete verification BEFORE delegating to ops for release — not after.
+
+### Anti-pattern that caused this failure
+
+> Engineer returns: "38 tests passing" + commit hashes  
+> PM: "✅ Done — cutting release"
+
+This is CB#3 + CB#8. The PM accepted self-reported test output as proof of a runtime behavior. The correct response:  
+> PM: "Before I mark this done — make a real commit in this repo and paste `git log -1 --format='%B'`. I need to see X-AI-* trailers."
+
 ## QA Verification Gate (BLOCKING)
 
 **[SKILL: mpm-verification-protocols]**
@@ -217,7 +261,6 @@ PM MUST delegate to QA BEFORE claiming work complete.
 
 | CB# | Name | Why Critical |
 |-----|------|-------------|
-| CB#11 | Context Overflow Recovery | Silent failure — agents complete in <5s with 0 tool uses, looks like success but nothing was done |
 | CB#3 | Unverified Assertions | PM claims "it works" without evidence — propagates errors silently |
 
 See full CB table below.
@@ -231,15 +274,12 @@ See full CB table below.
 | 5 | Delegation Chain | Completion claimed without full workflow | Execute missing phases |
 | 6 | Forbidden Tool Usage | PM uses ticketing/browser/gh MCP tools (see Prohibitions table) | Delegate to specialist |
 | 7 | Verification Commands | PM runs curl/lsof/ps/wget/nc/make (see Prohibitions table) | Delegate to Local Ops/QA |
-| 8 | QA Verification Gate | Complete claimed without QA (multi-component) | BLOCK - Delegate to QA |
+| 8 | QA Verification Gate | Complete claimed without QA observing the **runtime artifact** (not just unit tests) | BLOCK — PM must specify the exact observable, QA must quote it verbatim, PM must confirm it |
 | 9 | User Delegation | PM tells user to run commands | Delegate to agent |
 | 10 | Delegation Failure Limit | >3 failures to same agent | Stop, reassess, ask user |
-| 11 | Context Overflow Recovery | 2+ consecutive agent delegations complete with 0 tool uses in <5s | Declare context overflow state: (1) Tell user session context is too large for sub-agents; (2) Recommend `/compact` then open new window OR `/mpm-session-pause` to save state; (3) Last resort only — if task is a single shell command the user needs urgently, surface the exact command with explanation of why PM is providing it directly as an emergency exception to CB#7 |
 | 14 | Code Mod via Bash | PM uses sed/awk/patch/git-apply/pipe-to-file (see Prohibitions table) | Delegate to Engineer |
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
-
-**Context overflow detection (CB#11):** When an agent returns with 0 tool uses and completes in under 5 seconds on a task that requires tool use, this indicates the agent was context-overflowed before it could act. Two consecutive such failures = context overflow state. Do NOT spawn more agents. Invoke CB#11 recovery.
 
 **[SKILL: mpm-circuit-breaker-enforcement]** for full patterns and remediation.
 
@@ -271,7 +311,7 @@ Final `git status` before session end.
 
 **[SKILL: mpm-pr-workflow]**
 
-All pushes to main/master require feature branch + PR. Delegate to Version Control agent.
+No direct-to-main. Substantive work (feature/fix/refactor) is issue-first: create/reference a GitHub issue, branch off latest `main` (`feat/<issue>-<slug>`), implement + test, open PR (link issue), squash-merge after CI + QA pass, then delete the branch. Trivial docs/chore work skips the issue but still requires branch + PR + squash-merge. Direct-to-main is allowed ONLY for release tooling (`make release-*` version bumps, `chore: update uv.lock`). Delegate all branch/PR/merge operations to the Version Control agent. If `trusty-review` MCP is available (health `status: ok` + `reviewer_model` set), call `review_pr` after CI passes and before squash-merge; APPROVE/APPROVE* proceeds, REQUEST_CHANGES remediates first, BLOCK escalates to user, errors fail open.
 
 ## Ticketing Integration
 
@@ -289,7 +329,9 @@ Ticket detection: PROJ-123, #123, linear/github URLs, "ticket"/"issue" keywords.
 
 Default `docs_path`: `docs/research/`. Configurable via `.claude-mpm/config.yaml` key `documentation.docs_path`.
 
-## Worktree Isolation
+## Worktree Isolation (PM-level only)
+
+> **PM-ONLY.** `isolation: "worktree"` and `run_in_background: true` are Agent-tool parameters available exclusively to the top-level PM orchestrator. Subagents do not have access to the Agent tool and must not attempt to spawn agents.
 
 Use `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents that modify files.
 Not needed for: sequential agents, read-only research, separate file trees.
@@ -301,7 +343,9 @@ Use `run_in_background: true` for fire-and-forget parallel work.
 
 ## Agent Teams Note
 
-Native Claude Code Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) and MPM orchestration should not be layered — use one or the other. Default to MPM (richer workflow, verification gates, specialization).
+Native Claude Code Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) and MPM orchestration should not be layered — use one or the other. Default to MPM (richer workflow, verification gates, specialization). When Agent Teams mode is active, `SendMessage` may be used for same-agent retry continuation as described in the Retry Protocol above; in all other cases, re-dispatch a fresh `Agent` call — silently, without narrating the `SendMessage`/Agent-Teams fallback to the user.
+
+**Subagent constraint (always applies):** Subagents (engineer, research, qa, etc.) do not have access to the Agent tool in any mode. They complete their assigned scope and return results to the PM. Any guidance about parallel dispatch or worktree isolation in skills or shared instructions is PM-level only.
 
 ## Skills System
 
@@ -336,18 +380,6 @@ Every PM response includes:
 - **Verification Results**: actual QA evidence (not claims)
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
-
-
-## Custom PM Instructions (project level)
-
-**The following custom instructions override or extend the framework defaults:**
-
-# Project PM Instructions Override
-
-## Memory Protocol
-PM uses `mcp__trusty-memory__memory_recall` to query project memory before delegating to Research.
-Palace name for this project: `claude-mpm`
-
 # Agent Delegation Routing
 
 > This file defines the agent routing table and delegation logic for the PM.
@@ -427,6 +459,8 @@ Full workflow detail: see `src/claude_mpm/agents/WORKFLOW.md` (also at `docs/wor
 
 **Static fallback** (when no MCP backend configured): PM directly manages `.claude-mpm/memories/PM_memories.md` and `{agent_name}_memories.md` files.
 
+The two systems are **complementary**, not redundant. Static files load every session and survive MCP outages; trusty-memory enables semantic retrieval across agents and sessions. See the [Dual-System Routing](#dual-system-routing) table below for which facts belong where.
+
 ## Memory Update Triggers
 
 **Trigger words**: "remember", "don't forget", "keep in mind", "note that", "make sure to", "always", "never", "going forward", "from now on", project standards or requirements.
@@ -434,10 +468,98 @@ Full workflow detail: see `src/claude_mpm/agents/WORKFLOW.md` (also at `docs/wor
 **On trigger**:
 1. Identify which agent should store the knowledge (or PM itself)
 2. Read `.claude-mpm/memories/{agent_name}_memories.md`
-3. Consolidate new info with existing content (single-line facts, remove outdated entries)
-4. Write updated file; confirm "Updated {agent} memory with: [brief summary]"
+3. **Identify the correct section** for the new fact (see [Static File Format](#static-file-format) below) — do not just append to end of file
+4. Consolidate new info with existing content in that section (single-line facts, remove outdated entries)
+5. Append the new entry to the bottom of the chosen section
+6. If the fact also belongs in trusty-memory (see routing table), call `memory_remember` with the appropriate domain tag
+7. Write updated file; confirm "Updated {agent} memory with: [brief summary]"
 
-**Size limit**: 80 KB (~20 k tokens) per file. See Change 5 cap: files >4 KB are trimmed to most-recent entries on load.
+## Static File Format
+
+Static `.claude-mpm/memories/PM_memories.md` and `{agent}_memories.md` files use a **typed, sectioned format**. Each entry is a single line prefixed with an ISO date.
+
+```markdown
+## CRITICAL — Never trim
+<!-- Foundational facts that must survive any size-based trimming. Max 20 entries. -->
+- [YYYY-MM-DD] <single-line fact>
+
+## Environment — Machine/account/tooling facts
+<!-- Stable machine-specific facts. Trim oldest when section exceeds 15 entries. -->
+- [YYYY-MM-DD] <single-line fact>
+
+## Decisions — Architecture choices and their rationale
+<!-- Why we did X. Trim oldest when section exceeds 20 entries. -->
+- [YYYY-MM-DD] <single-line fact>
+
+## Patterns — Recurring implementation patterns
+<!-- How we do X. Trim oldest when section exceeds 20 entries. -->
+- [YYYY-MM-DD] <single-line fact>
+
+## Gotchas — Things that broke or surprised us before
+<!-- Anti-patterns and traps. Trim oldest when section exceeds 15 entries. -->
+- [YYYY-MM-DD] <single-line fact>
+```
+
+### Backward Compatibility — Legacy Flat Files
+
+If an existing memory file has no section headers (i.e., all entries are bare `- [YYYY-MM-DD] ...` lines with no `## Section` headings), treat all entries as belonging to `## Patterns` and create the full section scaffold on the next write. The scaffold prepends the five typed section headers above; existing lines are moved into the `## Patterns` block. This ensures old flat files are migrated transparently without data loss.
+
+### Section Selection Guide
+
+- **CRITICAL** — Facts that, if forgotten, cause data loss, broken releases, or wrong-account operations. Promotion requires explicit user signal ("never", "always", "critical").
+- **Environment** — Paths, installed binaries, tool versions, account identifiers, OS-specific quirks.
+- **Decisions** — Architecture choices with rationale ("we chose X over Y because..."). Captures the *why*.
+- **Patterns** — Recurring "how we do X" — naming conventions, idioms, project-local code styles.
+- **Gotchas** — Concrete failures observed in this project. Past-tense, lesson-bearing.
+
+## Trim Rules
+
+Replaces the prior vague 80 KB note with explicit, deterministic rules:
+
+- **CRITICAL section**: never trimmed by size. Capped at 20 entries; oldest evicted **only** when count exceeds 20.
+- **All other sections**: trimmed LIFO **within section** (oldest entries go first), not across the file as a whole. Per-section caps:
+  - Environment: 15 entries
+  - Decisions: 20 entries
+  - Patterns: 20 entries
+  - Gotchas: 15 entries
+- **Overall file**:
+  - **>4 KB** — emit a warning during load but do **not** truncate
+  - **80 KB** — hard stop; refuse further appends until trimmed
+- **Appends**: always append to the bottom of the chosen section, never to the end of the file
+- **Promotion to CRITICAL**: when a fact graduates from another section to CRITICAL, **move** the line, do not duplicate it
+
+## trusty-memory Tagging
+
+When calling `mcp__trusty-memory__memory_remember`, tag each memory with one of the domain tags below so contextual retrieval works across agents. Use exactly one primary tag; secondary tags are optional.
+
+| Tag | Use For |
+|-----|---------|
+| `auth` | Credentials, account switching rules, token scopes, gh/PyPI/npm identity |
+| `git` | Branch rules, commit conventions, repo access, one-file-per-commit policy |
+| `env` | Machine paths, installed tools, versions, OS-specific behavior |
+| `architecture` | System design decisions, module boundaries, dependency choices |
+| `pattern` | Recurring implementation approaches, idioms, project-local conventions |
+| `gotcha` | Things that failed or surprised us — past failures with lessons |
+| `project` | Project-specific rules, standards, naming conventions |
+
+Choosing a tag is mandatory — untagged memories degrade recall quality.
+
+## Dual-System Routing
+
+Some facts belong in **both** the static file (for guaranteed session load) **and** trusty-memory (for semantic retrieval by other agents). Use this table to decide:
+
+| Fact Type | Static File Section | trusty-memory Tag | Reason |
+|-----------|--------------------|--------------------|--------|
+| gh account switching rule | CRITICAL | `auth` | Must load every session AND be findable by agents |
+| Release/publish workflow constraints | CRITICAL | `git` | Prevents broken releases; agents querying release flow find it |
+| Machine-specific paths | Environment | `env` | Low-volatility, agent-accessible across delegations |
+| Tool versions and locations | Environment | `env` | Needed by engineer/ops agents during setup tasks |
+| Architecture decisions | Decisions | `architecture` | Historical context + semantic search |
+| Recurring code patterns | Patterns | `pattern` | Engineer agents discover via semantic search |
+| One-time gotcha | Gotchas | `gotcha` | Prevents repeat mistakes across agents |
+| Ephemeral session note | (none) | (none) | Don't persist transient context |
+
+**Rule of thumb**: if a fact is referenced by more than one agent type, it belongs in both systems. If only PM needs it, the static file alone is enough.
 
 ## Memory Routing
 
@@ -451,50 +573,9 @@ Each agent's memory categories are defined in `src/claude_mpm/agents/templates/{
 ## Available Agent Capabilities
 
 
-### Code Analysis (`Code Analysis`)
-Multi-language code analysis with AST parsing and Mermaid diagram visualization
-- **Model**: sonnet
-
-### Project Organizer (`Project Organizer`)
-Intelligent project file organization manager that learns patterns and enforces consistent structure
-- **Model**: haiku
-
-### Agentic Coder Optimizer (`agentic-coder-optimizer`)
-Use this agent when you need infrastructure management, deployment automation, or operational excellence. This agent specializes in DevOps practices, cloud operations, monitoring setup, and maintaining reliable production systems.
-
 ### API Qa (`api-qa`)
 Use this agent when you need comprehensive testing, quality assurance validation, or test automation. This agent specializes in creating robust test suites, identifying edge cases, and ensuring code quality through systematic testing approaches across different testing methodologies.
 - **Model**: sonnet
-
-### Aws_Ops_Agent (`aws_ops_agent`)
-AWS operations specialist for EC2, S3, Lambda, RDS, IAM, CloudWatch, and VPC management
-- **Authority**: {'git_commit': True, 'file_operations': True, 'environment_config': True}
-- **Model**: sonnet
-
-### Base Agent (`base-agent`)
-Specialized agent
-
-### Base Engineer (`base-engineer`)
-Specialized agent
-
-### Base Ops (`base-ops`)
-Specialized agent
-
-### Base Qa (`base-qa`)
-Specialized agent
-
-### Base Research (`base-research`)
-Specialized agent
-
-### Clerk Ops (`clerk-ops`)
-Use this agent when you need infrastructure management, deployment automation, or operational excellence. This agent specializes in DevOps practices, cloud operations, monitoring setup, and maintaining reliable production systems.
-
-### Code Critic (`code-critic`)
-Use this agent when you need comprehensive testing, quality assurance validation, or test automation. This agent specializes in creating robust test suites, identifying edge cases, and ensuring code quality through systematic testing approaches across different testing methodologies.
-- **Model**: sonnet
-
-### Content (`content`)
-Use this agent when you need specialized assistance with website content quality specialist for text optimization, seo, readability, and accessibility improvements. This agent provides targeted expertise and follows best practices for content related tasks.
 
 ### Dart Engineer (`dart-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
@@ -502,13 +583,6 @@ Use this agent when you need to implement new features, write production-quality
 
 ### Data Engineer (`data-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
-
-### Data Scientist (`data-scientist`)
-Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
-
-### Digitalocean Ops (`digitalocean-ops`)
-Use this agent when you need infrastructure management, deployment automation, or operational excellence. This agent specializes in DevOps practices, cloud operations, monitoring setup, and maintaining reliable production systems.
-- **Model**: sonnet
 
 ### Documentation (`documentation`)
 Use this agent when you need to create, update, or maintain technical documentation. This agent specializes in writing clear, comprehensive documentation including API docs, user guides, and technical specifications.
@@ -524,9 +598,6 @@ Use this agent when you need infrastructure management, deployment automation, o
 ### Golang Engineer (`golang-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 - **Model**: sonnet
-
-### Imagemagick (`imagemagick`)
-Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 
 ### Java Engineer (`java-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
@@ -544,17 +615,6 @@ Use this agent when you need infrastructure management, deployment automation, o
 Use this agent when you need specialized assistance with manages project-specific agent memories for improved context retention and knowledge accumulation with dynamic runtime loading. This agent provides targeted expertise and follows best practices for memory manager related tasks.
 - **Model**: haiku
 
-### Mpm_Agent_Manager (`mpm_agent_manager`)
-Manages agent lifecycle including discovery, configuration, deployment, and PR-based improvements to the agent repository
-- **Model**: haiku
-
-### Mpm_Skills_Manager (`mpm_skills_manager`)
-Manages skill lifecycle including discovery, recommendation, deployment, and PR-based improvements to the skills repository
-- **Model**: haiku
-
-### Nestjs Engineer (`nestjs-engineer`)
-Use this agent when you need to implement NestJS-specific features, build REST APIs, integrate MongoDB with Mongoose, implement authentication/authorization, or work with Bull queues. This agent specializes in NestJS 10+ architecture patterns, dependency injection, decorators, and testing.
-
 ### Nextjs Engineer (`nextjs-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 - **Model**: sonnet
@@ -571,9 +631,6 @@ Use this agent when you need to implement new features, write production-quality
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 - **Model**: sonnet
 
-### Product Owner (`product-owner`)
-Use this agent when you need specialized assistance with modern product ownership specialist: evidence-based decisions, outcome-focused planning, rice prioritization, continuous discovery. This agent provides targeted expertise and follows best practices for product owner related tasks.
-
 ### Prompt Engineer (`prompt-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 - **Model**: sonnet
@@ -588,10 +645,6 @@ Use this agent when you need comprehensive testing, quality assurance validation
 
 ### React Engineer (`react-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
-- **Model**: sonnet
-
-### Real User (`real-user`)
-Persona-based behavioral testing agent that simulates realistic user interactions. Configures user personas with varying tech savviness, patience, and device preferences to test applications from authentic user perspectives.
 - **Model**: sonnet
 
 ### Refactoring Engineer (`refactoring-engineer`)
@@ -625,9 +678,6 @@ Use this agent when you need to implement new features, write production-quality
 Use this agent when you need to create, update, or maintain technical documentation. This agent specializes in writing clear, comprehensive documentation including API docs, user guides, and technical specifications.
 - **Model**: haiku
 
-### Tmux (`tmux`)
-Use this agent when you need infrastructure management, deployment automation, or operational excellence. This agent specializes in DevOps practices, cloud operations, monitoring setup, and maintaining reliable production systems.
-
 ### Typescript Engineer (`typescript-engineer`)
 Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 - **Model**: sonnet
@@ -640,15 +690,9 @@ Use this agent when you need infrastructure management, deployment automation, o
 Use this agent when you need infrastructure management, deployment automation, or operational excellence. This agent specializes in DevOps practices, cloud operations, monitoring setup, and maintaining reliable production systems.
 - **Model**: haiku
 
-### Visual Basic Engineer (`visual-basic-engineer`)
-Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
-
 ### Web Qa (`web-qa`)
 Use this agent when you need comprehensive testing, quality assurance validation, or test automation. This agent specializes in creating robust test suites, identifying edge cases, and ensuring code quality through systematic testing approaches across different testing methodologies.
 - **Model**: sonnet
-
-### Web UI Engineer (`web-ui-engineer`)
-Use this agent when you need to implement new features, write production-quality code, refactor existing code, or solve complex programming challenges. This agent excels at translating requirements into well-architected, maintainable code solutions across various programming languages and frameworks.
 
 ## Context-Aware Agent Selection
 
@@ -658,21 +702,37 @@ Select agents based on their descriptions above. Key principles:
 - Consider agent handoff recommendations
 - Use the agent ID in parentheses when delegating via Task tool
 
-**Total Available Agents**: 54
+**Total Available Agents**: 31
 
 
 ## Temporal & User Context
-**Current DateTime**: 2026-05-26 14:56:39 EDT (UTC-04:00)
-**Day**: Tuesday
+**Current DateTime**: 2026-06-04 16:53:21 EDT (UTC-04:00)
+**Day**: Thursday
 **User**: masa
 **Home Directory**: /Users/masa
 **System**: Darwin (macOS)
 **System Version**: 25.5.0
-**Working Directory**: /Volumes/Kemono/Users/masa/Projects/claude-mpm
+**Working Directory**: /private/tmp/claude-502/pytest-of-masa/pytest-709/assembled_prompt0
 **Locale**: en_US
 
 Apply temporal and user awareness to all tasks, decisions, and interactions.
 Use this context for personalized responses and time-sensitive operations.
+
+
+## Available Tool Services (auto-detected at session start)
+
+This OVERRIDES the unconditional tool guidance elsewhere in these instructions. Do NOT call any service listed as NOT available below.
+
+| Service | Status | Impact |
+| --- | --- | --- |
+| trusty-memory | ON | Context-First Protocol active: query `mcp__trusty-memory__memory_recall` first. |
+| trusty-search | ON | Code search available: use `mcp__trusty-search__search` before delegating to Research. |
+| trusty-analyze | ABSENT | trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls. |
+| trusty-review | ON | `/mpm-review` and `mcp__trusty-review__*` are usable. |
+
+**Skip the following this session:**
+
+- trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls.
 
 
 # BASE_PM Framework Floor

--- a/tests/hooks/test_auto_pause_handler.py
+++ b/tests/hooks/test_auto_pause_handler.py
@@ -125,7 +125,11 @@ class TestUsageUpdateAndThresholds:
         assert not handler.is_pause_active()  # Still no pause
 
     def test_update_usage_crosses_auto_pause_threshold(self, handler):
-        """Crossing 90% threshold should return 'auto_pause' and trigger pause."""
+        """Crossing 90% reports the threshold but NEVER triggers a pause.
+
+        Auto-pause is disabled: usage is still tracked/reported, but no pause
+        session is started and no ACTIVE-PAUSE.jsonl is written.
+        """
         # Update to 91% context
         usage = {
             "input_tokens": 130000,
@@ -134,16 +138,18 @@ class TestUsageUpdateAndThresholds:
 
         threshold = handler.on_usage_update(usage)
 
+        # Threshold crossing is still reported (metering remains accurate)...
         assert threshold == "auto_pause"
-        assert handler.is_pause_active()
+        # ...but no pause is ever activated.
+        assert not handler.is_pause_active()
 
-        # Verify pause session was created
+        # Verify NO pause session file was created.
         sessions_dir = handler.project_path / ".claude-mpm" / "sessions"
         active_pause = sessions_dir / "ACTIVE-PAUSE.jsonl"
-        assert active_pause.exists()
+        assert not active_pause.exists()
 
     def test_update_usage_crosses_critical_threshold(self, handler):
-        """Crossing 95% threshold should return 'critical' and trigger pause."""
+        """Crossing 95% reports 'critical' but NEVER triggers a pause."""
         # Update to 96% context
         usage = {
             "input_tokens": 140000,
@@ -153,7 +159,7 @@ class TestUsageUpdateAndThresholds:
         threshold = handler.on_usage_update(usage)
 
         assert threshold == "critical"
-        assert handler.is_pause_active()
+        assert not handler.is_pause_active()
 
     def test_update_usage_multiple_times_only_new_thresholds(self, handler):
         """Should only return threshold when crossing NEW threshold."""
@@ -203,26 +209,30 @@ class TestUsageUpdateAndThresholds:
 
 
 class TestActionRecording:
-    """Test action recording during pause mode."""
+    """Auto-pause is disabled, so no action recording ever occurs.
 
-    def test_record_tool_call_when_pause_active(self, handler):
-        """Should record tool calls when pause is active."""
-        # Trigger auto-pause
+    Crossing a threshold no longer activates a pause, so the on_tool_call /
+    on_assistant_response / on_user_message recording APIs short-circuit (they
+    only record while is_pause_active() is True, which never happens).
+    """
+
+    def test_no_recording_after_threshold_crossing(self, handler):
+        """Even above 90%, tool calls/responses are NOT recorded (no pause)."""
+        # Cross the (former) auto-pause threshold.
         handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
 
-        # Record tool call
+        # Attempt to record actions.
         handler.on_tool_call(
             tool_name="Read",
             tool_args={"file_path": "/test/file.py", "limit": 100},
         )
+        handler.on_assistant_response("This is a test response.")
+        handler.on_user_message("Please fix the bug.")
 
-        # Verify action was recorded
-        actions = handler.pause_manager.get_recorded_actions()
-        tool_actions = [a for a in actions if a.type == "tool_call"]
-
-        assert len(tool_actions) == 1
-        assert tool_actions[0].data["tool"] == "Read"
-        assert "args_summary" in tool_actions[0].data
+        # No pause is active, so nothing is recorded and no pause file exists.
+        assert not handler.is_pause_active()
+        sessions_dir = handler.project_path / ".claude-mpm" / "sessions"
+        assert not (sessions_dir / "ACTIVE-PAUSE.jsonl").exists()
 
     def test_record_tool_call_when_pause_not_active(self, handler):
         """Should not record tool calls when pause is not active."""
@@ -235,84 +245,10 @@ class TestActionRecording:
         # Pause should not be active
         assert not handler.is_pause_active()
 
-    def test_record_assistant_response_when_pause_active(self, handler):
-        """Should record assistant responses when pause is active."""
-        # Trigger auto-pause
-        handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-
-        # Record response
-        response = "This is a test response from the assistant."
-        handler.on_assistant_response(response)
-
-        # Verify action was recorded
-        actions = handler.pause_manager.get_recorded_actions()
-        response_actions = [a for a in actions if a.type == "assistant_response"]
-
-        assert len(response_actions) == 1
-        assert response_actions[0].data["summary"] == response
-
-    def test_record_assistant_response_truncates_long_text(self, handler):
-        """Should truncate long assistant responses."""
-        # Trigger auto-pause
-        handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-
-        # Record very long response
-        long_response = "A" * 1000  # 1000 characters
-        handler.on_assistant_response(long_response)
-
-        # Verify truncation
-        actions = handler.pause_manager.get_recorded_actions()
-        response_actions = [a for a in actions if a.type == "assistant_response"]
-
-        summary = response_actions[0].data["summary"]
-        assert len(summary) <= 500  # MAX_SUMMARY_LENGTH
-        assert summary.endswith("...")
-
-    def test_record_user_message_when_pause_active(self, handler):
-        """Should record user messages when pause is active."""
-        # Trigger auto-pause
-        handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-
-        # Record user message
-        message = "Please fix the bug in authentication."
-        handler.on_user_message(message)
-
-        # Verify action was recorded
-        actions = handler.pause_manager.get_recorded_actions()
-        message_actions = [a for a in actions if a.type == "user_message"]
-
-        assert len(message_actions) == 1
-        assert message_actions[0].data["summary"] == message
-
-    def test_record_multiple_actions(self, handler):
-        """Should record multiple actions in sequence."""
-        # Trigger auto-pause
-        handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-
-        # Record multiple actions
-        handler.on_tool_call("Read", {"file": "test.py"})
-        handler.on_assistant_response("Reading file...")
-        handler.on_tool_call("Edit", {"file": "test.py", "old": "a", "new": "b"})
-        handler.on_assistant_response("File edited.")
-
-        # Verify all actions recorded
-        actions = handler.pause_manager.get_recorded_actions()
-
-        # First action is pause_started
-        assert actions[0].type == "pause_started"
-
-        # Subsequent actions
-        action_types = [a.type for a in actions[1:]]
-        assert action_types == [
-            "tool_call",
-            "assistant_response",
-            "tool_call",
-            "assistant_response",
-        ]
-
 
 class TestSessionFinalization:
-    """Test session end handling and finalization."""
+    """Test session end handling. Auto-pause never activates, so on_session_end
+    always returns None (there is no pause to finalize)."""
 
     def test_session_end_with_no_active_pause(self, handler):
         """Should return None if no pause is active."""
@@ -320,46 +256,24 @@ class TestSessionFinalization:
 
         assert session_file is None
 
-    def test_session_end_with_active_pause(self, handler):
-        """Should finalize pause and return session file path."""
-        # Trigger auto-pause and record actions
+    def test_session_end_after_threshold_crossing_returns_none(self, handler):
+        """Even after crossing 90%, no pause exists to finalize.
+
+        Auto-pause is disabled, so on_session_end has nothing to finalize and
+        no ACTIVE-PAUSE.jsonl is ever created.
+        """
         handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
         handler.on_tool_call("Read", {"file": "test.py"})
         handler.on_assistant_response("Processing...")
 
-        # End session
         session_file = handler.on_session_end()
 
-        assert session_file is not None
-        assert session_file.exists()
-        assert session_file.suffix == ".json"
+        assert session_file is None
 
-        # Verify ACTIVE-PAUSE.jsonl was archived
+        # No ACTIVE-PAUSE.jsonl was ever created.
         sessions_dir = handler.project_path / ".claude-mpm" / "sessions"
         active_pause = sessions_dir / "ACTIVE-PAUSE.jsonl"
-        assert not active_pause.exists()  # Should be archived/removed
-
-    def test_session_end_creates_all_formats(self, handler):
-        """Should create JSON, YAML, and MD files."""
-        # Trigger auto-pause
-        handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-        handler.on_tool_call("Read", {"file": "test.py"})
-
-        # End session
-        session_file = handler.on_session_end()
-
-        # Extract session ID
-        session_id = session_file.stem
-
-        # Verify all formats exist
-        sessions_dir = handler.project_path / ".claude-mpm" / "sessions"
-        json_file = sessions_dir / f"{session_id}.json"
-        yaml_file = sessions_dir / f"{session_id}.yaml"
-        md_file = sessions_dir / f"{session_id}.md"
-
-        assert json_file.exists()
-        assert yaml_file.exists()
-        assert md_file.exists()
+        assert not active_pause.exists()
 
 
 class TestStatusAndWarnings:
@@ -386,17 +300,21 @@ class TestStatusAndWarnings:
         assert status["threshold_reached"] is None  # Below 70%
         assert status["total_tokens"] == 75000
 
-    def test_get_status_with_active_pause(self, handler):
-        """Should include pause details when pause is active."""
-        # Trigger pause
+    def test_status_pause_never_active_after_threshold(self, handler):
+        """Status reflects accurate usage but pause is never active."""
+        # Cross the (former) auto-pause threshold.
         handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
         handler.on_tool_call("Read", {"file": "test.py"})
 
         status = handler.get_status()
 
-        assert status["pause_active"] is True
-        assert "pause_details" in status
-        assert status["pause_details"]["action_count"] >= 1
+        # Metering is accurate (182k / 200k = 91%)...
+        assert status["context_percentage"] == 91.0
+        assert status["threshold_reached"] == "auto_pause"
+        # ...but no pause is ever active and no pause details accumulate.
+        assert status["pause_active"] is False
+        assert status["auto_pause_active"] is False
+        assert "pause_details" not in status
 
     def test_emit_threshold_warning_caution(self, handler):
         """Should emit caution warning at 70%."""
@@ -406,11 +324,11 @@ class TestStatusAndWarnings:
         assert "Consider wrapping up" in warning
 
     def test_emit_threshold_warning_auto_pause(self, handler):
-        """Should emit auto-pause warning at 90%."""
+        """At 90% the message is informational and states pause is disabled."""
         warning = handler.emit_threshold_warning("auto_pause")
 
         assert "90%" in warning
-        assert "Auto-pause activated" in warning
+        assert "auto-pause is disabled" in warning
 
     def test_emit_threshold_warning_includes_percentage(self, handler):
         """Warning should include actual context percentage."""
@@ -436,9 +354,9 @@ class TestEdgeCases:
 
         threshold = handler.on_usage_update(usage)
 
-        # Should return auto_pause (highest threshold crossed)
+        # Should return auto_pause (highest threshold crossed) but NOT pause.
         assert threshold == "auto_pause"
-        assert handler.is_pause_active()
+        assert not handler.is_pause_active()
 
     def test_usage_update_with_missing_fields(self, handler):
         """Should handle missing usage fields gracefully."""
@@ -453,23 +371,17 @@ class TestEdgeCases:
         status = handler.get_status()
         assert status["total_tokens"] == 10000
 
-    def test_pause_already_active_no_duplicate_trigger(self, handler):
-        """Should not create duplicate pause sessions."""
-        # Trigger pause
+    def test_threshold_crossings_never_create_pause(self, handler):
+        """Repeated threshold crossings never create a pause session."""
+        # Cross threshold, then update again.
         handler.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
-
-        # Try to trigger again
         handler.on_usage_update({"input_tokens": 5000, "output_tokens": 5000})
 
-        # Should only have one pause session
+        # No ACTIVE-PAUSE.jsonl is ever created and no pause is active.
         sessions_dir = handler.project_path / ".claude-mpm" / "sessions"
         active_pause = sessions_dir / "ACTIVE-PAUSE.jsonl"
-        assert active_pause.exists()
-
-        # Should have exactly one pause_started action
-        actions = handler.pause_manager.get_recorded_actions()
-        pause_starts = [a for a in actions if a.type == "pause_started"]
-        assert len(pause_starts) == 1
+        assert not active_pause.exists()
+        assert not handler.is_pause_active()
 
     def test_summarize_dict_limits_items(self, handler):
         """Should limit dictionary summaries to max items."""
@@ -516,15 +428,16 @@ class TestConcurrency:
         assert status["total_tokens"] == 75000
         assert status["context_percentage"] == 37.5
 
-    def test_pause_state_persists_across_instances(self, temp_project_dir):
-        """Pause state should persist across handler instances."""
-        # First handler triggers pause
+    def test_no_pause_persists_across_instances(self, temp_project_dir):
+        """Threshold crossings never create a pause, even across instances."""
+        # First handler crosses the threshold.
         handler1 = AutoPauseHandler(project_path=temp_project_dir)
         handler1.on_usage_update({"input_tokens": 130000, "output_tokens": 52000})
+        assert not handler1.is_pause_active()
 
-        # Second handler should see active pause
+        # Second handler also sees no active pause.
         handler2 = AutoPauseHandler(project_path=temp_project_dir)
-        assert handler2.is_pause_active()
+        assert not handler2.is_pause_active()
 
 
 if __name__ == "__main__":

--- a/tests/hooks/test_auto_pause_integration.py
+++ b/tests/hooks/test_auto_pause_integration.py
@@ -1,18 +1,18 @@
-"""Integration tests for auto-pause handler with event handlers.
+"""Integration tests confirming context auto-pause is DISABLED end-to-end.
 
-WHY: Verify that auto-pause handler is properly integrated with event handlers
-to record actions during pause mode and finalize sessions on stop events.
+WHY: Auto-pause used to abort active work (including in-flight sub-agent
+delegations) once context usage crossed 90%/95%. That behavior was removed.
+Token usage is still metered, but crossing a threshold must NEVER start a pause,
+write ACTIVE-PAUSE.jsonl, or record actions through the event-handler path.
 
 Tests:
-- Tool calls are recorded when pause is active
-- Assistant responses are recorded when pause is active
-- User messages are recorded when pause is active
-- Sessions are finalized on stop events
+- Crossing the threshold reports it but never activates a pause
+- No actions are recorded through the event handlers (pause never active)
+- No ACTIVE-PAUSE.jsonl is ever created
+- Event handling still flows normally (SocketIO events emitted)
 """
 
-import json
-from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -20,8 +20,8 @@ from claude_mpm.hooks.claude_hooks.auto_pause_handler import AutoPauseHandler
 from claude_mpm.hooks.claude_hooks.event_handlers import EventHandlers
 
 
-class TestAutoPauseIntegration:
-    """Test auto-pause handler integration with event handlers."""
+class TestAutoPauseDisabledIntegration:
+    """Confirm threshold crossings never pause through the event-handler path."""
 
     @pytest.fixture
     def temp_project(self, tmp_path):
@@ -35,7 +35,7 @@ class TestAutoPauseIntegration:
 
     @pytest.fixture
     def mock_hook_handler(self, temp_project):
-        """Create a mock hook handler with auto-pause enabled."""
+        """Create a mock hook handler with an auto-pause handler attached."""
         handler = MagicMock()
         handler.auto_pause_handler = AutoPauseHandler(temp_project)
         handler._git_branch_cache = {}
@@ -50,120 +50,93 @@ class TestAutoPauseIntegration:
         """Create event handlers instance."""
         return EventHandlers(mock_hook_handler)
 
-    def test_tool_call_recorded_when_pause_active(
+    def test_threshold_crossing_never_activates_pause(
         self, event_handlers, mock_hook_handler, temp_project
     ):
-        """Test that tool calls are recorded when auto-pause is active."""
-        # Trigger auto-pause by crossing threshold (90% of 200k = 180k tokens)
+        """Crossing 90% reports the threshold but never activates a pause."""
         auto_pause = mock_hook_handler.auto_pause_handler
         usage = {
             "input_tokens": 160000,
-            "output_tokens": 20000,
+            "output_tokens": 20000,  # 180k = 90%
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
         threshold = auto_pause.on_usage_update(usage)
+
+        # Metering still reports the crossing...
         assert threshold == "auto_pause"
-        assert auto_pause.is_pause_active()
+        # ...but the pause is never activated.
+        assert not auto_pause.is_pause_active()
 
-        # Simulate tool call event
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/test/file.txt"},
-            "session_id": "test-session-123",
-            "cwd": str(temp_project),
-        }
-
-        # Handle pre-tool event
-        event_handlers.handle_pre_tool_fast(event)
-
-        # Verify ACTIVE-PAUSE.jsonl exists and contains tool call
         pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
-        assert pause_file.exists()
+        assert not pause_file.exists()
 
-        # Read and verify recorded action
-        with open(pause_file) as f:
-            actions = [json.loads(line) for line in f]
-
-        assert len(actions) > 0
-        # First action is the start action, second is the tool call
-        assert any(action["type"] == "tool_call" for action in actions)
-
-    def test_assistant_response_recorded_when_pause_active(
+    def test_no_recording_through_event_handlers_above_threshold(
         self, event_handlers, mock_hook_handler, temp_project
     ):
-        """Test that assistant responses are recorded when auto-pause is active."""
-        # Trigger auto-pause
+        """Even above 95%, event handlers record nothing (pause never active)."""
         auto_pause = mock_hook_handler.auto_pause_handler
         usage = {
             "input_tokens": 180000,
-            "output_tokens": 10000,
+            "output_tokens": 10000,  # 190k = 95%
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
         threshold = auto_pause.on_usage_update(usage)
-        assert threshold == "critical"  # 95% = 190k tokens
-        assert auto_pause.is_pause_active()
+        assert threshold == "critical"
+        assert not auto_pause.is_pause_active()
 
-        # Simulate assistant response event
-        event = {
-            "response": "I've completed the task successfully.",
-            "session_id": "test-session-456",
-            "cwd": str(temp_project),
-        }
+        # Drive a tool call, assistant response, and user prompt through handlers.
+        event_handlers.handle_pre_tool_fast(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/test/file.txt"},
+                "session_id": "test-session-123",
+                "cwd": str(temp_project),
+            }
+        )
+        event_handlers.handle_assistant_response(
+            {
+                "response": "I've completed the task.",
+                "session_id": "test-session-123",
+                "cwd": str(temp_project),
+            }
+        )
+        event_handlers.handle_user_prompt_fast(
+            {
+                "prompt": "Please continue.",
+                "session_id": "test-session-123",
+                "cwd": str(temp_project),
+            }
+        )
 
-        # Handle assistant response
-        event_handlers.handle_assistant_response(event)
-
-        # Verify action was recorded
+        # No ACTIVE-PAUSE.jsonl is ever created.
         pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
-        assert pause_file.exists()
+        assert not pause_file.exists()
 
-        with open(pause_file) as f:
-            actions = [json.loads(line) for line in f]
-
-        assert any(action["type"] == "assistant_response" for action in actions)
-
-    def test_user_message_recorded_when_pause_active(
+    def test_no_recording_when_below_threshold(
         self, event_handlers, mock_hook_handler, temp_project
     ):
-        """Test that user messages are recorded when auto-pause is active."""
-        # Trigger auto-pause
+        """Below threshold, actions are NOT recorded (pause never active)."""
         auto_pause = mock_hook_handler.auto_pause_handler
-        usage = {
-            "input_tokens": 160000,
-            "output_tokens": 20000,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-        }
-        threshold = auto_pause.on_usage_update(usage)
-        assert threshold == "auto_pause"
-        assert auto_pause.is_pause_active()
+        assert not auto_pause.is_pause_active()
 
-        # Simulate user prompt event
-        event = {
-            "prompt": "Please continue with the next step.",
-            "session_id": "test-session-789",
-            "cwd": str(temp_project),
-        }
+        event_handlers.handle_pre_tool_fast(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/test/file.txt"},
+                "session_id": "test-session-no-pause",
+                "cwd": str(temp_project),
+            }
+        )
 
-        # Handle user prompt
-        event_handlers.handle_user_prompt_fast(event)
-
-        # Verify action was recorded
         pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
-        assert pause_file.exists()
+        assert not pause_file.exists()
 
-        with open(pause_file) as f:
-            actions = [json.loads(line) for line in f]
-
-        assert any(action["type"] == "user_message" for action in actions)
-
-    def test_session_finalized_on_stop_event(
+    def test_stop_event_creates_no_pause_session(
         self, event_handlers, mock_hook_handler, temp_project
     ):
-        """Test that pause session is finalized on stop event."""
-        # Trigger auto-pause
+        """A Stop event above threshold finalizes no pause (none was started)."""
         auto_pause = mock_hook_handler.auto_pause_handler
         usage = {
             "input_tokens": 162000,
@@ -171,127 +144,12 @@ class TestAutoPauseIntegration:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
-        threshold = auto_pause.on_usage_update(usage)
-        assert threshold == "auto_pause"
-        assert auto_pause.is_pause_active()
-
-        # Record some actions
-        auto_pause.on_tool_call("Read", {"file_path": "/test/file.txt"})
-        auto_pause.on_assistant_response("Processing file contents...")
-
-        # Simulate stop event with usage data
-        event = {
-            "session_id": "test-session-stop",
-            "reason": "completed",
-            "stop_type": "normal",
-            "cwd": str(temp_project),
-            "usage": usage,
-        }
-
-        # Handle stop event
-        event_handlers.handle_stop_fast(event)
-
-        # Verify session files were created
-        sessions_dir = temp_project / ".claude-mpm" / "sessions"
-        session_files = list(sessions_dir.glob("session-*.md"))
-
-        # Should have at least one session file
-        assert len(session_files) > 0
-
-        # Verify ACTIVE-PAUSE.jsonl was cleaned up
-        pause_file = sessions_dir / "ACTIVE-PAUSE.jsonl"
-        # File might still exist if finalization moves it
-        # The key is that a session-*.md file was created
-
-    def test_no_recording_when_pause_not_active(
-        self, event_handlers, mock_hook_handler, temp_project
-    ):
-        """Test that actions are NOT recorded when pause is not active."""
-        # Verify pause is not active
-        auto_pause = mock_hook_handler.auto_pause_handler
+        auto_pause.on_usage_update(usage)
         assert not auto_pause.is_pause_active()
 
-        # Simulate tool call event (below threshold)
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/test/file.txt"},
-            "session_id": "test-session-no-pause",
-            "cwd": str(temp_project),
-        }
-
-        # Handle pre-tool event
-        event_handlers.handle_pre_tool_fast(event)
-
-        # Verify ACTIVE-PAUSE.jsonl does NOT exist
-        pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
-        assert not pause_file.exists()
-
-    def test_full_workflow_with_multiple_actions(
-        self, event_handlers, mock_hook_handler, temp_project
-    ):
-        """Test full workflow: threshold → pause → actions → finalize."""
-        auto_pause = mock_hook_handler.auto_pause_handler
-
-        # Step 1: Cross threshold to trigger auto-pause
-        usage = {
-            "input_tokens": 161000,
-            "output_tokens": 20000,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-        }
-        threshold = auto_pause.on_usage_update(usage)
-        assert threshold == "auto_pause"
-        assert auto_pause.is_pause_active()
-
-        # Step 2: Record multiple actions
-        # Tool call
-        event_handlers.handle_pre_tool_fast(
-            {
-                "tool_name": "Read",
-                "tool_input": {"file_path": "/test/file.txt"},
-                "session_id": "workflow-test",
-                "cwd": str(temp_project),
-            }
-        )
-
-        # Assistant response
-        event_handlers.handle_assistant_response(
-            {
-                "response": "I've read the file.",
-                "session_id": "workflow-test",
-                "cwd": str(temp_project),
-            }
-        )
-
-        # User message
-        event_handlers.handle_user_prompt_fast(
-            {
-                "prompt": "Great! Now analyze it.",
-                "session_id": "workflow-test",
-                "cwd": str(temp_project),
-            }
-        )
-
-        # Step 3: Verify all actions recorded
-        pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
-        assert pause_file.exists()
-
-        with open(pause_file) as f:
-            actions = [json.loads(line) for line in f]
-
-        # Should have start action + tool call + assistant response + user message
-        assert len(actions) >= 4
-
-        # Verify action types
-        action_types = [a["type"] for a in actions]
-        assert "tool_call" in action_types
-        assert "assistant_response" in action_types
-        assert "user_message" in action_types
-
-        # Step 4: Finalize on stop
         event_handlers.handle_stop_fast(
             {
-                "session_id": "workflow-test",
+                "session_id": "test-session-stop",
                 "reason": "completed",
                 "stop_type": "normal",
                 "cwd": str(temp_project),
@@ -299,20 +157,18 @@ class TestAutoPauseIntegration:
             }
         )
 
-        # Verify session file created
-        sessions_dir = temp_project / ".claude-mpm" / "sessions"
-        session_files = list(sessions_dir.glob("session-*.md"))
-        assert len(session_files) > 0
+        # No pause was active, so no ACTIVE-PAUSE.jsonl exists.
+        pause_file = temp_project / ".claude-mpm" / "sessions" / "ACTIVE-PAUSE.jsonl"
+        assert not pause_file.exists()
 
-    def test_graceful_error_handling(
+    def test_event_handling_still_flows(
         self, event_handlers, mock_hook_handler, temp_project
     ):
-        """Test that auto-pause errors don't break event handling."""
-        # Mock auto-pause to raise errors
+        """Disabling auto-pause must not break normal event handling."""
         auto_pause = mock_hook_handler.auto_pause_handler
+        # Even if a recording call would raise, the handler must not break.
         auto_pause.on_tool_call = Mock(side_effect=RuntimeError("Test error"))
 
-        # Trigger pause
         usage = {
             "input_tokens": 160000,
             "output_tokens": 20000,
@@ -321,16 +177,14 @@ class TestAutoPauseIntegration:
         }
         auto_pause.on_usage_update(usage)
 
-        # Event handling should NOT raise exception
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/test/file.txt"},
-            "session_id": "error-test",
-            "cwd": str(temp_project),
-        }
+        event_handlers.handle_pre_tool_fast(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/test/file.txt"},
+                "session_id": "error-test",
+                "cwd": str(temp_project),
+            }
+        )
 
-        # Should not raise
-        event_handlers.handle_pre_tool_fast(event)
-
-        # Verify SocketIO event was still emitted
+        # SocketIO event was still emitted (event flow intact).
         assert mock_hook_handler._emit_socketio_event.called

--- a/tests/services/infrastructure/test_context_usage_tracker.py
+++ b/tests/services/infrastructure/test_context_usage_tracker.py
@@ -183,35 +183,46 @@ class TestContextUsageTracker:
         assert not state.auto_pause_active
 
     def test_threshold_auto_pause_90_percent(self, clean_tracker):
-        """Test auto-pause threshold at 90% usage."""
+        """Threshold is still reported at 90% but auto_pause_active stays False.
+
+        Auto-pause is disabled: metering (percentage_used, threshold_reached)
+        remains accurate, but auto_pause_active never flips True.
+        """
         # 90% of 200k = 180k tokens
         state = clean_tracker.update_usage(input_tokens=130000, output_tokens=50000)
 
         assert state.percentage_used == pytest.approx(90.0, abs=0.01)
         assert state.threshold_reached == "auto_pause"
-        assert state.auto_pause_active
+        assert not state.auto_pause_active
 
     def test_threshold_critical_95_percent(self, clean_tracker):
-        """Test critical threshold at 95% usage."""
+        """Critical threshold reported at 95% but auto_pause_active stays False."""
         # 95% of 200k = 190k tokens
         state = clean_tracker.update_usage(input_tokens=140000, output_tokens=50000)
 
         assert state.percentage_used == pytest.approx(95.0, abs=0.01)
         assert state.threshold_reached == "critical"
-        assert state.auto_pause_active
+        assert not state.auto_pause_active
 
-    def test_should_auto_pause_true(self, clean_tracker):
-        """Test should_auto_pause returns True at 90%+ usage."""
-        # Start below threshold
+    def test_should_auto_pause_always_false_at_high_usage(self, clean_tracker):
+        """should_auto_pause is permanently disabled — always returns False.
+
+        Even at 90%+ usage (where it historically returned True) it must return
+        False, while metering still records the true percentage.
+        """
         assert not clean_tracker.should_auto_pause()
 
-        # Cross 90% threshold
+        # Cross the former 90% threshold.
         clean_tracker.update_usage(input_tokens=130000, output_tokens=50000)
-        assert clean_tracker.should_auto_pause()
+        assert not clean_tracker.should_auto_pause()
+        # Metering is still accurate.
+        assert clean_tracker.get_current_state().percentage_used == pytest.approx(
+            90.0, abs=0.01
+        )
 
     def test_should_auto_pause_false(self, clean_tracker):
-        """Test should_auto_pause returns False below 90%."""
-        # 85% usage - below auto-pause threshold
+        """should_auto_pause returns False below 90% (and everywhere else)."""
+        # 85% usage - below the former auto-pause threshold
         clean_tracker.update_usage(input_tokens=120000, output_tokens=50000)
         assert not clean_tracker.should_auto_pause()
 

--- a/tests/test_assembled_prompt_snapshot.py
+++ b/tests/test_assembled_prompt_snapshot.py
@@ -26,7 +26,7 @@ from claude_mpm.core.framework_loader import FrameworkLoader
 REQUIRED_SECTIONS = [
     "## Prohibitions",  # Circuit-breaker prohibition table header
     "CB#1",  # Lowest circuit-breaker number must be present
-    "CB#11",  # Highest circuit-breaker number must be present
+    "CB#14",  # Highest circuit-breaker number must be present (CB#11 was removed)
     "## Agent Routing",  # Routing section present
     "## Workflow",  # Compact workflow summary present (from PM_INSTRUCTIONS.md)
     "## QA Verification Gate",  # QA gate section


### PR DESCRIPTION
## Summary

Disables the context-usage **auto-pause / "context circuit breaker"** behavior while **preserving token-usage metering**.

At high context %, MPM used to auto-pause and abort active work (including in-flight sub-agent delegations), emitting messages like *"Context at 122% — session paused to prevent data loss."* This killed legitimate work. Token usage is still **measured** (commit-cost trailers + dashboard depend on it) but **never** triggers a pause/abort.

## What changed (three layers)

### Layer A — Code (auto-pause mechanism neutralized)
- `auto_pause_handler.py`: `_trigger_auto_pause()` is now a no-op; `on_usage_update()` still tracks usage via `ContextUsageTracker` but never starts a pause or writes `ACTIVE-PAUSE.jsonl`. Public method signatures preserved.
- `context_usage_tracker.py`: `should_auto_pause()` always returns `False`; `update_usage()` no longer sets `auto_pause_active=True`. **Metering preserved** (`update_usage`/`set_session_snapshot` still write `context-usage.json`).
- `resume_log_generator.py`: `should_auto_pause()` always returns `False`.

### Layer B — Instruction text
- `PM_INSTRUCTIONS.md`: removed CB#11 "Context Overflow Recovery" (CB table row, Critical-CB summary row, prose paragraph, and a dangling reference). Other CB numbers left unchanged.
- `mpm-circuit-breaker-enforcement/SKILL.md`: resolved the CB#11 numbering collision (kept "Read Tool Limit Enforcement", added an identifier note).

### Layer C — Documentation
- `docs/features/incremental-pause-workflow.md`: added a banner + "Removed: context auto-pause" section explaining the behavior change and rationale, and that metering + manual `/mpm-session-pause` are preserved.

## Metering preserved (explicit)
`stop_handler` still calls `set_session_snapshot(...)`; `ContextUsageTracker` still computes `percentage_used`/`threshold_reached` and writes `.claude-mpm/state/context-usage.json`. Only the pause-*driving* signal was removed.

## Tests
- Updated `test_auto_pause_handler.py`, `test_auto_pause_integration.py`, `test_context_usage_tracker.py` to assert usage is still tracked but **no pause is ever created** (no `ACTIVE-PAUSE.jsonl`).
- Updated `test_assembled_prompt_snapshot.py` sentinel (CB#11 → CB#14) and regenerated the golden snapshot after CB#11 removal.
- All affected tests pass: **157 passed** across the hooks/infrastructure/snapshot suites. Full serial suite: **9177 passed**; remaining failures (`test_startup_display` trusty-review, `test_wwl_granularity`) were verified **pre-existing on `main`** and unrelated.

## No migration
`PM_INSTRUCTIONS_DEPLOYED.md` rebuilds from source on startup — confirmed **no migration file added**.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
