### PR TITLE
feat(cli): auto-start mcp-vector-search daemon on startup

### DIFF
--- a/src/claude_mpm/cli/startup_logging.py
+++ b/src/claude_mpm/cli/startup_logging.py
@@ -16,6 +16,7 @@ DESIGN DECISIONS:
 
 import asyncio
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -701,6 +702,63 @@ async def trigger_vector_search_indexing(project_root: Path | None = None) -> No
         logger.debug(f"Failed to start vector search indexing: {e}")
 
 
+def _ensure_vector_search_daemon() -> None:
+    """
+    Best-effort start of the mcp-vector-search persistent daemon.
+
+    WHY: The optional mcp-vector-search daemon keeps the search index warm in
+    memory, providing dramatically faster code search. It is not started
+    automatically and does not survive reboots, so users otherwise have to run
+    `mvs daemon start` by hand.
+
+    ``daemon start`` is idempotent (a no-op if already running), so this is safe
+    to call on every launch. Set MCP_VECTOR_SEARCH_DAEMON=0 to opt out.
+    Fails silently - never blocks or breaks startup.
+    """
+    logger = get_logger("cli")
+
+    if os.environ.get("MCP_VECTOR_SEARCH_DAEMON", "1").lower() in (
+        "0",
+        "false",
+        "no",
+    ):
+        logger.debug("Vector search daemon autostart disabled via env")
+        return
+
+    try:
+        from ..services.mcp_config_manager import MCPConfigManager
+
+        manager = MCPConfigManager()
+        vector_search_path = manager.detect_service_path("mcp-vector-search")
+
+        if not vector_search_path:
+            logger.debug("mcp-vector-search not found, skipping daemon start")
+            return
+
+        # Build the command based on the service configuration
+        if "python" in vector_search_path:
+            cmd = [
+                vector_search_path,
+                "-m",
+                "mcp_vector_search.cli",
+                "daemon",
+                "start",
+            ]
+        else:
+            cmd = [vector_search_path, "daemon", "start"]
+
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        logger.debug("MCP Vector Search: ensured daemon is running")
+
+    except Exception as e:
+        # Don't let daemon startup failures prevent startup
+        logger.debug(f"Failed to start vector search daemon: {e}")
+
+
 def start_vector_search_indexing(project_root: Path | None = None) -> None:
     """
     Synchronous wrapper to trigger vector search indexing.
@@ -708,10 +766,17 @@ def start_vector_search_indexing(project_root: Path | None = None) -> None:
     This creates a new event loop if needed to run the async indexing function.
     Falls back to subprocess.Popen if async fails.
 
+    Also ensures the optional persistent mcp-vector-search daemon is running
+    (idempotent, opt-out via MCP_VECTOR_SEARCH_DAEMON=0).
+
     Args:
         project_root: Root directory for the project (defaults to cwd)
     """
     logger = get_logger("cli")
+
+    # Ensure the persistent daemon is running before kicking off indexing.
+    # This covers both the async and subprocess dispatch paths below.
+    _ensure_vector_search_daemon()
 
     try:
         # Try to get the current event loop

--- a/tests/test_startup_logging.py
+++ b/tests/test_startup_logging.py
@@ -9,12 +9,14 @@ import logging
 import tempfile
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from claude_mpm.cli.startup_logging import (
+    _ensure_vector_search_daemon,
     cleanup_old_startup_logs,
     get_latest_startup_log,
     setup_startup_logging,
+    start_vector_search_indexing,
 )
 from claude_mpm.services.diagnostics.checks.startup_log_check import StartupLogCheck
 from claude_mpm.services.diagnostics.models import DiagnosticStatus
@@ -255,3 +257,94 @@ class TestStartupLogCheck:
 
         fix_command = check._get_fix_command(analysis)
         assert fix_command == "claude-mpm deploy"  # First claude-mpm command found
