### PR TITLE
fix(release): re-clone homebrew tap fresh to avoid stale dirty-state failures

### DIFF
--- a/scripts/update_homebrew_tap.sh
+++ b/scripts/update_homebrew_tap.sh
@@ -215,6 +215,12 @@ clone_or_update_tap_repo() {
     # The /tmp clone is disposable — all authoritative state lives on origin.
     # Always start from a fresh clone so accumulated backups, dirty trees, or a
     # stale embedded-credential remote from a previous run cannot block the update.
+    # Hard guard: never let an empty/unset TAP_DIR reach `rm -rf`.
+    if [ -z "${TAP_DIR:-}" ]; then
+        log ERROR "TAP_DIR is empty or unset — refusing to run rm -rf"
+        return 1
+    fi
+
     if [ -d "$TAP_DIR" ]; then
         log INFO "Removing previous tap clone for a clean checkout..."
         cd /
@@ -252,6 +258,12 @@ update_formula() {
     cp "$formula_path" "$backup_file"
     log INFO "Created backup: ${backup_file}"
 
+    # Ensure the out-of-tree backup is cleaned up on every return path.
+    # Use a default expansion so the trap stays safe under `set -u` if it fires
+    # in a scope where backup_file is no longer bound (bash RETURN traps set in a
+    # function can also run for the caller's return without `set -o functrace`).
+    trap 'rm -f "${backup_file:-}"' RETURN
+
     if [ "$DRY_RUN" = true ]; then
         log INFO "[DRY RUN] Would update formula with:"
         log INFO "  Version: ${version}"
@@ -280,9 +292,6 @@ update_formula() {
     rm -f "${formula_path}.bak"
 
     log SUCCESS "Formula updated successfully"
-
-    # Edits succeeded — drop the out-of-tree restore backup so it doesn't linger.
-    rm -f "$backup_file"
 
     # Show diff
     if git diff --quiet "$formula_path"; then

--- a/scripts/update_homebrew_tap.sh
+++ b/scripts/update_homebrew_tap.sh
@@ -206,61 +206,28 @@ fetch_pypi_info() {
 clone_or_update_tap_repo() {
     log INFO "Setting up Homebrew tap repository..."
 
-    # clone/pull/push run through gh_git, which injects the required account's
+    # clone/push run through gh_git, which injects the required account's
     # token via a one-shot GIT_ASKPASS helper at runtime. Clone uses the bare
-    # $TAP_REPO URL (no embedded token), which sets `origin`; subsequent pull/push
-    # use the `origin` remote so the tracking branch updates. The token never
+    # $TAP_REPO URL (no embedded token), which sets `origin`; subsequent push
+    # uses the `origin` remote so the tracking branch updates. The token never
     # appears in argv, `git remote -v`, reflog, or any log.
 
+    # The /tmp clone is disposable — all authoritative state lives on origin.
+    # Always start from a fresh clone so accumulated backups, dirty trees, or a
+    # stale embedded-credential remote from a previous run cannot block the update.
     if [ -d "$TAP_DIR" ]; then
-        log INFO "Updating existing tap repository..."
-        cd "$TAP_DIR"
-
-        # Check if git repository is valid
-        if ! git rev-parse --git-dir > /dev/null 2>&1; then
-            log WARNING "Found corrupt git repository at ${TAP_DIR}"
-            log INFO "Removing corrupt directory and re-cloning..."
-            cd /
-            rm -rf "$TAP_DIR"
-
-            # Clone fresh repository
-            log INFO "Cloning tap repository..."
-            if ! gh_git clone "$TAP_REPO" "$TAP_DIR"; then
-                log ERROR "Failed to clone tap repository"
-                log ERROR "Check network connectivity and GitHub access"
-                return 1
-            fi
-            cd "$TAP_DIR"
-            log SUCCESS "Tap repository ready at: ${TAP_DIR}"
-            return 0
-        fi
-
-        # Check for uncommitted changes
-        if ! git diff --quiet; then
-            log WARNING "Tap repository has uncommitted changes"
-            git status --short
-
-            if [ "$DRY_RUN" = false ]; then
-                log ERROR "Cannot proceed with uncommitted changes"
-                log ERROR "Manual cleanup required: cd ${TAP_DIR} && git status"
-                return 1
-            fi
-        fi
-
-        # Pull via the `origin` remote (set by clone) so the tracking branch is
-        # updated and GIT_ASKPASS supplies credentials against origin's URL.
-        if ! gh_git pull origin main; then
-            log WARNING "Failed to pull latest changes, continuing with current state"
-        fi
-    else
-        log INFO "Cloning tap repository..."
-        if ! gh_git clone "$TAP_REPO" "$TAP_DIR"; then
-            log ERROR "Failed to clone tap repository"
-            log ERROR "Check network connectivity and GitHub access"
-            return 1
-        fi
-        cd "$TAP_DIR"
+        log INFO "Removing previous tap clone for a clean checkout..."
+        cd /
+        rm -rf "$TAP_DIR"
     fi
+
+    log INFO "Cloning tap repository..."
+    if ! gh_git clone "$TAP_REPO" "$TAP_DIR"; then
+        log ERROR "Failed to clone tap repository"
+        log ERROR "Check network connectivity and GitHub access"
+        return 1
+    fi
+    cd "$TAP_DIR"
 
     log SUCCESS "Tap repository ready at: ${TAP_DIR}"
     return 0
@@ -277,8 +244,11 @@ update_formula() {
         return 2
     fi
 
-    # Backup current formula
-    local backup_file="${formula_path}.backup.$(date +%Y%m%d_%H%M%S)"
+    # Backup current formula OUTSIDE the working tree so it never dirties the
+    # clone (a leftover backup inside $TAP_DIR is what historically accumulated
+    # untracked files and blocked subsequent releases).
+    local backup_file
+    backup_file="$(mktemp "${TMPDIR:-/tmp}/claude-mpm-formula.XXXXXX.backup")"
     cp "$formula_path" "$backup_file"
     log INFO "Created backup: ${backup_file}"
 
@@ -310,6 +280,9 @@ update_formula() {
     rm -f "${formula_path}.bak"
 
     log SUCCESS "Formula updated successfully"
+
+    # Edits succeeded — drop the out-of-tree restore backup so it doesn't linger.
+    rm -f "$backup_file"
 
     # Show diff
     if git diff --quiet "$formula_path"; then


### PR DESCRIPTION
## Problem

The v6.5.19 release validated the gh-identity sub-repo fix (#660/#661) — `claude-mpm-agents` and `claude-mpm-skills` synced hands-free. But the Homebrew tap update failed:

```
❌ Tap repository has uncommitted changes
❌ Cannot proceed with uncommitted changes
```

The formula stayed at 6.5.18. Root cause: `scripts/update_homebrew_tap.sh` reuses a persistent `/tmp/homebrew-claude-mpm-update` clone that accumulates dirty state across releases:
1. `update_formula()` wrote `.backup.<timestamp>` files INSIDE the working tree every run (13 had piled up), and
2. the "update existing clone" path aborted fatally on a dirty tree instead of restoring a clean state (the stale clone also carried an old embedded-credential remote URL from before the gh-identity fix).

## Fix

- `clone_or_update_tap_repo()` now treats the `/tmp` clone as disposable: if it exists, `rm -rf` and re-clone fresh via `gh_git clone` every run. This discards dirty state, accumulated backups, and any stale remote in one move.
- `update_formula()` now writes its backup OUTSIDE the working tree (`mktemp` under `$TMPDIR`) and removes it on the success path, so the tree is never dirtied.

`scripts/lib/gh_identity.sh` is unchanged. With this, `make release-publish` becomes fully hands-free.

## Verification

- `bash -n` clean; `shellcheck` introduces no new warnings (and removes one pre-existing SC2155).
- Dry-run exercises the new fresh-clone branch as expected.

Closes #662

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)