### PR TITLE
feat(security): guard credential/identity files against direct pushes to main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Pre-push guard: block direct pushes of credential/security-sensitive files to main.
+#
+# WHAT:
+#   Rejects a `git push` to `refs/heads/main` when any commit in the pushed
+#   range modifies a credential/security-sensitive file (see SENSITIVE below).
+#   Pushes that only touch non-sensitive files (e.g. the release version-bump
+#   path: VERSION, pyproject.toml, package.json, uv.lock) are allowed, as are
+#   all pushes to non-main branches.
+#
+# WHY:
+#   Incident: an agent ran `git push origin main` with a change to
+#   scripts/lib/gh_identity.sh (a credential-handling library), bypassing PR
+#   review. Credential/identity code must always pass through a Pull Request so
+#   it gets owner review (see .github/CODEOWNERS). Squash-merges of PRs are
+#   created server-side on GitHub and never pass through this local hook, so
+#   the legitimate PR path is unaffected. A CI backstop
+#   (.github/workflows/guard-sensitive-paths.yml) catches `--no-verify`
+#   bypasses or uninstalled hooks.
+#
+# Git invokes this as:  pre-push <remote-name> <remote-url>
+# and feeds lines on stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Sensitive paths. Clearly-defined, easily-extendable. Exact paths or globs;
+# matching is simple prefix/glob via shell `case`.
+# ---------------------------------------------------------------------------
+SENSITIVE=(
+    "scripts/lib/gh_identity.sh"
+    "scripts/lib/*credential*"
+    "scripts/lib/*identity*"
+)
+
+# Colors (match scripts/setup-git-hooks.sh style)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PROTECTED_REF="refs/heads/main"
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+# Return 0 if the given path matches any sensitive pattern.
+is_sensitive() {
+    local file="$1"
+    local pattern
+    for pattern in "${SENSITIVE[@]}"; do
+        # shellcheck disable=SC2254  # intentional glob match against patterns
+        case "$file" in
+            $pattern) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# Compute the changed-file set for the pushed range.
+changed_files() {
+    local local_sha="$1"
+    local remote_sha="$2"
+
+    if [ "$remote_sha" != "$ZERO_SHA" ]; then
+        # Normal case: remote main exists; diff what is new.
+        git diff --name-only "$remote_sha" "$local_sha"
+        return
+    fi
+
+    # Remote main absent. Prefer origin/main if we have it locally.
+    if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+        git diff --name-only origin/main "$local_sha"
+        return
+    fi
+
+    # Last-resort fallback: diff from the fork point (or the root commit).
+    local base
+    base="$(git merge-base --fork-point origin/main "$local_sha" 2>/dev/null \
+        || git rev-list --max-parents=0 "$local_sha" | tail -1)"
+    git diff --name-only "$base" "$local_sha"
+}
+
+violations=()
+
+while read -r _local_ref local_sha remote_ref remote_sha; do
+    # Only guard pushes to main.
+    [ "$remote_ref" = "$PROTECTED_REF" ] || continue
+
+    # Skip branch deletions (local sha all zeros).
+    [ "$local_sha" = "$ZERO_SHA" ] && continue
+
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        if is_sensitive "$file"; then
+            violations+=("$file")
+        fi
+    done < <(changed_files "$local_sha" "$remote_sha")
+done
+
+if [ "${#violations[@]}" -gt 0 ]; then
+    # De-duplicate the offending file list (portable; avoids bash 4 `mapfile`).
+    deduped=()
+    while IFS= read -r f; do
+        [ -n "$f" ] && deduped+=("$f")
+    done < <(printf '%s\n' "${violations[@]}" | sort -u)
+    violations=("${deduped[@]}")
+
+    echo -e "${RED}✖ Push to main rejected: credential/security-sensitive file(s) detected.${NC}" >&2
+    echo "" >&2
+    echo -e "${YELLOW}These files must NOT be pushed directly to main — they require a Pull Request${NC}" >&2
+    echo -e "${YELLOW}so an owner can review them (see .github/CODEOWNERS):${NC}" >&2
+    echo "" >&2
+    for f in "${violations[@]}"; do
+        echo -e "  ${RED}•${NC} $f" >&2
+    done
+    echo "" >&2
+    echo -e "${GREEN}How to proceed — open a Pull Request:${NC}" >&2
+    echo "  git switch -c fix/your-change            # create a feature branch" >&2
+    echo "  git push -u origin fix/your-change       # push the branch" >&2
+    echo "  gh pr create --fill                      # open a PR for owner review" >&2
+    echo "" >&2
+    echo -e "${YELLOW}An escape hatch (git push --no-verify) exists for genuine emergencies,${NC}" >&2
+    echo -e "${YELLOW}but it is logged and audited by CI (guard-sensitive-paths.yml) and${NC}" >&2
+    echo -e "${YELLOW}will open an alert issue. Do not use it to bypass review.${NC}" >&2
+    exit 1
+fi
+
+# No sensitive files touched — allow (this is the release version-bump path).
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,16 +24,6 @@
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Sensitive paths. Clearly-defined, easily-extendable. Exact paths or globs;
-# matching is simple prefix/glob via shell `case`.
-# ---------------------------------------------------------------------------
-SENSITIVE=(
-    "scripts/lib/gh_identity.sh"
-    "scripts/lib/*credential*"
-    "scripts/lib/*identity*"
-)
-
 # Colors (match scripts/setup-git-hooks.sh style)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,6 +32,65 @@ NC='\033[0m' # No Color
 
 PROTECTED_REF="refs/heads/main"
 ZERO_SHA="0000000000000000000000000000000000000000"