+
+
+class TestEnsureVectorSearchDaemon:
+    """Test the opt-out, idempotent vector search daemon autostart helper."""
+
+    @patch("claude_mpm.cli.startup_logging.subprocess.Popen")
+    def test_starts_daemon_when_service_found(self, mock_popen, monkeypatch):
+        """When the service path is found, Popen is called with `daemon start`."""
+        monkeypatch.delenv("MCP_VECTOR_SEARCH_DAEMON", raising=False)
+
+        manager = MagicMock()
+        manager.detect_service_path.return_value = "/usr/local/bin/mcp-vector-search"
+
+        with patch(
+            "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+            return_value=manager,
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args.args[0]
+        assert cmd[-2:] == ["daemon", "start"]
+
+    @patch("claude_mpm.cli.startup_logging.subprocess.Popen")
+    def test_starts_daemon_with_python_interpreter(self, mock_popen, monkeypatch):
+        """Python interpreter paths use the `-m mcp_vector_search.cli` form."""
+        monkeypatch.delenv("MCP_VECTOR_SEARCH_DAEMON", raising=False)
+
+        manager = MagicMock()
+        manager.detect_service_path.return_value = "/opt/venv/bin/python"
+
+        with patch(
+            "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+            return_value=manager,
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args.args[0]
+        assert cmd == [
+            "/opt/venv/bin/python",
+            "-m",
+            "mcp_vector_search.cli",
+            "daemon",
+            "start",
+        ]
+
+    @patch("claude_mpm.cli.startup_logging.subprocess.Popen")
+    def test_opt_out_via_env(self, mock_popen, monkeypatch):
+        """When MCP_VECTOR_SEARCH_DAEMON=0, Popen is never called."""
+        monkeypatch.setenv("MCP_VECTOR_SEARCH_DAEMON", "0")
+
+        manager = MagicMock()
+        manager.detect_service_path.return_value = "/usr/local/bin/mcp-vector-search"
+
+        with patch(
+            "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+            return_value=manager,
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+        manager.detect_service_path.assert_not_called()
+
+    @patch("claude_mpm.cli.startup_logging.subprocess.Popen")
+    def test_no_daemon_when_service_not_found(self, mock_popen, monkeypatch):
+        """When detect_service_path returns None, Popen is never called."""
+        monkeypatch.delenv("MCP_VECTOR_SEARCH_DAEMON", raising=False)
+
+        manager = MagicMock()
+        manager.detect_service_path.return_value = None
+
+        with patch(
+            "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+            return_value=manager,
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    @patch("claude_mpm.cli.startup_logging._ensure_vector_search_daemon")
+    @patch("claude_mpm.cli.startup_logging._start_vector_search_subprocess")
+    def test_start_indexing_invokes_daemon_helper(
+        self, _mock_subprocess, mock_ensure_daemon
+    ):
+        """start_vector_search_indexing always invokes the daemon helper."""
+        # No running event loop in the test, so it falls back to the subprocess
+        # dispatch path; either way the daemon helper must be called.
+        start_vector_search_indexing()
+
+        mock_ensure_daemon.assert_called_once()


### PR DESCRIPTION
## Problem

The optional `mcp-vector-search` persistent daemon keeps the code-search index warm in memory, providing dramatically faster search (~150x faster than cold searches). However, claude-mpm never starts it automatically, and the daemon does not survive reboots. Users have to remember to run `mvs daemon start` (i.e. `mcp-vector-search daemon start`) by hand every time, which most never do — so they silently miss out on the performance benefit.

## Solution

Piggyback on the existing `start_vector_search_indexing()` startup hook in `src/claude_mpm/cli/startup_logging.py`. A new helper `_ensure_vector_search_daemon()` is called once at the top of `start_vector_search_indexing()`, so it covers both the async (`trigger_vector_search_indexing`) and subprocess (`_start_vector_search_subprocess`) dispatch paths.

The helper is:

- **Idempotent** — `daemon start` is a no-op when the daemon is already running, so it is safe to call on every launch.
- **Opt-out** — set `MCP_VECTOR_SEARCH_DAEMON=0` (or `false`/`no`) to disable autostart entirely.
- **Silent-failing** — wrapped in a broad `except` that only logs at `debug` level; it never blocks or breaks startup.
- **Consistent** — it reuses the existing `MCPConfigManager.detect_service_path("mcp-vector-search")` pattern and the `"python" in vector_search_path` command-building branch, exactly mirroring the sibling indexing code already in this file.

If `mcp-vector-search` is not installed, `detect_service_path` returns `None` and the helper is a no-op.

## Notes

- Mirrors the existing indexing code style, imports, and logging conventions.
- Never blocks or breaks startup (best-effort, fire-and-forget `subprocess.Popen` with output discarded).
- Adds `import os` (the only new import; `subprocess` was already used in this file).
- Covered by unit tests in `tests/test_startup_logging.py` asserting: (1) `subprocess.Popen` is invoked with a command ending in `["daemon", "start"]` when the service is found, (2) it is not invoked when `MCP_VECTOR_SEARCH_DAEMON=0`, (3) it is not invoked when `detect_service_path` returns `None`, plus the Python-interpreter command form and that `start_vector_search_indexing()` invokes the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)