### PR TITLE
feat: verify trusty-search index present and fresh on startup (#649)

### DIFF
--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -502,25 +502,20 @@ class FrameworkLoader:
         reindex fired; daemon error → "" + no reindex + no exception.
         """
         try:
-            from claude_mpm.services.trusty_status import (
-                get_trusty_search_index_status,
-                is_index_missing_or_empty,
-                is_index_stale,
-                trigger_trusty_search_reindex,
-            )
+            import claude_mpm.services.trusty_status as _ts
 
-            status = get_trusty_search_index_status()
+            status = _ts.get_trusty_search_index_status()
 
-            if is_index_missing_or_empty(status):
+            if _ts.is_index_missing_or_empty(status):
                 index_id = self._resolve_reindex_id(status)
                 if index_id:
-                    trigger_trusty_search_reindex(index_id)
+                    _ts.trigger_trusty_search_reindex(index_id)
                 return "Index not found/empty — background indexing started."
 
-            if is_index_stale(status):
+            if _ts.is_index_stale(status):
                 index_id = self._resolve_reindex_id(status)
                 if index_id:
-                    trigger_trusty_search_reindex(index_id)
+                    _ts.trigger_trusty_search_reindex(index_id)
                 return "Index may be stale — background reindex started."
 
             return ""  # fresh index → no note
@@ -545,9 +540,9 @@ class FrameworkLoader:
             if isinstance(index_id, str) and index_id:
                 return index_id
         try:
-            from claude_mpm.services.trusty_status import _index_id_candidates
+            import claude_mpm.services.trusty_status as _ts
 
-            candidates = _index_id_candidates(Path.cwd())
+            candidates = _ts._index_id_candidates(Path.cwd().resolve())
             return candidates[0] if candidates else None
         except Exception:
             return None

--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -456,6 +456,13 @@ class FrameworkLoader:
             is_on = state == "on"
             label = status_labels.get(state, "ABSENT")
             impact = (impact_on if is_on else impact_off)[service]
+            # trusty-search ON: verify the project index exists & is fresh, and
+            # kick off a background reindex (non-blocking) if it is not. Any
+            # failure here is swallowed inside the helper so startup never breaks.
+            if is_on and service == "trusty-search":
+                note = self._trusty_search_index_note()
+                if note:
+                    impact = f"{impact} {note}"
             lines.append(f"| {service} | {label} | {impact} |")
             if not is_on:
                 negations.append(f"- {impact}")
@@ -475,6 +482,75 @@ class FrameworkLoader:
             )
 
         return "\n".join(lines) + "\n"
+
+    def _trusty_search_index_note(self) -> str:
+        """Why: When trusty-search is ON, the PM assumes code search "just works",
+        but a brand-new or stale index returns poor results. We check the
+        daemon's OWN view of this project's index (no git/mtime scanning) and, if
+        it is missing/empty/stale, fire a BACKGROUND reindex and tell the PM the
+        results may be incomplete this turn. Must never block or break startup.
+
+        What: Resolves the project's index via
+        ``get_trusty_search_index_status``; if missing/empty or daemon-stale,
+        triggers a fire-and-forget ``reindex`` and returns a short note to append
+        to the trusty-search row ("Index not found/empty — background indexing
+        started." / "Index may be stale — background reindex started."). Returns
+        ``""`` for a fresh index OR on ANY error (fail-open).
+
+        Test: ``tests/test_framework_loader_index_freshness.py`` — fresh → no
+        note + no reindex; missing/empty → note + reindex fired; stale → note +
+        reindex fired; daemon error → "" + no reindex + no exception.
+        """
+        try:
+            from claude_mpm.services.trusty_status import (
+                get_trusty_search_index_status,
+                is_index_missing_or_empty,
+                is_index_stale,
+                trigger_trusty_search_reindex,
+            )
+
+            status = get_trusty_search_index_status()
+
+            if is_index_missing_or_empty(status):
+                index_id = self._resolve_reindex_id(status)
+                if index_id:
+                    trigger_trusty_search_reindex(index_id)
+                return "Index not found/empty — background indexing started."
+
+            if is_index_stale(status):
+                index_id = self._resolve_reindex_id(status)
+                if index_id:
+                    trigger_trusty_search_reindex(index_id)
+                return "Index may be stale — background reindex started."
+
+            return ""  # fresh index → no note
+        except Exception as e:  # pragma: no cover - defensive fail-open
+            self.logger.debug(f"Skipping trusty-search index freshness check: {e}")
+            return ""
+
+    @staticmethod
+    def _resolve_reindex_id(status: dict | None) -> str | None:
+        """Why: The reindex POST needs an index ID. A matched (but empty/stale)
+        index reports its own ``index_id``; a wholly-missing index (status None)
+        has none, so we fall back to the first candidate derived from CWD.
+
+        What: Returns ``status["index_id"]`` when present, else the first
+        candidate from ``_index_id_candidates(Path.cwd())``, else ``None``.
+
+        Test: ``tests/test_framework_loader_index_freshness.py`` — status with
+        index_id returns it; None status returns the cwd-derived candidate.
+        """
+        if isinstance(status, dict):
+            index_id = status.get("index_id")
+            if isinstance(index_id, str) and index_id:
+                return index_id
+        try:
+            from claude_mpm.services.trusty_status import _index_id_candidates
+
+            candidates = _index_id_candidates(Path.cwd())
+            return candidates[0] if candidates else None
+        except Exception:
+            return None
 
     def _format_minimal_framework(self) -> str:
         """Format minimal framework instructions."""

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -252,6 +252,192 @@ def _cached_palace_exists(service: str, base_url: str, palace: str) -> bool:
     return exists
 
 
+def _index_id_candidates(cwd: Path) -> list[str]:
+    """Why: There is NO root_path→index lookup endpoint, so we must probe a small
+    set of likely index IDs and confirm the one whose ``root_path`` matches CWD.
+
+    What: Returns the ordered candidate index IDs for ``cwd``: an explicit
+    ``trusty_search.index_id`` config override first (if set), then the cwd
+    basename (e.g. ``claude-mpm``), then the path-derived ``"_".join(...)`` form
+    (e.g. ``Volumes_SSD1_Projects_claude-mpm``). De-duplicated, order preserved.
+
+    Test: ``tests/test_trusty_search_index.py::TestIndexIdCandidates`` — asserts
+    the override leads, both derived forms appear, and duplicates are dropped.
+    """
+    candidates: list[str] = []
+    config = _load_config()
+    section = config.get("trusty_search", {})
+    if isinstance(section, dict):
+        override = section.get("index_id")
+        if isinstance(override, str) and override.strip():
+            candidates.append(override.strip())
+
+    candidates.append(cwd.name)
+    parts = [p for p in str(cwd).split("/") if p]
+    if parts:
+        candidates.append("_".join(parts))
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for cid in candidates:
+        if cid and cid not in seen:
+            seen.add(cid)
+            ordered.append(cid)
+    return ordered
+
+
+def _fetch_index_status(base_url: str, index_id: str) -> dict[str, Any] | None:
+    """Why: The startup freshness check needs the daemon's own view of an index
+    (chunk_count, root_path, staleness signals) without scanning git/mtimes.
+
+    What: GETs ``{base_url}/indexes/{index_id}/status`` with a hard <=200ms
+    timeout and returns the parsed dict, or ``None`` on any non-2xx / network /
+    parse error (a missing index is a 404 → ``None``). urllib is imported lazily,
+    matching :func:`_health_check`. Never raises.
+
+    Test: ``tests/test_trusty_search_index.py`` — patches urlopen to return a
+    status body, a 404, and an error; asserts dict / None / None respectively.
+    """
+    import json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    url = f"{base_url}/indexes/{urllib.parse.quote(index_id, safe='')}/status"
+    try:
+        req = urllib.request.Request(url, method="GET")  # nosec B310 - localhost
+        with urllib.request.urlopen(  # nosec B310 - localhost
+            req, timeout=_HEALTH_TIMEOUT_S
+        ) as resp:
+            if not (200 <= resp.status < 300):
+                return None
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def get_trusty_search_index_status(cwd: Path | None = None) -> dict[str, Any] | None:
+    """Why: At startup we want the daemon's own status for THIS project's index so
+    we can decide whether to fire a background reindex — without git/mtime
+    scanning. Index IDs are not derivable from root_path via any endpoint, so we
+    probe candidates and confirm by matching ``root_path``.
+
+    What: Resolves ``cwd`` (defaults to ``Path.cwd()``), probes each candidate ID
+    from :func:`_index_id_candidates`, and returns the FIRST status dict whose
+    ``root_path`` resolves to the same path as ``cwd``. Reuses ``_base_url`` and
+    the <=200ms probe. Returns ``None`` on any failure or when no candidate
+    matches (fail-safe — the caller then treats the index as missing). Never
+    raises and never blocks longer than the bounded probes.
+
+    Test: ``tests/test_trusty_search_index.py`` — fresh index returns the dict;
+    a candidate whose root_path differs is skipped; all-miss / daemon-error
+    returns ``None``.
+    """
+    try:
+        resolved = (cwd or Path.cwd()).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    base_url, _host_port = _base_url("trusty-search")
+    for index_id in _index_id_candidates(resolved):
+        status = _fetch_index_status(base_url, index_id)
+        if not status:
+            continue
+        root = status.get("root_path")
+        if not isinstance(root, str):
+            continue
+        try:
+            if Path(root).resolve() == resolved:
+                return status
+        except (OSError, RuntimeError):
+            continue
+    return None
+
+
+def is_index_missing_or_empty(status: dict[str, Any] | None) -> bool:
+    """Why: "Missing or empty" is the primary trigger for a background reindex.
+
+    What: Returns ``True`` when ``status`` is ``None`` (no matching index found)
+    or when its ``chunk_count`` is absent / not a positive int (empty index).
+
+    Test: ``tests/test_trusty_search_index.py`` — None → True, chunk_count 0 →
+    True, missing key → True, chunk_count 65225 → False.
+    """
+    if not status:
+        return True
+    chunk_count = status.get("chunk_count")
+    return not (isinstance(chunk_count, int) and chunk_count > 0)
+
+
+def is_index_stale(status: dict[str, Any] | None) -> bool:
+    """Why: Beyond "missing/empty", the daemon exposes its OWN staleness signals;
+    we lean on those rather than scanning git HEAD / file mtimes ourselves.
+
+    What: Returns ``True`` when a non-empty index nonetheless shows a
+    daemon-reported problem: a non-null ``last_walk_error`` (the last index walk
+    failed) OR a ``status`` field that is not a healthy/terminal value
+    (anything other than ``"ready"``/``"idle"``/``"complete"`` — e.g. ``"error"``
+    or ``"failed"``). Returns ``False`` for a healthy populated index. Empty
+    indexes are handled by :func:`is_index_missing_or_empty`, so this returns
+    ``False`` for them to avoid double-counting.
+
+    Test: ``tests/test_trusty_search_index.py`` — last_walk_error set → True,
+    status "error" → True, status "ready" + no error → False, empty index →
+    False (deferred to missing/empty).
+    """
+    if is_index_missing_or_empty(status):
+        return False
+    assert status is not None  # narrowed by the guard above
+    if status.get("last_walk_error"):
+        return True
+    state = status.get("status")
+    if isinstance(state, str) and state.lower() not in {"ready", "idle", "complete"}:
+        return True
+    return False
+
+
+def trigger_trusty_search_reindex(index_id: str, cwd: Path | None = None) -> bool:
+    """Why: When the project index is missing/empty/stale we must refresh it
+    WITHOUT blocking startup. The daemon already has a background reindex queue
+    (``background_reindex_queue_depth``); we just enqueue and return.
+
+    What: Fires a fire-and-forget ``POST {base}/indexes/{index_id}/reindex`` in a
+    detached daemon thread so this call returns immediately (the daemon queues
+    the work and responds ``{"queued": true}``). Returns ``True`` if the request
+    was dispatched, ``False`` on dispatch failure. NEVER raises into the startup
+    path — all errors inside the thread are swallowed.
+
+    Test: ``tests/test_trusty_search_index.py`` — asserts a thread is started
+    (non-blocking) and the POST URL/method are correct; an error inside the
+    thread does not propagate.
+    """
+    import threading
+    import urllib.parse
+    import urllib.request
+
+    base_url, _host_port = _base_url("trusty-search")
+    url = f"{base_url}/indexes/{urllib.parse.quote(index_id, safe='')}/reindex"
+
+    def _post() -> None:
+        try:
+            req = urllib.request.Request(  # nosec B310 - localhost
+                url, method="POST", data=b""
+            )
+            with urllib.request.urlopen(  # nosec B310 - localhost
+                req, timeout=_HEALTH_TIMEOUT_S
+            ):
+                pass
+        except Exception:
+            pass  # fire-and-forget: the daemon may already be reindexing
+
+    try:
+        threading.Thread(target=_post, daemon=True).start()
+        return True
+    except Exception:
+        return False
+
+
 def _mcp_servers_from_file(path: Path) -> frozenset[str]:
     """Why: Centralise the read-one-mcp-json logic so both the project and user
     paths share the same parse/guard/error-handling without duplication.

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -273,7 +273,7 @@ def _index_id_candidates(cwd: Path) -> list[str]:
             candidates.append(override.strip())
 
     candidates.append(cwd.name)
-    parts = [p for p in str(cwd).split("/") if p]
+    parts = [p for p in cwd.parts if p and p != "/"]
     if parts:
         candidates.append("_".join(parts))
 
@@ -388,7 +388,8 @@ def is_index_stale(status: dict[str, Any] | None) -> bool:
     """
     if is_index_missing_or_empty(status):
         return False
-    assert status is not None  # narrowed by the guard above
+    if status is None:  # narrowed by the guard above; explicit for -O safety
+        return False
     if status.get("last_walk_error"):
         return True
     state = status.get("status")

--- a/tests/test_framework_loader_index_freshness.py
+++ b/tests/test_framework_loader_index_freshness.py
@@ -1,0 +1,163 @@
+"""Tests for FrameworkLoader trusty-search index freshness wiring (#649).
+
+Why: When trusty-search is ON, a missing/empty/stale index silently degrades
+code search. The loader must (a) check the daemon's OWN index status, (b) fire a
+BACKGROUND reindex when not fresh, and (c) annotate the trusty-search row — all
+fail-open so framework assembly never breaks and startup is never blocked.
+
+What: Exercises ``_trusty_search_index_note`` and the integration through
+``_generate_tool_status_section`` against mocked freshness helpers, asserting the
+note text and whether the reindex trigger fired for fresh / missing / stale /
+error cases.
+
+Test: ``uv run pytest tests/test_framework_loader_index_freshness.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from claude_mpm.core.framework_loader import FrameworkLoader
+from claude_mpm.services import trusty_status
+
+
+def _stub_loader():
+    """Minimal stand-in exposing what the freshness methods touch: ``logger`` and
+    the real ``_resolve_reindex_id`` (a staticmethod ``_trusty_search_index_note``
+    calls via ``self``)."""
+    return SimpleNamespace(
+        logger=logging.getLogger("test_index_freshness"),
+        _resolve_reindex_id=FrameworkLoader._resolve_reindex_id,
+    )
+
+
+def _patch_freshness(monkeypatch, *, status, missing, stale):
+    """Patch the four trusty_status symbols the loader imports, and record any
+    reindex trigger calls. Returns the list that captures triggered index IDs."""
+    triggered: list[str] = []
+
+    monkeypatch.setattr(
+        trusty_status, "get_trusty_search_index_status", lambda cwd=None: status
+    )
+    monkeypatch.setattr(trusty_status, "is_index_missing_or_empty", lambda s: missing)
+    monkeypatch.setattr(trusty_status, "is_index_stale", lambda s: stale)
+    monkeypatch.setattr(
+        trusty_status,
+        "trigger_trusty_search_reindex",
+        lambda index_id, cwd=None: triggered.append(index_id) or True,
+    )
+    return triggered
+
+
+class TestIndexNote:
+    def test_fresh_no_note_no_reindex(self, monkeypatch):
+        """Fresh index → empty note and NO reindex fired."""
+        triggered = _patch_freshness(
+            monkeypatch,
+            status={"index_id": "claude-mpm", "chunk_count": 100},
+            missing=False,
+            stale=False,
+        )
+        note = FrameworkLoader._trusty_search_index_note(_stub_loader())
+        assert note == ""
+        assert triggered == []
+
+    def test_missing_empty_note_and_reindex(self, monkeypatch):
+        """Missing/empty index → note + reindex fired with the resolved ID."""
+        triggered = _patch_freshness(
+            monkeypatch,
+            status={"index_id": "claude-mpm", "chunk_count": 0},
+            missing=True,
+            stale=False,
+        )
+        note = FrameworkLoader._trusty_search_index_note(_stub_loader())
+        assert note == "Index not found/empty — background indexing started."
+        assert triggered == ["claude-mpm"]
+
+    def test_status_none_resolves_cwd_candidate(self, monkeypatch):
+        """Wholly-missing index (status None) → reindex uses the cwd candidate."""
+        monkeypatch.setattr(Path, "cwd", lambda: Path("/Volumes/SSD1/Projects/foo"))
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+        triggered = _patch_freshness(
+            monkeypatch, status=None, missing=True, stale=False
+        )
+        note = FrameworkLoader._trusty_search_index_note(_stub_loader())
+        assert "background indexing started" in note
+        assert triggered == ["foo"]  # cwd basename candidate
+
+    def test_stale_note_and_reindex(self, monkeypatch):
+        """Daemon-stale index → stale note + reindex fired."""
+        triggered = _patch_freshness(
+            monkeypatch,
+            status={"index_id": "claude-mpm", "chunk_count": 5, "status": "error"},
+            missing=False,
+            stale=True,
+        )
+        note = FrameworkLoader._trusty_search_index_note(_stub_loader())
+        assert note == "Index may be stale — background reindex started."
+        assert triggered == ["claude-mpm"]
+
+    def test_error_fails_open(self, monkeypatch):
+        """Any exception in the freshness path → empty note, no reindex, no raise."""
+
+        def boom(cwd=None):
+            raise OSError("daemon unreachable")
+
+        monkeypatch.setattr(trusty_status, "get_trusty_search_index_status", boom)
+        note = FrameworkLoader._trusty_search_index_note(_stub_loader())
+        assert note == ""
+
+
+class TestResolveReindexId:
+    def test_prefers_status_index_id(self):
+        rid = FrameworkLoader._resolve_reindex_id({"index_id": "my-index"})
+        assert rid == "my-index"
+
+    def test_none_status_falls_back_to_cwd_candidate(self, monkeypatch):
+        monkeypatch.setattr(Path, "cwd", lambda: Path("/Volumes/SSD1/Projects/bar"))
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+        assert FrameworkLoader._resolve_reindex_id(None) == "bar"
+
+
+class TestSectionIntegration:
+    """The note must appear ON the trusty-search row in the rendered block."""
+
+    def _render(self, monkeypatch, *, note):
+        monkeypatch.setattr(
+            trusty_status,
+            "get_trusty_capabilities",
+            lambda: {
+                "trusty-memory": "absent",
+                "trusty-search": "on",
+                "trusty-analyze": "absent",
+                "trusty-review": "absent",
+            },
+        )
+        stub = _stub_loader()
+        # _generate_tool_status_section calls self._trusty_search_index_note();
+        # bind a fixed return on the stub so we test only the row-rendering wiring.
+        stub._trusty_search_index_note = lambda: note
+        return FrameworkLoader._generate_tool_status_section(stub)
+
+    def test_note_appended_to_search_row(self, monkeypatch):
+        block = self._render(
+            monkeypatch, note="Index not found/empty — background indexing started."
+        )
+        search_row = next(
+            line for line in block.splitlines() if "| trusty-search |" in line
+        )
+        assert "background indexing started" in search_row
+        assert "| ON |" in search_row
+
+    def test_no_note_leaves_row_clean(self, monkeypatch):
+        block = self._render(monkeypatch, note="")
+        search_row = next(
+            line for line in block.splitlines() if "| trusty-search |" in line
+        )
+        assert "background" not in search_row
+        assert "stale" not in search_row

--- a/tests/test_trusty_search_index.py
+++ b/tests/test_trusty_search_index.py
@@ -262,13 +262,36 @@ class TestReindexTrigger:
 
 
 def test_resolve_latency_bounded(monkeypatch):
-    """Why: Startup-path budget — resolution must stay well under a second even
-    when every candidate is probed and misses."""
-    import time
+    """Why: Startup-path budget — resolution must probe at most ONE request per
+    candidate and never loop unboundedly. A flat wall-clock assertion is fragile
+    (CI machines vary widely and the mock has zero latency). Instead we assert
+    that the number of urlopen calls is exactly bounded by the number of
+    candidates, which directly guards against accidentally-added unbounded loops
+    or O(n²) probing strategies.
 
+    What: With two candidates (basename + path-derived) the mock should be called
+    at most twice; the call count is a deterministic, fast, and stable guard.
+
+    Test: monkeypatch records every urlopen call; assert count <= len(candidates).
+    """
     monkeypatch.setattr(Path, "cwd", lambda: CWD)
     monkeypatch.setattr(trusty_status, "_load_config", dict)
-    _patch_urlopen(monkeypatch, lambda url, method: _FakeResp(404, None))
-    t0 = time.perf_counter()
-    assert get_trusty_search_index_status() is None
-    assert (time.perf_counter() - t0) < 1.0
+
+    call_count = 0
+
+    def counting_handler(url, method):
+        nonlocal call_count
+        call_count += 1
+        return _FakeResp(404, None)
+
+    _patch_urlopen(monkeypatch, counting_handler)
+
+    result = get_trusty_search_index_status()
+    assert result is None
+
+    expected_candidates = len(_index_id_candidates(CWD))
+    assert expected_candidates > 0, "test invariant: CWD must have ≥1 candidate"
+    assert call_count <= expected_candidates, (
+        f"probed {call_count} times but only {expected_candidates} candidates exist — "
+        "unbounded probing detected"
+    )

--- a/tests/test_trusty_search_index.py
+++ b/tests/test_trusty_search_index.py
@@ -1,0 +1,274 @@
+"""Unit tests for trusty-search index freshness helpers (GitHub #649).
+
+Why: At startup we want the daemon's OWN view of this project's index so we can
+fire a BACKGROUND reindex when it is missing/empty/stale — without git/mtime
+scanning. These tests pin the resolution, freshness classification, and the
+non-blocking reindex trigger, all of which must be fail-open and never block.
+
+What: Exercises ``_index_id_candidates``, ``_fetch_index_status``,
+``get_trusty_search_index_status``, ``is_index_missing_or_empty``,
+``is_index_stale`` and ``trigger_trusty_search_reindex`` against a mocked daemon
+HTTP layer.
+
+Test: ``uv run pytest tests/test_trusty_search_index.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.claude_mpm.services import trusty_status
+from src.claude_mpm.services.trusty_status import (
+    _index_id_candidates,
+    get_trusty_search_index_status,
+    is_index_missing_or_empty,
+    is_index_stale,
+    trigger_trusty_search_reindex,
+)
+
+CWD = Path("/Volumes/SSD1/Projects/claude-mpm")
+
+
+def _fresh_status(index_id: str = "claude-mpm", root: str = str(CWD)) -> dict:
+    """A healthy, populated index status payload (mirrors the daemon shape)."""
+    return {
+        "index_id": index_id,
+        "chunk_count": 65225,
+        "root_path": root,
+        "last_walk_error": None,
+        "status": "ready",
+    }
+
+
+class TestIndexIdCandidates:
+    """Why: ID resolution drives every probe; the override must win and the two
+    derived forms must both be tried without duplicates."""
+
+    def test_basename_and_path_derived(self):
+        cands = _index_id_candidates(CWD)
+        assert cands == ["claude-mpm", "Volumes_SSD1_Projects_claude-mpm"]
+
+    def test_config_override_leads(self, monkeypatch):
+        monkeypatch.setattr(
+            trusty_status,
+            "_load_config",
+            lambda: {"trusty_search": {"index_id": "my-custom-id"}},
+        )
+        cands = _index_id_candidates(CWD)
+        assert cands[0] == "my-custom-id"
+        assert "claude-mpm" in cands
+
+    def test_dedup_when_basename_equals_override(self, monkeypatch):
+        monkeypatch.setattr(
+            trusty_status,
+            "_load_config",
+            lambda: {"trusty_search": {"index_id": "claude-mpm"}},
+        )
+        cands = _index_id_candidates(CWD)
+        assert cands.count("claude-mpm") == 1
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for urlopen's HTTPResponse."""
+
+    def __init__(self, status: int, body: dict | None):
+        self.status = status
+        self._body = json.dumps(body).encode() if body is not None else b""
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _patch_urlopen(monkeypatch, handler):
+    """Patch urllib.request.urlopen with ``handler(url, method) -> _FakeResp``."""
+    import urllib.request
+
+    def _fake(req, timeout=None):
+        return handler(req.full_url, req.get_method())
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake)
+
+
+class TestFetchAndResolve:
+    """Why: Resolution must confirm root_path matches CWD and fail-safe to None."""
+
+    def test_first_candidate_matches(self, monkeypatch):
+        monkeypatch.setattr(Path, "cwd", lambda: CWD)
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+
+        def handler(url, method):
+            assert method == "GET"
+            assert url.endswith("/indexes/claude-mpm/status")
+            return _FakeResp(200, _fresh_status())
+
+        _patch_urlopen(monkeypatch, handler)
+        status = get_trusty_search_index_status()
+        assert status is not None
+        assert status["index_id"] == "claude-mpm"
+
+    def test_root_path_mismatch_skipped(self, monkeypatch):
+        monkeypatch.setattr(Path, "cwd", lambda: CWD)
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+        # Both candidates resolve, but only the SECOND has the matching root_path.
+        responses = {
+            "claude-mpm": _fresh_status(root="/some/other/project"),
+            "Volumes_SSD1_Projects_claude-mpm": _fresh_status(
+                index_id="Volumes_SSD1_Projects_claude-mpm"
+            ),
+        }
+
+        def handler(url, method):
+            cid = url.split("/indexes/")[1].split("/status")[0]
+            return _FakeResp(200, responses[cid])
+
+        _patch_urlopen(monkeypatch, handler)
+        status = get_trusty_search_index_status()
+        assert status is not None
+        assert status["index_id"] == "Volumes_SSD1_Projects_claude-mpm"
+
+    def test_all_miss_returns_none(self, monkeypatch):
+        monkeypatch.setattr(Path, "cwd", lambda: CWD)
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+        _patch_urlopen(monkeypatch, lambda url, method: _FakeResp(404, None))
+        assert get_trusty_search_index_status() is None
+
+    def test_daemon_error_returns_none(self, monkeypatch):
+        monkeypatch.setattr(Path, "cwd", lambda: CWD)
+        monkeypatch.setattr(trusty_status, "_load_config", dict)
+
+        def boom(req, timeout=None):
+            raise OSError("connection refused")
+
+        import urllib.request
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        assert get_trusty_search_index_status() is None  # fail-safe, no raise
+
+
+class TestFreshnessClassification:
+    """Why: The note/reindex decision hinges on correct missing/empty/stale
+    classification from the daemon's OWN signals (no git scanning)."""
+
+    def test_missing_or_empty(self):
+        assert is_index_missing_or_empty(None) is True
+        assert is_index_missing_or_empty({"chunk_count": 0}) is True
+        assert is_index_missing_or_empty({}) is True
+        assert is_index_missing_or_empty(_fresh_status()) is False
+
+    def test_stale_signals(self):
+        # Healthy populated index → not stale.
+        assert is_index_stale(_fresh_status()) is False
+        # Daemon reported a walk error → stale.
+        st = _fresh_status()
+        st["last_walk_error"] = "permission denied"
+        assert is_index_stale(st) is True
+        # Non-terminal/unhealthy status field → stale.
+        st = _fresh_status()
+        st["status"] = "error"
+        assert is_index_stale(st) is True
+        # Empty index is NOT double-counted as stale (deferred to missing/empty).
+        assert is_index_stale({"chunk_count": 0}) is False
+        assert is_index_stale(None) is False
+
+
+class TestReindexTrigger:
+    """Why: The reindex MUST be non-blocking and fail-open — it can never delay
+    or crash startup."""
+
+    def test_dispatches_thread_and_returns_immediately(self, monkeypatch):
+        captured: dict = {}
+
+        class _FakeThread:
+            def __init__(self, target=None, daemon=None):
+                captured["target"] = target
+                captured["daemon"] = daemon
+
+            def start(self):
+                captured["started"] = True
+
+        import threading
+
+        monkeypatch.setattr(threading, "Thread", _FakeThread)
+        ok = trigger_trusty_search_reindex("claude-mpm")
+        assert ok is True
+        assert captured["started"] is True
+        assert captured["daemon"] is True  # detached, never joins startup
+
+    def test_posts_correct_url_inside_thread(self, monkeypatch):
+        calls: list = []
+
+        def handler(url, method):
+            calls.append((url, method))
+            return _FakeResp(200, {"queued": True})
+
+        _patch_urlopen(monkeypatch, handler)
+        # Run synchronously by making Thread.start() call the target immediately.
+        import threading
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+        ok = trigger_trusty_search_reindex("claude-mpm")
+        assert ok is True
+        assert len(calls) == 1
+        url, method = calls[0]
+        assert url.endswith("/indexes/claude-mpm/reindex")
+        assert method == "POST"
+
+    def test_thread_error_does_not_propagate(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise OSError("daemon busy")
+
+        import threading
+        import urllib.request
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None):
+                self._target = target
+
+            def start(self):
+                self._target()  # would raise if the inner POST were unguarded
+
+        monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+        # Must not raise: the inner _post swallows everything.
+        assert trigger_trusty_search_reindex("claude-mpm") is True
+
+    def test_dispatch_failure_returns_false(self, monkeypatch):
+        import threading
+
+        class _BadThread:
+            def __init__(self, *a, **k):
+                pass
+
+            def start(self):
+                raise RuntimeError("cannot start thread")
+
+        monkeypatch.setattr(threading, "Thread", _BadThread)
+        assert trigger_trusty_search_reindex("claude-mpm") is False
+
+
+def test_resolve_latency_bounded(monkeypatch):
+    """Why: Startup-path budget — resolution must stay well under a second even
+    when every candidate is probed and misses."""
+    import time
+
+    monkeypatch.setattr(Path, "cwd", lambda: CWD)
+    monkeypatch.setattr(trusty_status, "_load_config", dict)
+    _patch_urlopen(monkeypatch, lambda url, method: _FakeResp(404, None))
+    t0 = time.perf_counter()
+    assert get_trusty_search_index_status() is None
+    assert (time.perf_counter() - t0) < 1.0


### PR DESCRIPTION
## Summary

When `trusty-search` is detected ON at startup, the PM prompt-assembly phase (`FrameworkLoader._generate_tool_status_section`) now verifies this project has a usable index and fires a **non-blocking background reindex** if the index is missing, empty, or the daemon signals staleness. A concise note is appended to the trusty-search row in the "Available Tool Services" block so the PM knows search results may be incomplete this turn. This runs in the synchronous Python phase BEFORE the Claude Code subprocess starts (the model cannot call MCP tools that early).

## Design decisions (binding)

1. **Auto-reindex in the BACKGROUND** — fire-and-forget `POST {base}/indexes/{id}/reindex` dispatched in a detached daemon thread; the call returns immediately and NEVER blocks or delays startup. The daemon queues the work via its own `background_reindex_queue_depth`.
2. **Freshness via trusty-search's OWN signal — no git-HEAD / mtime scanning.** Index missing (no candidate ID resolves to CWD `root_path`) or empty (`chunk_count <= 0`) → reindex. Daemon-reported staleness (`last_walk_error`, non-ready `status`) → reindex. Otherwise fresh → no note.

## Fail-open guarantees

- `trigger_trusty_search_reindex` dispatches a daemon thread and returns `True`/`False` immediately; the HTTP POST runs inside the thread with a <=200ms timeout and all errors swallowed (`except Exception: pass`).
- `_trusty_search_index_note` wraps the entire check in `try/except`, returning `""` on any error so startup never raises.
- All probes (`_fetch_index_status`, `get_trusty_search_index_status`) use bounded <=200ms timeouts and never raise.

## Files

- `src/claude_mpm/services/trusty_status.py` — `get_trusty_search_index_status`, `is_index_missing_or_empty`, `is_index_stale`, `trigger_trusty_search_reindex`, `_index_id_candidates`, `_fetch_index_status` (+186 lines).
- `src/claude_mpm/core/framework_loader.py` — `_trusty_search_index_note` + `_resolve_reindex_id` wiring into `_generate_tool_status_section` (+76 lines).

## Test evidence

`uv run pytest -p no:xdist tests/test_trusty_search_index.py tests/test_framework_loader_index_freshness.py` — **23 passed in 0.14s**. Covers candidate ID resolution + root_path matching, missing/empty/stale classification, non-blocking thread dispatch (bounded latency), POST URL correctness, in-thread error swallowing, dispatch-failure path, fresh-index no-op, daemon-error fail-open, and the section-row integration.

`uv run ruff format --check` + `uv run ruff check` on all four feature files: clean.

Rebased onto latest `main` (`ca64c3c44`, PR #648) with zero conflicts (disjoint files).

Closes #649

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