+
+# Sentinel emitted by changed_files() when it cannot resolve a diff base.
+# changed_files runs in a process substitution, so it cannot abort the whole
+# push directly; the parent loop watches for this line and fails closed.
+BASE_FAILURE_SENTINEL=$'\x01__PREPUSH_BASE_RESOLUTION_FAILED__'
+
+# ---------------------------------------------------------------------------
+# Sensitive paths come from the single canonical source .githooks/sensitive-
+# patterns (newline-delimited globs; supports `#` comments and blank lines).
+# This file is shared with .github/workflows/guard-sensitive-paths.yml so the
+# policy is defined in exactly one place.
+#
+# The hook is copied into .git/hooks/pre-push at install time (see
+# scripts/setup-git-hooks.sh), so resolve the patterns file relative to the
+# repo root first, then fall back to this hook's own directory.
+# ---------------------------------------------------------------------------
+resolve_patterns_file() {
+    local root
+    if root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$root" ]; then
+        echo "$root/.githooks/sensitive-patterns"
+        return
+    fi
+    # Fall back to the hook's own location.
+    local hook_dir
+    hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    echo "$hook_dir/sensitive-patterns"
+}
+
+PATTERNS_FILE="$(resolve_patterns_file)"
+
+# Fail closed: a missing policy file must not silently disable the guard.
+if [ ! -f "$PATTERNS_FILE" ]; then
+    echo -e "${RED}✖ pre-push guard cannot find its sensitive-paths policy file:${NC}" >&2
+    echo "       $PATTERNS_FILE" >&2
+    echo -e "${YELLOW}       Refusing push (fail-closed). Reinstall hooks via scripts/setup-git-hooks.sh${NC}" >&2
+    echo -e "${YELLOW}       or restore .githooks/sensitive-patterns.${NC}" >&2
+    exit 1
+fi
+
+# Load patterns into an array, skipping blank lines and `#` comments.
+SENSITIVE=()
+while IFS= read -r line || [ -n "$line" ]; do
+    # Strip leading/trailing whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in
+        \#*) continue ;;
+    esac
+    SENSITIVE+=("$line")
+done < "$PATTERNS_FILE"
+
+# Fail closed: an empty (all-comment) policy file would guard nothing.
+if [ "${#SENSITIVE[@]}" -eq 0 ]; then
+    echo -e "${RED}✖ pre-push guard loaded zero patterns from:${NC}" >&2
+    echo "       $PATTERNS_FILE" >&2
+    echo -e "${YELLOW}       Refusing push (fail-closed) — the policy file defines no sensitive paths.${NC}" >&2
+    exit 1
+fi
 
 # Return 0 if the given path matches any sensitive pattern.
 is_sensitive() {
@@ -77,6 +126,21 @@ changed_files() {
     local base
     base="$(git merge-base --fork-point origin/main "$local_sha" 2>/dev/null \
         || git rev-list --max-parents=0 "$local_sha" | tail -1)"
+
+    # Fail closed: if we cannot determine a base (e.g. a shallow clone with no
+    # reachable root), an empty base makes `git diff "" "$local_sha"` inspect
+    # NOTHING and the guard would silently pass — a fail-open security gap.
+    # NOTE: changed_files runs inside a process substitution, so a bare
+    # `exit 1` here would only kill the subshell and the parent would carry on
+    # (fail-open). Instead emit a sentinel line that the parent loop detects
+    # and turns into a hard, fail-closed rejection.
+    if [ -z "$base" ]; then
+        echo "ERROR: pre-push guard cannot determine a diff base for $local_sha — refusing push (fail-closed)." >&2
+        echo "       If this is a legitimate edge case, push the change via a PR." >&2
+        echo "$BASE_FAILURE_SENTINEL"
+        return
+    fi
+
     git diff --name-only "$base" "$local_sha"
 }
 
@@ -91,6 +155,12 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
 
     while IFS= read -r file; do
         [ -n "$file" ] || continue
+        # Fail closed if the base could not be resolved (sentinel from
+        # changed_files): we cannot prove the push is safe, so reject it.
+        if [ "$file" = "$BASE_FAILURE_SENTINEL" ]; then
+            echo -e "${RED}✖ Push to main rejected: pre-push guard could not determine a diff base (fail-closed).${NC}" >&2
+            exit 1
+        fi
         if is_sensitive "$file"; then
             violations+=("$file")
         fi

--- a/.githooks/sensitive-patterns
+++ b/.githooks/sensitive-patterns
@@ -1,0 +1,5 @@
+# Credential / identity handling — must go through a PR (never a direct push to main).
+# Consumed by .githooks/pre-push and .github/workflows/guard-sensitive-paths.yml.
+scripts/lib/gh_identity.sh
+scripts/lib/*credential*
+scripts/lib/*identity*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # All files require owner approval
 * @bobmatnyc
+
+# Security-sensitive: credential/identity handling. Changes require owner review
+# and MUST go through a PR (never a direct push to main — enforced by .githooks/pre-push).
+/scripts/lib/gh_identity.sh @bobmatnyc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,8 @@
 
 # Security-sensitive: credential/identity handling. Changes require owner review
 # and MUST go through a PR (never a direct push to main — enforced by .githooks/pre-push).
+# Globs mirror the patterns guarded by .githooks/sensitive-patterns so any future
+# credential/identity file also requires owner review.
 /scripts/lib/gh_identity.sh @bobmatnyc
+/scripts/lib/*credential* @bobmatnyc
+/scripts/lib/*identity*   @bobmatnyc

--- a/.github/workflows/guard-sensitive-paths.yml
+++ b/.github/workflows/guard-sensitive-paths.yml
@@ -36,12 +36,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Keep this list in sync with .githooks/pre-push (SENSITIVE array).
-          SENSITIVE_PATTERNS=(
-            "scripts/lib/gh_identity.sh"
-            "scripts/lib/*credential*"
-            "scripts/lib/*identity*"
-          )
+          # Sensitive patterns come from the single canonical source
+          # .githooks/sensitive-patterns (checked out in CI), shared with
+          # .githooks/pre-push so the policy lives in exactly one place.
+          # Same parse: skip blank lines and `#` comments.
+          PATTERNS_FILE=".githooks/sensitive-patterns"
+
+          # Fail closed: a missing policy file must not silently disable the guard.
+          if [ ! -f "$PATTERNS_FILE" ]; then
+            echo "::error::Sensitive-paths policy file missing: $PATTERNS_FILE"
+            exit 1
+          fi
+
+          SENSITIVE_PATTERNS=()
+          while IFS= read -r line || [ -n "$line" ]; do
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            [ -n "$line" ] || continue
+            case "$line" in
+              \#*) continue ;;
+            esac
+            SENSITIVE_PATTERNS+=("$line")
+          done < "$PATTERNS_FILE"
+
+          if [ "${#SENSITIVE_PATTERNS[@]}" -eq 0 ]; then
+            echo "::error::Sensitive-paths policy file defines no patterns: $PATTERNS_FILE"
+            exit 1
+          fi
 
           ZERO_SHA="0000000000000000000000000000000000000000"
 
@@ -81,10 +102,25 @@ jobs:
 
             [ "$commit_has_sensitive" -eq 1 ] || continue
 
-            # Does this commit trace to a MERGED PR?
-            merged_pr_count="$(gh api \
-              "repos/${REPO}/commits/${sha}/pulls" \
-              --jq '[.[] | select(.merged_at != null)] | length' 2>/dev/null || echo 0)"
+            # Does this commit trace to a MERGED PR? The
+            # commits/<sha>/pulls association index is updated asynchronously,
+            # so for a just-merged commit it can transiently return empty and
+            # produce a false-positive "direct push" alert. Retry a few times,
+            # treating a non-empty merged-PR result as success as soon as it
+            # appears.
+            merged_pr_count=0
+            for attempt in 1 2 3; do
+              merged_pr_count="$(gh api \
+                "repos/${REPO}/commits/${sha}/pulls" \
+                --jq '[.[] | select(.merged_at != null)] | length' 2>/dev/null || echo 0)"
+              if [ "${merged_pr_count:-0}" -gt 0 ]; then
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "No merged PR association yet for ${sha} (attempt ${attempt}/3); retrying after 5s (async index)."
+                sleep 5
+              fi
+            done
 
             if [ "${merged_pr_count:-0}" -gt 0 ]; then
               echo "✅ Commit ${sha} touches sensitive files but traces to a merged PR."

--- a/.github/workflows/guard-sensitive-paths.yml
+++ b/.github/workflows/guard-sensitive-paths.yml
@@ -1,0 +1,114 @@
+name: Guard sensitive paths
+
+# WHAT: CI backstop for the local .githooks/pre-push guard. For every push to
+#   main, it checks whether any credential/security-sensitive file changed and,
+#   if so, whether the change arrived via a MERGED pull request. A sensitive
+#   change with no associated merged PR was pushed directly (hook bypassed via
+#   --no-verify, or the hook was never installed) and fails the job loudly.
+# WHY: The local pre-push hook can be skipped (--no-verify) or simply not
+#   installed. This server-side check ensures credential/identity files always
+#   trace back to a reviewed PR.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  guard-sensitive-paths:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify sensitive changes trace to a merged PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+
+          # Keep this list in sync with .githooks/pre-push (SENSITIVE array).
+          SENSITIVE_PATTERNS=(
+            "scripts/lib/gh_identity.sh"
+            "scripts/lib/*credential*"
+            "scripts/lib/*identity*"
+          )
+
+          ZERO_SHA="0000000000000000000000000000000000000000"
+
+          # First push of a branch (no prior commit to diff against) — skip.
+          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "$ZERO_SHA" ]; then
+            echo "No prior commit (first push); nothing to check."
+            exit 0
+          fi
+
+          is_sensitive() {
+            local file="$1" pattern
+            for pattern in "${SENSITIVE_PATTERNS[@]}"; do
+              # shellcheck disable=SC2254
+              case "$file" in
+                $pattern) return 0 ;;
+              esac
+            done
+            return 1
+          }
+
+          violation=0
+
+          # Iterate every commit in the pushed range.
+          for sha in $(git rev-list "${BEFORE}..${AFTER}"); do
+            # Files changed by this specific commit.
+            changed="$(git diff-tree --no-commit-id --name-only -r "$sha")"
+
+            commit_has_sensitive=0
+            offending_files=""
+            while IFS= read -r file; do
+              [ -n "$file" ] || continue
+              if is_sensitive "$file"; then
+                commit_has_sensitive=1
+                offending_files="${offending_files}${file}\n"
+              fi
+            done <<< "$changed"
+
+            [ "$commit_has_sensitive" -eq 1 ] || continue
+
+            # Does this commit trace to a MERGED PR?
+            merged_pr_count="$(gh api \
+              "repos/${REPO}/commits/${sha}/pulls" \
+              --jq '[.[] | select(.merged_at != null)] | length' 2>/dev/null || echo 0)"
+
+            if [ "${merged_pr_count:-0}" -gt 0 ]; then
+              echo "✅ Commit ${sha} touches sensitive files but traces to a merged PR."
+              continue
+            fi
+
+            violation=1
+            echo "::error::Direct push of credential/security-sensitive file(s) to main detected in commit ${sha}:"
+            echo -e "$offending_files" | sed '/^$/d' | while IFS= read -r f; do
+              echo "::error::  - $f"
+            done
+
+            # Best-effort alert issue.
+            short_sha="${sha:0:12}"
+            gh issue create \
+              --repo "${REPO}" \
+              --title "⚠️ Direct push of credential file to main detected: ${short_sha}" \
+              --body "$(printf 'Commit %s pushed credential/security-sensitive file(s) directly to main without a merged PR.\n\nOffending file(s):\n%b\n\nCredential/identity files must go through a Pull Request (see .github/CODEOWNERS and .githooks/pre-push). If --no-verify was used to bypass the local hook, please open a retroactive PR and document the reason.' "$sha" "$offending_files")" \
+              2>/dev/null || echo "::warning::Could not open alert issue (continuing)."
+          done
+
+          if [ "$violation" -eq 1 ]; then
+            echo "::error::One or more credential/security-sensitive files were pushed directly to main."
+            exit 1
+          fi
+
+          echo "All sensitive changes (if any) trace to merged PRs. OK."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ Closes #447"
 
 ---
 
+## 🔴 Security: credential files
+
+Credential/identity files (e.g. `scripts/lib/gh_identity.sh`) must **never** be pushed directly to `main` — always open a Pull Request so they get owner review. This is enforced by `.githooks/pre-push` (install via `scripts/setup-git-hooks.sh`), which blocks direct pushes to `main` that touch sensitive paths, and by a CI backstop (`.github/workflows/guard-sensitive-paths.yml`) that catches `--no-verify` bypasses. Release version-bump pushes (VERSION, pyproject.toml, etc.) are unaffected.
+
+---
+
 ## 🔴 Test Workflow
 
 ```bash

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -58,8 +58,22 @@ EOF
 # Make the hook executable
 chmod +x "$HOOKS_DIR/prepare-commit-msg"
 
+# Install the pre-push guard that blocks direct pushes of credential/security-
+# sensitive files (e.g. scripts/lib/gh_identity.sh) to main. The canonical
+# source lives in .githooks/pre-push (checked into the repo); copy it in.
+PRE_PUSH_SRC="$PROJECT_ROOT/.githooks/pre-push"
+if [ -f "$PRE_PUSH_SRC" ]; then
+    cp "$PRE_PUSH_SRC" "$HOOKS_DIR/pre-push"
+    chmod +x "$HOOKS_DIR/pre-push"
+else
+    echo -e "${YELLOW}⚠️  .githooks/pre-push not found — skipping credential-push guard install.${NC}"
+fi
+
 echo -e "${GREEN}✅ Git hooks installed successfully!${NC}"
 echo -e "${YELLOW}The prepare-commit-msg hook will automatically convert:${NC}"
 echo "  '🤖 Generated with [Claude Code]' → '🤖👥 Generated with [Claude MPM]'"
+echo ""
+echo -e "${GREEN}The pre-push hook guards against direct pushes of credential/security-sensitive${NC}"
+echo -e "${GREEN}files (e.g. scripts/lib/gh_identity.sh) to main — those must go through a PR.${NC}"
 echo ""
 echo -e "${GREEN}Claude MPM branding will be applied to all commits automatically.${NC}"


### PR DESCRIPTION
## Motivation

In this release cycle an agent ran `git push origin main` with a change to `scripts/lib/gh_identity.sh` (a credential-handling library), bypassing PR review (documented in #664). This adds a path-scoped guard so credential/security-sensitive files can only reach `main` via a reviewed PR — while preserving the documented `make release-*` version-bump direct-push workflow.

GitHub can't natively express "require a PR only for these paths" (PR-required is branch-wide and would block release version-bump pushes), so this uses a layered, path-scoped approach.

## What's added

1. **`.githooks/pre-push`** — blocks a direct push to `main` whose pushed commits modify any sensitive path (seeded with `scripts/lib/gh_identity.sh` + `scripts/lib/*credential*` / `*identity*` globs). Pushes touching only non-sensitive files (version bumps) pass through. Only `main` is guarded; feature branches are never blocked. PR squash-merges happen server-side and never hit this hook.
2. **`scripts/setup-git-hooks.sh`** — now installs the `pre-push` hook alongside the existing `prepare-commit-msg`.
3. **`.github/CODEOWNERS`** — explicit, commented entry for `scripts/lib/gh_identity.sh` documenting the review requirement (in addition to the existing `* @bobmatnyc`).
4. **`.github/workflows/guard-sensitive-paths.yml`** — CI backstop catching `--no-verify` / uninstalled-hook bypasses: on push to `main`, any sensitive-path change whose commit has no associated *merged* PR fails the job and opens an alert issue.
5. **`CLAUDE.md`** — short 🔴 security note documenting the policy.

## Behavior verified (pre-push hook, simulated stdin)

| Case | Result |
|------|--------|
| Sensitive file → `main` | ❌ exit 1 (rejected with guidance) |
| Version bump only → `main` | ✅ exit 0 (allowed — release path preserved) |
| Sensitive file → feature branch | ✅ exit 0 (only `main` guarded) |

`bash -n` + `shellcheck` clean (bash 3.2-compatible); workflow YAML validated.

Refs #664

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)