### PR TITLE
feat(cli): auto-start mcp-vector-search and trusty-search daemons on startup

### DIFF
--- a/src/claude_mpm/cli/startup_logging.py
+++ b/src/claude_mpm/cli/startup_logging.py
@@ -16,6 +16,7 @@ DESIGN DECISIONS:
 
 import asyncio
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -701,6 +702,114 @@ async def trigger_vector_search_indexing(project_root: Path | None = None) -> No
         logger.debug(f"Failed to start vector search indexing: {e}")
 
 
+def _ensure_vector_search_daemon() -> None:
+    """
+    Best-effort start of the mcp-vector-search persistent daemon.
+
+    WHAT: Idempotently starts the mcp-vector-search background daemon so the
+    search index stays warm across sessions.
+
+    WHY: The optional mcp-vector-search daemon keeps the search index warm in
+    memory, providing dramatically faster code search. It is not started
+    automatically and does not survive reboots, so users otherwise have to run
+    ``mvs daemon start`` by hand.
+
+    ``daemon start`` is idempotent (a no-op if already running), so this is
+    safe to call on every launch. Set MCP_VECTOR_SEARCH_DAEMON=0 (or
+    ``false``/``no``) to opt out. Fails silently — never blocks or breaks
+    startup.
+    """
+    logger = get_logger("cli")
+
+    if os.environ.get("MCP_VECTOR_SEARCH_DAEMON", "1").lower() in (
+        "0",
+        "false",
+        "no",
+    ):
+        logger.debug("Vector search daemon autostart disabled via env")
+        return
+
+    try:
+        from ..services.mcp_config_manager import MCPConfigManager
+
+        manager = MCPConfigManager()
+        vector_search_path = manager.detect_service_path("mcp-vector-search")
+
+        if not vector_search_path:
+            logger.debug("mcp-vector-search not found, skipping daemon start")
+            return
+
+        # Use basename to detect Python interpreter (avoids false positives from
+        # paths like /home/pythonuser/bin/mcp-vector-search)
+        basename = Path(vector_search_path).name
+        if basename.startswith("python"):
+            cmd = [
+                vector_search_path,
+                "-m",
+                "mcp_vector_search.cli",
+                "daemon",
+                "start",
+            ]
+        else:
+            cmd = [vector_search_path, "daemon", "start"]
+
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # detach from parent; avoids zombie on POSIX
+        )
+        logger.debug("mcp-vector-search: ensured daemon is running")
+
+    except Exception as e:
+        logger.debug(f"Failed to start mcp-vector-search daemon: {e}")
+
+
+def _ensure_trusty_search_daemon() -> None:
+    """
+    Best-effort start of the trusty-search persistent daemon.
+
+    WHAT: Idempotently starts the trusty-search HTTP daemon on :7878 so
+    semantic code search is available from the first query.
+
+    WHY: trusty-search runs a persistent HTTP daemon on :7878 that serves
+    semantic code search. Starting it on every launch is idempotent (it
+    exits immediately if already running). Set TRUSTY_SEARCH_DAEMON=0 (or
+    ``false``/``no``) to opt out. Fails silently — never blocks or breaks
+    startup.
+    """
+    logger = get_logger("cli")
+
+    if os.environ.get("TRUSTY_SEARCH_DAEMON", "1").lower() in ("0", "false", "no"):
+        logger.debug("trusty-search daemon autostart disabled via env")
+        return
+
+    try:
+        from ..services.mcp_config_manager import MCPConfigManager
+
+        manager = MCPConfigManager()
+        trusty_path = manager.detect_service_path("trusty-search")
+
+        if not trusty_path:
+            logger.debug("trusty-search not found, skipping daemon start")
+            return
+
+        # ``trusty-search start`` self-spawns a detached background copy and
+        # returns immediately; it is a no-op when the daemon is already running.
+        cmd = [trusty_path, "start"]
+
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # detach from parent; avoids zombie on POSIX
+        )
+        logger.debug("trusty-search: ensured daemon is running")
+
+    except Exception as e:
+        logger.debug(f"Failed to start trusty-search daemon: {e}")
+
+
 def start_vector_search_indexing(project_root: Path | None = None) -> None:
     """
     Synchronous wrapper to trigger vector search indexing.
@@ -708,10 +817,17 @@ def start_vector_search_indexing(project_root: Path | None = None) -> None:
     This creates a new event loop if needed to run the async indexing function.
     Falls back to subprocess.Popen if async fails.
 
+    Also ensures the mcp-vector-search and trusty-search daemons are running
+    (idempotent, opt-out via MCP_VECTOR_SEARCH_DAEMON=0 / TRUSTY_SEARCH_DAEMON=0).
+
     Args:
         project_root: Root directory for the project (defaults to cwd)
     """
     logger = get_logger("cli")
+
+    # Ensure persistent daemons are running before kicking off indexing.
+    _ensure_vector_search_daemon()
+    _ensure_trusty_search_daemon()
 
     try:
         # Try to get the current event loop

