### PR TITLE
fix(release): resolve gh identity in cloned sub-repos during release publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -994,7 +994,8 @@ update-homebrew-tap: ## Update Homebrew tap formula after PyPI publish (non-bloc
 	else \
 		echo "$(YELLOW)⚠️  Could not find release-wheels.yml run ID — attempting Homebrew update anyway$(NC)"; \
 	fi
-	@VERSION=$$(cat VERSION); \
+	@export GH_REQUIRED_ACCOUNT="$$(cat .gh-account 2>/dev/null | tr -d '[:space:]')"; \
+	VERSION=$$(cat VERSION); \
 	if [ -f "scripts/update_homebrew_tap.sh" ]; then \
 		./scripts/update_homebrew_tap.sh "$$VERSION" --auto-push || { \
 			echo "$(YELLOW)⚠️  Homebrew tap update failed (non-blocking)$(NC)"; \

--- a/scripts/publish_to_pypi.sh
+++ b/scripts/publish_to_pypi.sh
@@ -16,6 +16,19 @@ set -e  # Exit on error
 #
 # Description: Publishes the claude-mpm SDIST to PyPI using credentials from ~/.pypirc
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve and export the required GitHub account from the main repo's .gh-account
+# so child scripts (homebrew tap, agents sync) that cd into cloned sub-repos
+# without their own .gh-account marker still push under the correct identity.
+# shellcheck source=scripts/lib/gh_identity.sh
+. "$SCRIPT_DIR/lib/gh_identity.sh"
+if [ -z "${GH_REQUIRED_ACCOUNT:-}" ]; then
+    if _acct="$(gh_required_account 2>/dev/null)" && [ -n "$_acct" ]; then
+        export GH_REQUIRED_ACCOUNT="$_acct"
+    fi
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/publish_to_pypi.sh
+++ b/scripts/publish_to_pypi.sh
@@ -26,6 +26,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -z "${GH_REQUIRED_ACCOUNT:-}" ]; then
     if _acct="$(gh_required_account 2>/dev/null)" && [ -n "$_acct" ]; then
         export GH_REQUIRED_ACCOUNT="$_acct"
+    else
+        echo "WARNING: could not resolve required GitHub account from .gh-account; " \
+             "sub-repo pushes (homebrew tap, agents) may fall back to the OS keyring " \
+             "and fail or use the wrong identity." >&2
     fi
 fi
 

--- a/scripts/push_to_agents_repo.sh
+++ b/scripts/push_to_agents_repo.sh
@@ -22,6 +22,18 @@ AGENTS_REPO_URL="https://github.com/bobmatnyc/claude-mpm-agents.git"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# Resolve and export the required GitHub account from the main repo's .gh-account
+# BEFORE we cd into the temp-dir clone of claude-mpm-agents. That clone has no
+# .gh-account marker, so gh_required_account would otherwise fail to resolve once
+# CWD is the clone, and the authenticated push would fall back to the wrong
+# credential helper.
+# shellcheck source=scripts/lib/gh_identity.sh
+. "$SCRIPT_DIR/lib/gh_identity.sh"
+if [ -z "${GH_REQUIRED_ACCOUNT:-}" ] && [ -f "$PROJECT_ROOT/.gh-account" ]; then
+    GH_REQUIRED_ACCOUNT="$(tr -d '[:space:]' < "$PROJECT_ROOT/.gh-account")"
+    export GH_REQUIRED_ACCOUNT
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -257,8 +269,11 @@ print_info "Committing changes..."
 git commit -m "$COMMIT_MSG"
 
 # Push changes
+# Use gh_git so the push authenticates as the exported GH_REQUIRED_ACCOUNT
+# (resolved from the main repo's .gh-account) instead of the host-keyed
+# credential store, which can resolve to the wrong identity in this clone.
 print_info "Pushing to remote..."
-git push origin main
+gh_git push origin main
 
 print_success "Successfully synced files to agents repository!"
 print_info "Commit message:"

--- a/scripts/push_to_agents_repo.sh
+++ b/scripts/push_to_agents_repo.sh
@@ -29,9 +29,17 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # credential helper.
 # shellcheck source=scripts/lib/gh_identity.sh
 . "$SCRIPT_DIR/lib/gh_identity.sh"
+if ! command -v gh_git >/dev/null 2>&1; then
+    echo "ERROR: gh_git not available (failed to source lib/gh_identity.sh)" >&2
+    exit 1
+fi
 if [ -z "${GH_REQUIRED_ACCOUNT:-}" ] && [ -f "$PROJECT_ROOT/.gh-account" ]; then
-    GH_REQUIRED_ACCOUNT="$(tr -d '[:space:]' < "$PROJECT_ROOT/.gh-account")"
-    export GH_REQUIRED_ACCOUNT
+    _acct="$(tr -d '[:space:]' < "$PROJECT_ROOT/.gh-account")"
+    if printf '%s' "$_acct" | grep -Eq '^[A-Za-z0-9-]+$'; then
+        export GH_REQUIRED_ACCOUNT="$_acct"
+    else
+        echo "WARNING: .gh-account contents not a valid GitHub username; ignoring" >&2
+    fi
 fi
 
 # Colors for output


### PR DESCRIPTION
## Problem

During `make release-publish`, the `claude-mpm-agents` sync and Homebrew-tap update both push from temp-dir clones that contain no `.gh-account` marker. With `GH_REQUIRED_ACCOUNT` unset, `scripts/lib/gh_identity.sh::gh_required_account()` can't resolve the account, so the authenticated push falls back to the OS keyring (which may resolve to the wrong account, e.g. `bob-duetto`) and fails. This required manual git pushes on the v6.5.18 release.

Confirmed during this work: even with `gh auth status` showing `bobmatnyc`, a plain `git push` from a fresh clone resolved to `bob-duetto` via osxkeychain — exactly the failure mode.

## Fix

Export `GH_REQUIRED_ACCOUNT` (resolved from the main repo's `.gh-account`) at the three release orchestration entry points, so every child script operating inside a cloned sub-repo inherits the correct identity and the `gh_git` askpass mechanism (which bypasses the OS keyring) authenticates correctly:

- `scripts/publish_to_pypi.sh` — source `lib/gh_identity.sh`, export `GH_REQUIRED_ACCOUNT` while CWD is the project root
- `scripts/push_to_agents_repo.sh` — export `GH_REQUIRED_ACCOUNT` from `$PROJECT_ROOT/.gh-account` before cloning; switch the agents-repo push from plain `git push` to `gh_git push` so the exported identity is actually enforced
- `Makefile` `update-homebrew-tap` — export `GH_REQUIRED_ACCOUNT` in the same logical recipe line as the tap-update invocation

`scripts/lib/gh_identity.sh` is unchanged — its resolution logic is correct; it just needed `GH_REQUIRED_ACCOUNT` fed to it.

Belt-and-suspenders (done separately, outside this PR): `.gh-account` markers were committed to `bobmatnyc/claude-mpm-agents` and `bobmatnyc/homebrew-claude-mpm`.

## Verification

- `make -n update-homebrew-tap` parses cleanly (export + invocation render as one logical shell line)
- `shellcheck` on both modified scripts: no new warnings
- `bash -n` parse check passed

Closes #660

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)