### PR TITLE
fix: gate Homebrew tap update on sdist availability (Closes #652)

### DIFF
--- a/scripts/update_homebrew_tap.sh
+++ b/scripts/update_homebrew_tap.sh
@@ -113,83 +113,94 @@ validate_version() {
     return 0
 }
 
-wait_for_pypi_package() {
+# Extract the sdist URL + sha256 from a PyPI version-JSON payload, in a single
+# JSON parse, emitting "<url>\t<sha256>" on stdout.
+#
+# Why: PyPI's `<pkg>/<version>/json` endpoint becomes resolvable (HTTP 200) as
+# soon as the FIRST distribution file is published. During CI release the wheels
+# are uploaded before the sdist (observed ~8s gap for v6.5.16), so a naive
+# "version exists" gate races ahead of the sdist and the extraction finds only
+# `bdist_wheel` entries in urls[] — the historical "Failed to extract package
+# URL" failure. Distinguishing "no sdist yet" (exit 3, retryable) from malformed
+# JSON (exit 1) lets the caller poll instead of hard-failing.
+# What: Parses stdin JSON; prints "url<TAB>sha256" for the sole sdist entry.
+# Exit: 0 found; 3 valid JSON but no sdist present yet (retryable); 1 parse error.
+# Test: Pipe v6.5.16 JSON -> prints the .tar.gz url + 64-char sha256, exit 0;
+#       pipe wheels-only JSON -> exit 3; pipe "{}" -> exit 3; pipe "x" -> exit 1.
+extract_sdist_info() {
+    python3 -c '
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)  # malformed/empty response — not a "missing sdist" condition
+for u in data.get("urls", []):
+    if u.get("packagetype") == "sdist":
+        try:
+            print("%s\t%s" % (u["url"], u["digests"]["sha256"]))
+        except (KeyError, TypeError):
+            sys.exit(1)
+        sys.exit(0)
+sys.exit(3)  # JSON parsed but the sdist is not indexed yet — retryable
+'
+}
+
+# Poll PyPI until the sdist (not just any file) for $version is available, then
+# capture its URL + sha256 into PACKAGE_URL / PACKAGE_SHA256.
+#
+# Why: Replaces the old two-step "wait for HTTP 200, then immediately extract"
+# flow that raced the wheel-before-sdist publish order (issue #652). Gating on
+# the sdist's presence — with a bounded retry — is the actual readiness signal
+# the formula update needs, and folding extraction into the same loop removes
+# the second, unguarded query that produced "Failed to extract package URL".
+# What: Retries with linear backoff; on success exports PACKAGE_URL/SHA256.
+# Test: Run against an existing version -> exports a *.tar.gz url + sha256;
+#       run against a never-published version -> fails after max_attempts with
+#       an endpoint-qualified error and a copy-pasteable manual fallback.
+fetch_pypi_info() {
     local version="$1"
-    # PyPI publishing now happens in CI (release-wheels.yml), not locally, so
-    # the sdist may take a few minutes to build + publish after the tag push.
-    # Use a longer retry window so the Homebrew update rarely falls back.
+    local pypi_url="https://pypi.org/pypi/${PYPI_PACKAGE}/${version}/json"
+    # CI builds + publishes the sdist after the wheels, so allow a generous,
+    # bounded window. Linear backoff: cumulative wait ~ 3*(1+2+...+20) ≈ 10 min.
     local max_attempts=20
     local attempt=1
     local wait_time=3
+    local pypi_json result rc
 
-    log INFO "Waiting for PyPI package to be available..."
+    log INFO "Waiting for PyPI sdist to be available for ${version}..."
+    log INFO "  Endpoint: ${pypi_url}"
 
-    while [ $attempt -le $max_attempts ]; do
-        if curl -sf "https://pypi.org/pypi/${PYPI_PACKAGE}/${version}/json" > /dev/null 2>&1; then
-            log SUCCESS "PyPI package found for version ${version}"
-            return 0
+    while [ "$attempt" -le "$max_attempts" ]; do
+        if pypi_json=$(curl -sf "$pypi_url" 2>/dev/null); then
+            # Capture stdout and exit code without tripping `set -e`.
+            result=$(printf '%s' "$pypi_json" | extract_sdist_info) && rc=0 || rc=$?
+
+            if [ "$rc" -eq 0 ]; then
+                PACKAGE_URL="${result%%$'\t'*}"
+                PACKAGE_SHA256="${result##*$'\t'}"
+                export PACKAGE_URL PACKAGE_SHA256
+                log SUCCESS "Package URL: ${PACKAGE_URL}"
+                log SUCCESS "SHA256: ${PACKAGE_SHA256}"
+                return 0
+            elif [ "$rc" -eq 3 ]; then
+                log WARNING "sdist not yet indexed for ${version} (attempt ${attempt}/${max_attempts}); wheels may have published first"
+            else
+                log WARNING "Unexpected PyPI JSON response for ${version} (attempt ${attempt}/${max_attempts})"
+            fi
+        else
+            log WARNING "PyPI version JSON not yet available for ${version} (attempt ${attempt}/${max_attempts})"
         fi
 
-        log WARNING "PyPI package not yet available (attempt ${attempt}/${max_attempts})"
         sleep $((wait_time * attempt))
         attempt=$((attempt + 1))
     done
 
-    log ERROR "PyPI package not found after ${max_attempts} attempts"
-    log ERROR "Manual fallback: Wait for PyPI to propagate, then run:"
-    log ERROR "  cd homebrew-tools && ./scripts/update_formula.sh ${version}"
+    log ERROR "No sdist found for ${PYPI_PACKAGE} ${version} after ${max_attempts} attempts."
+    log ERROR "  Queried: ${pypi_url}"
+    log ERROR "  The sdist is likely still building/publishing in CI (release-wheels.yml)."
+    log ERROR "  Once available, re-run the tap update manually:"
+    log ERROR "    ./scripts/update_homebrew_tap.sh ${version} --auto-push"
     return 1
-}
-
-fetch_pypi_info() {
-    local version="$1"
-    local pypi_url="https://pypi.org/pypi/${PYPI_PACKAGE}/${version}/json"
-    local pypi_json
-    local package_url
-    local package_sha256
-
-    log INFO "Fetching package information from PyPI..."
-
-    if ! pypi_json=$(curl -sf "$pypi_url"); then
-        log ERROR "Failed to fetch PyPI package info"
-        return 1
-    fi
-
-    # Extract tarball URL and SHA256
-    if ! package_url=$(echo "$pypi_json" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for url_info in data.get('urls', []):
-    if url_info.get('packagetype') == 'sdist':
-        print(url_info['url'])
-        sys.exit(0)
-sys.exit(1)
-" 2>/dev/null); then
-        log ERROR "Failed to extract package URL from PyPI"
-        return 1
-    fi
-
-    if ! package_sha256=$(echo "$pypi_json" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for url_info in data.get('urls', []):
-    if url_info.get('packagetype') == 'sdist':
-        print(url_info['digests']['sha256'])
-        sys.exit(0)
-sys.exit(1)
-" 2>/dev/null); then
-        log ERROR "Failed to extract SHA256 from PyPI"
-        return 1
-    fi
-
-    log SUCCESS "Package URL: ${package_url}"
-    log SUCCESS "SHA256: ${package_sha256}"
-
-    # Export for use by other functions
-    export PACKAGE_URL="$package_url"
-    export PACKAGE_SHA256="$package_sha256"
-
-    return 0
 }
 
 clone_or_update_tap_repo() {
@@ -548,16 +559,11 @@ main() {
         return $exit_code
     fi
 
-    # Step 2: Wait for PyPI package
-    if ! wait_for_pypi_package "$VERSION"; then
-        log ERROR "PyPI package not available"
-        log ERROR "This is non-blocking. Manual fallback instructions above."
-        return 1
-    fi
-
-    # Step 3: Fetch PyPI package info
+    # Step 2: Wait for the PyPI sdist, then capture its URL + SHA256.
+    # The readiness poll and extraction are now a single sdist-aware loop
+    # (issue #652), so this no longer races the wheel-before-sdist publish order.
     if ! fetch_pypi_info "$VERSION"; then
-        log ERROR "Failed to fetch PyPI package information"
+        log ERROR "Failed to fetch PyPI sdist information"
         return 1
     fi
 


### PR DESCRIPTION
Closes #652

## Root cause

The Homebrew tap update step of `make release-publish` recurrently failed with `Failed to extract package URL`, leaving the formula lagging every release.

PyPI publishing happens in CI (`release-wheels.yml`), and the **wheels are uploaded before the sdist**. Confirmed against real `v6.5.16` metadata — the sdist landed ~8s after the first wheel:

```
19:26:23Z  bdist_wheel  ...macosx_10_9_x86_64.whl
19:26:25Z  bdist_wheel  ...macosx_11_0_arm64.whl
19:26:27Z  bdist_wheel  ...manylinux2014_aarch64.whl
19:26:29Z  bdist_wheel  ...manylinux2014_x86_64.whl
19:26:31Z  sdist        claude_mpm-6.5.16.tar.gz   <-- last
```

`wait_for_pypi_package()` returned success as soon as `<version>/json` returned HTTP 200 (true the moment the first *wheel* published), then `fetch_pypi_info()` immediately scanned `urls[]` for an sdist that wasn't indexed yet and hard-failed. The JSON parsing was already correct — the bug was an **insufficient readiness gate plus no retry around extraction**.

## Fix

- New `extract_sdist_info()`: single JSON parse returning `url<TAB>sha256`. Exit 3 = valid JSON but no sdist yet (**retryable**); exit 1 = parse error.
- `fetch_pypi_info()` now polls until the **sdist** specifically appears (bounded linear backoff, ~10 min window) and then exports `PACKAGE_URL`/`PACKAGE_SHA256` in the same loop — eliminating the second, unguarded query.
- Removed the now-redundant `wait_for_pypi_package()` and its `main()` call.
- Failure message is actionable: prints the version + exact endpoint queried and a copy-pasteable manual fallback (`./scripts/update_homebrew_tap.sh <version> --auto-push`). Never silently passes.
- gh-identity-safe push path from #648 is **unchanged**.

## Verification

**Before (lines 116–193):** two-step `wait_for_pypi_package` (HTTP-200 only) then `fetch_pypi_info` scanning `urls[]` with no retry → `Failed to extract package URL` when sdist not yet indexed.

**After:** sdist-aware poll. Tested against real PyPI:

```
== 6.5.16 (sdist present) ==        exit=0
URL:    https://files.pythonhosted.org/packages/08/39/.../claude_mpm-6.5.16.tar.gz
SHA256: 59ff57fc2c09a204918ec41c4234a81d428f9def5537fa7dad757d8ce2d9acf2   (matches PyPI)
== wheels-only (simulated race) ==  exit=3   (retryable, no longer hard-fails)
== empty {} ==                      exit=3
== malformed ==                     exit=1
```

Full-script `--dry-run 6.5.16` resolves the correct URL+sha256 and proceeds to the formula update.

`shellcheck`: same 4 pre-existing findings (SC1091/SC2129/SC2155/SC2329 on unchanged lines); **zero new findings** on changed lines.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)