### PR TITLE
docs: two distinct documentation standards — Product PRD + Engineering Spec (de-hybridized) + skills

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -54,7 +54,7 @@ templates, IDs, and skills. **Neither absorbs the other.**
 | **Organized by** | Product **AREA** / feature | Engineering **SUBSYSTEM** |
 | **Primary content** | Problem, personas, goals, user stories, requirements, acceptance criteria, success metrics. | Inputs/Outputs/Pre/Postconditions/Errors, Rationale, Implementing Modules. |
 | **Skill** | `prd-authoring` | `spec-authoring` |
-| **Lifecycle** | Draft → Review → Approved → In-development → Shipped → Superseded | Draft → Review → Active → Superseded |
+| **Lifecycle** | Draft → Review → Approved → In-development → Shipped → Superseded | Draft → Draft (in review) → Active → Superseded |
 
 **The link is bidirectional:**
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,270 @@
+# Product PRD Standard
+
+**Status:** Active
+**Version:** v1
+**Owner:** Product (Product Owner / Product Manager)
+**Scope:** Portable standard for authoring **Product Requirements Documents (PRDs)** in
+`docs/prd/`. claude-mpm is the reference instantiation; other projects may adopt this standard
+independently.
+
+---
+
+## Table of Contents
+
+1. [Purpose: What a PRD Is](#1-purpose-what-a-prd-is)
+2. [PRDs vs. Specs: Two Distinct Standards](#2-prds-vs-specs-two-distinct-standards)
+3. [PRD ID Grammar — `PRD-{AREA}-{NN}`](#3-prd-id-grammar--prd-area-nn)
+4. [Information Architecture & Areas](#4-information-architecture--areas)
+5. [PRD Lifecycle](#5-prd-lifecycle)
+6. [README & Internal-Link Conventions](#6-readme--internal-link-conventions)
+7. [PRD → SPEC Linkage](#7-prd--spec-linkage)
+8. [Research Conventions](#8-research-conventions)
+
+---
+
+## 1. Purpose: What a PRD Is
+
+A **PRD (Product Requirements Document)** answers one set of questions:
+
+> **What problem are we solving, for which users, what must the solution do, and what does
+> success look like?**
+
+It is owned by **Product** (a Product Owner or Product Manager). It is deliberately *not* an
+engineering design: it states the **requirements and intent**, not the behavioral contract or
+the implementation. The engineering contract that realizes a PRD lives in a separate, distinct
+standard — the **Engineering Spec Authoring Standard** ([`docs/specs/AUTHORING.md`](../specs/AUTHORING.md)).
+
+This file is the **governance doc** for PRDs: ID grammar, information architecture, lifecycle,
+link conventions, and the PRD→SPEC traceability convention. The copy-pasteable PRD document
+itself is [`TEMPLATE.md`](TEMPLATE.md).
+
+---
+
+## 2. PRDs vs. Specs: Two Distinct Standards
+
+PRD and SPEC are **two distinct standards**, owned by different people, with their own homes,
+templates, IDs, and skills. **Neither absorbs the other.**
+
+| | **PRD** (this standard) | **SPEC** ([`docs/specs/`](../specs/AUTHORING.md)) |
+|---|--------------------------|----------------------------------------------------|
+| **Owner** | Product (Product Owner / PM) | Engineering / Architecture |
+| **Answers** | What problem, for which users, what requirements, what success looks like. | The behavioral contract & how it is implemented. |
+| **Home** | `docs/prd/` | `docs/specs/` |
+| **ID namespace** | `PRD-{AREA}-{NN}` | `SPEC-{SUBSYSTEM}-{NN}~{rev}` |
+| **Organized by** | Product **AREA** / feature | Engineering **SUBSYSTEM** |
+| **Primary content** | Problem, personas, goals, user stories, requirements, acceptance criteria, success metrics. | Inputs/Outputs/Pre/Postconditions/Errors, Rationale, Implementing Modules. |
+| **Skill** | `prd-authoring` | `spec-authoring` |
+| **Lifecycle** | Draft → Review → Approved → In-development → Shipped → Superseded | Draft → Review → Active → Superseded |
+
+**The link is bidirectional:**
+
+- **PRD → SPEC (downward):** each PRD requirement links *down* to the spec(s) that implement it,
+  recorded in the PRD's **Linked Specs** traceability table (§7).
+- **SPEC → PRD (upward):** each spec section that realizes a requirement cites *up* to the
+  `PRD-{AREA}-{NN}` it implements (from its Rationale or References).
+
+Distinct ID namespaces, distinct directories, distinct owners, bidirectional cross-references.
+A PRD never specifies inputs/outputs/error contracts (that is the spec's job); a spec never
+specifies the problem, personas, or success metrics (that is the PRD's job).
+
+---
+
+## 3. PRD ID Grammar — `PRD-{AREA}-{NN}`
+
+Every individually-trackable **requirement** in a PRD carries a stable ID:
+
+```
+PRD-{AREA}-{NN}
+```
+
+| Component | Format | Example | Notes |
+|-----------|--------|---------|-------|
+| `PRD` | Literal prefix | `PRD` | Always uppercase |
+| `{AREA}` | Uppercase alpha, hyphens allowed | `SEARCH`, `ONBOARDING`, `MODEL-ROUTING` | The product area; matches the PRD file name |
+| `{NN}` | Two-digit zero-padded integer | `01`, `12` | Sequential within the area |
+
+**Full example:** `PRD-SEARCH-03`.
+
+### No revision suffix
+
+Unlike spec IDs (`~{rev}`), PRD IDs have **no revision suffix**. Requirements evolve through the
+**lifecycle** (§5) and through supersession, not through a tilde counter. When a requirement
+materially changes after it has shipped, supersede it with a new ID and mark the old one
+`Superseded` (§5). This keeps PRD IDs stable references that a spec can cite without churn.
+
+### Declaration rule
+
+A requirement ID is **declared** when it appears as a named heading anchor in the PRD's
+*Requirements* section:
+
+```markdown
+### Sub-second relevance ranking {#PRD-SEARCH-03}
+**ID:** PRD-SEARCH-03
+```
+
+IDs appearing in prose, tables, or other documents (including this README) are references, not
+declarations. Each PRD area file owns its own `{NN}` sequence.
+
+---
+
+## 4. Information Architecture & Areas
+
+The IA mirrors the spec side's flatness — two levels:
+
+```
+Area (file)  →  Requirements (governed PRD-{AREA}-{NN} items)
+```
+
+- **Area** = one product area or feature = one file `docs/prd/{area}.md`. The uppercased name is
+  the `{AREA}` token in every requirement ID in that file.
+- **Requirement** = one governed `PRD-{AREA}-{NN}` item in the file's *Requirements* section.
+
+### Choosing an area
+
+Organize PRDs by **product area / feature** — the unit a Product Owner reasons about and a user
+would name ("search", "onboarding", "billing"). This is intentionally **different** from the
+engineering SUBSYSTEM axis used by specs: one product area is often realized by several
+subsystems, and one subsystem may serve several areas. Do not force PRD areas to match spec
+subsystems; record the cross-mapping via the Linked Specs table (§7).
+
+### Add an area vs. add a requirement
+
+- **Add a requirement** (the common case) when the new need fits an existing area's scope.
+- **Add a new area file** when the need is a cohesive, separately-owned product surface with
+  several requirements' worth of content.
+
+### Naming
+
+- `{AREA}` token: UPPERCASE alpha, hyphens allowed (`SEARCH`, `MODEL-ROUTING`).
+- File name: lowercase form of the token — `model-routing.md` ↔ `PRD-MODEL-ROUTING-01`.
+- The token appears in every requirement ID; renaming it is a breaking change to every spec that
+  cites it. Choose durable names.
+
+---
+
+## 5. PRD Lifecycle
+
+A PRD (and each requirement within it) moves through a product lifecycle, tracked in the
+header-block **Status** field (and per-requirement `**Status:**` where they diverge):
+
+| Stage | Meaning | Status value |
+|-------|---------|--------------|
+| **Draft** | Problem and requirements being written; not yet agreed. | `Draft` |
+| **Review** | Stakeholder review of problem framing, requirements, and success metrics. | `Review` |
+| **Approved** | Product has signed off. Requirements are stable enough for engineering to spec against. | `Approved` |
+| **In-development** | Implementing specs are being authored/built (`SPEC-…` linked). | `In-development` |
+| **Shipped** | The requirement is live; success metrics are being measured. | `Shipped` |
+| **Superseded** | Replaced by a newer requirement; retained for history; links forward. | `Superseded` |
+
+### Handoff to engineering
+
+Engineering should begin authoring specs once a requirement reaches **Approved**. The
+`PRD-{AREA}-{NN}` is the inception trigger for a spec (see
+[`docs/specs/AUTHORING.md` §8](../specs/AUTHORING.md)).
+
+### Supersession
+
+When a requirement materially changes after Approval/Ship, do not rewrite it in place — IDs are
+stable references that specs cite. Instead:
+
+- Mark the old requirement `**Status:** Superseded` and add `**Superseded-by:** PRD-{AREA}-{NN}`.
+- Create a new requirement with a new ID and `**Supersedes:** PRD-{AREA}-{NN}`.
+- Update the Linked Specs table so engineering knows the contract target moved.
+
+---
+
+## 6. README & Internal-Link Conventions
+
+### 6.1 Every directory has an orienting index
+
+`docs/prd/` is indexed by this `README.md`. Any new subdirectory (e.g. `research/`) must carry
+its own index that orients a reader: what lives here, the naming convention, and where to go
+next.
+
+### 6.2 Cross-reference conventions
+
+- **Within and across PRD files**, link to requirements by their stable `#PRD-…` anchor with a
+  relative path: `[PRD-SEARCH-03](search.md#PRD-SEARCH-03)`. Never link by mutable heading text.
+- **PRD ↔ SPEC** is the core cross-standard link (§7): the PRD's *Linked Specs* table maps each
+  requirement to the implementing `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs (path into `../specs/`); the
+  spec cites the `PRD-{AREA}-{NN}` back.
+- **PRD ↔ research** — a requirement's *References* links to the `research/NN-topic-slug.md`
+  document(s) that justify it (§8).
+- **PRD ↔ ADR** — when a product decision is significant and hard to reverse, link the ADR
+  (`docs/adr/NNNN-*.md`).
+
+### 6.3 No dangling anchors
+
+Before committing, confirm every `#PRD-…` and `#SPEC-…` anchor you link to is actually declared
+in the target file, and every relative path resolves. A link to a nonexistent anchor is a silent
+traceability gap.
+
+---
+
+## 7. PRD → SPEC Linkage
+
+This is the convention that connects the two standards. Every PRD carries a **Linked Specs**
+traceability table mapping each requirement to the engineering spec(s) that implement it.
+
+```markdown
+## Linked Specs
+
+| Requirement | Implementing spec(s) | Status |
+|-------------|----------------------|--------|
+| [PRD-SEARCH-01](#PRD-SEARCH-01) | [SPEC-INTEGRATIONS-04~1](../specs/integrations.md#SPEC-INTEGRATIONS-04~1) | Active |
+| [PRD-SEARCH-03](#PRD-SEARCH-03) | [SPEC-SESSIONS-07~2](../specs/sessions.md#SPEC-SESSIONS-07~2), [SPEC-INTEGRATIONS-05~1](../specs/integrations.md#SPEC-INTEGRATIONS-05~1) | In-development |
+| [PRD-SEARCH-04](#PRD-SEARCH-04) | _(not yet specced)_ | Approved |
+```
+
+### Rules
+
+1. **One row per requirement.** Every `PRD-{AREA}-{NN}` declared in the file appears in the
+   table, even if not yet specced (use `_(not yet specced)_`).
+2. **A requirement may map to many specs.** A product requirement is frequently realized by
+   several subsystems — list all implementing `SPEC-…~{rev}` IDs.
+3. **Cite the revision.** Reference specs at the `~{rev}` you validated against. If the spec
+   bumps its `~{rev}`, Product should re-confirm the requirement still holds and update the row.
+4. **Bidirectional.** The implementing spec section must cite this `PRD-{AREA}-{NN}` back (from
+   its Rationale or References). The link only counts if both directions exist.
+5. **Distinct namespaces.** Never reuse a `SPEC-…` ID as a PRD ID or vice versa. The directories
+   (`docs/prd/` vs `docs/specs/`), owners (Product vs Engineering), and templates stay separate.
+
+### Why this matters
+
+The Linked Specs table is the product-side half of a Requirements Traceability Matrix: it lets a
+Product Owner answer "is requirement X implemented, and by what?" and lets engineering answer
+"why does this contract exist?" — without either standard absorbing the other.
+
+---
+
+## 8. Research Conventions
+
+Pre-PRD **product / user / market / competitive** research lives in `docs/prd/research/`,
+separate from the requirements themselves (mirroring `docs/specs/research/` on the engineering
+side, but for product questions).
+
+- **Naming:** `docs/prd/research/NN-topic-slug.md` — `NN` two-digit sequence, `topic-slug` a
+  short hyphenated description (e.g. `03-search-user-interviews.md`).
+- **Scope:** define the question; user/market/competitive research; evidence gathering; citing
+  sources; validating assumptions; evidence-based decisions linked to ADRs. The full product
+  research discipline lives in the `prd-authoring` skill's `prd-research-practices.md`.
+- **Boundary:** product research justifies the *requirement*; **technical** research (algorithms,
+  benchmarks, how to build it) belongs to `docs/specs/research/` on the engineering side.
+
+A requirement's *References* block links to the research doc(s) that justify it. Every non-obvious
+requirement cites its evidence.
+
+---
+
+## References
+
+- [`TEMPLATE.md`](TEMPLATE.md) — the copy-pasteable PRD document template.
+- [`../specs/AUTHORING.md`](../specs/AUTHORING.md) — the **Engineering Spec Authoring Standard**
+  (the engineering-owned companion; specs realize PRD requirements).
+- [`../specs/README.md`](../specs/README.md) — Spec-Linked Documentation (SLD): how code traces
+  to specs (the downstream half of the engineering side).
+- `prd-authoring` skill (`src/claude_mpm/skills/bundled/main/prd-authoring/`) — the agent-facing
+  companion to this standard.
+- `spec-authoring` skill (`src/claude_mpm/skills/bundled/main/spec-authoring/`) — the engineering
+  spec-authoring companion.
+- `mpm-adr` skill / `docs/adr/` — Architecture Decision Records for significant decisions.

--- a/docs/prd/TEMPLATE.md
+++ b/docs/prd/TEMPLATE.md
@@ -1,0 +1,165 @@
+# {Product Area} — PRD
+
+> Copy this file to `docs/prd/{area}.md` and fill it in. Delete this blockquote and any
+> `{placeholder}` guidance. This template implements the **Product PRD Standard**
+> ([`README.md`](README.md)). A PRD is **product-owned**; it states the problem and
+> requirements, never the engineering contract (that is a SPEC — see
+> [`../specs/AUTHORING.md`](../specs/AUTHORING.md)).
+
+**Title:** {Product Area} — {one-line description}
+**Status:** Draft | Review | Approved | In-development | Shipped | Superseded
+**Owner:** Product ({Product Owner / PM name or role})
+**Version:** v{N}
+**Last-updated:** {YYYY-MM-DD}
+**Related specs/ADRs:** [SPEC-{SUBSYSTEM}-{NN}~{rev}](../specs/{subsystem}.md#SPEC-{SUBSYSTEM}-{NN}~{rev}), `docs/adr/NNNN-*.md`
+
+---
+
+## Problem & Context
+
+{The *why*. What problem are we solving, and why now? What is the current pain, the evidence
+that it matters, and the cost of not solving it? Link the product research that establishes the
+problem (`research/NN-*.md`). Keep this about the problem, not the solution.}
+
+---
+
+## Target Users / Personas
+
+{Who has this problem? Name the personas or user segments and what they are trying to do.}
+
+| Persona | Who they are | What they need |
+|---------|--------------|----------------|
+| {Persona A} | {context} | {need} |
+| {Persona B} | {context} | {need} |
+
+---
+
+## Goals & Non-Goals
+
+**Goals**
+- {What this PRD is trying to achieve, in product terms.}
+
+**Non-Goals**
+- {Explicitly out of scope. Non-goals prevent requirement sprawl and set expectations.}
+
+---
+
+## User Stories / Jobs-to-be-Done
+
+{Frame the need from the user's perspective. Use the form that fits — user stories or JTBD.}
+
+- As a **{persona}**, I want **{capability}** so that **{outcome}**.
+- When **{situation}**, I want to **{motivation}**, so I can **{expected result}**.
+
+---
+
+## Requirements
+
+> Each requirement is a stable, individually-trackable `PRD-{AREA}-{NN}` item. Declare the ID in
+> the heading anchor and the `**ID:**` field (see [`README.md` §3](README.md#3-prd-id-grammar--prd-area-nn)).
+> Split functional and non-functional requirements.
+
+### Functional Requirements
+
+#### {Requirement title} {#PRD-{AREA}-01}
+**ID:** PRD-{AREA}-01
+**Status:** Draft | Approved | In-development | Shipped | Superseded
+**Priority:** Must | Should | Could | Won't (MoSCoW)
+
+{What the product must do, in product terms — the capability the user gets. Do **not** specify
+inputs/outputs/error contracts here; that is the implementing SPEC's job. Cite the research that
+justifies a non-obvious requirement.}
+
+#### {Requirement title} {#PRD-{AREA}-02}
+**ID:** PRD-{AREA}-02
+**Status:** Draft
+**Priority:** Should
+
+{…}
+
+### Non-Functional Requirements
+
+#### {Quality attribute} {#PRD-{AREA}-03}
+**ID:** PRD-{AREA}-03
+**Status:** Draft
+**Priority:** Must
+
+{Performance, reliability, security, accessibility, compliance, etc. State the target in
+measurable product terms — e.g. "search results return in under 1 second at p95." The engineering
+*how* lives in the linked spec.}
+
+---
+
+## Acceptance Criteria
+
+> What must be observably true for each requirement to be considered done, from the user's /
+> product's perspective. Group by requirement ID.
+
+**PRD-{AREA}-01**
+- [ ] {An externally observable, product-level check.}
+- [ ] {Another.}
+
+**PRD-{AREA}-03**
+- [ ] {Measurable acceptance check for the non-functional requirement.}
+
+---
+
+## Success Metrics / KPIs
+
+> How we will know the shipped feature succeeded. Distinct from acceptance criteria: these are
+> measured *after* launch.
+
+| Metric | Baseline | Target | How measured |
+|--------|----------|--------|--------------|
+| {e.g. search adoption} | {current} | {goal} | {instrumentation / source} |
+| {e.g. p95 result latency} | {current} | {goal} | {monitoring} |
+
+---
+
+## Scope & Out-of-Scope
+
+**In scope**
+- {What this PRD covers.}
+
+**Out of scope**
+- {What it explicitly does not cover — defer to a future PRD or mark as a non-goal.}
+
+---
+
+## Risks & Assumptions
+
+| Risk / Assumption | Type | Impact | Mitigation / Validation |
+|-------------------|------|--------|--------------------------|
+| {…} | Risk | {H/M/L} | {how we reduce or accept it} |
+| {…} | Assumption | {H/M/L} | {how we will validate it; promote to ADR if it becomes a commitment} |
+
+---
+
+## Open Questions
+
+- {Unresolved product decisions. Keep distinct from requirements so requirements stay stable.}
+
+---
+
+## Linked Specs
+
+> The PRD→SPEC traceability table (see [`README.md` §7](README.md#7-prd--spec-linkage)). One row
+> per requirement. A requirement may map to several specs. Reference specs at the `~{rev}` you
+> validated against. The implementing spec must cite this PRD ID back.
+
+| Requirement | Implementing spec(s) | Status |
+|-------------|----------------------|--------|
+| [PRD-{AREA}-01](#PRD-{AREA}-01) | [SPEC-{SUBSYSTEM}-{NN}~{rev}](../specs/{subsystem}.md#SPEC-{SUBSYSTEM}-{NN}~{rev}) | Active |
+| [PRD-{AREA}-02](#PRD-{AREA}-02) | _(not yet specced)_ | Approved |
+| [PRD-{AREA}-03](#PRD-{AREA}-03) | [SPEC-{SUBSYSTEM}-{MM}~{rev}](../specs/{subsystem}.md#SPEC-{SUBSYSTEM}-{MM}~{rev}) | In-development |
+
+---
+
+## References
+
+- `research/NN-topic-slug.md` — product/user/market/competitive research justifying requirements.
+- `docs/adr/NNNN-*.md` — Architecture Decision Records for significant product decisions.
+- {External sources: user interviews, market data, competitive analysis, with links.}
+- [`README.md`](README.md) — the Product PRD Standard governing this document.
+- [`../specs/AUTHORING.md`](../specs/AUTHORING.md) — the Engineering Spec Authoring Standard
+  (where the implementing contracts are authored).

--- a/docs/specs/AUTHORING.md
+++ b/docs/specs/AUTHORING.md
@@ -1,48 +1,80 @@
-# Spec Authoring Standard
+# Engineering Spec Authoring Standard
 
 **Status:** Active
 **Version:** v1
-**Scope:** Portable standard for authoring product specifications in `docs/specs/`. claude-mpm is the reference instantiation; other projects may adopt this standard independently.
+**Owner:** Engineering / Architecture
+**Scope:** Portable standard for authoring **engineering specifications** in `docs/specs/`. claude-mpm is the reference instantiation; other projects may adopt this standard independently.
 
 ---
 
 ## Table of Contents
 
 1. [Purpose: Authoring vs. Traceability](#1-purpose-authoring-vs-traceability)
-2. [The Spec Document Model (Hybrid Contract + PRD)](#2-the-spec-document-model-hybrid-contract--prd)
-3. [Information Architecture & Categories](#3-information-architecture--categories)
-4. [Granularity: One ID per Verifiable Behavior](#4-granularity-one-id-per-verifiable-behavior)
-5. [README & Internal-Link Conventions](#5-readme--internal-link-conventions)
-6. [Research Before Speccing](#6-research-before-speccing)
-7. [Spec Lifecycle](#7-spec-lifecycle)
-8. [Relationship to Spec-Linked Documentation (SLD)](#8-relationship-to-spec-linked-documentation-sld)
+2. [Specs vs. PRDs: Two Distinct Standards](#2-specs-vs-prds-two-distinct-standards)
+3. [The Spec Document Model (Behavior Contract)](#3-the-spec-document-model-behavior-contract)
+4. [Information Architecture & Subsystems](#4-information-architecture--subsystems)
+5. [Granularity: One ID per Verifiable Behavior](#5-granularity-one-id-per-verifiable-behavior)
+6. [README & Internal-Link Conventions](#6-readme--internal-link-conventions)
+7. [Research Before Speccing](#7-research-before-speccing)
+8. [Spec Lifecycle](#8-spec-lifecycle)
+9. [Relationship to Spec-Linked Documentation (SLD)](#9-relationship-to-spec-linked-documentation-sld)
 
 ---
 
 ## 1. Purpose: Authoring vs. Traceability
 
-This standard answers one question: **how do you author a product specification in `docs/specs/`?**
+This standard answers one question: **how does an engineer or architect author an engineering specification in `docs/specs/`?**
 
-It is the companion to [`README.md`](README.md), the Spec-Linked Documentation (SLD) convention guide. The two are deliberately distinct and you need both:
+A spec here is a **behavioral contract**: a precise, testable statement of *what* a subsystem does (inputs, outputs, pre/postconditions, error conditions) and *why* it is designed that way (rationale), linked to the modules that implement it. It is owned by **Engineering / Architecture**.
+
+This standard is the companion to [`README.md`](README.md), the Spec-Linked Documentation (SLD) convention guide. The two are deliberately distinct and you need both:
 
 | Document | Question it answers | Audience |
 |----------|---------------------|----------|
-| **`AUTHORING.md`** (this file) | *How do I write a spec?* — scope a subsystem, assign IDs, structure the document, decide granularity, run research, manage the lifecycle. | Spec authors (documentation agents, PMs, engineers drafting a subsystem). |
+| **`AUTHORING.md`** (this file) | *How do I write an engineering spec?* — scope a subsystem, assign IDs, structure the document, decide granularity, run technical research, manage the lifecycle. | Engineers / architects drafting a subsystem; documentation agents. |
 | [**`README.md`**](README.md) | *How does code trace to a spec?* — the ID grammar, docstring `References` blocks, the four-status CI checker, the WWL code-granularity model. | Engineers linking code to specs; reviewers verifying coverage. |
 
 A useful mnemonic: **AUTHORING.md is upstream of the contract; README.md is downstream of it.** You author a spec section here; SLD then keeps source code in sync with it.
 
 This standard does **not** redefine anything README.md owns. The **ID grammar**, the **declaration rule** (`{#SPEC-...}` anchors / `**ID:**` fields), the **Behavior Contract / Rationale / Implementing Modules** section skeleton, the **four-status model**, and the **WWL thresholds** all live in README.md. This file references them and tells you how to *produce* documents that satisfy them.
 
-> **Canonical grammar:** Spec IDs follow `SPEC-{CATEGORY}-{NN}~{rev}` (e.g. `SPEC-HOOKS-01~1`). The full grammar, including the declaration rule and when to bump `~{rev}`, is defined in [`README.md` §4 — Spec ID Grammar](README.md#4-spec-id-grammar). Do not re-derive it; cite it.
+> **Canonical grammar:** Spec IDs follow `SPEC-{SUBSYSTEM}-{NN}~{rev}` (e.g. `SPEC-HOOKS-01~1`). The full grammar, including the declaration rule and when to bump `~{rev}`, is defined in [`README.md` §4 — Spec ID Grammar](README.md#4-spec-id-grammar). Do not re-derive it; cite it.
 
 ---
 
-## 2. The Spec Document Model (Hybrid Contract + PRD)
+## 2. Specs vs. PRDs: Two Distinct Standards
 
-A claude-mpm spec is a **hybrid**: it carries the precision of a *behavior contract* (testable WHAT/WHY, the SLD core) and the framing of a lightweight *Product Requirements Document* (purpose, scope, acceptance criteria, open questions). One bounded subsystem or domain maps to one file: `docs/specs/{category}.md`.
+A SPEC is **not** a PRD, and this standard is deliberately scoped to the spec side only.
 
-### 2.1 Document skeleton
+| | **SPEC** (this standard) | **PRD** ([`docs/prd/`](../prd/README.md)) |
+|---|--------------------------|--------------------------------------------|
+| **Owner** | Engineering / Architecture | Product (Product Owner / PM) |
+| **Answers** | The behavioral contract & how it is implemented. | What problem, for which users, what requirements, and what success looks like. |
+| **Home** | `docs/specs/` | `docs/prd/` |
+| **ID namespace** | `SPEC-{SUBSYSTEM}-{NN}~{rev}` | `PRD-{AREA}-{NN}` |
+| **Primary content** | Inputs/Outputs/Pre/Postconditions/Errors, Rationale, Implementing Modules. | Problem, personas, goals, user stories, requirements, acceptance criteria, success metrics. |
+
+**Do not** put product framing in a spec. Problem statements, target users, personas, user stories, acceptance criteria, and success metrics belong to **PRDs**, not specs. A spec records the *engineering contract* that realizes one or more PRD requirements.
+
+**The link (spec → PRD, upward):** a spec section that implements a product requirement cites the `PRD-{AREA}-{NN}` it implements — from its **Rationale** or **References**:
+
+```markdown
+### Rationale (WHY)
+This contract realizes [PRD-SEARCH-03](../prd/semantic-search.md#PRD-SEARCH-03):
+sub-second relevance ranking is a product requirement, not an implementation choice.
+```
+
+The PRD links back **downward** to the spec(s) implementing it via its *Linked Specs* traceability table (see [`docs/prd/README.md`](../prd/README.md)). The two namespaces, directories, owners, and templates stay distinct; neither template absorbs the other.
+
+---
+
+## 3. The Spec Document Model (Behavior Contract)
+
+A claude-mpm spec is a **behavior contract**: a testable statement of observable WHAT and the WHY behind it, linked to implementing modules. One bounded subsystem or domain maps to one file: `docs/specs/{subsystem}.md`.
+
+This standard adds **no** product sections (no problem statement, no personas, no acceptance criteria, no success metrics). Those are PRD concerns (§2). The spec carries exactly the SLD section skeleton plus orienting wrappers (header, Purpose & Scope, ToC, Open Questions, References).
+
+### 3.1 Document skeleton
 
 Every spec file has the following structure, top to bottom:
 
@@ -51,10 +83,10 @@ Every spec file has the following structure, top to bottom:
 
 **Status:** Active | Draft | Superseded | Deprecated
 **Version:** v{N}
-**Category:** {UPPERCASE-CATEGORY}
-**Owner:** {team or role}
+**Subsystem:** {UPPERCASE-SUBSYSTEM}
+**Owner:** Engineering / Architecture (team or role)
 **Last-updated:** {YYYY-MM-DD}
-**Related specs:** [{CATEGORY}](other.md), ...
+**Related:** [{SUBSYSTEM}](other.md), [PRD-{AREA}-{NN}](../prd/{area}.md#PRD-{AREA}-{NN}), ...
 
 ## Purpose & Scope
 {2–5 sentences: what this subsystem is responsible for, and — equally important —
@@ -63,10 +95,10 @@ what is explicitly out of scope. Out-of-scope statements prevent ID sprawl.}
 ## Table of Contents
 {One row per governed section: ID → section anchor → implementing module(s).}
 
-## {Section Title} {#SPEC-{CATEGORY}-{NN}~{rev}}
-**ID:** SPEC-{CATEGORY}-{NN}~{rev}
+## {Section Title} {#SPEC-{SUBSYSTEM}-{NN}~{rev}}
+**ID:** SPEC-{SUBSYSTEM}-{NN}~{rev}
 **Status:** Active | Draft | Superseded
-**Supersedes:** SPEC-{CATEGORY}-{MM}~{rev}   (if applicable)
+**Supersedes:** SPEC-{SUBSYSTEM}-{MM}~{rev}   (if applicable)
 
 ### Behavior Contract (WHAT)
 - **Inputs:** ...
@@ -76,39 +108,35 @@ what is explicitly out of scope. Out-of-scope statements prevent ID sprawl.}
 - **Error conditions:** ...
 
 ### Rationale (WHY)
-{Design decisions and constraints — why this contract over alternatives. Never HOW.}
+{Design decisions and constraints — why this contract over alternatives. Never HOW.
+Cite the PRD-{AREA}-{NN} requirement this contract realizes, if any.}
 
 ### Implementing Modules
 | Module | Role |
 |--------|------|
 | `pkg.module` | ... |
 
-### Acceptance Criteria / Success Metrics
-- [ ] {An externally observable check a reviewer or test can evaluate.}
-- {Optional success metric: target latency, error rate, adoption, etc.}
-
 ## Open Questions / Future Work
 {Unresolved decisions, deferred behavior, known gaps. Keep distinct from the contract.}
 
 ## References
-{Links to research docs, ADRs, external prior art, related specs.}
+{Links to research docs, ADRs, the PRD requirement(s) realized, external prior art, related specs.}
 ```
 
-The three middle subsections — **Behavior Contract (WHAT)**, **Rationale (WHY)**, **Implementing Modules** — are owned by the SLD convention ([`README.md` §5](README.md#5-spec-section-structure)) and are reused verbatim. This standard adds two PRD-flavored wrappers around them: the **header block** and **Acceptance Criteria / Success Metrics**.
+The three middle subsections — **Behavior Contract (WHAT)**, **Rationale (WHY)**, **Implementing Modules** — are owned by the SLD convention ([`README.md` §5](README.md#5-spec-section-structure)) and are reused **verbatim**. This standard adds only orienting wrappers around them (the header block, Purpose & Scope, ToC, Open Questions, References). It deliberately does **not** add Acceptance Criteria or Success Metrics — those are PRD sections (§2).
 
-### 2.2 Why each part exists
+### 3.2 Why each part exists
 
-- **Header block** — makes status and ownership scannable; `Last-updated` and `Related specs` give a reader orientation without reading the body.
+- **Header block** — makes status and ownership scannable; `Last-updated` and `Related` give a reader orientation without reading the body. `Owner` is always an engineering team/role.
 - **Purpose & Scope** — the boundary statement that decides what becomes an ID *here* vs. in another file.
 - **Table of Contents (ID → section → modules)** — the per-file traceability index; mirrors the project-level index in [`README.md`](README.md).
-- **Behavior Contract (WHAT)** — the testable, observable contract. This is what acceptance checks and SLD docstring links attach to.
-- **Rationale (WHY)** — mandatory. A section without a WHY is incomplete ([`README.md` §5 Content Rules](README.md#5-spec-section-structure)).
+- **Behavior Contract (WHAT)** — the testable, observable contract. This is what SLD docstring links attach to.
+- **Rationale (WHY)** — mandatory. A section without a WHY is incomplete ([`README.md` §5 Content Rules](README.md#5-spec-section-structure)). Where the contract realizes a product requirement, cite the `PRD-{AREA}-{NN}`.
 - **Implementing Modules** — the HOW-link: where the behavior lives in code. SLD verifies these references bidirectionally.
-- **Acceptance Criteria / Success Metrics** — the PRD addition: each criterion is a check a reviewer (or test) can evaluate to decide "done." Drives the granularity test in §4.
 - **Open Questions / Future Work** — keeps exploratory thinking *out* of the contract so the contract stays stable.
-- **References** — every non-obvious decision points back to the research or ADR that justifies it (§6).
+- **References** — every non-obvious decision points back to the research, ADR, or PRD requirement that justifies it (§7).
 
-### 2.3 Filled mini-example
+### 3.3 Filled mini-example
 
 ```markdown
 ## Disk-cached version check {#SPEC-HOOKS-14~1}
@@ -134,31 +162,28 @@ purely local. Failing closed to the cached value preserves hook latency targets.
 | Module | Role |
 |--------|------|
 | `claude_mpm.hooks.version_check` | Reads/writes the cache and performs the gated network check. |
-
-### Acceptance Criteria / Success Metrics
-- [ ] A second invocation within the TTL performs zero network calls (assert via mock).
-- [ ] A simulated network failure returns the cached value and does not raise.
-- Target: added hook latency from this check ≤ 1 ms on a cache hit.
 ```
+
+(Note: there is **no** Acceptance Criteria subsection. The observable behavior in the contract is what tests assert against; product-level acceptance criteria, if any, live in the linked PRD.)
 
 ---
 
-## 3. Information Architecture & Categories
+## 4. Information Architecture & Subsystems
 
-### 3.1 Two levels only
+### 4.1 Two levels only
 
-The IA is intentionally flat: **Category → numbered sections.**
+The IA is intentionally flat: **Subsystem → numbered sections.**
 
-- **Category** = one bounded subsystem or domain = one file, `docs/specs/{category}.md`. The category name (uppercased) is the `{CATEGORY}` token in every ID declared in that file.
-- **Sections** = the governed `SPEC-{CATEGORY}-{NN}~{rev}` units within the file, numbered sequentially.
+- **Subsystem** = one bounded subsystem or domain = one file, `docs/specs/{subsystem}.md`. The subsystem name (uppercased) is the `{SUBSYSTEM}` token in every ID declared in that file.
+- **Sections** = the governed `SPEC-{SUBSYSTEM}-{NN}~{rev}` units within the file, numbered sequentially.
 
-There is no third level. Resist nesting sub-subsystems inside a file; if a section needs its own children, that is a signal to split it into a new section (or, if the whole cluster is large and independently owned, a new category — see §3.3).
+There is no third level. Resist nesting sub-subsystems inside a file; if a section needs its own children, that is a signal to split it into a new section (or, if the whole cluster is large and independently owned, a new subsystem — see §4.3).
 
-### 3.2 claude-mpm's existing categories
+### 4.2 claude-mpm's existing subsystems
 
-The reference instantiation governs seven categories, one file each:
+The reference instantiation governs seven subsystems, one file each:
 
-| File | Category token | Domain |
+| File | Subsystem token | Domain |
 |------|----------------|--------|
 | [`agents.md`](agents.md) | `AGENTS` | Agent templates, assembly, deployment. |
 | [`cli.md`](cli.md) | `CLI` | Click commands and interactive wizards. |
@@ -168,114 +193,114 @@ The reference instantiation governs seven categories, one file each:
 | [`sessions.md`](sessions.md) | `SESSIONS` | Session lifecycle, runtime, persistence. |
 | [`skills.md`](skills.md) | `SKILLS` | Skill definitions, discovery, deployment. |
 
-### 3.3 When to add a category vs. a section
+### 4.3 When to add a subsystem vs. a section
 
-Add a **section** to an existing category (the common case) when the new behavior belongs to a subsystem that already has a file.
+Add a **section** to an existing subsystem (the common case) when the new behavior belongs to a subsystem that already has a file.
 
-Add a **new category** (a new file) only when **all** of these hold:
+Add a **new subsystem** (a new file) only when **all** of these hold:
 
 1. **Bounded domain.** The behavior forms a cohesive subsystem with a clear boundary, not a feature of an existing one.
 2. **Independent ownership / lifecycle.** It can be specced, reviewed, and versioned without churning an existing file.
-3. **Several sections' worth.** It will hold more than one or two IDs; a single behavior belongs as a section, not a category.
+3. **Several sections' worth.** It will hold more than one or two IDs; a single behavior belongs as a section, not a subsystem.
 
-If you are unsure, prefer a section. Categories are cheap to read but expensive to split later (IDs are stable and cannot be renamed without a supersession).
+If you are unsure, prefer a section. Subsystems are cheap to read but expensive to split later (IDs are stable and cannot be renamed without a supersession).
 
-### 3.4 Naming
+### 4.4 Naming
 
-- Category tokens are **UPPERCASE alpha, hyphens allowed** (e.g. `HOOKS`, `INTEGRATIONS`, a hypothetical `MODEL-ROUTING`). This matches the `{CATEGORY}` slot in [`README.md` §4](README.md#4-spec-id-grammar).
+- Subsystem tokens are **UPPERCASE alpha, hyphens allowed** (e.g. `HOOKS`, `INTEGRATIONS`, a hypothetical `MODEL-ROUTING`). This matches the `{SUBSYSTEM}` slot in [`README.md` §4](README.md#4-spec-id-grammar).
 - The file name is the **lowercase** form of the token: `model-routing.md` ↔ `SPEC-MODEL-ROUTING-01~1`.
 - Keep tokens short and durable. The token appears in every ID and in every docstring reference; renaming it is a breaking change.
 
 ---
 
-## 4. Granularity: One ID per Verifiable Behavior
+## 5. Granularity: One ID per Verifiable Behavior
 
-### 4.1 The test
+### 5.1 The test
 
-**One spec ID = one independently-verifiable behavior or requirement.** The litmus test:
+**One spec ID = one independently-verifiable behavior.** The litmus test:
 
-> *Could you write a single acceptance check or test that passes or fails against this section?*
+> *Could you write a single test that passes or fails against this section's Behavior Contract?*
 
 If yes, it is one ID. If a section needs several unrelated checks that could pass or fail independently, it is probably several IDs.
 
-### 4.2 Too broad / too narrow
+### 5.2 Too broad / too narrow
 
-- **Too broad** ("the hooks subsystem dispatches events") — split. You cannot write *one* acceptance check for it; PreToolUse enforcement, PostToolUse observability, and Stop handling each have distinct contracts. Each becomes its own ID.
-- **Too narrow** ("the dispatcher lowercases the event name") — merge. That is an implementation detail of a larger behavior (event routing), not an independently-verifiable requirement. It belongs in the WHAT of the routing section, not its own ID.
+- **Too broad** ("the hooks subsystem dispatches events") — split. You cannot write *one* contract test for it; PreToolUse enforcement, PostToolUse observability, and Stop handling each have distinct contracts. Each becomes its own ID.
+- **Too narrow** ("the dispatcher lowercases the event name") — merge. That is an implementation detail of a larger behavior (event routing), not an independently-verifiable contract. It belongs in the WHAT of the routing section, not its own ID.
 
-### 4.3 Split / merge heuristics
+### 5.3 Split / merge heuristics
 
 Split when a section has:
 - Multiple, unrelated error-condition clusters.
 - Distinct callers relying on distinct, separable outputs.
-- An Acceptance Criteria list whose items have no logical reason to pass or fail together.
+- Contract clauses that have no logical reason to change together.
 
 Merge when sections share:
 - The same inputs/outputs and the same implementing module, differing only in incidental detail.
 - A contract where changing one inevitably changes the other (they are one behavior described twice).
 
-### 4.4 `~rev` bumps and WWL alignment
+### 5.4 `~rev` bumps and WWL alignment
 
 - Bump `~{rev}` only on a **material change to the behavior contract** (inputs, outputs, pre/postconditions, error conditions). Clarifying prose does not bump. The authority is [`README.md` §4 — When to Increment `~{rev}`](README.md#4-spec-id-grammar).
 - A contract that justifies its own spec ID typically governs code that crosses the **SLD WWL thresholds** (function > 50 LOC or cyclomatic complexity > 10) and therefore requires a docstring link. See [`README.md` §6a — WWL Granularity Model](README.md#6a-code-level-granularity-the-wwl-model). Spec granularity and code-link granularity should be consistent: if a behavior is too small to warrant a WWL link, it is usually too small to warrant its own spec ID.
 
 ---
 
-## 5. README & Internal-Link Conventions
+## 6. README & Internal-Link Conventions
 
-### 5.1 Every directory has an orienting index
+### 6.1 Every directory has an orienting index
 
-`docs/specs/` is indexed by [`README.md`](README.md). The research subdirectory is indexed by [`research/`](#6-research-before-speccing) conventions (§6). Any new directory under `docs/specs/` must carry a `README.md` (or equivalent index) that orients a reader: what lives here, what the naming convention is, and where to go next.
+`docs/specs/` is indexed by [`README.md`](README.md). The research subdirectory is indexed by [`research/`](#7-research-before-speccing) conventions (§7). Any new directory under `docs/specs/` must carry a `README.md` (or equivalent index) that orients a reader: what lives here, what the naming convention is, and where to go next.
 
-### 5.2 Cross-reference conventions
+### 6.2 Cross-reference conventions
 
 - **Within and across spec files**, link to sections by their stable `#SPEC-…` anchor using a relative path: `[SPEC-HOOKS-01~1](hooks.md#SPEC-HOOKS-01~1)`. Never link by mutable heading text alone.
-- **Spec ↔ code** is maintained by SLD, not by manual links: the spec's *Implementing Modules* table names the module; the module's docstring carries the `References` block. The CI checker keeps them in sync. See [§8](#8-relationship-to-spec-linked-documentation-sld) and [`README.md` §6](README.md#6-docstring-references-format).
-- **Spec ↔ research** — a spec section's *References* block links to the `research/NN-topic-slug.md` document(s) that justify its non-obvious decisions (§6).
+- **Spec ↔ code** is maintained by SLD, not by manual links: the spec's *Implementing Modules* table names the module; the module's docstring carries the `References` block. The CI checker keeps them in sync. See [§9](#9-relationship-to-spec-linked-documentation-sld) and [`README.md` §6](README.md#6-docstring-references-format).
+- **Spec ↔ PRD** — a spec section's *Rationale* or *References* cites the `PRD-{AREA}-{NN}` requirement it realizes, using a relative path into `docs/prd/`: `[PRD-SEARCH-03](../prd/semantic-search.md#PRD-SEARCH-03)`. The PRD lists this spec in its *Linked Specs* table (see [`docs/prd/README.md`](../prd/README.md)). The link is bidirectional and the namespaces stay distinct.
+- **Spec ↔ research** — a spec section's *References* block links to the `research/NN-topic-slug.md` document(s) that justify its non-obvious decisions (§7).
 - **Spec ↔ ADR** — when a section embodies a significant, hard-to-reverse architectural decision, link to its Architecture Decision Record. claude-mpm uses the `mpm-adr` skill (Nygard-template ADRs under `docs/adr/`). Cite the ADR from the section's *Rationale* or *References*: "Decision recorded in `docs/adr/0007-...md`."
 
-### 5.3 No dangling anchors
+### 6.3 No dangling anchors
 
-Before committing, confirm every `#SPEC-…` anchor you link to is actually declared by a heading in the target file, and every relative path resolves. A link to a nonexistent anchor is a silent traceability gap.
+Before committing, confirm every `#SPEC-…` and `#PRD-…` anchor you link to is actually declared by a heading in the target file, and every relative path resolves. A link to a nonexistent anchor is a silent traceability gap.
 
 ---
 
-## 6. Research Before Speccing
+## 7. Research Before Speccing
 
-### 6.1 The `research/` directory
+### 7.1 The `research/` directory
 
-Pre-spec investigation lives in [`docs/specs/research/`](research/), **separate from the spec contract**. The SLD checker explicitly excludes this directory ([`README.md` §4 — Subsystem Allowlist](README.md#4-spec-id-grammar)), so research notes never count as spec declarations and never appear in coverage. Keep exploratory thinking here so the spec files stay clean contracts.
+Pre-spec **engineering / technical** investigation lives in [`docs/specs/research/`](research/), **separate from the spec contract**. The SLD checker explicitly excludes this directory ([`README.md` §4 — Subsystem Allowlist](README.md#4-spec-id-grammar)), so research notes never count as spec declarations and never appear in coverage. Keep exploratory thinking here so the spec files stay clean contracts.
 
-- **Naming:** `NN-topic-slug.md`, where `NN` is a two-digit sequence (`01`, `02`, …) and `topic-slug` is a short hyphenated description — e.g. `05-sdd-best-practices.md`.
-- **Purpose:** capture the evidence and reasoning that *led to* a spec, so the spec itself can stay terse and every non-obvious decision is traceable to its justification.
+- **Naming:** `NN-topic-slug.md`, where `NN` is a two-digit sequence (`01`, `02`, …) and `topic-slug` is a short hyphenated description — e.g. `05-cache-eviction-strategies.md`.
+- **Purpose:** capture the technical evidence and reasoning that *led to* a spec contract (algorithms, prior art, benchmarks, trade-offs), so the spec itself can stay terse and every non-obvious decision is traceable to its justification.
+- **Scope:** this is *technical* research — how to build it. *Product / user / market* research belongs to the PRD side (`docs/prd/research/`, see [`docs/prd/README.md`](../prd/README.md)).
 
-### 6.2 How to research before speccing (general best practices)
+### 7.2 How to research before speccing (engineering focus)
 
-This is project-agnostic; the `research/` directory is where the output lands.
-
-1. **Define the question.** State precisely what decision the research must inform. A research doc without a question becomes an unfocused dump.
-2. **Gather evidence across sources.** Look at, at minimum:
+1. **Define the technical question.** State precisely what design decision the research must inform. A research doc without a question becomes an unfocused dump.
+2. **Gather technical evidence.** Look at, at minimum:
    - **Code / prior art** — how does the current system (or a comparable one) already do this?
-   - **User / market need** — who needs this behavior and why?
-   - **Competitive / external prior art** — existing tools, standards, papers. (SLD itself is grounded in OpenFastTrace, DO-178C RTM, etc. — see [`README.md` §2](README.md#2-lineage-oft-rtm-and-decades-of-prior-art) for the model.)
+   - **Algorithms / standards / papers** — existing techniques, RFCs, benchmarks. (SLD itself is grounded in OpenFastTrace, DO-178C RTM, etc. — see [`README.md` §2](README.md#2-lineage-oft-rtm-and-decades-of-prior-art).)
+   - **Constraints** — latency, memory, concurrency, failure modes the contract must respect.
 3. **Cite sources with links.** Every claim that drives a decision gets a citable source (URL, file path, or commit). Unsourced assertions are assumptions, not evidence.
 4. **Record assumptions explicitly.** Mark what you are *assuming* vs. what you *verified*. Link assumptions that became architectural commitments to an ADR (`mpm-adr`).
 5. **Keep research distinct from the contract.** The research doc may explore alternatives, dead ends, and trade-offs. The spec records only the *chosen* contract. Do not let exploratory prose leak into the Behavior Contract.
 
-### 6.3 The citation rule
+### 7.3 The citation rule
 
-**Every non-obvious spec decision cites its research.** If a section's Rationale makes a claim that a reasonable reviewer would ask "why?" about, that claim links to a `research/NN-*.md` doc, an ADR, or an external source. Obvious decisions need no citation; non-obvious ones always do.
+**Every non-obvious spec decision cites its justification.** If a section's Rationale makes a claim that a reasonable reviewer would ask "why?" about, that claim links to a `research/NN-*.md` doc, an ADR, the PRD requirement it realizes, or an external source. Obvious decisions need no citation; non-obvious ones always do.
 
 ---
 
-## 7. Spec Lifecycle
+## 8. Spec Lifecycle
 
 A spec moves through a defined lifecycle, tracked in the header-block **Status** field (and per-section `**Status:**` where sections diverge):
 
 | Stage | Meaning | Status value |
 |-------|---------|--------------|
-| **Inception** | The need is identified; no document yet. | (no file) |
-| **Research** | Investigation underway in `research/`; question defined, evidence gathering. | (research doc only) |
+| **Inception** | The need is identified (often by an approved PRD requirement); no document yet. | (no file) |
+| **Research** | Technical investigation underway in `research/`; question defined, evidence gathering. | (research doc only) |
 | **Draft** | Spec sections written but not yet implemented/reviewed. CI tolerates uncovered IDs via the draft exemption — see [`README.md` §9b](README.md#9b-draft-specs--incremental-backfill). | `Draft` / `draft (pending backfill)` |
 | **Review** | Sections complete; human review of semantic correctness and code linkage in progress. | `Draft` (during review) |
 | **Active** | Reviewed, implementing modules linked, CI green. The contract is binding. | `Active` |
@@ -287,30 +312,34 @@ A spec moves through a defined lifecycle, tracked in the header-block **Status**
 When a section is superseded, do **not** delete it — IDs are stable history. Instead:
 
 - Mark the old section `**Status:** Superseded`.
-- Add `**Superseded-by:** SPEC-{CATEGORY}-{NN}~{rev}` to the old section.
-- Add `**Supersedes:** SPEC-{CATEGORY}-{MM}~{rev}` to the new section (per [`README.md` §5](README.md#5-spec-section-structure)).
+- Add `**Superseded-by:** SPEC-{SUBSYSTEM}-{NN}~{rev}` to the old section.
+- Add `**Supersedes:** SPEC-{SUBSYSTEM}-{MM}~{rev}` to the new section (per [`README.md` §5](README.md#5-spec-section-structure)).
 
 This preserves a navigable chain so a reader landing on an old docstring reference can follow it forward to the current contract.
 
 ---
 
-## 8. Relationship to Spec-Linked Documentation (SLD)
+## 9. Relationship to Spec-Linked Documentation (SLD)
 
 This standard and SLD are two halves of one discipline:
 
-- **Spec Authoring Standard (this file)** = *authoring*. How to write the spec: scope, structure, IDs, granularity, research, lifecycle.
+- **Engineering Spec Authoring Standard (this file)** = *authoring*. How to write the spec: scope, structure, IDs, granularity, research, lifecycle.
 - **[SLD](README.md)** = *traceability*. How code stays linked to the spec: docstring `References`, the four-status checker, WWL code granularity.
 
 **The handoff:** You author a section here (with a stable ID, a Behavior Contract, an Implementing Modules table). SLD then takes over — engineers add `References: SPEC-…` blocks to the named modules, and the CI checker (`tests/test_spec_traceability.py`) enforces bidirectional completeness. A `~rev` bump you make here (on a contract change) is what SLD's OUTDATED status detects downstream.
 
 Read both: this file to **write** a spec; [`README.md`](README.md) to **trace code to it**. The companion skills mirror this split — `spec-authoring` (this standard) and `spec-linked-docs` (traceability) — and cross-reference each other.
 
+> **Specs implement PRD requirements.** A spec is the engineering contract that realizes a product requirement. When a section implements a `PRD-{AREA}-{NN}`, cite it (§2, §6.2). Product framing (problem, users, acceptance, metrics) stays in the PRD ([`docs/prd/`](../prd/README.md)); the spec stays a contract.
+
 ---
 
 ## References
 
 - [`README.md`](README.md) — Spec-Linked Documentation (SLD) convention guide (ID grammar, section structure, four-status model, WWL).
-- [`research/`](research/) — pre-spec investigation documents (`NN-topic-slug.md`).
+- [`../prd/README.md`](../prd/README.md) — the **Product PRD Standard** (the product-owned companion; specs realize PRD requirements).
+- [`research/`](research/) — pre-spec technical investigation documents (`NN-topic-slug.md`).
 - `mpm-adr` skill / `docs/adr/` — Architecture Decision Records (Nygard template) for significant, hard-to-reverse decisions.
 - `spec-authoring` skill (`src/claude_mpm/skills/bundled/main/spec-authoring/`) — the agent-facing companion to this standard.
+- `prd-authoring` skill (`src/claude_mpm/skills/bundled/main/prd-authoring/`) — the product-side companion (authoring PRDs).
 - `spec-linked-docs` skill (`src/claude_mpm/skills/bundled/universal/spec-linked-docs/`) — the traceability companion.

--- a/docs/specs/AUTHORING.md
+++ b/docs/specs/AUTHORING.md
@@ -1,0 +1,316 @@
+# Spec Authoring Standard
+
+**Status:** Active
+**Version:** v1
+**Scope:** Portable standard for authoring product specifications in `docs/specs/`. claude-mpm is the reference instantiation; other projects may adopt this standard independently.
+
+---
+
+## Table of Contents
+
+1. [Purpose: Authoring vs. Traceability](#1-purpose-authoring-vs-traceability)
+2. [The Spec Document Model (Hybrid Contract + PRD)](#2-the-spec-document-model-hybrid-contract--prd)
+3. [Information Architecture & Categories](#3-information-architecture--categories)
+4. [Granularity: One ID per Verifiable Behavior](#4-granularity-one-id-per-verifiable-behavior)
+5. [README & Internal-Link Conventions](#5-readme--internal-link-conventions)
+6. [Research Before Speccing](#6-research-before-speccing)
+7. [Spec Lifecycle](#7-spec-lifecycle)
+8. [Relationship to Spec-Linked Documentation (SLD)](#8-relationship-to-spec-linked-documentation-sld)
+
+---
+
+## 1. Purpose: Authoring vs. Traceability
+
+This standard answers one question: **how do you author a product specification in `docs/specs/`?**
+
+It is the companion to [`README.md`](README.md), the Spec-Linked Documentation (SLD) convention guide. The two are deliberately distinct and you need both:
+
+| Document | Question it answers | Audience |
+|----------|---------------------|----------|
+| **`AUTHORING.md`** (this file) | *How do I write a spec?* — scope a subsystem, assign IDs, structure the document, decide granularity, run research, manage the lifecycle. | Spec authors (documentation agents, PMs, engineers drafting a subsystem). |
+| [**`README.md`**](README.md) | *How does code trace to a spec?* — the ID grammar, docstring `References` blocks, the four-status CI checker, the WWL code-granularity model. | Engineers linking code to specs; reviewers verifying coverage. |
+
+A useful mnemonic: **AUTHORING.md is upstream of the contract; README.md is downstream of it.** You author a spec section here; SLD then keeps source code in sync with it.
+
+This standard does **not** redefine anything README.md owns. The **ID grammar**, the **declaration rule** (`{#SPEC-...}` anchors / `**ID:**` fields), the **Behavior Contract / Rationale / Implementing Modules** section skeleton, the **four-status model**, and the **WWL thresholds** all live in README.md. This file references them and tells you how to *produce* documents that satisfy them.
+
+> **Canonical grammar:** Spec IDs follow `SPEC-{CATEGORY}-{NN}~{rev}` (e.g. `SPEC-HOOKS-01~1`). The full grammar, including the declaration rule and when to bump `~{rev}`, is defined in [`README.md` §4 — Spec ID Grammar](README.md#4-spec-id-grammar). Do not re-derive it; cite it.
+
+---
+
+## 2. The Spec Document Model (Hybrid Contract + PRD)
+
+A claude-mpm spec is a **hybrid**: it carries the precision of a *behavior contract* (testable WHAT/WHY, the SLD core) and the framing of a lightweight *Product Requirements Document* (purpose, scope, acceptance criteria, open questions). One bounded subsystem or domain maps to one file: `docs/specs/{category}.md`.
+
+### 2.1 Document skeleton
+
+Every spec file has the following structure, top to bottom:
+
+```markdown
+# {Subsystem} Subsystem — Spec
+
+**Status:** Active | Draft | Superseded | Deprecated
+**Version:** v{N}
+**Category:** {UPPERCASE-CATEGORY}
+**Owner:** {team or role}
+**Last-updated:** {YYYY-MM-DD}
+**Related specs:** [{CATEGORY}](other.md), ...
+
+## Purpose & Scope
+{2–5 sentences: what this subsystem is responsible for, and — equally important —
+what is explicitly out of scope. Out-of-scope statements prevent ID sprawl.}
+
+## Table of Contents
+{One row per governed section: ID → section anchor → implementing module(s).}
+
+## {Section Title} {#SPEC-{CATEGORY}-{NN}~{rev}}
+**ID:** SPEC-{CATEGORY}-{NN}~{rev}
+**Status:** Active | Draft | Superseded
+**Supersedes:** SPEC-{CATEGORY}-{MM}~{rev}   (if applicable)
+
+### Behavior Contract (WHAT)
+- **Inputs:** ...
+- **Outputs:** ...
+- **Preconditions:** ...
+- **Postconditions:** ...
+- **Error conditions:** ...
+
+### Rationale (WHY)
+{Design decisions and constraints — why this contract over alternatives. Never HOW.}
+
+### Implementing Modules
+| Module | Role |
+|--------|------|
+| `pkg.module` | ... |
+
+### Acceptance Criteria / Success Metrics
+- [ ] {An externally observable check a reviewer or test can evaluate.}
+- {Optional success metric: target latency, error rate, adoption, etc.}
+
+## Open Questions / Future Work
+{Unresolved decisions, deferred behavior, known gaps. Keep distinct from the contract.}
+
+## References
+{Links to research docs, ADRs, external prior art, related specs.}
+```
+
+The three middle subsections — **Behavior Contract (WHAT)**, **Rationale (WHY)**, **Implementing Modules** — are owned by the SLD convention ([`README.md` §5](README.md#5-spec-section-structure)) and are reused verbatim. This standard adds two PRD-flavored wrappers around them: the **header block** and **Acceptance Criteria / Success Metrics**.
+
+### 2.2 Why each part exists
+
+- **Header block** — makes status and ownership scannable; `Last-updated` and `Related specs` give a reader orientation without reading the body.
+- **Purpose & Scope** — the boundary statement that decides what becomes an ID *here* vs. in another file.
+- **Table of Contents (ID → section → modules)** — the per-file traceability index; mirrors the project-level index in [`README.md`](README.md).
+- **Behavior Contract (WHAT)** — the testable, observable contract. This is what acceptance checks and SLD docstring links attach to.
+- **Rationale (WHY)** — mandatory. A section without a WHY is incomplete ([`README.md` §5 Content Rules](README.md#5-spec-section-structure)).
+- **Implementing Modules** — the HOW-link: where the behavior lives in code. SLD verifies these references bidirectionally.
+- **Acceptance Criteria / Success Metrics** — the PRD addition: each criterion is a check a reviewer (or test) can evaluate to decide "done." Drives the granularity test in §4.
+- **Open Questions / Future Work** — keeps exploratory thinking *out* of the contract so the contract stays stable.
+- **References** — every non-obvious decision points back to the research or ADR that justifies it (§6).
+
+### 2.3 Filled mini-example
+
+```markdown
+## Disk-cached version check {#SPEC-HOOKS-14~1}
+
+**ID:** SPEC-HOOKS-14~1
+**Status:** Active
+
+### Behavior Contract (WHAT)
+- **Inputs:** The current package version string; a cache file path under `~/.claude-mpm/`.
+- **Outputs:** A boolean `update_available` and the latest known version string.
+- **Preconditions:** The cache file may be absent or stale.
+- **Postconditions:** On a cache miss older than the TTL, the cache is refreshed; the
+  returned value always reflects either a fresh check or a within-TTL cached value.
+- **Error conditions:** Network failure returns the last cached value and never raises;
+  a corrupt cache file is treated as a miss.
+
+### Rationale (WHY)
+Hook handlers must not block on network I/O. A disk cache with a TTL bounds the cost of
+the version check to one network round-trip per TTL window, keeping the common path
+purely local. Failing closed to the cached value preserves hook latency targets.
+
+### Implementing Modules
+| Module | Role |
+|--------|------|
+| `claude_mpm.hooks.version_check` | Reads/writes the cache and performs the gated network check. |
+
+### Acceptance Criteria / Success Metrics
+- [ ] A second invocation within the TTL performs zero network calls (assert via mock).
+- [ ] A simulated network failure returns the cached value and does not raise.
+- Target: added hook latency from this check ≤ 1 ms on a cache hit.
+```
+
+---
+
+## 3. Information Architecture & Categories
+
+### 3.1 Two levels only
+
+The IA is intentionally flat: **Category → numbered sections.**
+
+- **Category** = one bounded subsystem or domain = one file, `docs/specs/{category}.md`. The category name (uppercased) is the `{CATEGORY}` token in every ID declared in that file.
+- **Sections** = the governed `SPEC-{CATEGORY}-{NN}~{rev}` units within the file, numbered sequentially.
+
+There is no third level. Resist nesting sub-subsystems inside a file; if a section needs its own children, that is a signal to split it into a new section (or, if the whole cluster is large and independently owned, a new category — see §3.3).
+
+### 3.2 claude-mpm's existing categories
+
+The reference instantiation governs seven categories, one file each:
+
+| File | Category token | Domain |
+|------|----------------|--------|
+| [`agents.md`](agents.md) | `AGENTS` | Agent templates, assembly, deployment. |
+| [`cli.md`](cli.md) | `CLI` | Click commands and interactive wizards. |
+| [`hooks.md`](hooks.md) | `HOOKS` | PreToolUse/PostToolUse and lifecycle hook handlers, enforcement. |
+| [`integrations.md`](integrations.md) | `INTEGRATIONS` | MCP servers and external service integration. |
+| [`manifest.md`](manifest.md) | `MANIFEST` | Manifest, presets, model routing. |
+| [`sessions.md`](sessions.md) | `SESSIONS` | Session lifecycle, runtime, persistence. |
+| [`skills.md`](skills.md) | `SKILLS` | Skill definitions, discovery, deployment. |
+
+### 3.3 When to add a category vs. a section
+
+Add a **section** to an existing category (the common case) when the new behavior belongs to a subsystem that already has a file.
+
+Add a **new category** (a new file) only when **all** of these hold:
+
+1. **Bounded domain.** The behavior forms a cohesive subsystem with a clear boundary, not a feature of an existing one.
+2. **Independent ownership / lifecycle.** It can be specced, reviewed, and versioned without churning an existing file.
+3. **Several sections' worth.** It will hold more than one or two IDs; a single behavior belongs as a section, not a category.
+
+If you are unsure, prefer a section. Categories are cheap to read but expensive to split later (IDs are stable and cannot be renamed without a supersession).
+
+### 3.4 Naming
+
+- Category tokens are **UPPERCASE alpha, hyphens allowed** (e.g. `HOOKS`, `INTEGRATIONS`, a hypothetical `MODEL-ROUTING`). This matches the `{CATEGORY}` slot in [`README.md` §4](README.md#4-spec-id-grammar).
+- The file name is the **lowercase** form of the token: `model-routing.md` ↔ `SPEC-MODEL-ROUTING-01~1`.
+- Keep tokens short and durable. The token appears in every ID and in every docstring reference; renaming it is a breaking change.
+
+---
+
+## 4. Granularity: One ID per Verifiable Behavior
+
+### 4.1 The test
+
+**One spec ID = one independently-verifiable behavior or requirement.** The litmus test:
+
+> *Could you write a single acceptance check or test that passes or fails against this section?*
+
+If yes, it is one ID. If a section needs several unrelated checks that could pass or fail independently, it is probably several IDs.
+
+### 4.2 Too broad / too narrow
+
+- **Too broad** ("the hooks subsystem dispatches events") — split. You cannot write *one* acceptance check for it; PreToolUse enforcement, PostToolUse observability, and Stop handling each have distinct contracts. Each becomes its own ID.
+- **Too narrow** ("the dispatcher lowercases the event name") — merge. That is an implementation detail of a larger behavior (event routing), not an independently-verifiable requirement. It belongs in the WHAT of the routing section, not its own ID.
+
+### 4.3 Split / merge heuristics
+
+Split when a section has:
+- Multiple, unrelated error-condition clusters.
+- Distinct callers relying on distinct, separable outputs.
+- An Acceptance Criteria list whose items have no logical reason to pass or fail together.
+
+Merge when sections share:
+- The same inputs/outputs and the same implementing module, differing only in incidental detail.
+- A contract where changing one inevitably changes the other (they are one behavior described twice).
+
+### 4.4 `~rev` bumps and WWL alignment
+
+- Bump `~{rev}` only on a **material change to the behavior contract** (inputs, outputs, pre/postconditions, error conditions). Clarifying prose does not bump. The authority is [`README.md` §4 — When to Increment `~{rev}`](README.md#4-spec-id-grammar).
+- A contract that justifies its own spec ID typically governs code that crosses the **SLD WWL thresholds** (function > 50 LOC or cyclomatic complexity > 10) and therefore requires a docstring link. See [`README.md` §6a — WWL Granularity Model](README.md#6a-code-level-granularity-the-wwl-model). Spec granularity and code-link granularity should be consistent: if a behavior is too small to warrant a WWL link, it is usually too small to warrant its own spec ID.
+
+---
+
+## 5. README & Internal-Link Conventions
+
+### 5.1 Every directory has an orienting index
+
+`docs/specs/` is indexed by [`README.md`](README.md). The research subdirectory is indexed by [`research/`](#6-research-before-speccing) conventions (§6). Any new directory under `docs/specs/` must carry a `README.md` (or equivalent index) that orients a reader: what lives here, what the naming convention is, and where to go next.
+
+### 5.2 Cross-reference conventions
+
+- **Within and across spec files**, link to sections by their stable `#SPEC-…` anchor using a relative path: `[SPEC-HOOKS-01~1](hooks.md#SPEC-HOOKS-01~1)`. Never link by mutable heading text alone.
+- **Spec ↔ code** is maintained by SLD, not by manual links: the spec's *Implementing Modules* table names the module; the module's docstring carries the `References` block. The CI checker keeps them in sync. See [§8](#8-relationship-to-spec-linked-documentation-sld) and [`README.md` §6](README.md#6-docstring-references-format).
+- **Spec ↔ research** — a spec section's *References* block links to the `research/NN-topic-slug.md` document(s) that justify its non-obvious decisions (§6).
+- **Spec ↔ ADR** — when a section embodies a significant, hard-to-reverse architectural decision, link to its Architecture Decision Record. claude-mpm uses the `mpm-adr` skill (Nygard-template ADRs under `docs/adr/`). Cite the ADR from the section's *Rationale* or *References*: "Decision recorded in `docs/adr/0007-...md`."
+
+### 5.3 No dangling anchors
+
+Before committing, confirm every `#SPEC-…` anchor you link to is actually declared by a heading in the target file, and every relative path resolves. A link to a nonexistent anchor is a silent traceability gap.
+
+---
+
+## 6. Research Before Speccing
+
+### 6.1 The `research/` directory
+
+Pre-spec investigation lives in [`docs/specs/research/`](research/), **separate from the spec contract**. The SLD checker explicitly excludes this directory ([`README.md` §4 — Subsystem Allowlist](README.md#4-spec-id-grammar)), so research notes never count as spec declarations and never appear in coverage. Keep exploratory thinking here so the spec files stay clean contracts.
+
+- **Naming:** `NN-topic-slug.md`, where `NN` is a two-digit sequence (`01`, `02`, …) and `topic-slug` is a short hyphenated description — e.g. `05-sdd-best-practices.md`.
+- **Purpose:** capture the evidence and reasoning that *led to* a spec, so the spec itself can stay terse and every non-obvious decision is traceable to its justification.
+
+### 6.2 How to research before speccing (general best practices)
+
+This is project-agnostic; the `research/` directory is where the output lands.
+
+1. **Define the question.** State precisely what decision the research must inform. A research doc without a question becomes an unfocused dump.
+2. **Gather evidence across sources.** Look at, at minimum:
+   - **Code / prior art** — how does the current system (or a comparable one) already do this?
+   - **User / market need** — who needs this behavior and why?
+   - **Competitive / external prior art** — existing tools, standards, papers. (SLD itself is grounded in OpenFastTrace, DO-178C RTM, etc. — see [`README.md` §2](README.md#2-lineage-oft-rtm-and-decades-of-prior-art) for the model.)
+3. **Cite sources with links.** Every claim that drives a decision gets a citable source (URL, file path, or commit). Unsourced assertions are assumptions, not evidence.
+4. **Record assumptions explicitly.** Mark what you are *assuming* vs. what you *verified*. Link assumptions that became architectural commitments to an ADR (`mpm-adr`).
+5. **Keep research distinct from the contract.** The research doc may explore alternatives, dead ends, and trade-offs. The spec records only the *chosen* contract. Do not let exploratory prose leak into the Behavior Contract.
+
+### 6.3 The citation rule
+
+**Every non-obvious spec decision cites its research.** If a section's Rationale makes a claim that a reasonable reviewer would ask "why?" about, that claim links to a `research/NN-*.md` doc, an ADR, or an external source. Obvious decisions need no citation; non-obvious ones always do.
+
+---
+
+## 7. Spec Lifecycle
+
+A spec moves through a defined lifecycle, tracked in the header-block **Status** field (and per-section `**Status:**` where sections diverge):
+
+| Stage | Meaning | Status value |
+|-------|---------|--------------|
+| **Inception** | The need is identified; no document yet. | (no file) |
+| **Research** | Investigation underway in `research/`; question defined, evidence gathering. | (research doc only) |
+| **Draft** | Spec sections written but not yet implemented/reviewed. CI tolerates uncovered IDs via the draft exemption — see [`README.md` §9b](README.md#9b-draft-specs--incremental-backfill). | `Draft` / `draft (pending backfill)` |
+| **Review** | Sections complete; human review of semantic correctness and code linkage in progress. | `Draft` (during review) |
+| **Active** | Reviewed, implementing modules linked, CI green. The contract is binding. | `Active` |
+| **Superseded** | Replaced by a newer section; retained for history. Links forward to its replacement. | `Superseded` |
+| **Deprecated** | The behavior is being removed; no replacement. | `Deprecated` |
+
+### Supersession links
+
+When a section is superseded, do **not** delete it — IDs are stable history. Instead:
+
+- Mark the old section `**Status:** Superseded`.
+- Add `**Superseded-by:** SPEC-{CATEGORY}-{NN}~{rev}` to the old section.
+- Add `**Supersedes:** SPEC-{CATEGORY}-{MM}~{rev}` to the new section (per [`README.md` §5](README.md#5-spec-section-structure)).
+
+This preserves a navigable chain so a reader landing on an old docstring reference can follow it forward to the current contract.
+
+---
+
+## 8. Relationship to Spec-Linked Documentation (SLD)
+
+This standard and SLD are two halves of one discipline:
+
+- **Spec Authoring Standard (this file)** = *authoring*. How to write the spec: scope, structure, IDs, granularity, research, lifecycle.
+- **[SLD](README.md)** = *traceability*. How code stays linked to the spec: docstring `References`, the four-status checker, WWL code granularity.
+
+**The handoff:** You author a section here (with a stable ID, a Behavior Contract, an Implementing Modules table). SLD then takes over — engineers add `References: SPEC-…` blocks to the named modules, and the CI checker (`tests/test_spec_traceability.py`) enforces bidirectional completeness. A `~rev` bump you make here (on a contract change) is what SLD's OUTDATED status detects downstream.
+
+Read both: this file to **write** a spec; [`README.md`](README.md) to **trace code to it**. The companion skills mirror this split — `spec-authoring` (this standard) and `spec-linked-docs` (traceability) — and cross-reference each other.
+
+---
+
+## References
+
+- [`README.md`](README.md) — Spec-Linked Documentation (SLD) convention guide (ID grammar, section structure, four-status model, WWL).
+- [`research/`](research/) — pre-spec investigation documents (`NN-topic-slug.md`).
+- `mpm-adr` skill / `docs/adr/` — Architecture Decision Records (Nygard template) for significant, hard-to-reverse decisions.
+- `spec-authoring` skill (`src/claude_mpm/skills/bundled/main/spec-authoring/`) — the agent-facing companion to this standard.
+- `spec-linked-docs` skill (`src/claude_mpm/skills/bundled/universal/spec-linked-docs/`) — the traceability companion.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -225,7 +225,9 @@ Do NOT increment the revision for:
 Only files matching the pattern `docs/specs/{subsystem}.md` (directly in `docs/specs/`,
 not in subdirectories) are scanned for declared spec IDs. The research directory
 (`docs/specs/research/`) is explicitly excluded. This file (`docs/specs/README.md`) is also
-excluded because it contains example IDs in prose that are not declarations.
+excluded because it contains example IDs in prose that are not declarations. The authoring
+guide (`docs/specs/AUTHORING.md`) is excluded for the same reason — it contains example IDs
+in its templates and filled mini-example, which are illustrative, not declarations.
 
 **Declaration rule:** A spec ID is considered *declared* only when it appears in a section
 heading in the form `## ... {#SPEC-...}` (a Markdown heading with a named anchor), or as the

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/SKILL.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: prd-authoring
+description: "Standard for authoring product PRDs in docs/prd/: state the problem, users, requirements, and success; assign PRD-{AREA}-{NN} IDs; link down to specs."
+version: 1.0.0
+category: documentation
+agent_types: [product-owner, pm]
+tags: [prd, product, requirements, authoring, standards]
+effort: medium
+user-invocable: true
+progressive_disclosure:
+  entry_point:
+    summary: "Author product PRDs in docs/prd/ using the PRD-{AREA}-{NN} grammar, a product-owned template (problem, users, requirements, acceptance, metrics), and a product lifecycle. PRDs are realized by engineering specs."
+    when_to_use: "When defining a product problem and its requirements, creating a docs/prd/{area}.md file, adding PRD-{AREA}-{NN} requirements, running product/user/market research, or mapping requirements to implementing specs."
+    quick_start: "1. Read docs/prd/README.md for ID grammar 2. Pick/create the area file from TEMPLATE.md 3. State problem, users, requirements 4. Add acceptance criteria + success metrics 5. Fill the Linked Specs table"
+  references:
+    - prd-template.md
+    - prd-research-practices.md
+    - prd-lifecycle.md
+    - prd-to-spec-linkage.md
+    - ia-and-categories.md
+---
+
+# PRD Authoring
+
+## Overview
+
+This skill is the agent-facing entry point to the **Product PRD Standard**: how to *write*
+Product Requirements Documents in `docs/prd/`. A PRD answers **what problem, for which users,
+what requirements, and what success looks like** — and is owned by **Product** (Product Owner /
+PM).
+
+It has a distinct engineering companion — keep the roles separate:
+
+- **`prd-authoring`** (this skill) = **authoring product PRDs.** State the problem, target users,
+  goals, user stories, requirements, acceptance criteria, and success metrics; assign stable
+  `PRD-{AREA}-{NN}` IDs; run product/user/market research; map requirements down to implementing
+  specs.
+- **`spec-authoring`** = **engineering specs** (a separate, engineering-owned standard —
+  `docs/specs/`, `SPEC-{SUBSYSTEM}-{NN}~{rev}`). Specs *implement* PRD requirements.
+- **`spec-linked-docs`** = traceability between specs and source code.
+
+> **PRD ≠ SPEC.** A PRD is a *product* requirements doc (`PRD-{AREA}-{NN}`, in `docs/prd/`,
+> owned by Product). A SPEC is an *engineering* behavior contract (`SPEC-{SUBSYSTEM}-{NN}~{rev}`,
+> in `docs/specs/`, owned by Engineering). A PRD requirement is **realized by** one or more
+> specs; list them in the Linked Specs table. Do **not** put inputs/outputs/error contracts in a
+> PRD — that is the spec's job.
+
+**Full standard:** [`docs/prd/README.md`](../../../../../../docs/prd/README.md).
+This skill orients and links; `README.md` is the authoritative, portable standard, and
+[`docs/prd/TEMPLATE.md`](../../../../../../docs/prd/TEMPLATE.md) is the copy-pasteable document.
+
+> **Use this skill, do not duplicate it.** SKILL.md is a concise router. The detailed rules live
+> in `docs/prd/README.md` and the five reference files below. Read the reference you need.
+
+---
+
+## When to Use
+
+- Defining a product problem and turning it into stable requirements.
+- Creating a new `docs/prd/{area}.md` file for a product area.
+- Adding a governed `PRD-{AREA}-{NN}` requirement to an existing PRD.
+- Running product / user / market / competitive research and recording it.
+- Mapping requirements to the engineering spec(s) that implement them (Linked Specs table).
+- Moving a PRD through its lifecycle (Draft → Review → Approved → In-development → Shipped).
+
+If your task is instead authoring the *engineering contract*, use **`spec-authoring`**.
+
+---
+
+## Core Model (at a glance)
+
+A PRD is **product-owned**: one product area = one file (`docs/prd/{area}.md`). Each governed
+requirement has a stable `{#PRD-{AREA}-{NN}}` ID. A PRD document carries:
+
+- **Header** — Title, Status, **Owner = Product**, Version, Last-updated, Related specs/ADRs.
+- **Problem & Context** — the *why*.
+- **Target Users / Personas**, **Goals & Non-Goals**, **User Stories / JTBD**.
+- **Requirements** — Functional & Non-functional, each a stable `PRD-{AREA}-{NN}` item.
+- **Acceptance Criteria**, **Success Metrics / KPIs**.
+- **Scope & Out-of-Scope**, **Risks & Assumptions**, **Open Questions**.
+- **Linked Specs** — the PRD→SPEC traceability table.
+- **References** — research + sources.
+
+PRD IDs have **no** `~{rev}` suffix — requirements evolve via lifecycle and supersession, not a
+tilde counter.
+
+The copy-pasteable template is [`docs/prd/TEMPLATE.md`](../../../../../../docs/prd/TEMPLATE.md)
+(and [`references/prd-template.md`](references/prd-template.md) explains how to fill it).
+
+---
+
+## Quick Start
+
+1. **Read the grammar.** [`docs/prd/README.md` §3](../../../../../../docs/prd/README.md) defines
+   `PRD-{AREA}-{NN}` and the declaration rule. Do not invent IDs.
+2. **Pick or create the area file.** One product area = one file. See
+   [`references/ia-and-categories.md`](references/ia-and-categories.md).
+3. **Apply the template.** Copy [`docs/prd/TEMPLATE.md`](../../../../../../docs/prd/TEMPLATE.md);
+   fill problem, users, requirements, acceptance criteria, success metrics. Guidance in
+   [`references/prd-template.md`](references/prd-template.md).
+4. **Ground it in research.** Non-obvious requirements cite product/user/market research. See
+   [`references/prd-research-practices.md`](references/prd-research-practices.md).
+5. **Map requirements to specs.** Fill the Linked Specs table; engineering authors the specs and
+   cites the PRD ID back. See [`references/prd-to-spec-linkage.md`](references/prd-to-spec-linkage.md).
+6. **Manage the lifecycle.** Draft → Review → Approved → In-development → Shipped → Superseded.
+   See [`references/prd-lifecycle.md`](references/prd-lifecycle.md).
+
+---
+
+## Reference Files
+
+| Reference | Read it when you need to… |
+|-----------|---------------------------|
+| [`prd-template.md`](references/prd-template.md) | Fill the PRD document section by section. |
+| [`prd-research-practices.md`](references/prd-research-practices.md) | Run product/user/market/competitive research and cite evidence. |
+| [`prd-lifecycle.md`](references/prd-lifecycle.md) | Walk the lifecycle (Draft → Shipped → Superseded) and the review checklist. |
+| [`prd-to-spec-linkage.md`](references/prd-to-spec-linkage.md) | Build and maintain the PRD→SPEC traceability table. |
+| [`ia-and-categories.md`](references/ia-and-categories.md) | Choose/name a product area; decide add-area vs. add-requirement. |
+
+---
+
+## Relationship to Specs
+
+A PRD states *what* and *why*; a spec states the *engineering contract* that realizes it. The two
+are distinct standards (distinct dirs, IDs, owners, templates) with a **bidirectional link**: the
+PRD's Linked Specs table points *down* to implementing `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs; each
+spec section cites the `PRD-{AREA}-{NN}` it implements *up*. Read `spec-authoring` when you need
+to understand or coordinate the engineering side.

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/SKILL.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: prd-authoring
 description: "Standard for authoring product PRDs in docs/prd/: state the problem, users, requirements, and success; assign PRD-{AREA}-{NN} IDs; link down to specs."
 version: 1.0.0
 category: documentation
-agent_types: [product-owner, pm]
+agent_types: [product, product-owner, pm]
 tags: [prd, product, requirements, authoring, standards]
 effort: medium
 user-invocable: true

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/references/ia-and-categories.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/references/ia-and-categories.md
@@ -1,0 +1,119 @@
+# Information Architecture & Product Areas
+
+How product PRDs are organized into files, how to choose and name a product **AREA**, and the
+rule for deciding whether new work is a **requirement** in an existing area or a **new area
+file**. Agent-facing copy of [`docs/prd/README.md` §4](../../../../../../../docs/prd/README.md).
+
+---
+
+## 1. Two levels only
+
+The IA mirrors the engineering side's flatness:
+
+```
+Area (file)  →  Requirements (governed PRD-{AREA}-{NN} items)
+```
+
+- **Area** = one product area or feature = one file `docs/prd/{area}.md`. The uppercased name is
+  the `{AREA}` token in every requirement ID in that file.
+- **Requirement** = one governed `PRD-{AREA}-{NN}` item in the file's *Requirements* section.
+
+There is no third level. If a requirement seems to need sub-requirements with their own
+acceptance criteria, that is a signal to split it into sibling requirements.
+
+---
+
+## 2. Organize by product AREA, not engineering subsystem
+
+A product **AREA** is the unit a Product Owner reasons about and a user would name:
+
+- `SEARCH`, `ONBOARDING`, `BILLING`, `NOTIFICATIONS`, `GOVERNANCE`.
+
+This is **intentionally a different axis** from the engineering SUBSYSTEM used by specs:
+
+- One product area is frequently realized by **several** subsystems.
+- One subsystem may serve **several** product areas.
+
+Do **not** force PRD areas to match spec subsystems. Organize PRDs by the product surface; record
+the cross-mapping via the Linked Specs table (see
+[`prd-to-spec-linkage.md`](prd-to-spec-linkage.md)).
+
+> Example: the product area `PRD-SEARCH` may be realized by `SPEC-INTEGRATIONS` (the vector index
+> adapter) and `SPEC-SESSIONS` (query session handling). Neither subsystem is "the search
+> subsystem"; search is a *product* concept spanning them.
+
+---
+
+## 3. Add a requirement vs. add an area
+
+### Default: add a requirement
+
+Adding a `PRD-{AREA}-{NN}` item to an existing area file is the **common case**. Do this when the
+new need fits an existing area's scope. Append a `#### {Title} {#PRD-{AREA}-{NN+1}}` requirement,
+add acceptance criteria and a Linked Specs row.
+
+### Add a new area file only when ALL of these hold
+
+1. **Cohesive product surface.** The need forms a recognizable product area with a clear
+   boundary — not a feature of an existing one.
+2. **Separately owned / planned.** It can be prioritized, reviewed, and shipped on its own
+   cadence.
+3. **Several requirements' worth.** It will hold more than one or two requirements. A single need
+   is a *requirement*, never an area.
+
+If even one fails, prefer a requirement in the nearest existing area.
+
+### Decision flow
+
+```
+New product need
+        │
+        ▼
+Does an existing area's scope cover it? ──yes──▶ add a REQUIREMENT there
+        │ no
+        ▼
+Cohesive, separately-planned surface with ≥3 requirements' worth? ──no──▶ add a REQUIREMENT
+        │ yes                                                              to the nearest area
+        ▼
+   add a NEW AREA file docs/prd/{area}.md
+```
+
+---
+
+## 4. Naming an area
+
+- **Token:** UPPERCASE alpha, hyphens allowed — `SEARCH`, `MODEL-ROUTING`. Matches the `{AREA}`
+  slot in [`README.md` §3](../../../../../../../docs/prd/README.md).
+- **File name:** lowercase form of the token — `model-routing.md` ↔ `PRD-MODEL-ROUTING-01`.
+- **Durability:** the token appears in every requirement ID **and in every spec that cites it**.
+  Renaming it breaks those cross-standard links. Choose durable, user-recognizable names.
+- **User-facing language:** prefer the word a user or PM would use (`SEARCH`) over an internal
+  code name.
+
+---
+
+## 5. Every directory has an orienting index
+
+`docs/prd/` is indexed by its `README.md`. Any new subdirectory (e.g. `research/`) carries its
+own index that orients a reader: what lives here, the naming convention, where to go next — the
+same rule the engineering side applies under `docs/specs/`.
+
+---
+
+## 6. Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Creating an area per engineering subsystem | Organize by product surface; map to subsystems via Linked Specs. |
+| One area file per requirement | Group related requirements into an area. |
+| Naming an area after an internal code name | Use the user-facing product term. |
+| Renaming an `{AREA}` token to tidy up | Don't — it breaks spec cross-references. Supersede instead. |
+| Putting acceptance/metrics in the spec | Those are PRD sections; the spec stays a contract. |
+
+---
+
+## See also
+
+- [`prd-to-spec-linkage.md`](prd-to-spec-linkage.md) — recording the AREA↔SUBSYSTEM mapping.
+- [`prd-template.md`](prd-template.md) — the requirement structure within an area.
+- [`docs/prd/README.md` §4](../../../../../../../docs/prd/README.md) — the authoritative IA rules.

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-lifecycle.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-lifecycle.md
@@ -1,0 +1,128 @@
+# PRD Lifecycle & Review
+
+The end-to-end lifecycle of a product PRD and the review checklist. Agent-facing copy of
+[`docs/prd/README.md` §5](../../../../../../../docs/prd/README.md).
+
+---
+
+## 1. Lifecycle stages
+
+A PRD (and each requirement within it) moves through a **product** lifecycle, distinct from the
+engineering spec lifecycle. Tracked in the header-block **Status** field and per-requirement
+`**Status:**` where they diverge:
+
+| Stage | Meaning | Status value |
+|-------|---------|--------------|
+| **Draft** | Problem and requirements being written; not yet agreed. | `Draft` |
+| **Review** | Stakeholder review of problem framing, requirements, success metrics. | `Review` |
+| **Approved** | Product has signed off. Requirements are stable enough to spec against. | `Approved` |
+| **In-development** | Implementing specs authored/built; `SPEC-…` linked. | `In-development` |
+| **Shipped** | Live; success metrics being measured. | `Shipped` |
+| **Superseded** | Replaced by a newer requirement; retained for history; links forward. | `Superseded` |
+
+> Contrast with the **spec** lifecycle (Draft → Review → Active → Superseded). The PRD has extra
+> product-facing states (`Approved`, `In-development`, `Shipped`) because it tracks a product
+> commitment through delivery, not just a contract's validity.
+
+---
+
+## 2. The lifecycle flow
+
+```
+[Draft]        Problem + requirements written. Research linked. Status: Draft.
+     │
+     ▼
+[Review]       Stakeholders review problem framing, requirements, metrics.
+     │
+     ▼
+[Approved]     Product signs off. ── handoff ──▶ Engineering begins spec-authoring
+     │                                            (PRD-{AREA}-{NN} is the spec's inception trigger)
+     ▼
+[In-development]  Implementing specs authored/built; Linked Specs table filled with SPEC IDs.
+     │
+     ▼
+[Shipped]      Feature live. Success metrics measured against baseline/target.
+     │
+     ▼ (if requirements materially change post-ship)
+[Superseded]   New requirement ID created; old one marked Superseded with forward link.
+```
+
+### Stage detail
+
+1. **Draft.** Copy `TEMPLATE.md`. Write the problem, users, requirements, acceptance criteria,
+   metrics. Ground non-obvious requirements in research (`prd-research-practices.md`).
+2. **Review.** Stakeholders (eng lead, design, GTM as relevant) review. Confirm the problem is
+   real, requirements are testable, metrics are measurable, non-goals are explicit.
+3. **Approved.** Product signs off. This is the **handoff to engineering**: a requirement at
+   `Approved` is the inception trigger for a spec
+   ([`docs/specs/AUTHORING.md` §8](../../../../../../../docs/specs/AUTHORING.md)).
+4. **In-development.** As engineering authors specs, fill the **Linked Specs** table with the
+   `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs realizing each requirement. Confirm each spec cites the PRD
+   ID back (bidirectional link — `prd-to-spec-linkage.md`).
+5. **Shipped.** Feature is live. Begin measuring success metrics against their baselines/targets.
+6. **Superseded.** See below.
+
+---
+
+## 3. Supersession (no `~rev` on PRD IDs)
+
+PRD IDs have **no** `~{rev}` suffix. When a requirement materially changes after Approval/Ship,
+do **not** rewrite it in place — specs cite it as a stable reference. Instead:
+
+- Mark the old requirement `**Status:** Superseded` and add `**Superseded-by:** PRD-{AREA}-{NN}`.
+- Create a new requirement with a new ID and `**Supersedes:** PRD-{AREA}-{NN}`.
+- Update the **Linked Specs** table so engineering knows the contract target moved (the old
+  spec may need a `~rev` bump or supersession of its own).
+
+This preserves a navigable history: a spec citing an old `PRD-{AREA}-{NN}` can follow the chain
+forward to the current requirement.
+
+---
+
+## 4. Review checklist
+
+Before moving a PRD to **Approved**, confirm:
+
+### Structure
+- [ ] Header block present: Title, Status, **Owner = Product**, Version, Last-updated,
+      Related specs/ADRs.
+- [ ] Each requirement has a `{#PRD-{AREA}-{NN}}` anchor and matching `**ID:**` field.
+- [ ] Requirements split into Functional and Non-functional.
+
+### Content
+- [ ] Problem & Context states the *why* with evidence (not a solution).
+- [ ] Target users / personas named.
+- [ ] Goals **and** Non-Goals are explicit.
+- [ ] Each requirement is one independently-trackable need, with a MoSCoW priority.
+- [ ] **No engineering contract leaked in** — no inputs/outputs/error handling, no module names
+      as requirements. (Cite the implementing spec instead.)
+- [ ] Acceptance criteria are observable and grouped by requirement ID.
+- [ ] Success metrics have baseline, target, and measurement source.
+
+### Research & links
+- [ ] Non-obvious requirements cite product/user/market research or an ADR.
+- [ ] Every `#PRD-…` / `#SPEC-…` anchor linked exists; every relative path resolves (no dangling
+      links).
+
+### Traceability
+- [ ] The **Linked Specs** table has a row for every requirement (use `_(not yet specced)_`
+      where appropriate).
+- [ ] For each filled row, the implementing spec cites this `PRD-{AREA}-{NN}` back.
+
+---
+
+## 5. Handoffs
+
+| To | When | Skill |
+|----|------|-------|
+| Engineering | At `Approved`, to author implementing specs | `spec-authoring` |
+| Engineering | As specs go Active, to confirm the Linked Specs table | `spec-authoring` |
+| Product | Post-ship, to measure success metrics | (this skill) |
+
+---
+
+## See also
+
+- [`prd-to-spec-linkage.md`](prd-to-spec-linkage.md) — the bidirectional link the lifecycle relies on.
+- [`prd-template.md`](prd-template.md) — the document being moved through the lifecycle.
+- [`docs/prd/README.md` §5](../../../../../../../docs/prd/README.md) — the authoritative lifecycle.

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-research-practices.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-research-practices.md
@@ -1,0 +1,148 @@
+# Product Research Practices
+
+The general research discipline for the **product** side: how to turn a fuzzy problem into
+evidence-grounded requirements. This is where general research best practices live for PRDs —
+defining the question, user/market/competitive research, evidence gathering, citing sources,
+validating assumptions, and making evidence-based decisions. Authoritative pointer:
+[`docs/prd/README.md` §8](../../../../../../../docs/prd/README.md).
+
+> **Boundary.** Product research justifies the *requirement* ("who needs this and why").
+> **Technical** research (algorithms, benchmarks, how to build it) belongs to the engineering
+> side (`docs/specs/research/`; the `spec-authoring` skill's `research-conventions.md`). Keep
+> them in separate directories so each standard stays clean.
+
+---
+
+## 1. Where product research lives
+
+```
+docs/prd/research/NN-topic-slug.md
+```
+
+- `NN` — two-digit sequence, monotonic within the directory.
+- `topic-slug` — short hyphenated description: `03-search-user-interviews.md`,
+  `07-competitive-pricing-scan.md`.
+- Excluded from spec traceability (it is not under `docs/specs/`); it never appears in the SLD
+  checker.
+
+---
+
+## 2. The research loop
+
+### Step 1 — Define the question
+
+State the *decision* the research must inform, in product terms. A research doc without a
+question becomes an unfocused dump.
+
+> ✅ "Do users abandon search because results are slow, irrelevant, or both?"
+> ❌ "Search research."
+
+### Step 2 — Choose the right kind of research
+
+| Kind | Answers | Typical methods |
+|------|---------|-----------------|
+| **User research** | What do users actually need / do / struggle with? | Interviews, surveys, session analytics, support tickets, usability tests. |
+| **Market research** | Is there demand? How large / urgent? | Market sizing, trend data, analyst reports, segment analysis. |
+| **Competitive research** | How do others solve this? Where is the gap? | Competitor teardowns, feature matrices, pricing scans, reviews. |
+| **Internal data** | What does our own usage say? | Product analytics, funnels, retention cohorts, NPS/CSAT. |
+
+Most PRDs need a blend of user + competitive + internal data.
+
+### Step 3 — Gather evidence
+
+- Talk to (or observe) real users; do not substitute opinion for data.
+- Pull quantitative signals (funnels, drop-off, adoption) from product analytics.
+- Survey the competitive landscape for prior art and table-stakes expectations.
+- Record raw evidence (quotes, numbers, screenshots) so conclusions are auditable.
+
+### Step 4 — Cite sources with links
+
+Every claim that drives a requirement gets a citable source: an interview note, an analytics
+query, a competitor URL, a report. **Unsourced assertions are assumptions, not evidence** —
+mark them as such (Step 5).
+
+### Step 5 — Validate assumptions explicitly
+
+Separate what you **verified** from what you are **assuming**.
+
+- Tag each as `[verified]` or `[assumed]`.
+- For `[assumed]` items, state *how* you will validate (experiment, A/B test, prototype, more
+  interviews).
+- When an assumption becomes a committed product bet, promote it to an **ADR**
+  (`mpm-adr`, `docs/adr/NNNN-*.md`) and cite it from the PRD.
+
+### Step 6 — Make an evidence-based decision
+
+The research's *Decision* is what becomes a requirement (or a non-goal). Keep exploratory
+analysis in the research doc; the PRD records only the chosen requirements, each citing the
+research that justifies it.
+
+---
+
+## 3. The citation rule
+
+**Every non-obvious requirement cites its evidence.** If a reviewer would ask "why do we believe
+users need this?", the requirement links to a `research/NN-*.md` doc, an ADR, or an external
+source. Obvious requirements need no citation; non-obvious ones always do.
+
+---
+
+## 4. Product research doc skeleton
+
+```markdown
+# {NN} — {Topic}
+
+**Question:** {the product decision this research informs}
+**Status:** Open | Resolved → {PRD-AREA-NN}
+**Date:** {YYYY-MM-DD}
+
+## Context
+{What prompted this. Which product area / problem.}
+
+## Method
+{Who/what we studied: N interviews, analytics window, competitors examined.}
+
+## Findings
+{What the evidence shows. Cite every claim.}
+
+## Assumptions
+- [verified] {…} — source: {link}
+- [assumed]  {…} — validation plan: {experiment / A-B / prototype}; promote to ADR if committed
+
+## Decision
+{The requirement(s) this justifies, or the non-goal it rules out.}
+
+## Sources
+- {interview notes / analytics query / competitor URL / report}
+```
+
+---
+
+## 5. Evidence-based decisions and ADRs
+
+Significant, hard-to-reverse **product** decisions (a pricing model, a platform bet, a
+deprecation) should be recorded as ADRs via the `mpm-adr` skill, the same Nygard template the
+engineering side uses. The PRD requirement cites the ADR; the ADR captures the alternatives and
+why this one was chosen. This keeps the *why* durable even as the team changes.
+
+---
+
+## 6. Research → PRD handoff
+
+When research resolves:
+
+1. Set the research doc's `Status:` to `Resolved → PRD-{AREA}-{NN}`.
+2. Write (or update) the requirement, encoding only the **Decision**.
+3. From the requirement's prose or the PRD References, link back to the research doc.
+4. Record any committed bet as an ADR and link it.
+
+This leaves a chain: requirement → evidence → sources, mirroring the engineering side's
+spec → rationale → research chain.
+
+---
+
+## See also
+
+- [`prd-template.md`](prd-template.md) — where requirements and citations land.
+- The `spec-authoring` skill's `research-conventions.md` — the **technical** research counterpart.
+- [`docs/prd/README.md` §8](../../../../../../../docs/prd/README.md) — the authoritative pointer.

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-template.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-template.md
@@ -1,0 +1,148 @@
+# Filling the PRD Template
+
+How to fill [`docs/prd/TEMPLATE.md`](../../../../../../../docs/prd/TEMPLATE.md) section by section.
+The canonical, copy-pasteable document is `TEMPLATE.md` itself; this reference explains *what
+goes in each section* and the common mistakes. The authoritative standard is
+[`docs/prd/README.md`](../../../../../../../docs/prd/README.md).
+
+> **PRD ≠ SPEC.** A PRD states the problem and requirements; it never states inputs/outputs,
+> pre/postconditions, or error contracts. Those are the implementing **spec's** job
+> (`docs/specs/`). When you feel the urge to write "the function returns…", stop — that belongs
+> in a `SPEC-{SUBSYSTEM}-{NN}~{rev}`. Cite the spec instead via the Linked Specs table.
+
+---
+
+## Header block
+
+| Field | What to put | Rule |
+|-------|-------------|------|
+| `Title` | `{Area} — {one-line}` | Reader knows the area at a glance. |
+| `Status` | `Draft \| Review \| Approved \| In-development \| Shipped \| Superseded` | The product lifecycle (see `prd-lifecycle.md`). |
+| `Owner` | **Product** (Product Owner / PM name or role) | Always Product. If an engineer is the owner, you are probably writing a spec. |
+| `Version` | `v{N}` | Bump on substantial revisions. |
+| `Last-updated` | `YYYY-MM-DD` | Update on every material edit. |
+| `Related specs/ADRs` | Relative links into `../specs/` and `docs/adr/` | Orienting pointers; the full mapping is the Linked Specs table. |
+
+---
+
+## Problem & Context — the *why*
+
+State the problem, the evidence it matters, and the cost of inaction. Keep it about the
+**problem**, not the solution. Link the research that establishes it.
+
+- ✅ "Users abandon search after the first irrelevant result; session logs show 38% drop-off
+  after one query (research/03-search-funnel.md)."
+- ❌ "We will add a vector index with RRF fusion." (That is a solution / engineering detail.)
+
+---
+
+## Target Users / Personas
+
+Name the user segments and what they are trying to do. A requirement without a persona is a
+requirement without a customer. Use the table in the template.
+
+---
+
+## Goals & Non-Goals
+
+- **Goals** — product outcomes, not features. "Users find the right result on the first query."
+- **Non-Goals** — explicitly out of scope. Non-goals are the single most effective tool against
+  requirement sprawl; write them deliberately.
+
+---
+
+## User Stories / Jobs-to-be-Done
+
+Frame each need from the user's perspective:
+
+- `As a {persona}, I want {capability} so that {outcome}.`
+- `When {situation}, I want to {motivation}, so I can {expected result}.`
+
+These motivate the requirements; they are not themselves the trackable requirements.
+
+---
+
+## Requirements — the trackable core
+
+Each requirement is a stable `PRD-{AREA}-{NN}` item, declared in a heading anchor plus an
+`**ID:**` field:
+
+```markdown
+#### Sub-second relevance ranking {#PRD-SEARCH-03}
+**ID:** PRD-SEARCH-03
+**Status:** Approved
+**Priority:** Must
+
+Search results must be ordered by relevance and the first screen must be useful without
+scrolling. (Why: research/03-search-funnel.md shows users judge quality on the first result.)
+```
+
+Rules:
+
+- **Split functional vs. non-functional.** Functional = what it does; non-functional = quality
+  attributes (performance, reliability, security, accessibility, compliance).
+- **State non-functional targets measurably** in *product* terms ("results in under 1s at p95"),
+  leaving the engineering *how* to the spec.
+- **Use MoSCoW priority** (Must / Should / Could / Won't) so scope tradeoffs are explicit.
+- **One requirement = one independently-trackable need.** If two needs ship and succeed
+  independently, they are two IDs.
+- **No engineering contract.** No inputs/outputs/error handling — cite the implementing spec.
+
+---
+
+## Acceptance Criteria
+
+Observable, product-level checks for "done," grouped by requirement ID. Distinct from success
+metrics: acceptance is checked *at/ before* ship; metrics are measured *after*.
+
+```markdown
+**PRD-SEARCH-03**
+- [ ] First result is relevant for the top 20 known queries (manual eval).
+- [ ] No horizontal scroll needed to see the first result on a 1280px viewport.
+```
+
+---
+
+## Success Metrics / KPIs
+
+How you will know it worked after launch. Always include baseline, target, and measurement
+source.
+
+| Metric | Baseline | Target | How measured |
+|--------|----------|--------|--------------|
+| First-query success rate | 62% | ≥ 85% | search analytics |
+| p95 result latency | 1.4s | ≤ 1.0s | monitoring dashboard |
+
+---
+
+## Scope & Out-of-Scope, Risks & Assumptions, Open Questions
+
+- **Scope / Out-of-Scope** — reinforce the Goals/Non-Goals at the requirement level.
+- **Risks & Assumptions** — tabulate; mark assumptions for validation; promote load-bearing
+  assumptions to ADRs (see `prd-research-practices.md`).
+- **Open Questions** — keep unresolved decisions *out* of the requirements so requirements stay
+  stable.
+
+---
+
+## Linked Specs
+
+The PRD→SPEC traceability table. One row per requirement, mapping to implementing
+`SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs. Full rules in
+[`prd-to-spec-linkage.md`](prd-to-spec-linkage.md).
+
+---
+
+## References
+
+Cite the research docs and external sources that justify the PRD. Every non-obvious requirement
+points to its evidence.
+
+---
+
+## See also
+
+- [`docs/prd/TEMPLATE.md`](../../../../../../../docs/prd/TEMPLATE.md) — the document to copy.
+- [`prd-to-spec-linkage.md`](prd-to-spec-linkage.md) · [`prd-lifecycle.md`](prd-lifecycle.md) ·
+  [`prd-research-practices.md`](prd-research-practices.md) · [`ia-and-categories.md`](ia-and-categories.md)
+- [`docs/prd/README.md`](../../../../../../../docs/prd/README.md) — the authoritative standard.

--- a/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-to-spec-linkage.md
+++ b/src/claude_mpm/skills/bundled/main/prd-authoring/references/prd-to-spec-linkage.md
@@ -1,0 +1,123 @@
+# PRD → SPEC Linkage
+
+How to build and maintain the bidirectional link between a **product** PRD and the **engineering**
+spec(s) that implement it. This is the convention that connects the two distinct standards
+without either absorbing the other. Authoritative pointer:
+[`docs/prd/README.md` §7](../../../../../../../docs/prd/README.md).
+
+---
+
+## 1. Two standards, one bidirectional link
+
+| | PRD | SPEC |
+|---|-----|------|
+| Owner | Product | Engineering |
+| Home | `docs/prd/` | `docs/specs/` |
+| ID | `PRD-{AREA}-{NN}` | `SPEC-{SUBSYSTEM}-{NN}~{rev}` |
+| Organized by | product **AREA** | engineering **SUBSYSTEM** |
+
+They are linked in **both directions**:
+
+- **PRD → SPEC (downward):** the PRD's *Linked Specs* table maps each requirement to the spec(s)
+  that implement it.
+- **SPEC → PRD (upward):** each spec section that realizes a requirement cites the
+  `PRD-{AREA}-{NN}` in its Rationale or References.
+
+A link **only counts when both directions exist.** A Linked Specs row with no reciprocal cite in
+the spec (or vice versa) is an incomplete link — fix it before marking the requirement
+`In-development`.
+
+---
+
+## 2. The Linked Specs table
+
+Every PRD carries this table near the end of the document:
+
+```markdown
+## Linked Specs
+
+| Requirement | Implementing spec(s) | Status |
+|-------------|----------------------|--------|
+| [PRD-SEARCH-01](#PRD-SEARCH-01) | [SPEC-INTEGRATIONS-04~1](../specs/integrations.md#SPEC-INTEGRATIONS-04~1) | Active |
+| [PRD-SEARCH-03](#PRD-SEARCH-03) | [SPEC-SESSIONS-07~2](../specs/sessions.md#SPEC-SESSIONS-07~2), [SPEC-INTEGRATIONS-05~1](../specs/integrations.md#SPEC-INTEGRATIONS-05~1) | In-development |
+| [PRD-SEARCH-04](#PRD-SEARCH-04) | _(not yet specced)_ | Approved |
+```
+
+### Rules
+
+1. **One row per requirement.** Every `PRD-{AREA}-{NN}` declared in the file appears, even if not
+   yet specced (use `_(not yet specced)_`). This makes coverage gaps visible.
+2. **Many-to-many is normal.** One requirement is often realized by several subsystems; list all
+   implementing `SPEC-…~{rev}` IDs. One subsystem may also serve several requirements.
+3. **Cite the revision you validated against.** Reference specs at the `~{rev}` Product confirmed
+   the requirement against. If a spec bumps `~{rev}`, Product re-confirms the requirement still
+   holds and updates the row.
+4. **Bidirectional.** The implementing spec section must cite this `PRD-{AREA}-{NN}` back. Both
+   directions or it does not count.
+5. **Distinct namespaces.** Never reuse a `SPEC-…` ID as a PRD ID or vice versa.
+
+---
+
+## 3. The reciprocal cite on the spec side
+
+For each filled row, the engineering spec section names the PRD requirement it realizes — in its
+**Rationale** (preferred) or **References**:
+
+```markdown
+### Rationale (WHY)
+This contract realizes [PRD-SEARCH-03](../prd/search.md#PRD-SEARCH-03): sub-second relevance
+ranking is a product requirement, not an implementation choice.
+```
+
+Engineering owns writing this (via the `spec-authoring` skill); Product confirms it exists when
+filling the Linked Specs row.
+
+---
+
+## 4. Why AREA ≠ SUBSYSTEM (and that's fine)
+
+PRDs are organized by product **AREA** (what a user/PM names); specs by engineering **SUBSYSTEM**
+(what changes together / one team owns). They deliberately do not map 1:1:
+
+```
+PRD-SEARCH-03  ──realized by──▶  SPEC-SESSIONS-07~2   (query session handling)
+               └─also by────────▶  SPEC-INTEGRATIONS-05~1 (vector index adapter)
+
+SPEC-HOOKS-12~1  ──realizes──▶  PRD-GOVERNANCE-02  (model-tier policy)
+                 └─also──────▶  PRD-COST-04        (spend guardrails)
+```
+
+The Linked Specs table is exactly the artifact that records this many-to-many mapping. Do **not**
+rename a product AREA to match a subsystem or vice versa — record the relationship in the table
+instead. See [`ia-and-categories.md`](ia-and-categories.md) for choosing areas.
+
+---
+
+## 5. Maintaining the link over time
+
+| Event | What to do |
+|-------|------------|
+| Requirement reaches `Approved` | Engineering authors a spec; add the SPEC ID to the row once it exists. |
+| Spec bumps `~{rev}` (contract changed) | Update the row's `~{rev}`; re-confirm the requirement still holds. |
+| Spec is superseded | Point the row at the new SPEC ID; supersede the requirement if intent changed. |
+| Requirement superseded | New PRD ID; carry forward / re-target the spec links (see `prd-lifecycle.md` §3). |
+| Requirement shipped | Status column → `Shipped`/`Active`; begin measuring success metrics. |
+
+---
+
+## 6. Traceability as a product asset
+
+The Linked Specs table is the product-side half of a Requirements Traceability Matrix. It lets a
+Product Owner answer **"is requirement X implemented, and by what?"** and lets engineering answer
+**"why does this contract exist?"** — the bidirectional trace OpenFastTrace/DO-178C disciplines
+formalize, applied across the product/engineering boundary instead of within code.
+
+---
+
+## See also
+
+- [`prd-template.md`](prd-template.md) — where the Linked Specs table sits in the document.
+- [`ia-and-categories.md`](ia-and-categories.md) — why AREA and SUBSYSTEM are different axes.
+- The `spec-authoring` skill — the engineering side that writes the reciprocal cite.
+- [`docs/prd/README.md` §7](../../../../../../../docs/prd/README.md) — the authoritative convention.
+- [`docs/specs/AUTHORING.md` §2](../../../../../../../docs/specs/AUTHORING.md) — the spec side's view of the same link.

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/SKILL.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: spec-authoring
+description: "Standard for authoring engineering behavior-contract specs in docs/specs/: scope subsystems, assign stable IDs, structure docs, manage lifecycle."
+version: 1.0.0
+category: documentation
+agent_types: [engineer, documentation]
+tags: [specification, spec, authoring, engineering, standards]
+effort: medium
+user-invocable: true
+progressive_disclosure:
+  entry_point:
+    summary: "Author engineering specs in docs/specs/ using the SPEC-{SUBSYSTEM}-{NN}~{rev} grammar, a behavior-contract template, and a defined lifecycle. Specs are engineering-owned and implement PRD requirements."
+    when_to_use: "When creating a new docs/specs/{subsystem}.md file, adding spec sections, deciding granularity, establishing a new subsystem, or running pre-spec technical research."
+    quick_start: "1. Read docs/specs/README.md for ID grammar 2. Pick/create the subsystem file 3. Apply the spec template 4. Cite the PRD requirement realized 5. Link implementing modules 6. Run the CI traceability check"
+  references:
+    - spec-template.md
+    - category-taxonomy.md
+    - granularity-guide.md
+    - research-conventions.md
+    - authoring-workflow.md
+---
+
+# Spec Authoring
+
+## Overview
+
+This skill is the agent-facing entry point to the **Engineering Spec Authoring Standard**:
+how to *write* engineering specifications in `docs/specs/`. A spec is a **behavior contract**
+(testable WHAT + WHY, linked to implementing modules), owned by **Engineering / Architecture**.
+
+It has two distinct companions — keep the roles separate:
+
+- **`spec-authoring`** (this skill) = **authoring engineering specs.** Scope a subsystem into a
+  file, assign stable IDs, structure a behavior-contract document, decide granularity, run
+  pre-spec technical research, and move a spec through its lifecycle.
+- **`spec-linked-docs`** (SLD) = **traceability.** Keep source code in sync with the spec via
+  docstring `References` and a CI checker.
+- **`prd-authoring`** = **product PRDs** (a separate, product-owned standard — `docs/prd/`).
+
+> **SPEC ≠ PRD.** A SPEC is an *engineering* contract (`SPEC-{SUBSYSTEM}-{NN}~{rev}`, in
+> `docs/specs/`, owned by Engineering). A PRD is a *product* requirements doc
+> (`PRD-{AREA}-{NN}`, in `docs/prd/`, owned by Product). A spec **implements** a PRD
+> requirement and cites it; product framing (problem, users, acceptance criteria, metrics)
+> stays in the PRD. Do **not** put PRD content in a spec.
+
+**Full standard:** [`docs/specs/AUTHORING.md`](../../../../../../docs/specs/AUTHORING.md).
+This skill orients and links; `AUTHORING.md` is the authoritative, portable standard.
+The **ID grammar** itself lives in [`docs/specs/README.md`](../../../../../../docs/specs/README.md)
+— defer to it; never re-derive it.
+
+> **Use this skill, do not duplicate it.** SKILL.md is a concise router. The detailed rules
+> live in `AUTHORING.md` and the five reference files below. Read the reference you need.
+
+---
+
+## When to Use
+
+- Creating a new `docs/specs/{subsystem}.md` file for a subsystem.
+- Adding a governed `SPEC-{SUBSYSTEM}-{NN}~{rev}` section to an existing spec.
+- Deciding whether a behavior is one ID, several, or none.
+- Deciding whether to add a new subsystem (file) or a section to an existing one.
+- Running pre-spec *technical* research and recording it in `docs/specs/research/`.
+- Moving a spec through its lifecycle (Draft → Review → Active → Superseded).
+
+If your task is instead *linking code to an existing spec*, use **`spec-linked-docs`**.
+If you are authoring product requirements, use **`prd-authoring`**.
+
+---
+
+## Core Model (at a glance)
+
+A claude-mpm spec is a **behavior contract**: one bounded subsystem = one file
+(`docs/specs/{subsystem}.md`). Each governed section has a stable
+`{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` ID and contains:
+
+- **Behavior Contract (WHAT)** — Inputs / Outputs / Preconditions / Postconditions / Error conditions.
+- **Rationale (WHY)** — design decisions and constraints (mandatory; never HOW). Cite the
+  `PRD-{AREA}-{NN}` requirement realized, if any.
+- **Implementing Modules** — the HOW-link table (SLD verifies these).
+
+Around the governed sections sit a **header block** (Status, Version, Subsystem, Owner=eng,
+Last-updated, Related), **Purpose & Scope**, a **Table of Contents** (ID → section →
+modules), **Open Questions / Future Work**, and **References**.
+
+There is **no** Acceptance Criteria or Success Metrics section — those are PRD concerns.
+
+The copy-pasteable template is in [`references/spec-template.md`](references/spec-template.md).
+
+---
+
+## Quick Start
+
+1. **Read the grammar.** [`docs/specs/README.md` §4](../../../../../../docs/specs/README.md)
+   defines `SPEC-{SUBSYSTEM}-{NN}~{rev}` and the declaration rule. Do not invent IDs.
+2. **Pick or create the subsystem file.** One bounded subsystem = one file. See
+   [`references/category-taxonomy.md`](references/category-taxonomy.md) for the existing
+   seven subsystems and the add-subsystem-vs-section rules.
+3. **Apply the spec template.** Copy [`references/spec-template.md`](references/spec-template.md);
+   fill the header block, Purpose & Scope, ToC, and each governed section.
+4. **Get granularity right.** One ID per independently-verifiable behavior. Use the litmus
+   test and split/merge heuristics in
+   [`references/granularity-guide.md`](references/granularity-guide.md).
+5. **Cite the PRD requirement realized** (if any) and your research. Non-obvious decisions
+   link to `docs/specs/research/NN-topic-slug.md`. See
+   [`references/research-conventions.md`](references/research-conventions.md).
+6. **Link implementing modules** in each section's table; engineers then add SLD
+   `References` blocks (handoff to `spec-linked-docs`).
+7. **Run the CI check.** `uv run pytest tests/test_spec_traceability.py` verifies the
+   traceability graph. Draft sections are exempt from UNCOVERED (see README §9b).
+
+---
+
+## Reference Files
+
+| Reference | Read it when you need to… |
+|-----------|---------------------------|
+| [`spec-template.md`](references/spec-template.md) | Copy the canonical behavior-contract spec document template. |
+| [`category-taxonomy.md`](references/category-taxonomy.md) | See existing subsystems; decide add-subsystem vs. add-section; name a subsystem. |
+| [`granularity-guide.md`](references/granularity-guide.md) | Decide whether a behavior is one ID, several, or none; split/merge. |
+| [`research-conventions.md`](references/research-conventions.md) | Run pre-spec *technical* research and record it in `docs/specs/research/`. |
+| [`authoring-workflow.md`](references/authoring-workflow.md) | Walk the full lifecycle (Inception → Superseded) and the review checklist. |
+
+---
+
+## Relationship to SLD and PRDs
+
+`spec-authoring` is upstream of the contract; `spec-linked-docs` is downstream of it. You
+author a section here; SLD then keeps source code in sync with it via docstring `References`
+and the four-status CI checker. A `~rev` bump you make on a contract change is what SLD's
+OUTDATED status detects.
+
+A spec **implements** product requirements. The `prd-authoring` skill (`docs/prd/`) is the
+product-owned companion: PRDs state the problem and requirements; specs state the engineering
+contract that realizes them and cite the `PRD-{AREA}-{NN}`. Read both skills when a feature
+spans product intent and engineering contract.

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/references/authoring-workflow.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/references/authoring-workflow.md
@@ -1,0 +1,143 @@
+# Authoring Workflow & Lifecycle
+
+The end-to-end workflow for taking an engineering spec from inception to active (and eventually
+to superseded), plus the review checklist. Agent-facing copy of
+[`docs/specs/AUTHORING.md` §8](../../../../../../../docs/specs/AUTHORING.md).
+
+---
+
+## 1. Lifecycle stages
+
+A spec moves through a defined lifecycle, tracked in the header-block **Status** field (and
+per-section `**Status:**` where sections diverge):
+
+| Stage | Meaning | Status value |
+|-------|---------|--------------|
+| **Inception** | Need identified — often by an approved `PRD-{AREA}-{NN}` requirement. No document yet. | (no file) |
+| **Research** | Technical investigation underway in `research/`; question defined, evidence gathering. | (research doc only) |
+| **Draft** | Spec sections written but not yet implemented/reviewed. CI tolerates uncovered IDs via the draft exemption ([`README.md` §9b](../../../../../../../docs/specs/README.md)). | `Draft` / `draft (pending backfill)` |
+| **Review** | Sections complete; human review of semantic correctness and code linkage in progress. | `Draft` (during review) |
+| **Active** | Reviewed, implementing modules linked, CI green. The contract is binding. | `Active` |
+| **Superseded** | Replaced by a newer section; retained for history; links forward. | `Superseded` |
+| **Deprecated** | Behavior being removed; no replacement. | `Deprecated` |
+
+---
+
+## 2. The authoring loop (Inception → Active)
+
+```
+PRD requirement approved (or technical need identified)
+        │
+        ▼
+[Inception]  Identify the subsystem. Existing file or new? → category-taxonomy.md
+        │
+        ▼
+[Research]   Non-obvious decisions? Write docs/specs/research/NN-*.md → research-conventions.md
+        │
+        ▼
+[Draft]      Apply spec-template.md. Mark **Status:** draft (pending backfill).
+             - One ID per verifiable behavior → granularity-guide.md
+             - Cite the PRD-{AREA}-{NN} realized
+             - Fill Behavior Contract, Rationale, Implementing Modules
+             - Add ToC rows; verify anchors resolve
+        │
+        ▼
+[Review]     Human review: does each contract match intended behavior? Are links real?
+        │
+        ▼
+[Backfill]   Engineers add SLD References blocks to implementing modules (spec-linked-docs)
+        │
+        ▼
+[Active]     Remove the draft marker. CI UNCOVERED enforcement now applies.
+             Update PRD's Linked Specs table with the now-Active SPEC IDs.
+```
+
+### Step detail
+
+1. **Inception.** Confirm the driving need. If it comes from product, note the
+   `PRD-{AREA}-{NN}`. Decide subsystem placement using
+   [`category-taxonomy.md`](category-taxonomy.md).
+2. **Research (if needed).** For any non-obvious decision, write a research doc first
+   ([`research-conventions.md`](research-conventions.md)). Skip for obvious contracts.
+3. **Draft.** Copy [`spec-template.md`](spec-template.md). Mark sections
+   `**Status:** draft (pending backfill)` so CI stays green while code is unwritten. Size each
+   section with [`granularity-guide.md`](granularity-guide.md). Cite the PRD requirement.
+4. **Review.** A human (or reviewing agent) confirms the contract is correct and the
+   Implementing Modules table names the right code. This catches the false-confidence risk SLD
+   warns about — CI proves links *exist*, not that they are *correct*.
+5. **Backfill.** Engineers add `References: SPEC-…` blocks to the named module docstrings. This
+   is the `spec-linked-docs` handoff.
+6. **Active.** Remove the `draft` marker (`**Status:** Active`). Normal UNCOVERED enforcement
+   applies immediately — if backfill missed a reference, CI catches it. Update the PRD's
+   *Linked Specs* table so the product side now points to a live contract.
+
+---
+
+## 3. Supersession (changing a contract that already shipped)
+
+When a contract materially changes, you do **not** edit the old ID's meaning in place — IDs are
+stable history.
+
+- If the change is a **contract revision** of the same behavior: bump `~{rev}` on the same ID
+  (`SPEC-HOOKS-05~1` → `SPEC-HOOKS-05~2`). Docstrings on the old rev are flagged OUTDATED.
+- If the change **replaces** the behavior with a different one: create a **new ID** and mark the
+  old one superseded:
+  - Old section: `**Status:** Superseded` + `**Superseded-by:** SPEC-{SUBSYSTEM}-{NN}~{rev}`.
+  - New section: `**Supersedes:** SPEC-{SUBSYSTEM}-{MM}~{rev}`.
+
+This preserves a navigable chain: a reader landing on an old docstring reference follows it
+forward to the current contract.
+
+---
+
+## 4. Review checklist
+
+Before marking a spec section **Active**, confirm:
+
+### Structure
+- [ ] Header block present: Status, Version, Subsystem, **Owner = engineering team/role**,
+      Last-updated, Related.
+- [ ] Section has a stable `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` anchor and matching `**ID:**` field.
+- [ ] ToC has a row for the section (ID → anchor → modules).
+
+### Content
+- [ ] Behavior Contract covers Inputs, Outputs, Preconditions, Postconditions, Error conditions.
+- [ ] Rationale (WHY) is present and non-empty — a section without WHY is incomplete.
+- [ ] **No HOW** in the contract or rationale (no "first we…, then we…").
+- [ ] **No PRD content** leaked in — no problem statement, personas, user stories, acceptance
+      criteria, or success metrics. (Those are in the PRD; cite it instead.)
+- [ ] Implementing Modules table names real modules.
+
+### Granularity
+- [ ] One independently-verifiable behavior per ID ([`granularity-guide.md`](granularity-guide.md)).
+- [ ] `~rev` bumped iff the contract changed materially.
+
+### Links & traceability
+- [ ] The `PRD-{AREA}-{NN}` realized (if any) is cited, and the PRD's Linked Specs table will be
+      updated to point back.
+- [ ] Every `#SPEC-…` / `#PRD-…` anchor linked actually exists; every relative path resolves
+      (no dangling links).
+- [ ] Non-obvious decisions cite research / ADR / PRD / external source.
+
+### CI
+- [ ] `uv run pytest tests/test_spec_traceability.py` passes.
+- [ ] Draft sections carry `**Status:** draft (pending backfill)` until code is linked.
+
+---
+
+## 5. Handoffs
+
+| To | When | Skill |
+|----|------|-------|
+| Engineers | After Draft/Review, to add docstring `References` | `spec-linked-docs` |
+| Product Owner | To update the PRD's Linked Specs table once specs are Active | `prd-authoring` |
+| Reviewer | At Review stage, to verify semantic correctness | (human / QA agent) |
+
+---
+
+## See also
+
+- [`spec-template.md`](spec-template.md) · [`category-taxonomy.md`](category-taxonomy.md) ·
+  [`granularity-guide.md`](granularity-guide.md) · [`research-conventions.md`](research-conventions.md)
+- [`docs/specs/AUTHORING.md`](../../../../../../../docs/specs/AUTHORING.md) — the authoritative standard.
+- [`docs/specs/README.md`](../../../../../../../docs/specs/README.md) — SLD traceability (the downstream half).

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/references/category-taxonomy.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/references/category-taxonomy.md
@@ -1,0 +1,134 @@
+# Subsystem Taxonomy (Information Architecture)
+
+How specs are organized into files, the existing subsystems, and the rule for deciding whether
+new behavior is a **section** in an existing subsystem or a **new subsystem** (a new file).
+This is the agent-facing copy of [`docs/specs/AUTHORING.md` §4](../../../../../../../docs/specs/AUTHORING.md).
+
+> Terminology: in the spec ID grammar `SPEC-{SUBSYSTEM}-{NN}~{rev}`, the `{SUBSYSTEM}` token is
+> the organizing unit. One subsystem = one file = one token. (Earlier drafts called this a
+> "category"; the canonical word is **subsystem**, matching `docs/specs/README.md` §4.)
+
+---
+
+## 1. Two levels only
+
+The information architecture is intentionally flat:
+
+```
+Subsystem (file)  →  numbered Sections (governed SPEC IDs)
+```
+
+- **Subsystem** = one bounded subsystem or domain = one file `docs/specs/{subsystem}.md`.
+  The uppercased name is the `{SUBSYSTEM}` token in every ID declared in that file.
+- **Section** = one governed `SPEC-{SUBSYSTEM}-{NN}~{rev}` unit, numbered sequentially within
+  the file.
+
+There is **no third level**. If a section seems to need its own sub-sections with their own
+contracts, that is a signal to split it into sibling sections — not to nest.
+
+---
+
+## 2. claude-mpm's existing subsystems
+
+The reference instantiation governs seven subsystems, one file each. New work should usually
+land as a **section** in one of these:
+
+| File | Token | Domain | Typical behaviors |
+|------|-------|--------|-------------------|
+| [`agents.md`](../../../../../../../docs/specs/agents.md) | `AGENTS` | Agent templates, assembly, deployment | Template assembly, frontmatter merge, deploy pipeline |
+| [`cli.md`](../../../../../../../docs/specs/cli.md) | `CLI` | Click commands and interactive wizards | Command parsing, wizard flows, output formatting |
+| [`hooks.md`](../../../../../../../docs/specs/hooks.md) | `HOOKS` | Hook handlers and enforcement | PreToolUse/PostToolUse, Stop, model-tier enforcement |
+| [`integrations.md`](../../../../../../../docs/specs/integrations.md) | `INTEGRATIONS` | MCP servers, external services | MCP server contracts, external API adapters |
+| [`manifest.md`](../../../../../../../docs/specs/manifest.md) | `MANIFEST` | Manifest, presets, model routing | Preset resolution, model-tier routing |
+| [`sessions.md`](../../../../../../../docs/specs/sessions.md) | `SESSIONS` | Session lifecycle, runtime, persistence | Session start/resume/pause, state persistence |
+| [`skills.md`](../../../../../../../docs/specs/skills.md) | `SKILLS` | Skill definitions, discovery, deployment | Discovery, validation, selective deployment |
+
+When in doubt, open the candidate file and read its **Purpose & Scope**. If your behavior fits
+that boundary statement, it is a section there.
+
+---
+
+## 3. Add a section vs. add a subsystem
+
+### Default: add a section
+
+Adding a numbered section to an existing subsystem file is the **common case**. Do this when the
+new behavior belongs to a subsystem that already has a file. It costs nothing structurally:
+append a `## {Title} {#SPEC-{SUBSYSTEM}-{NN+1}~1}` section and add a ToC row.
+
+### Add a new subsystem only when ALL of these hold
+
+1. **Bounded domain.** The behavior forms a cohesive subsystem with a clear boundary — not a
+   feature of an existing one.
+2. **Independent ownership / lifecycle.** It can be specced, reviewed, and versioned without
+   churning an existing file.
+3. **Several sections' worth.** It will hold more than one or two IDs. A single behavior is a
+   *section*, never a subsystem.
+
+If even one fails, prefer a section. **Subsystems are cheap to read but expensive to split
+later** — IDs are stable and cannot be renamed without a supersession chain.
+
+### Decision flow
+
+```
+New behavior to spec
+        │
+        ▼
+Does an existing subsystem's Purpose & Scope cover it? ──yes──▶ add a SECTION there
+        │ no
+        ▼
+Is it a bounded domain with independent lifecycle AND ≥3 sections' worth? ──no──▶ add a SECTION
+        │ yes                                                                       to the nearest fit
+        ▼
+   add a NEW SUBSYSTEM file docs/specs/{subsystem}.md
+```
+
+---
+
+## 4. Naming a subsystem
+
+- **Token:** UPPERCASE alpha, hyphens allowed — `HOOKS`, `INTEGRATIONS`, a hypothetical
+  `MODEL-ROUTING`. Matches the `{SUBSYSTEM}` slot in
+  [`README.md` §4](../../../../../../../docs/specs/README.md).
+- **File name:** the lowercase form of the token: `model-routing.md` ↔ `SPEC-MODEL-ROUTING-01~1`.
+- **Durability:** the token appears in **every** ID and **every** docstring `References` line.
+  Renaming it is a breaking change across the whole traceability graph. Choose a name you will
+  not want to change.
+- **Brevity:** keep it short. `SPEC-MODEL-ROUTING-01~1` is fine; `SPEC-MODEL-ROUTING-AND-PRESET-SELECTION-01~1`
+  is a smell that you are bundling two subsystems.
+
+---
+
+## 5. Mapping product AREAs to engineering SUBSYSTEMs
+
+PRDs are organized by product **AREA** (`PRD-{AREA}-{NN}`); specs are organized by engineering
+**SUBSYSTEM** (`SPEC-{SUBSYSTEM}-{NN}~{rev}`). **These do not have to match 1:1** — and usually
+do not:
+
+- One product AREA (e.g. `PRD-SEARCH`) may be realized by several subsystems
+  (`SPEC-INTEGRATIONS`, `SPEC-SESSIONS`).
+- One subsystem (e.g. `SPEC-HOOKS`) may serve several product AREAs.
+
+Organize specs by the **engineering boundary** (what changes together, what one team owns), not
+by the product feature. Record the cross-mapping via the bidirectional links: the spec cites the
+`PRD-{AREA}-{NN}` it realizes; the PRD lists the `SPEC-…` IDs in its *Linked Specs* table. See
+[`docs/prd/README.md`](../../../../../../../docs/prd/README.md).
+
+---
+
+## 6. Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Creating a new subsystem for a single behavior | Make it a section in the nearest existing subsystem. |
+| Naming a subsystem after a product feature | Name it after the engineering boundary; link to the PRD AREA instead. |
+| Renaming an existing token to "clean it up" | Don't. Renames break every docstring reference. Supersede instead. |
+| Nesting sub-subsystems inside one file | Split into sibling sections, or a new subsystem if it meets all three criteria. |
+
+---
+
+## See also
+
+- [`spec-template.md`](spec-template.md) — the per-section template once you have chosen the file.
+- [`granularity-guide.md`](granularity-guide.md) — within a subsystem, how many IDs.
+- [`docs/specs/AUTHORING.md` §4](../../../../../../../docs/specs/AUTHORING.md) — the authoritative IA rules.

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/references/granularity-guide.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/references/granularity-guide.md
@@ -1,0 +1,150 @@
+# Granularity Guide
+
+How to decide whether a behavior is **one** spec ID, **several**, or **none** (folded into a
+larger section). Agent-facing copy of [`docs/specs/AUTHORING.md` §5](../../../../../../../docs/specs/AUTHORING.md).
+Granularity discipline is what keeps the traceability graph meaningful: too coarse and an ID
+spans untestable territory; too fine and the spec drowns in trivia.
+
+---
+
+## 1. The litmus test
+
+> **One spec ID = one independently-verifiable behavior.**
+>
+> *Could you write a single test that passes or fails against this section's Behavior Contract?*
+
+- **Yes, one test** → one ID.
+- **Needs several unrelated tests that pass/fail independently** → probably several IDs.
+- **Cannot write any meaningful test in isolation** → too small; fold it into a larger section.
+
+The test is about the **Behavior Contract**, not the code. A 300-line function with one
+observable contract is one ID. Five 10-line functions that together implement one contract are
+also one ID.
+
+---
+
+## 2. Too broad
+
+**Symptom:** the section title is a subsystem summary, and the Behavior Contract lists
+unrelated input/output clusters.
+
+> ❌ "The hooks subsystem dispatches events."
+
+You cannot write *one* test for it. PreToolUse enforcement, PostToolUse observability, and Stop
+handling each have distinct inputs, outputs, and error modes.
+
+**Fix — split** into:
+- `SPEC-HOOKS-05~1` PreToolUse enforcement pipeline
+- `SPEC-HOOKS-06~1` PostToolUse observability pipeline
+- `SPEC-HOOKS-07~1` Stop lifecycle handler
+
+Each now has a single, testable contract.
+
+### Split when a section has
+
+- Multiple, **unrelated** error-condition clusters.
+- Distinct callers relying on distinct, **separable** outputs.
+- Contract clauses that have no logical reason to change together (changing one would not
+  ripple into the other).
+
+---
+
+## 3. Too narrow
+
+**Symptom:** the section describes an implementation detail, not an externally observable
+contract.
+
+> ❌ "The dispatcher lowercases the event name before routing."
+
+That is a step inside a larger behavior (event routing). It is not independently verifiable from
+the caller's perspective — a caller cannot observe the lowercasing, only the routing result.
+
+**Fix — merge** it into the WHAT of the routing section. It is a detail of `SPEC-HOOKS-03~1`
+(event routing), not its own ID.
+
+### Merge when sections share
+
+- The **same inputs/outputs** and the **same implementing module**, differing only in incidental
+  detail.
+- A contract where changing one **inevitably** changes the other — they are one behavior
+  described twice.
+
+---
+
+## 4. Worked examples
+
+### Example A — correctly split
+
+A session manager that (1) creates sessions and (2) resumes them from disk. Different inputs
+(new vs. existing session ID), different outputs (fresh state vs. restored state), different
+error modes (quota vs. corrupt-file). → **two IDs**: `SPEC-SESSIONS-01~1` (create),
+`SPEC-SESSIONS-02~1` (resume).
+
+### Example B — correctly merged
+
+A validator that checks a config dict has keys `a`, `b`, and `c`. Three checks, but one
+contract ("config is structurally valid"), one input, one output, one caller. → **one ID**; the
+three checks are bullets inside the Behavior Contract's Preconditions/Error conditions.
+
+### Example C — the gray zone
+
+A retry wrapper that retries on 429 and on 5xx. Are these one behavior or two? Apply the test:
+*does a single test exercise both?* If the retry policy is one function with one config, it is
+**one ID** (`SPEC-…-NN~1`) whose Error conditions enumerate both triggers. If 429 and 5xx are
+handled by separately-configured, separately-owned code paths, split.
+
+---
+
+## 5. `~rev` bumps
+
+The `~{rev}` suffix tracks **material changes to the behavior contract** — inputs, outputs,
+pre/postconditions, error conditions. Authority: [`README.md` §4](../../../../../../../docs/specs/README.md).
+
+| Change | Bump `~rev`? |
+|--------|--------------|
+| Added a new error condition | **Yes** — contract changed |
+| Changed an output type or guarantee | **Yes** |
+| Tightened a precondition | **Yes** |
+| Reworded the Rationale for clarity | No |
+| Fixed a typo | No |
+| Added an Implementing Modules row | No |
+
+When you bump, any docstring still referencing the old `~rev` is flagged **OUTDATED** by the CI
+checker — that is the intended signal that code must re-acknowledge the new contract.
+
+---
+
+## 6. Alignment with the SLD WWL model
+
+Spec granularity and **code-link** granularity should be consistent. SLD's WWL model
+([`README.md` §6a](../../../../../../../docs/specs/README.md)) says a function requires its own
+WHAT/WHY/LINK docstring when it exceeds **50 LOC** or **cyclomatic complexity 10**.
+
+Rule of thumb:
+
+- A behavior that justifies its own spec ID usually governs code that crosses a WWL threshold.
+- A behavior too small to warrant a WWL link is usually too small to warrant its own spec ID —
+  fold it into a larger section's WHAT.
+
+If you find a spec ID whose only implementing code is a 5-line helper below both thresholds,
+that ID is probably too narrow (§3).
+
+---
+
+## 7. Quick checklist
+
+Before finalizing a section's granularity:
+
+- [ ] One Behavior Contract, one test could pass/fail against it.
+- [ ] No unrelated error-condition clusters in the same section.
+- [ ] No implementation-detail-only sections (those fold into a WHAT).
+- [ ] Implementing code plausibly crosses a WWL threshold (else reconsider).
+- [ ] If you split, each new ID has its own clean contract and a ToC row.
+
+---
+
+## See also
+
+- [`spec-template.md`](spec-template.md) — the section structure you are sizing.
+- [`category-taxonomy.md`](category-taxonomy.md) — which file the section(s) live in.
+- [`docs/specs/AUTHORING.md` §5](../../../../../../../docs/specs/AUTHORING.md) — the authoritative rules.

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/references/research-conventions.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/references/research-conventions.md
@@ -1,0 +1,151 @@
+# Research Conventions (Engineering / Technical)
+
+How to run and record **engineering / technical** research before writing a spec. Agent-facing
+copy of [`docs/specs/AUTHORING.md` §7](../../../../../../../docs/specs/AUTHORING.md).
+
+> **Scope boundary.** This is *technical* research — algorithms, prior art, benchmarks,
+> failure modes, "how should we build it." **Product / user / market / competitive** research
+> belongs to the PRD side (`docs/prd/research/`; see the `prd-authoring` skill). Keep the two
+> separate: technical research justifies the *contract*; product research justifies the
+> *requirement*.
+
+---
+
+## 1. The `docs/specs/research/` directory
+
+Pre-spec technical investigation lives in [`docs/specs/research/`](../../../../../../../docs/specs/research/),
+**separate from the spec contract**.
+
+- The SLD checker **excludes** this directory ([`README.md` §4 Subsystem Allowlist](../../../../../../../docs/specs/README.md)),
+  so research notes never count as spec declarations and never appear in coverage.
+- Keep exploratory thinking here so the spec files stay clean, terse contracts.
+
+### Naming
+
+```
+docs/specs/research/NN-topic-slug.md
+```
+
+- `NN` — two-digit sequence (`01`, `02`, …), monotonic within the directory.
+- `topic-slug` — short hyphenated description: `05-cache-eviction-strategies.md`,
+  `12-mcp-transport-tradeoffs.md`.
+
+### Purpose
+
+Capture the **technical evidence and reasoning** that led to a spec contract — algorithms
+considered, prior art surveyed, benchmarks run, trade-offs weighed — so the spec itself can stay
+terse and every non-obvious decision is traceable to its justification.
+
+---
+
+## 2. How to research before speccing
+
+A repeatable five-step loop for technical pre-spec work:
+
+### Step 1 — Define the technical question
+
+State precisely what design decision the research must inform. A research doc without a question
+becomes an unfocused dump.
+
+> ✅ "Which cache-eviction policy meets the ≤100ms read target under 10k-key working sets?"
+> ❌ "Caching."
+
+### Step 2 — Gather technical evidence
+
+At minimum, look at:
+
+- **Code / prior art** — how does the current system (or a comparable one) already do this?
+  Read the existing implementation; cite file paths and commits.
+- **Algorithms / standards / papers** — existing techniques, RFCs, benchmarks. (SLD itself is
+  grounded in OpenFastTrace and DO-178C RTM — see [`README.md` §2](../../../../../../../docs/specs/README.md).)
+- **Constraints** — latency, memory, concurrency, failure modes the contract must respect.
+  These often become the Preconditions and Error conditions of the eventual contract.
+
+### Step 3 — Cite sources with links
+
+Every claim that drives a decision gets a citable source: a URL, a `file:line`, or a commit
+hash. **Unsourced assertions are assumptions, not evidence** (and must be marked as such — Step 4).
+
+### Step 4 — Record assumptions explicitly
+
+Separate what you **verified** from what you are **assuming**. Mark assumptions clearly. When an
+assumption becomes an architectural commitment, promote it to an ADR (`mpm-adr`,
+`docs/adr/NNNN-*.md`) and cite the ADR from the spec.
+
+### Step 5 — Keep research distinct from the contract
+
+The research doc may explore alternatives, dead ends, and trade-offs. The spec records only the
+**chosen** contract. Do **not** let exploratory prose leak into the Behavior Contract — that is
+the most common way a clean spec rots.
+
+---
+
+## 3. The citation rule
+
+**Every non-obvious spec decision cites its justification.**
+
+If a section's Rationale makes a claim a reasonable reviewer would ask "why?" about, that claim
+links to:
+
+- a `research/NN-*.md` doc, or
+- an ADR (`docs/adr/NNNN-*.md`), or
+- the `PRD-{AREA}-{NN}` requirement it realizes (for *why this is needed*), or
+- an external source (RFC, paper, benchmark).
+
+Obvious decisions need no citation; non-obvious ones always do.
+
+---
+
+## 4. Research doc skeleton
+
+```markdown
+# {NN} — {Topic}
+
+**Question:** {the precise decision this research informs}
+**Status:** Open | Resolved → {SPEC-SUBSYSTEM-NN~1}
+**Date:** {YYYY-MM-DD}
+
+## Context
+{What prompted this. Link the PRD-{AREA}-{NN} or the spec section that needs the answer.}
+
+## Options considered
+| Option | Pros | Cons | Evidence |
+|--------|------|------|----------|
+| A | … | … | [link] |
+| B | … | … | [link] |
+
+## Findings
+{What the evidence shows. Cite every claim.}
+
+## Assumptions
+- [verified] {…} — source: {link}
+- [assumed]  {…} — promote to ADR if it becomes a commitment
+
+## Decision
+{The chosen contract, in one or two sentences. This is what the spec section will encode.}
+
+## Sources
+- {URL / file:line / commit / RFC / paper}
+```
+
+---
+
+## 5. Research → spec handoff
+
+When research resolves:
+
+1. Set the research doc's `Status:` to `Resolved → SPEC-{SUBSYSTEM}-{NN}~1`.
+2. Write (or update) the spec section, encoding only the **Decision** as the contract.
+3. From the section's Rationale or References, link back to the research doc.
+4. If a load-bearing assumption became a commitment, record an ADR and link it too.
+
+This leaves a navigable chain: spec contract → rationale → research → sources.
+
+---
+
+## See also
+
+- [`authoring-workflow.md`](authoring-workflow.md) — where research sits in the full lifecycle.
+- [`spec-template.md`](spec-template.md) — where citations land (Rationale, References).
+- The `prd-authoring` skill's `prd-research-practices.md` — the **product** research counterpart.
+- [`docs/specs/AUTHORING.md` §7](../../../../../../../docs/specs/AUTHORING.md) — the authoritative rules.

--- a/src/claude_mpm/skills/bundled/main/spec-authoring/references/spec-template.md
+++ b/src/claude_mpm/skills/bundled/main/spec-authoring/references/spec-template.md
@@ -1,0 +1,152 @@
+# Spec Template (Behavior Contract)
+
+Copy-pasteable template for an engineering spec file at `docs/specs/{subsystem}.md`. This is
+the agent-facing copy of the canonical model in
+[`docs/specs/AUTHORING.md` §3](../../../../../../../docs/specs/AUTHORING.md). The behavior-contract
+section skeleton itself is owned by SLD ([`docs/specs/README.md` §5](../../../../../../../docs/specs/README.md)) —
+reuse it verbatim.
+
+> **SPEC ≠ PRD.** This template carries **no** product sections — no problem statement, no
+> personas, no acceptance criteria, no success metrics. Those belong to the PRD
+> (`docs/prd/`, owned by Product). A spec is the engineering contract that *realizes* a PRD
+> requirement; cite the `PRD-{AREA}-{NN}` from the section's Rationale or References.
+
+---
+
+## Full file template
+
+```markdown
+# {Subsystem} Subsystem — Spec
+
+**Status:** Active | Draft | Superseded | Deprecated
+**Version:** v{N}
+**Subsystem:** {UPPERCASE-SUBSYSTEM}
+**Owner:** Engineering / Architecture ({team or role})
+**Last-updated:** {YYYY-MM-DD}
+**Related:** [{SUBSYSTEM}](other.md), [PRD-{AREA}-{NN}](../prd/{area}.md#PRD-{AREA}-{NN})
+
+## Purpose & Scope
+
+{2–5 sentences. What this subsystem is responsible for, and — equally important — what is
+explicitly out of scope. Out-of-scope statements prevent ID sprawl. If this subsystem realizes
+a product requirement, name the PRD area here.}
+
+## Table of Contents
+
+| ID | Section | Implementing module(s) |
+|----|---------|--------------------------|
+| SPEC-{SUBSYSTEM}-01~1 | [{Section title}](#section-anchor-spec-subsystem-011) | `pkg.module` |
+
+## {Section Title} {#SPEC-{SUBSYSTEM}-01~1}
+
+**ID:** SPEC-{SUBSYSTEM}-01~1
+**Status:** Active | Draft | Superseded
+**Supersedes:** SPEC-{SUBSYSTEM}-NN~{rev}   (only if applicable)
+
+### Behavior Contract (WHAT)
+
+*Observable behavior from the caller's perspective. No implementation steps (no HOW).*
+
+- **Inputs:** {what the caller supplies; types, ranges, sources}
+- **Outputs:** {what the caller receives; types, guarantees}
+- **Preconditions:** {what must hold before the behavior is invoked}
+- **Postconditions:** {what is guaranteed to hold afterward}
+- **Error conditions:** {failure modes and their observable effects — raises, returns, retries}
+
+### Rationale (WHY)
+
+{Design decisions and constraints — why this contract over alternatives. Never HOW.
+If this contract realizes a product requirement, cite it:
+"Realizes [PRD-{AREA}-{NN}](../prd/{area}.md#PRD-{AREA}-{NN})."}
+
+### Implementing Modules
+
+| Module | Role |
+|--------|------|
+| `pkg.module` | {what this module contributes to the contract} |
+
+## Open Questions / Future Work
+
+{Unresolved decisions, deferred behavior, known gaps. Keep distinct from the contract.}
+
+## References
+
+- [PRD-{AREA}-{NN}](../prd/{area}.md#PRD-{AREA}-{NN}) — the product requirement this spec realizes.
+- `research/NN-topic-slug.md` — technical research behind a non-obvious decision.
+- `docs/adr/NNNN-*.md` — ADR for a significant, hard-to-reverse decision.
+- [{RELATED-SUBSYSTEM}](other.md) — related spec.
+```
+
+---
+
+## Field-by-field guidance
+
+### Header block
+
+| Field | Rule |
+|-------|------|
+| `Status` | File-level status. Per-section `**Status:**` overrides where sections diverge. |
+| `Version` | `v{N}`, bumped for substantial file-level revisions; orthogonal to per-ID `~{rev}`. |
+| `Subsystem` | The UPPERCASE token. Must equal the `{SUBSYSTEM}` slot in every ID in this file. |
+| `Owner` | **Always an engineering team or role.** A spec is engineering-owned. If you find yourself wanting to name a PM here, you are writing a PRD — go to `docs/prd/`. |
+| `Last-updated` | `YYYY-MM-DD`. Update on every material edit. |
+| `Related` | Relative links to sibling spec files and to the `PRD-{AREA}-{NN}` requirement(s) realized. |
+
+### The three governed subsections (verbatim from SLD)
+
+- **Behavior Contract (WHAT)** — the only place outputs/guarantees are stated. Active voice
+  from the caller's perspective: "Accepts…", "Returns…", "Raises…". This is what tests assert
+  against and what SLD docstring links attach to.
+- **Rationale (WHY)** — mandatory. Explains *why this contract* over alternatives, plus the
+  product requirement realized. A section without a WHY is incomplete.
+- **Implementing Modules** — names the code that fulfills the contract. SLD verifies these
+  references bidirectionally against docstring `References` blocks.
+
+### What is deliberately absent
+
+| Section you might expect | Where it actually lives |
+|--------------------------|--------------------------|
+| Problem statement / context | PRD — `docs/prd/{area}.md` |
+| Target users / personas | PRD |
+| User stories / jobs-to-be-done | PRD |
+| Acceptance criteria | PRD |
+| Success metrics / KPIs | PRD |
+
+If a reviewer asks "where are the acceptance criteria?", the answer is: in the linked PRD. The
+spec's Behavior Contract is the *engineering* contract; product acceptance is a product concern.
+
+---
+
+## Minimal section (smallest valid governed section)
+
+```markdown
+## Cache TTL refresh {#SPEC-CACHE-03~1}
+
+**ID:** SPEC-CACHE-03~1
+**Status:** Active
+
+### Behavior Contract (WHAT)
+- **Inputs:** A cache key and a TTL in seconds.
+- **Outputs:** The cached value if within TTL; otherwise a freshly computed value.
+- **Preconditions:** None.
+- **Postconditions:** A value computed within the last TTL seconds is returned.
+- **Error conditions:** Computation failure propagates; the stale value is not returned.
+
+### Rationale (WHY)
+Bounds recompute cost to once per TTL window. Realizes
+[PRD-PERF-02](../prd/performance.md#PRD-PERF-02): sub-100ms reads under load.
+
+### Implementing Modules
+| Module | Role |
+|--------|------|
+| `claude_mpm.cache.ttl` | Stores values with timestamps and gates recompute. |
+```
+
+---
+
+## See also
+
+- [`category-taxonomy.md`](category-taxonomy.md) — which file (subsystem) the section belongs in.
+- [`granularity-guide.md`](granularity-guide.md) — whether the behavior is one ID or several.
+- [`docs/specs/AUTHORING.md`](../../../../../../../docs/specs/AUTHORING.md) — the authoritative standard.
+- [`docs/specs/README.md`](../../../../../../../docs/specs/README.md) — ID grammar and section skeleton (SLD).

--- a/tests/test_spec_traceability.py
+++ b/tests/test_spec_traceability.py
@@ -67,6 +67,7 @@ _DECL_ANCHOR_RE = re.compile(r"\{#(SPEC-[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*-\d+~\d+)\}
 _SPEC_EXCLUDE_GLOBS = [
     "research/**/*.md",  # Research documents
     "README.md",  # This convention document
+    "AUTHORING.md",  # Authoring-standard guide (contains example IDs, not declarations)
 ]
 
 
@@ -196,6 +197,8 @@ def _is_excluded_spec_file(path: Path, spec_dir: Path) -> bool:
     Exclusion rule (documented in docs/specs/README.md, section 4):
     - docs/specs/research/**  — research documents
     - docs/specs/README.md    — the convention guide itself (contains example IDs)
+    - docs/specs/AUTHORING.md — the authoring-standard guide (contains example IDs
+      in templates and a filled mini-example; these are illustrative, not declarations)
     """
     try:
         rel = path.relative_to(spec_dir)


### PR DESCRIPTION
Closes #654

## Summary

Reworks the in-progress branch into **two distinct, independently-owned documentation standards**, correcting a prior draft that merged product PRDs and engineering specs into a single hybrid.

- **PRD** = product-owned (Product Owner / PM). *What problem, for which users, what requirements, what success looks like.* Home `docs/prd/`, IDs `PRD-{AREA}-{NN}`, skill `prd-authoring`.
- **SPEC** = engineering/architecture-owned. *The behavioral contract & how it's implemented.* Home `docs/specs/`, IDs `SPEC-{SUBSYSTEM}-{NN}~{rev}`, skill `spec-authoring`.
- **Bidirectional link:** a PRD requirement links *down* to implementing spec(s) via its *Linked Specs* table; a spec section links *up* to the `PRD-{AREA}-{NN}` it realizes. Distinct directories, IDs, owners, and templates — neither absorbs the other.

## Deliverable 1 — Engineering Spec Authoring Standard (de-hybridized)
- **`docs/specs/AUTHORING.md`** reworked to a **pure behavior-contract** standard. Removed PRD-flavored content (problem/personas/user-stories as primary, **Acceptance Criteria**, **Success Metrics**); kept Behavior Contract (WHAT) / Rationale (WHY) / Implementing Modules verbatim from SLD. Engineering ownership stated explicitly; added the spec→PRD citation convention.
- **`spec-authoring` skill** (`src/claude_mpm/skills/bundled/main/spec-authoring/`): SKILL.md (`agent_types: [engineer, documentation]`, user-invocable) + 5 references — `spec-template`, `category-taxonomy`, `granularity-guide`, `research-conventions`, `authoring-workflow`.

## Deliverable 2 — Product PRD Standard (new, product-owned)
- **`docs/prd/README.md`** — governance: `PRD-{AREA}-{NN}` grammar, IA by product AREA, lifecycle (Draft→Review→Approved→In-development→Shipped→Superseded), link conventions, PRD→SPEC traceability. Portable.
- **`docs/prd/TEMPLATE.md`** — problem, personas, goals/non-goals, user stories, functional/non-functional requirements (`{#PRD-{AREA}-{NN}}`), acceptance criteria, success metrics, scope, risks, **Linked Specs** table, references.
- **`prd-authoring` skill** (`src/claude_mpm/skills/bundled/main/prd-authoring/`): SKILL.md (`agent_types: [product-owner, pm]`, user-invocable) + 5 references — `prd-template`, `prd-research-practices`, `prd-lifecycle`, `prd-to-spec-linkage`, `ia-and-categories`.

## Test-checker fix
- `tests/test_spec_traceability.py`: excluded `docs/specs/AUTHORING.md` from spec ID scanning (it carries example IDs in templates/mini-example, not authoritative declarations — same rationale as the existing `README.md` exclusion). Documented in `docs/specs/README.md` §4.

## Verification
- Both skills discovered and pass `_validate_skill_structure` (`valid: True`, no errors).
- Each skill's `progressive_disclosure.references` matches its `references/` files **exactly** (5/5 each; no dangling-reference bug).
- `tests/test_spec_traceability.py`: 11 passed. Skills test suite: 628 passed.
- No dangling rendered internal links (62 clickable links checked, 0 dangling); PRD↔spec link tables use real anchors/conventions.
- `uv run ruff check tests/test_spec_traceability.py`: all checks passed.
- One file per commit (17 commits); `docs:` / `feat:` / `test:` prefixes; gh identity `bobmatnyc`.

Do not merge — review requested.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)