--- a/tests/test_startup_logging.py
+++ b/tests/test_startup_logging.py
@@ -6,12 +6,15 @@ creates timestamped files, and can be analyzed by the doctor command.
 """
 
 import logging
+import subprocess
 import tempfile
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from claude_mpm.cli.startup_logging import (
+    _ensure_trusty_search_daemon,
+    _ensure_vector_search_daemon,
     cleanup_old_startup_logs,
     get_latest_startup_log,
     setup_startup_logging,
@@ -255,3 +258,231 @@ class TestStartupLogCheck:
 
         fix_command = check._get_fix_command(analysis)
         assert fix_command == "claude-mpm deploy"  # First claude-mpm command found
+
+
+class TestEnsureVectorSearchDaemon:
+    """Tests for _ensure_vector_search_daemon()."""
+
+    def test_starts_daemon_with_direct_binary(self):
+        """Binary path (no python in basename) uses direct binary invocation."""
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = (
+            "/usr/local/bin/mcp-vector-search"
+        )
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_called_once_with(
+            ["/usr/local/bin/mcp-vector-search", "daemon", "start"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def test_starts_daemon_with_python_basename(self):
+        """Path whose basename starts with 'python' uses -m module invocation."""
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = "/opt/venv/bin/python3"
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_called_once_with(
+            [
+                "/opt/venv/bin/python3",
+                "-m",
+                "mcp_vector_search.cli",
+                "daemon",
+                "start",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def test_pythonuser_path_not_misdetected(self):
+        """Path /home/pythonuser/bin/mcp-vector-search uses binary mode, not python mode.
+
+        The basename is 'mcp-vector-search', not 'python...' — the directory
+        component containing 'python' must not influence the detection.
+        """
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = (
+            "/home/pythonuser/bin/mcp-vector-search"
+        )
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_called_once_with(
+            ["/home/pythonuser/bin/mcp-vector-search", "daemon", "start"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def test_opt_out_via_env(self):
+        """MCP_VECTOR_SEARCH_DAEMON=0 suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "0"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_opt_out_via_env_false(self):
+        """MCP_VECTOR_SEARCH_DAEMON=false suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "false"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_opt_out_via_env_no(self):
+        """MCP_VECTOR_SEARCH_DAEMON=no suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "no"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_no_daemon_when_service_not_found(self):
+        """Returns without calling Popen when detect_service_path returns None."""
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = None
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_vector_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_exception_does_not_propagate(self):
+        """Any unexpected exception is swallowed — startup must not break."""
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.dict("os.environ", {"MCP_VECTOR_SEARCH_DAEMON": "1"}),
+        ):
+            # Must not raise
+            _ensure_vector_search_daemon()
+
+
+class TestEnsureTrustySearchDaemon:
+    """Tests for _ensure_trusty_search_daemon()."""
+
+    def test_starts_daemon_when_service_found(self):
+        """Popen is called with `trusty-search start` when binary is found."""
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = "/usr/local/bin/trusty-search"
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_trusty_search_daemon()
+
+        mock_popen.assert_called_once_with(
+            ["/usr/local/bin/trusty-search", "start"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def test_opt_out_via_env(self):
+        """TRUSTY_SEARCH_DAEMON=0 suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "0"}),
+        ):
+            _ensure_trusty_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_opt_out_via_env_false(self):
+        """TRUSTY_SEARCH_DAEMON=false suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "false"}),
+        ):
+            _ensure_trusty_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_opt_out_via_env_no(self):
+        """TRUSTY_SEARCH_DAEMON=no suppresses daemon start."""
+        with (
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "no"}),
+        ):
+            _ensure_trusty_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_no_daemon_when_service_not_found(self):
+        """Returns without calling Popen when detect_service_path returns None."""
+        mock_manager = MagicMock()
+        mock_manager.detect_service_path.return_value = None
+
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                return_value=mock_manager,
+            ),
+            patch("claude_mpm.cli.startup_logging.subprocess.Popen") as mock_popen,
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "1"}),
+        ):
+            _ensure_trusty_search_daemon()
+
+        mock_popen.assert_not_called()
+
+    def test_exception_does_not_propagate(self):
+        """Any unexpected exception is swallowed — startup must not break."""
+        with (
+            patch(
+                "claude_mpm.services.mcp_config_manager.MCPConfigManager",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.dict("os.environ", {"TRUSTY_SEARCH_DAEMON": "1"}),
+        ):
+            # Must not raise
+            _ensure_trusty_search_daemon()


### PR DESCRIPTION
## Summary

Automatically start the `mcp-vector-search` (mvs) and `trusty-search` persistent daemons on claude-mpm startup when they are installed.

### Motivation

Both daemons keep their search indexes warm in memory, providing dramatically faster code search. Users currently have to start them manually after every reboot. Starting them on launch is idempotent — both daemons are no-ops if already running.

### Changes

**`src/claude_mpm/cli/startup_logging.py`**

- `_ensure_vector_search_daemon()` — best-effort `mcp-vector-search daemon start`, opt-out via `MCP_VECTOR_SEARCH_DAEMON=0`. Incorporates PR #656 from @joaovieira-duetto with the following review fixes applied:
  - `start_new_session=True` on `Popen` to avoid zombie processes on POSIX
  - `Path(path).name.startswith("python")` instead of `"python" in path` (avoids false-positive on `/home/pythonuser/...`)
  - Docstring updated to document all opt-out values (`0`, `false`, `no`)
- `_ensure_trusty_search_daemon()` — best-effort `trusty-search start`, opt-out via `TRUSTY_SEARCH_DAEMON=0`
- `start_vector_search_indexing()` updated to call both helpers before indexing

**`tests/test_startup_logging.py`** — 14 new tests across two test classes covering both daemons: direct binary, Python interpreter path detection, false-positive path guard, all opt-out values, service-not-found, exception swallowing.

### Notes

- Depends on PR #658 (fix/upgrade-check-source-install) — merge #658 first so the diff for this PR is clean.
- Both helpers are silent-failing: any exception is caught at `debug` level and never blocks startup.
- Replaces / supersedes external PR #656 (incorporates the same feature with review fixes and trusty-search support added).

Closes #656

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)