### PR TITLE
feat(trusty-search): opt-in index allowlist management (search-index command)

### DIFF
--- a/docs/integrations/trusty-search.md
+++ b/docs/integrations/trusty-search.md
@@ -7,7 +7,7 @@ Trusty Search is a high-performance semantic code search engine written in Rust,
 ## Features
 
 - **Semantic Code Search** - Find code by meaning, not just keywords
-- **Automatic Indexing** - Codebases indexed on demand
+- **Opt-in Indexing** - Explicit index registration via CLI (no auto-indexing)
 - **Multiple Search Modes**:
   - **Text-to-code**: Natural language queries ("authentication middleware")
   - **Code-to-code**: Find similar code patterns
@@ -38,9 +38,10 @@ This will:
 1. Check for Rust/cargo installation
 2. Install trusty-search Rust binary via cargo
 3. Start daemon process on port 7878
-4. Register project index in trusty-search
-5. Configure MCP server in `.mcp.json`
-6. Make search tools available in Claude Code
+4. Configure MCP server in `.mcp.json`
+5. Make search tools available in Claude Code
+
+**Note**: The daemon no longer auto-indexes projects. See [Index Management](#index-management) below to register your first project.
 
 ### What Gets Installed
 
@@ -153,13 +154,45 @@ Search with rich context and focus areas:
 - Exploratory code discovery
 - Understanding code relationships
 
-### CLI Commands
+### MPM Search-Index Commands
+
+MPM provides a dedicated command group for managing the trusty-search allowlist:
+
+```bash
+# Add a project to the allowlist
+claude-mpm search-index add ~/Projects/my-app
+
+# Alias: si (short form)
+claude-mpm si add ~/Projects/my-app
+
+# Add with a custom index name
+claude-mpm search-index add ~/Projects/my-app --name my-project
+
+# List all registered projects
+claude-mpm search-index list
+
+# Alias for list: ls
+claude-mpm search-index ls
+
+# Output as JSON
+claude-mpm search-index list --json
+
+# Remove a project from the allowlist
+claude-mpm search-index remove ~/Projects/my-app
+
+# Alias for remove: rm
+claude-mpm search-index rm ~/Projects/my-app
+```
+
+### trusty-search Daemon Commands
+
+After registering a project, use trusty-search CLI tools:
 
 ```bash
 # Check daemon status
 trusty-search status
 
-# Index a project
+# Index a project (after registration)
 trusty-search index /path/to/project
 
 # Search from command line
@@ -171,17 +204,68 @@ trusty-search list-projects
 
 ## Index Management
 
-### Automatic Indexing
+### Opt-in Indexing Model
 
-When you run `claude-mpm setup trusty-search`:
-1. Project root is registered with daemon
-2. Full codebase is indexed
-3. Index stored in daemon's local cache
-4. Search tools become available
+trusty-search uses an **opt-in indexing model**: a directory is indexed only when explicitly registered via MPM. No auto-indexing occurs on daemon startup or project changes.
+
+#### Adding a Project to the Index
+
+```bash
+# Register a project root for indexing
+claude-mpm search-index add ~/Projects/my-app
+
+# Register with an explicit index name (optional, default: directory basename)
+claude-mpm search-index add ~/Projects/my-app --name my-app
+```
+
+This command:
+1. Validates the path against a denylist of sensitive directories
+2. Resolves the path to its canonical absolute form
+3. Writes an entry to the trusty-search allowlist (`~/Library/Application Support/trusty-search/indexes.toml` on macOS)
+4. Prints next steps (run `trusty-search index` inside the directory to trigger indexing)
+
+After adding a project, trigger the initial index build:
+
+```bash
+cd ~/Projects/my-app
+trusty-search index
+```
+
+#### Listing Registered Projects
+
+```bash
+# View all registered project roots
+claude-mpm search-index list
+
+# Output as JSON (for scripting)
+claude-mpm search-index list --json
+```
+
+#### Removing a Project from the Index
+
+```bash
+# Unregister a project root
+claude-mpm search-index remove ~/Projects/my-app
+```
+
+### Denylist: Paths Refused
+
+MPM will refuse to add the following paths (security restriction):
+
+- **System roots**: `$HOME` itself, `/`, `/tmp`, `/etc`, `/var`
+- **Credential directories**: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker`
+- **Any directory containing a `.env` file** at the top level (prevents secret exposure)
+
+If you try to register a denied path, you'll see an error:
+
+```
+Denied: Refusing to index '/Users/you': this path is in the sensitive-path denylist 
+(home directory, /tmp, or a system root). Choose a specific project subdirectory instead.
+```
 
 ### Manual Reindexing
 
-Force reindex when needed:
+After registering a project, force a full reindex when needed:
 
 ```bash
 # Reindex current project
@@ -194,6 +278,54 @@ trusty-search index src/
 trusty-search clear
 trusty-search index .
 ```
+
+### Allowlist File Location and Schema
+
+The opt-in allowlist is stored in a TOML file:
+
+**Platform-specific locations:**
+
+- **macOS**: `~/Library/Application Support/trusty-search/indexes.toml`
+- **Linux**: `~/.local/share/trusty-search/indexes.toml`
+- **Windows**: `%APPDATA%/trusty-search/indexes.toml`
+
+**Override**: Set `TRUSTY_DATA_DIR` environment variable to use a custom location.
+
+**Schema** (TOML array-of-tables format):
+
+```toml
+[[index]]
+id = "my-project"
+root_path = "/absolute/path/to/project"
+colocated = true  # store index data inside <root_path>/.trusty-search/
+
+# Additional optional fields:
+# include_docs = true        # default: true
+# respect_gitignore = true   # default: true
+# lexical_only = false       # default: false
+# skip_kg = false            # default: false
+# include_paths = []         # subtree restrictions
+# exclude_globs = []         # glob exclusions
+# extensions = []            # extension allow-list
+# domain_terms = []          # intent-classifier vocabulary
+# path_filter = []           # subdirectory glob filter
+```
+
+**Example allowlist**:
+
+```toml
+[[index]]
+id = "claude-mpm"
+root_path = "/Users/you/Projects/claude-mpm"
+colocated = true
+
+[[index]]
+id = "trusty-tools"
+root_path = "/Users/you/Projects/trusty-tools"
+colocated = true
+```
+
+You normally manage this file via `claude-mpm search-index add/list/remove` — direct TOML editing is supported but not recommended.
 
 ## Performance
 
@@ -226,6 +358,14 @@ claude-mpm setup mcp-vector-search --force  # or manual cleanup
 
 # Install trusty-search
 claude-mpm setup trusty-search
+
+# Register your projects (required — no auto-indexing)
+claude-mpm search-index add ~/Projects/my-app
+claude-mpm search-index add ~/Projects/another-app
+
+# Trigger initial indexing for each project
+cd ~/Projects/my-app && trusty-search index
+cd ~/Projects/another-app && trusty-search index
 
 # Remove old index (optional)
 rm -rf .vector-index/
@@ -302,8 +442,9 @@ claude-mpm setup trusty-search --force
 This will:
 1. Rebuild the Rust binary via cargo
 2. Restart daemon
-3. Re-register project index
-4. Update `.mcp.json`
+3. Update `.mcp.json`
+
+**Note**: The allowlist is preserved. Your registered projects will remain active. If you need to re-register projects, use `claude-mpm search-index add` again.
 
 ## Further Reading
 

--- a/src/claude_mpm/cli/commands/search_index.py
+++ b/src/claude_mpm/cli/commands/search_index.py
@@ -1,0 +1,278 @@
+"""
+``claude-mpm search-index`` command — manage the trusty-search opt-in allowlist.
+
+WHAT: CLI entry point for add / list / remove operations on the trusty-search
+      ``indexes.toml`` opt-in allowlist.  Never auto-indexes; requires an
+      explicit path argument from the user.
+WHY:  trusty-search (trusty-tools#767) moves to an opt-in indexing model.
+      MPM owns the tool-side write path so users have a single, safe command
+      to register project roots rather than hand-editing TOML.
+
+DENYLIST enforced on add:
+  - $HOME itself
+  - /tmp, /, /etc, /var
+  - ~/.ssh, ~/.aws, ~/.gnupg, ~/.config/gcloud, ~/.kube, ~/.docker
+  - Any directory whose top level contains a .env file
+
+References
+----------
+LINK: none  (introduced by GitHub issue #668)
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.table import Table
+
+from ...services.trusty_search_allowlist import (
+    AllowlistWriteError,
+    DeniedPathError,
+    add_root,
+    default_allowlist_path,
+    list_roots,
+    remove_root,
+)
+
+console = Console()
+
+
+def add_search_index_parser(subparsers) -> None:
+    """Register the ``search-index`` command group with its subcommands.
+
+    WHAT: Adds ``search-index`` (alias ``si``) with three sub-actions:
+    ``add``, ``list``, and ``remove``.  Uses argparse nested subparsers so
+    the command reads naturally as ``claude-mpm search-index add <path>``.
+    WHY:  Keeps the allowlist surface explicit and symmetrical with
+    ``trusty-search index`` / ``trusty-search list``.
+    """
+    import argparse
+
+    group_parser = subparsers.add_parser(
+        "search-index",
+        aliases=["si"],
+        help="Manage the trusty-search opt-in index allowlist",
+        description=(
+            "Manage which project roots trusty-search is allowed to index.\n\n"
+            "trusty-search uses an opt-in model: a directory is indexed ONLY if\n"
+            "explicitly registered here.  MPM never auto-registers directories.\n\n"
+            "The allowlist lives at:\n"
+            f"  {default_allowlist_path()}"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Register a project root for indexing
+  claude-mpm search-index add ~/Projects/my-app
+
+  # Register with an explicit index name
+  claude-mpm search-index add ~/Projects/my-app --name my-app
+
+  # List all registered roots
+  claude-mpm search-index list
+
+  # Remove a project root
+  claude-mpm search-index remove ~/Projects/my-app
+""",
+    )
+
+    sub = group_parser.add_subparsers(dest="si_subcommand", metavar="SUBCOMMAND")
+    sub.required = True
+
+    # ---- add ----
+    add_p = sub.add_parser(
+        "add",
+        help="Add a directory root to the allowlist",
+        description=(
+            "Register a project directory for trusty-search indexing.\n\n"
+            "The path is resolved to its absolute canonical form before writing.\n"
+            "Adding an already-registered root is a safe no-op (idempotent).\n\n"
+            "REFUSED paths: $HOME, /tmp, /, /etc, /var, ~/.ssh, ~/.aws, ~/.gnupg,\n"
+            "~/.config/gcloud, ~/.kube, ~/.docker, and any directory that contains\n"
+            "a top-level .env file."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_p.add_argument("path", help="Directory to register for indexing")
+    add_p.add_argument(
+        "--name",
+        "-n",
+        dest="index_id",
+        metavar="NAME",
+        default=None,
+        help=(
+            "Override the index ID (default: directory basename). "
+            "Must match [A-Za-z0-9._-]+ after sanitization."
+        ),
+    )
+    add_p.set_defaults(func=_handle_add)
+
+    # ---- list ----
+    list_p = sub.add_parser(
+        "list",
+        aliases=["ls"],
+        help="List all registered roots",
+        description="Show all project roots currently in the trusty-search allowlist.",
+    )
+    list_p.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output as JSON instead of a formatted table",
+    )
+    list_p.set_defaults(func=_handle_list)
+
+    # ---- remove ----
+    rm_p = sub.add_parser(
+        "remove",
+        aliases=["rm"],
+        help="Remove a directory root from the allowlist",
+        description=(
+            "Un-register a project directory from the trusty-search allowlist.\n"
+            "The path is resolved before matching so both the raw and canonical\n"
+            "forms are accepted.  No-op when the entry does not exist."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    rm_p.add_argument("path", help="Directory to remove from the allowlist")
+    rm_p.set_defaults(func=_handle_remove)
+
+    group_parser.set_defaults(func=_handle_group_default)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_group_default(args) -> int:
+    """Show help when ``search-index`` is called without a subcommand."""
+    # argparse sub.required=True handles this — guard is defensive.
+    console.print(
+        "[yellow]Usage:[/yellow] claude-mpm search-index <add|list|remove> ...\n"
+        "Run [cyan]claude-mpm search-index --help[/cyan] for details."
+    )
+    return 1
+
+
+def _handle_add(args) -> int:
+    """Execute ``search-index add <path> [--name NAME]``.
+
+    WHAT: Calls :func:`add_root` with the user-supplied path.  Prints a
+    clear success or already-exists message.  On denylist or validation
+    errors, prints a red error and exits with code 1.
+    WHY:  All path resolution, denylist checking, and TOML writing is
+    delegated to the service layer; this handler only handles I/O.
+    """
+    try:
+        added, message = add_root(args.path, index_id=getattr(args, "index_id", None))
+    except DeniedPathError as exc:
+        console.print(f"[red]Denied:[/red] {exc}")
+        return 1
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        return 1
+    except AllowlistWriteError as exc:
+        console.print(f"[red]Write error:[/red] {exc}")
+        return 1
+
+    if added:
+        console.print(f"[green]Added:[/green] {message}")
+        console.print(
+            "[dim]Run [cyan]trusty-search index[/cyan] inside the directory "
+            "to trigger the initial index build.[/dim]"
+        )
+    else:
+        console.print(f"[yellow]Already registered:[/yellow] {message}")
+    return 0
+
+
+def _handle_list(args) -> int:
+    """Execute ``search-index list [--json]``.
+
+    WHAT: Reads the allowlist and renders it either as a Rich table (default)
+    or as JSON (with ``--json``).  Exits with code 0 even when the list is
+    empty.
+    WHY:  Provides a read-only view of the allowlist without invoking the
+    daemon so it works even when trusty-search is not running.
+    """
+    try:
+        entries = list_roots()
+    except AllowlistWriteError as exc:
+        console.print(f"[red]Read error:[/red] {exc}")
+        return 1
+
+    if getattr(args, "output_json", False):
+        import json
+
+        console.print(json.dumps(entries, indent=2, default=str))
+        return 0
+
+    if not entries:
+        console.print(
+            "[yellow]No entries in the trusty-search allowlist.[/yellow]\n"
+            "Use [cyan]claude-mpm search-index add <path>[/cyan] to register a project."
+        )
+        return 0
+
+    table = Table(title="trusty-search opt-in allowlist", show_header=True)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Root path", style="white")
+    table.add_column("Flags", style="dim")
+
+    for entry in entries:
+        flags_parts: list[str] = []
+        if entry.get("colocated"):
+            flags_parts.append("colocated")
+        if entry.get("lexical_only"):
+            flags_parts.append("lexical_only")
+        if entry.get("skip_kg"):
+            flags_parts.append("skip_kg")
+        flags = ", ".join(flags_parts) if flags_parts else ""
+
+        table.add_row(
+            str(entry.get("id", "")),
+            str(entry.get("root_path", "")),
+            flags,
+        )
+
+    console.print(table)
+    return 0
+
+
+def _handle_remove(args) -> int:
+    """Execute ``search-index remove <path>``.
+
+    WHAT: Calls :func:`remove_root` with the user-supplied path.  Prints a
+    success or not-found message.  On write errors exits with code 1.
+    WHY:  Lets users cleanly un-register a project without hand-editing TOML.
+    """
+    try:
+        removed, message = remove_root(args.path)
+    except AllowlistWriteError as exc:
+        console.print(f"[red]Write error:[/red] {exc}")
+        return 1
+
+    if removed:
+        console.print(f"[green]Removed:[/green] {message}")
+    else:
+        console.print(f"[yellow]Not found:[/yellow] {message}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level dispatch (called from executor)
+# ---------------------------------------------------------------------------
+
+
+def handle_search_index(args) -> int:
+    """Dispatch the search-index command to the appropriate subcommand handler.
+
+    WHAT: If args carries a ``func`` attribute (set by argparse set_defaults),
+    calls it; otherwise falls back to showing help.
+    WHY:  Consistent with how other command handlers work in this codebase —
+    argparse ``set_defaults(func=...)`` lets us avoid a manual if/elif chain.
+    """
+    func = getattr(args, "func", None)
+    if callable(func):
+        return func(args)
+    return _handle_group_default(args)

--- a/src/claude_mpm/cli/executor.py
+++ b/src/claude_mpm/cli/executor.py
@@ -475,6 +475,13 @@ def execute_command(command: str, args) -> int:
 
         return run_ztk(args)
 
+    # Handle search-index allowlist command (trusty-search opt-in, issue #668)
+    if command in ("search-index", "si"):
+        from .commands.search_index import handle_search_index
+
+        result = handle_search_index(args)
+        return result if result is not None else 0
+
     # Handle llmlingua-stats command with lazy import (experimental)
     if command == "llmlingua-stats":
         from .commands.llmlingua_stats import run_llmlingua_stats
@@ -550,6 +557,8 @@ def execute_command(command: str, args) -> int:
         "ztk-stats",
         "llmlingua-stats",
         "manifest",
+        "search-index",
+        "si",
     ]
 
     suggestion = suggest_similar_commands(command, all_commands)

--- a/src/claude_mpm/cli/parsers/base_parser.py
+++ b/src/claude_mpm/cli/parsers/base_parser.py
@@ -745,6 +745,14 @@ def create_parser(
     except ImportError:
         pass
 
+    # Add search-index allowlist command (trusty-search opt-in, issue #668)
+    try:
+        from ..commands.search_index import add_search_index_parser
+
+        add_search_index_parser(subparsers)
+    except ImportError:
+        pass
+
     # Add manifest command parser (init / validate / show)
     try:
         from .manifest_parser import add_manifest_subparser

--- a/src/claude_mpm/services/trusty_search_allowlist.py
+++ b/src/claude_mpm/services/trusty_search_allowlist.py
@@ -41,9 +41,12 @@ LINK: none  (feature introduced in this PR, spec lives in GitHub issue #668)
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Sensitive path denylist
@@ -61,16 +64,32 @@ _DENYLIST_PARENTS: frozenset[str] = frozenset(
     ]
 )
 
-# Top-level paths that are themselves forbidden (and whose sub-paths inherit).
-_DENYLIST_ROOTS: frozenset[str] = frozenset(
+# Paths that are EXACT-MATCH-ONLY refusals: the path itself is refused but its
+# subdirectories are NOT blocked.  $HOME is the critical case — real projects
+# live at ~/Projects/..., ~/code/..., etc. and must remain allowed.
+_DENYLIST_EXACT_ONLY: frozenset[str] = frozenset(
     [
-        str(Path.home()),  # $HOME itself
-        "/tmp",  # nosec B108 — we're BLOCKING /tmp from indexing, not using it
-        "/",
+        str(Path.home()),  # $HOME itself — NOT its subdirectories
+        "/",  # filesystem root exact-match
+    ]
+)
+
+# Paths whose entire SUBTREE is refused (the root AND any descendant).
+# These are ephemeral/system directories where no real project should live.
+_DENYLIST_SUBTREE_ROOTS: frozenset[str] = frozenset(
+    [
+        "/tmp",  # nosec B108 — BLOCKING /tmp from indexing, not using it
+        "/var/tmp",  # nosec B108 — BLOCKING /var/tmp from indexing, not using it
+        "/private/tmp",  # macOS resolves /tmp → /private/tmp
+        "/private/var/folders",  # macOS per-user temp (e.g. /private/var/folders/xx/...)
         "/etc",
         "/var",
     ]
 )
+
+# Keep _DENYLIST_ROOTS as the union for any callers that still reference it
+# (the string-equality check in _check_denylist uses _DENYLIST_EXACT_ONLY now).
+_DENYLIST_ROOTS: frozenset[str] = _DENYLIST_EXACT_ONLY | _DENYLIST_SUBTREE_ROOTS
 
 
 class DeniedPathError(Exception):
@@ -148,7 +167,7 @@ def _derive_id(path: Path) -> str:
     WHY:  The daemon uses the id as both a lookup key and a filesystem path
     component; unsafe characters would break either.
     """
-    raw = path.name or path.parts[-1] if path.parts else "project"
+    raw = path.name or (path.parts[-1] if path.parts else "") or "project"
     return re.sub(r"[^A-Za-z0-9._-]", "_", raw) or "project"
 
 
@@ -156,32 +175,42 @@ def _check_denylist(resolved: Path) -> None:
     """Raise DeniedPathError if *resolved* is a forbidden path.
 
     WHAT: Checks the resolved path against:
-      1. Exact denylist roots ($HOME, /tmp, /, /etc, /var).
-      2. Parent-tree denylist (~/.ssh, ~/.aws, etc.).
-      3. Any directory containing a .env file at its top level.
+      1. Exact-match refusals: $HOME and / (subdirectories of $HOME are ALLOWED).
+      2. Subtree refusals: /tmp, /etc, /var and their subdirectories.
+      3. Parent-tree denylist (~/.ssh, ~/.aws, etc.).
+      4. Any directory containing a .env file at its top level.
     WHY:  Prevents accidental indexing of credential stores, temp dirs, and
-    directories that expose secrets via .env files to the search index.
+    directories that expose secrets via .env files to the search index.  $HOME
+    is exact-match only so that ~/Projects/... and ~/code/... remain allowed —
+    these are where real projects live.
     """
     resolved_str = str(resolved)
+    resolved_normalized = resolved_str.rstrip("/")
 
-    # 1. Exact denylist roots
-    if resolved_str in _DENYLIST_ROOTS:
-        raise DeniedPathError(
-            f"Refusing to index '{resolved_str}': this path is in the "
-            "sensitive-path denylist (home directory, /tmp, or a system root). "
-            "Choose a specific project subdirectory instead."
-        )
-
-    # Also refuse anything whose resolved string IS a denylist root's string
-    # (handles trailing-slash variants)
-    for root in _DENYLIST_ROOTS:
-        if resolved_str.rstrip("/") == root.rstrip("/"):
+    # 1. Exact-match-only refusals ($HOME and /)
+    for root in _DENYLIST_EXACT_ONLY:
+        if resolved_normalized == root.rstrip("/"):
             raise DeniedPathError(
-                f"Refusing to index '{resolved_str}': matches the denylist root "
-                f"'{root}'. Choose a specific project subdirectory instead."
+                f"Refusing to index '{resolved_str}': this path is in the "
+                "sensitive-path denylist (home directory or filesystem root). "
+                "Choose a specific project subdirectory instead."
             )
 
-    # 2. Parent-tree denylist
+    # 2. Subtree refusals: the root AND any descendant are refused
+    for subtree_root in _DENYLIST_SUBTREE_ROOTS:
+        subtree_path = Path(subtree_root)
+        try:
+            resolved.relative_to(subtree_path)
+            # If we reach here the path IS subtree_root or a descendant of it
+            raise DeniedPathError(
+                f"Refusing to index '{resolved_str}': this path is inside the "
+                f"ephemeral/system directory '{subtree_root}'. "
+                "Choose a persistent project directory instead."
+            )
+        except ValueError:
+            pass  # not inside this subtree — OK
+
+    # 3. Parent-tree denylist (~/.ssh, ~/.aws, etc.)
     for denied_parent in _DENYLIST_PARENTS:
         try:
             resolved.relative_to(denied_parent)
@@ -194,7 +223,7 @@ def _check_denylist(resolved: Path) -> None:
         except ValueError:
             pass  # not relative — OK
 
-    # 3. .env file guard
+    # 4. .env file guard
     env_file = resolved / ".env"
     try:
         if env_file.exists():
@@ -204,8 +233,14 @@ def _check_denylist(resolved: Path) -> None:
                 "secrets to trusty-search. Remove or gitignore the .env file "
                 "and retry, or use --exclude '.env' via trusty-search directly."
             )
-    except (OSError, PermissionError):
-        pass  # cannot stat — do not block on permission errors
+    except PermissionError:
+        logger.warning(
+            "Permission denied checking for .env file in '%s'; "
+            "proceeding without the .env guard for this path.",
+            resolved_str,
+        )
+    except OSError:
+        pass  # other stat errors — do not block
 
 
 # ---------------------------------------------------------------------------
@@ -255,10 +290,10 @@ def _save_registry(path: Path, entries: list[dict]) -> None:
     WHY:  The ``toml`` library produces spec-compliant output with proper
     ``[[index]]`` array-of-tables that the Rust serde deserialiser expects.
     """
-    import toml
-
     data: dict = {"index": entries}
     try:
+        import toml
+
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".toml.mpm_tmp")
         serialized = toml.dumps(data)

--- a/src/claude_mpm/services/trusty_search_allowlist.py
+++ b/src/claude_mpm/services/trusty_search_allowlist.py
@@ -1,0 +1,409 @@
+"""
+trusty-search opt-in index allowlist manager.
+
+WHAT: Read, write, and query the trusty-search ``indexes.toml`` registry so
+      MPM can add/list/remove project roots on explicit user request only.
+WHY:  trusty-search is moving to an opt-in indexing model (trusty-tools#767).
+      A directory is indexed only if explicitly present in the allowlist.
+      MPM is the component that writes that config — but ONLY when the user
+      asks; no auto-indexing of cwd/worktrees/transient directories.
+
+Schema (confirmed from PersistedIndex in
+  trusty-tools/crates/trusty-search/src/service/persistence.rs
+and the live ~/Library/Application Support/trusty-search/indexes.toml)::
+
+    [[index]]
+    id = "my-project"          # derived from root_path basename (or user-supplied)
+    root_path = "/abs/path"    # absolute, resolved path to the project root
+    colocated = true           # store index data inside <root_path>/.trusty-search/
+    # All remaining fields are optional:
+    # include_docs = true      # default true — omitted when true to keep TOML compact
+    # respect_gitignore = true # default true — omitted when true
+    # lexical_only = false     # default false — omitted when false
+    # skip_kg = false          # default false — omitted when false
+    # include_paths = []       # subtree restrictions
+    # exclude_globs = []       # glob exclusions
+    # extensions = []          # extension allow-list
+    # domain_terms = []        # intent-classifier vocabulary
+    # path_filter = []         # subdirectory glob filter
+
+Location note: on macOS the live path is
+  ~/Library/Application Support/trusty-search/indexes.toml
+(``dirs::data_local_dir()`` in Rust maps to Application Support on macOS).
+The TRUSTY_DATA_DIR env var overrides this; once trusty-tools#767 ships the
+location may move to ``~/.config/trusty-search/indexes.toml`` — callers use
+:func:`default_allowlist_path` so the change only needs to land here.
+
+References
+----------
+LINK: none  (feature introduced in this PR, spec lives in GitHub issue #668)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Sensitive path denylist
+# ---------------------------------------------------------------------------
+
+# Literal paths whose parents (or themselves) must never be indexed.
+_DENYLIST_PARENTS: frozenset[str] = frozenset(
+    [
+        str(Path.home() / ".ssh"),
+        str(Path.home() / ".aws"),
+        str(Path.home() / ".gnupg"),
+        str(Path.home() / ".config" / "gcloud"),
+        str(Path.home() / ".kube"),
+        str(Path.home() / ".docker"),
+    ]
+)
+
+# Top-level paths that are themselves forbidden (and whose sub-paths inherit).
+_DENYLIST_ROOTS: frozenset[str] = frozenset(
+    [
+        str(Path.home()),  # $HOME itself
+        "/tmp",  # nosec B108 — we're BLOCKING /tmp from indexing, not using it
+        "/",
+        "/etc",
+        "/var",
+    ]
+)
+
+
+class DeniedPathError(Exception):
+    """Raised when a path is in the denylist."""
+
+
+class AllowlistWriteError(OSError):
+    """Raised when the allowlist file cannot be written."""
+
+
+def default_allowlist_path() -> Path:
+    """Return the platform-appropriate path to the trusty-search indexes.toml.
+
+    WHAT: Resolves ``TRUSTY_DATA_DIR`` env var first, then falls back to the
+    OS-appropriate data directory (``~/Library/Application Support/trusty-search``
+    on macOS, ``~/.local/share/trusty-search`` on Linux).
+    WHY:  Mirrors the Rust ``data_dir()`` function in
+    ``trusty-search/src/service/persistence.rs`` so MPM writes to the exact
+    same file the daemon reads.  Using ``platformdirs`` (or its equivalent via
+    stdlib ``pathlib``) avoids hard-coding the macOS path.
+
+    Note: once trusty-tools#767 ships the location may change to
+    ``~/.config/trusty-search/indexes.toml``.  Update this function then.
+    """
+    override = os.environ.get("TRUSTY_DATA_DIR", "")
+    if override:
+        return Path(override) / "indexes.toml"
+
+    # Mirrors dirs::data_local_dir() in Rust:
+    #   macOS  → ~/Library/Application Support
+    #   Linux  → ~/.local/share
+    #   Windows→ %APPDATA%/Local
+    import platform
+
+    system = platform.system()
+    if system == "Darwin":
+        data_dir = Path.home() / "Library" / "Application Support" / "trusty-search"
+    elif system == "Windows":
+        appdata = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA") or ""
+        data_dir = (
+            Path(appdata) / "trusty-search"
+            if appdata
+            else Path.home() / "trusty-search"
+        )
+    else:
+        # Linux / other POSIX
+        xdg_data = os.environ.get("XDG_DATA_HOME", "")
+        base = Path(xdg_data) if xdg_data else Path.home() / ".local" / "share"
+        data_dir = base / "trusty-search"
+
+    return data_dir / "indexes.toml"
+
+
+def _resolve_path(raw: str | Path) -> Path:
+    """Expand user home, resolve symlinks, and return an absolute path.
+
+    WHAT: Applies expanduser + resolve to normalize any user-supplied path to
+    its canonical absolute form so the daemon's root_path comparisons work.
+    WHY:  The daemon stores and compares resolved paths; a relative or symlink
+    path would create a duplicate that never matches.
+    """
+    p = Path(raw).expanduser()
+    try:
+        resolved = p.resolve()
+    except (OSError, RuntimeError):
+        resolved = p.absolute()
+    return resolved
+
+
+def _derive_id(path: Path) -> str:
+    """Derive a safe index ID from the directory name.
+
+    WHAT: Returns the basename of the path, sanitized to ``[A-Za-z0-9._-]``
+    only (matching trusty-search's ``sanitize_id``).
+    WHY:  The daemon uses the id as both a lookup key and a filesystem path
+    component; unsafe characters would break either.
+    """
+    raw = path.name or path.parts[-1] if path.parts else "project"
+    return re.sub(r"[^A-Za-z0-9._-]", "_", raw) or "project"
+
+
+def _check_denylist(resolved: Path) -> None:
+    """Raise DeniedPathError if *resolved* is a forbidden path.
+
+    WHAT: Checks the resolved path against:
+      1. Exact denylist roots ($HOME, /tmp, /, /etc, /var).
+      2. Parent-tree denylist (~/.ssh, ~/.aws, etc.).
+      3. Any directory containing a .env file at its top level.
+    WHY:  Prevents accidental indexing of credential stores, temp dirs, and
+    directories that expose secrets via .env files to the search index.
+    """
+    resolved_str = str(resolved)
+
+    # 1. Exact denylist roots
+    if resolved_str in _DENYLIST_ROOTS:
+        raise DeniedPathError(
+            f"Refusing to index '{resolved_str}': this path is in the "
+            "sensitive-path denylist (home directory, /tmp, or a system root). "
+            "Choose a specific project subdirectory instead."
+        )
+
+    # Also refuse anything whose resolved string IS a denylist root's string
+    # (handles trailing-slash variants)
+    for root in _DENYLIST_ROOTS:
+        if resolved_str.rstrip("/") == root.rstrip("/"):
+            raise DeniedPathError(
+                f"Refusing to index '{resolved_str}': matches the denylist root "
+                f"'{root}'. Choose a specific project subdirectory instead."
+            )
+
+    # 2. Parent-tree denylist
+    for denied_parent in _DENYLIST_PARENTS:
+        try:
+            resolved.relative_to(denied_parent)
+            # If we get here the path is inside denied_parent
+            raise DeniedPathError(
+                f"Refusing to index '{resolved_str}': the path is inside the "
+                f"sensitive directory '{denied_parent}'. "
+                "This directory likely contains credentials or secret keys."
+            )
+        except ValueError:
+            pass  # not relative — OK
+
+    # 3. .env file guard
+    env_file = resolved / ".env"
+    try:
+        if env_file.exists():
+            raise DeniedPathError(
+                f"Refusing to index '{resolved_str}': a '.env' file was found "
+                "at the top level of this directory. Indexing it would expose "
+                "secrets to trusty-search. Remove or gitignore the .env file "
+                "and retry, or use --exclude '.env' via trusty-search directly."
+            )
+    except (OSError, PermissionError):
+        pass  # cannot stat — do not block on permission errors
+
+
+# ---------------------------------------------------------------------------
+# TOML read/write helpers (using stdlib ``tomllib`` + ``toml`` for write)
+# ---------------------------------------------------------------------------
+
+
+def _load_registry(path: Path) -> list[dict]:
+    """Read indexes.toml and return the list of ``[[index]]`` entries.
+
+    WHAT: Parses the TOML file and returns the ``index`` array as a list of
+    plain dicts.  Returns an empty list when the file does not exist.
+    WHY:  ``tomllib`` (Python 3.11+ stdlib) is used for reading — it is
+    zero-dependency.  The ``toml`` package (project dep) handles writing.
+
+    :raises AllowlistWriteError: if the file exists but is unreadable/corrupt.
+    """
+    if not path.exists():
+        return []
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            import toml as tomllib  # type: ignore[no-redef, assignment]
+
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except Exception as exc:
+        raise AllowlistWriteError(
+            f"Could not read trusty-search allowlist at {path}: {exc}"
+        ) from exc
+    entries = data.get("index", [])
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict)]
+
+
+def _save_registry(path: Path, entries: list[dict]) -> None:
+    """Write *entries* back to *path* as ``[[index]]`` array-of-tables TOML.
+
+    WHAT: Serialises the entry list using the ``toml`` package (a project dep).
+    Writes atomically via a sibling temp file + rename so the daemon never
+    sees a half-written file.
+    WHY:  The ``toml`` library produces spec-compliant output with proper
+    ``[[index]]`` array-of-tables that the Rust serde deserialiser expects.
+    """
+    import toml
+
+    data: dict = {"index": entries}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".toml.mpm_tmp")
+        serialized = toml.dumps(data)
+        tmp.write_text(serialized, encoding="utf-8")
+        tmp.replace(path)
+    except Exception as exc:
+        raise AllowlistWriteError(
+            f"Could not write trusty-search allowlist at {path}: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def add_root(
+    raw_path: str | Path,
+    *,
+    index_id: str | None = None,
+    allowlist_path: Path | None = None,
+) -> tuple[bool, str]:
+    """Add a directory root to the trusty-search opt-in allowlist.
+
+    WHAT: Resolves and validates *raw_path*, checks the denylist, then writes
+    an ``[[index]]`` entry to the allowlist TOML.  Idempotent: adding an
+    existing root (same resolved path) is a no-op.
+    WHY:  MPM must only write the allowlist on EXPLICIT user request.  This
+    function is only ever called from the CLI ``search-index add`` command —
+    never from startup, hooks, or any other automatic path.
+
+    Args:
+        raw_path:       Directory to register (will be expanded + resolved).
+        index_id:       Override the derived index ID.  Defaults to the
+                        directory basename.
+        allowlist_path: Override the allowlist file location (used in tests;
+                        defaults to :func:`default_allowlist_path`).
+
+    Returns:
+        ``(added, message)`` where *added* is ``True`` when a new entry was
+        written, ``False`` when the entry already existed (idempotent no-op).
+
+    Raises:
+        DeniedPathError:     if the path is in the denylist.
+        ValueError:          if the path is not a directory.
+        AllowlistWriteError: if the TOML file cannot be read or written.
+    """
+    resolved = _resolve_path(raw_path)
+
+    # Must be (or become) a real directory.
+    if not resolved.is_dir():
+        raise ValueError(
+            f"'{raw_path}' is not a directory (resolved: '{resolved}'). "
+            "trusty-search can only index directories."
+        )
+
+    _check_denylist(resolved)
+
+    index_id = index_id or _derive_id(resolved)
+    resolved_str = str(resolved)
+
+    allowlist = allowlist_path or default_allowlist_path()
+    entries = _load_registry(allowlist)
+
+    # Idempotency check: same root_path → no-op
+    for entry in entries:
+        if entry.get("root_path") == resolved_str:
+            return (
+                False,
+                f"'{resolved_str}' is already in the trusty-search allowlist "
+                f"(id: {entry.get('id', '?')}).",
+            )
+
+    new_entry: dict = {
+        "id": index_id,
+        "root_path": resolved_str,
+        "colocated": True,
+    }
+    entries.append(new_entry)
+    _save_registry(allowlist, entries)
+    return (
+        True,
+        f"Added '{resolved_str}' to the trusty-search allowlist (id: {index_id}).",
+    )
+
+
+def list_roots(
+    *,
+    allowlist_path: Path | None = None,
+) -> list[dict]:
+    """Return all index entries from the trusty-search allowlist.
+
+    WHAT: Reads the TOML file and returns the full list of ``[[index]]`` dicts.
+    Returns an empty list when the file does not exist.
+    WHY:  Provides a read-only view of what trusty-search will index so users
+    can verify their opt-in registrations without invoking the daemon.
+
+    Args:
+        allowlist_path: Override the allowlist file location (used in tests).
+
+    Returns:
+        List of entry dicts, each with at least ``id`` and ``root_path`` keys.
+    """
+    allowlist = allowlist_path or default_allowlist_path()
+    return _load_registry(allowlist)
+
+
+def remove_root(
+    raw_path: str | Path,
+    *,
+    allowlist_path: Path | None = None,
+) -> tuple[bool, str]:
+    """Remove a directory root from the trusty-search opt-in allowlist.
+
+    WHAT: Resolves *raw_path* and removes any ``[[index]]`` entry whose
+    ``root_path`` matches the resolved path.  No-op when no matching entry
+    exists.
+    WHY:  Lets users un-register a project cleanly without manually editing
+    the TOML file.
+
+    Args:
+        raw_path:       Directory to remove (will be expanded + resolved).
+        allowlist_path: Override the allowlist file location (used in tests).
+
+    Returns:
+        ``(removed, message)`` where *removed* is ``True`` when an entry was
+        deleted, ``False`` when no matching entry was found.
+
+    Raises:
+        AllowlistWriteError: if the TOML file cannot be read or written.
+    """
+    resolved = _resolve_path(raw_path)
+    resolved_str = str(resolved)
+
+    allowlist = allowlist_path or default_allowlist_path()
+    entries = _load_registry(allowlist)
+
+    original_count = len(entries)
+    kept = [e for e in entries if e.get("root_path") != resolved_str]
+
+    if len(kept) == original_count:
+        return (
+            False,
+            f"'{resolved_str}' was not found in the trusty-search allowlist.",
+        )
+
+    _save_registry(allowlist, kept)
+    return (True, f"Removed '{resolved_str}' from the trusty-search allowlist.")

--- a/tests/services/test_trusty_search_allowlist.py
+++ b/tests/services/test_trusty_search_allowlist.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 import toml
 
+import claude_mpm.services.trusty_search_allowlist as _mod
 from claude_mpm.services.trusty_search_allowlist import (
     AllowlistWriteError,
     DeniedPathError,
@@ -34,6 +35,34 @@ from claude_mpm.services.trusty_search_allowlist import (
 )
 
 # ---------------------------------------------------------------------------
+# Module fixture: keep _DENYLIST_SUBTREE_ROOTS free of the host's real tmp
+# directory so that pytest's tmp_path (which lives in /private/tmp on macOS)
+# is usable as a fake project root in non-denylist tests.
+#
+# The denylist tests that prove /tmp subtrees ARE refused pass literal paths
+# such as Path("/tmp/foo") directly — those still match the "/tmp" entry in
+# the set, so the fix is transparent to those tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_subtree_roots_for_tmp_path(monkeypatch, tmp_path):
+    """Remove the *resolved* tmp root from _DENYLIST_SUBTREE_ROOTS so that
+    pytest's tmp_path (which macOS resolves to /private/tmp/...) can be used
+    as a safe project directory in tests that are NOT testing denylist logic.
+    """
+    resolved_tmp_root = tmp_path.resolve()
+    # Walk up to find which subtree root (if any) covers tmp_path.
+    # On macOS: /private/tmp/claude-NNN/... → /private/tmp is the match.
+    safe_set = frozenset(
+        root
+        for root in _mod._DENYLIST_SUBTREE_ROOTS
+        if not resolved_tmp_root.is_relative_to(Path(root))
+    )
+    monkeypatch.setattr(_mod, "_DENYLIST_SUBTREE_ROOTS", safe_set)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -46,7 +75,13 @@ def _write_toml(path: Path, entries: list[dict]) -> None:
 
 def _read_toml(path: Path) -> list[dict]:
     """Read back the index entries from a TOML file."""
-    import tomllib
+    try:
+        import tomllib  # Python 3.11+ stdlib
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            import toml as tomllib  # type: ignore[no-redef, assignment]
 
     with path.open("rb") as f:
         data = tomllib.load(f)
@@ -172,6 +207,137 @@ class TestCheckDenylist:
         # .env.example should be fine — only exactly ".env" is blocked
         (tmp_path / ".env.example").write_text("", encoding="utf-8")
         _check_denylist(tmp_path)  # should not raise
+
+    # --- Subtree denylist (fix #2) -------------------------------------------
+
+    def test_rejects_tmp_subdirectory(self):
+        """A path under /tmp must be refused even though /tmp itself is the root."""
+        with pytest.raises(DeniedPathError, match="ephemeral/system"):
+            _check_denylist(Path("/tmp/foo"))
+
+    def test_rejects_tmp_deep_subdirectory(self):
+        """Deeply nested /tmp path must also be refused."""
+        with pytest.raises(DeniedPathError, match="ephemeral/system"):
+            _check_denylist(Path("/tmp/a/b/c/my-project"))
+
+    def test_rejects_etc_subdirectory(self):
+        """A path under /etc must be refused."""
+        with pytest.raises(DeniedPathError, match="ephemeral/system"):
+            _check_denylist(Path("/etc/nginx"))
+
+    def test_rejects_var_subdirectory(self):
+        """A path under /var must be refused."""
+        with pytest.raises(DeniedPathError, match="ephemeral/system"):
+            _check_denylist(Path("/var/log"))
+
+    def test_home_subdirectory_is_allowed(self, tmp_path, monkeypatch):
+        """CRITICAL: a subdirectory of $HOME must NOT be refused.
+
+        Real projects live at ~/Projects/..., ~/code/..., etc.  If we blanket-
+        block the $HOME subtree the whole feature breaks.  This test is the
+        regression guard — if it fails the denylist logic is wrong.
+        """
+        # Fake $HOME to tmp_path so we are not patching real dotfiles.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Reconstruct the denylist constants with the patched home.
+        import importlib
+
+        import claude_mpm.services.trusty_search_allowlist as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_DENYLIST_EXACT_ONLY",
+            frozenset([str(tmp_path), "/"]),
+        )
+        monkeypatch.setattr(
+            mod,
+            "_DENYLIST_PARENTS",
+            frozenset(
+                [
+                    str(tmp_path / ".ssh"),
+                    str(tmp_path / ".aws"),
+                    str(tmp_path / ".gnupg"),
+                    str(tmp_path / ".config" / "gcloud"),
+                    str(tmp_path / ".kube"),
+                    str(tmp_path / ".docker"),
+                ]
+            ),
+        )
+
+        # Create a realistic project directory under the fake home.
+        project = tmp_path / "Projects" / "demo"
+        project.mkdir(parents=True)
+
+        # Must NOT raise — this is the allowed case.
+        mod._check_denylist(project)
+
+    def test_home_exact_is_refused(self, tmp_path, monkeypatch):
+        """$HOME itself must still be refused (exact-match)."""
+        import claude_mpm.services.trusty_search_allowlist as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_DENYLIST_EXACT_ONLY",
+            frozenset([str(tmp_path), "/"]),
+        )
+        monkeypatch.setattr(mod, "_DENYLIST_PARENTS", frozenset())
+
+        with pytest.raises(DeniedPathError, match="sensitive-path denylist"):
+            mod._check_denylist(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _save_registry — AllowlistWriteError on import/write failure (fix #1)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveRegistryWriteError:
+    def test_raises_allowlist_write_error_on_write_failure(self, tmp_path, monkeypatch):
+        """_save_registry must raise AllowlistWriteError (not a bare exception)
+        when the underlying write fails.
+        """
+        from claude_mpm.services import trusty_search_allowlist as mod
+
+        # Simulate a write failure by making the directory read-only.
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        target = ro_dir / "indexes.toml"
+
+        # Patch toml.dumps to raise an OSError so we do not need filesystem
+        # tricks (chmod is unreliable in sandboxed CI environments).
+        import toml as toml_mod
+
+        monkeypatch.setattr(
+            toml_mod, "dumps", lambda _: (_ for _ in ()).throw(OSError("disk full"))
+        )
+
+        with pytest.raises(AllowlistWriteError, match="Could not write"):
+            mod._save_registry(
+                target, [{"id": "x", "root_path": "/x", "colocated": True}]
+            )
+
+    def test_raises_allowlist_write_error_on_import_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """If the toml import fails (e.g. uninstalled), AllowlistWriteError is
+        raised rather than a bare ImportError propagating to the caller.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _block_toml(name, *args, **kwargs):
+            if name == "toml":
+                raise ImportError("toml not installed")
+            return real_import(name, *args, **kwargs)
+
+        from claude_mpm.services import trusty_search_allowlist as mod
+
+        monkeypatch.setattr(builtins, "__import__", _block_toml)
+        target = tmp_path / "indexes.toml"
+
+        with pytest.raises(AllowlistWriteError, match="Could not write"):
+            mod._save_registry(target, [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_trusty_search_allowlist.py
+++ b/tests/services/test_trusty_search_allowlist.py
@@ -1,0 +1,488 @@
+"""
+Unit tests for trusty-search opt-in index allowlist manager (GitHub #668).
+
+WHAT: Tests for :mod:`claude_mpm.services.trusty_search_allowlist` — the
+      service that add/list/removes entries from the trusty-search
+      ``indexes.toml`` allowlist.
+WHY:  Verifies denylist enforcement, idempotent add, TOML round-trip,
+      path normalisation, and remove semantics — all using injected tmp
+      paths so the real ``~/Library/Application Support/trusty-search/
+      indexes.toml`` is NEVER touched.
+
+LINK: none  (introduced by GitHub issue #668)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import toml
+
+from claude_mpm.services.trusty_search_allowlist import (
+    AllowlistWriteError,
+    DeniedPathError,
+    _check_denylist,
+    _derive_id,
+    _load_registry,
+    _resolve_path,
+    _save_registry,
+    add_root,
+    default_allowlist_path,
+    list_roots,
+    remove_root,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(path: Path, entries: list[dict]) -> None:
+    """Write a minimal indexes.toml directly (bypassing the service write path)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(toml.dumps({"index": entries}), encoding="utf-8")
+
+
+def _read_toml(path: Path) -> list[dict]:
+    """Read back the index entries from a TOML file."""
+    import tomllib
+
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return data.get("index", [])
+
+
+# ---------------------------------------------------------------------------
+# default_allowlist_path
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultAllowlistPath:
+    def test_env_override_takes_precedence(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TRUSTY_DATA_DIR", str(tmp_path))
+        result = default_allowlist_path()
+        assert result == tmp_path / "indexes.toml"
+
+    def test_returns_path_object(self, monkeypatch):
+        monkeypatch.delenv("TRUSTY_DATA_DIR", raising=False)
+        result = default_allowlist_path()
+        assert isinstance(result, Path)
+        assert result.name == "indexes.toml"
+
+    def test_macos_path_contains_application_support(self, monkeypatch):
+        monkeypatch.delenv("TRUSTY_DATA_DIR", raising=False)
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        result = default_allowlist_path()
+        assert "Application Support" in str(result)
+        assert "trusty-search" in str(result)
+
+    def test_linux_path_contains_local_share(self, monkeypatch):
+        monkeypatch.delenv("TRUSTY_DATA_DIR", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        result = default_allowlist_path()
+        assert ".local/share" in str(result)
+        assert "trusty-search" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePath:
+    def test_expands_home_tilde(self):
+        result = _resolve_path("~/")
+        assert not str(result).startswith("~")
+        assert result.is_absolute()
+
+    def test_returns_absolute_path(self, tmp_path):
+        result = _resolve_path(tmp_path)
+        assert result.is_absolute()
+
+    def test_accepts_path_object(self, tmp_path):
+        result = _resolve_path(tmp_path)
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# _derive_id
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveId:
+    def test_basename_used(self):
+        assert _derive_id(Path("/projects/my-app")) == "my-app"
+
+    def test_sanitizes_unsafe_chars(self):
+        assert _derive_id(Path("/projects/my app!")) == "my_app_"
+
+    def test_allows_dots_and_dashes(self):
+        assert _derive_id(Path("/projects/my.proj-1")) == "my.proj-1"
+
+    def test_fallback_for_empty(self):
+        # Edge: a path whose name resolves to empty string — should return "project"
+        result = _derive_id(Path("/"))
+        assert result  # must be non-empty
+
+
+# ---------------------------------------------------------------------------
+# _check_denylist
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDenylist:
+    def test_rejects_home_root(self):
+        home = Path.home().resolve()
+        with pytest.raises(DeniedPathError, match="sensitive-path denylist"):
+            _check_denylist(home)
+
+    def test_rejects_slash_tmp(self):
+        with pytest.raises(DeniedPathError):
+            _check_denylist(Path("/tmp"))
+
+    def test_rejects_filesystem_root(self):
+        with pytest.raises(DeniedPathError):
+            _check_denylist(Path("/"))
+
+    def test_rejects_ssh_subpath(self):
+        # Use ~/.ssh itself — always a subpath of the denylist parent
+        ssh_sub = Path.home() / ".ssh"
+        with pytest.raises(DeniedPathError):
+            _check_denylist(ssh_sub)
+
+    def test_rejects_aws_subpath(self):
+        # Use ~/.aws itself — always a subpath of the denylist parent
+        aws_sub = Path.home() / ".aws"
+        with pytest.raises(DeniedPathError):
+            _check_denylist(aws_sub)
+
+    def test_rejects_dotenv_dir(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("SECRET=abc", encoding="utf-8")
+        with pytest.raises(DeniedPathError, match=r"\.env"):
+            _check_denylist(tmp_path)
+
+    def test_accepts_normal_project_dir(self, tmp_path):
+        # Must NOT raise
+        _check_denylist(tmp_path)
+
+    def test_accepts_project_with_env_example(self, tmp_path):
+        # .env.example should be fine — only exactly ".env" is blocked
+        (tmp_path / ".env.example").write_text("", encoding="utf-8")
+        _check_denylist(tmp_path)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _load_registry / _save_registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIO:
+    def test_load_nonexistent_returns_empty(self, tmp_path):
+        result = _load_registry(tmp_path / "indexes.toml")
+        assert result == []
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "indexes.toml"
+        entries = [{"id": "proj", "root_path": "/abs/path", "colocated": True}]
+        _save_registry(path, entries)
+        loaded = _load_registry(path)
+        assert loaded == entries
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "deep" / "nested" / "indexes.toml"
+        _save_registry(path, [])
+        assert path.exists()
+
+    def test_load_corrupt_file_raises(self, tmp_path):
+        path = tmp_path / "indexes.toml"
+        path.write_bytes(b"\x00\x01corrupt bytes\xff")
+        with pytest.raises(AllowlistWriteError):
+            _load_registry(path)
+
+    def test_array_of_tables_schema(self, tmp_path):
+        """Saved TOML must use [[index]] array-of-tables, not inline arrays."""
+        path = tmp_path / "indexes.toml"
+        entries = [
+            {"id": "a", "root_path": "/a", "colocated": True},
+            {"id": "b", "root_path": "/b", "colocated": True},
+        ]
+        _save_registry(path, entries)
+        content = path.read_text(encoding="utf-8")
+        assert "[[index]]" in content, "TOML must use [[index]] array-of-tables"
+
+    def test_save_is_atomic(self, tmp_path):
+        """Temp file must be cleaned up after a successful write."""
+        path = tmp_path / "indexes.toml"
+        _save_registry(path, [{"id": "x", "root_path": "/x", "colocated": True}])
+        tmp_file = path.with_suffix(".toml.mpm_tmp")
+        assert not tmp_file.exists(), "Temp file should be renamed away after write"
+
+
+# ---------------------------------------------------------------------------
+# add_root
+# ---------------------------------------------------------------------------
+
+
+class TestAddRoot:
+    def test_adds_new_entry(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "my_project"
+        project.mkdir()
+
+        added, msg = add_root(project, allowlist_path=toml_path)
+
+        assert added is True
+        assert "my_project" in msg
+        entries = _read_toml(toml_path)
+        assert len(entries) == 1
+        assert entries[0]["root_path"] == str(project.resolve())
+        assert entries[0]["colocated"] is True
+
+    def test_idempotent_on_duplicate(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "app"
+        project.mkdir()
+
+        add_root(project, allowlist_path=toml_path)
+        added, msg = add_root(project, allowlist_path=toml_path)
+
+        assert added is False
+        assert "already in" in msg
+        entries = _read_toml(toml_path)
+        assert len(entries) == 1, "Duplicate entry must not be written"
+
+    def test_custom_index_id(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "app"
+        project.mkdir()
+
+        add_root(project, index_id="custom-id", allowlist_path=toml_path)
+
+        entries = _read_toml(toml_path)
+        assert entries[0]["id"] == "custom-id"
+
+    def test_appends_to_existing_entries(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        _write_toml(
+            toml_path, [{"id": "existing", "root_path": "/other", "colocated": True}]
+        )
+
+        project = tmp_path / "new_proj"
+        project.mkdir()
+        add_root(project, allowlist_path=toml_path)
+
+        entries = _read_toml(toml_path)
+        assert len(entries) == 2
+
+    def test_rejects_denylist_path(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        with pytest.raises(DeniedPathError):
+            add_root(Path.home(), allowlist_path=toml_path)
+
+    def test_rejects_nonexistent_path(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        with pytest.raises(ValueError, match="not a directory"):
+            add_root(tmp_path / "does_not_exist", allowlist_path=toml_path)
+
+    def test_rejects_file_path(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        a_file = tmp_path / "file.txt"
+        a_file.write_text("", encoding="utf-8")
+        with pytest.raises(ValueError, match="not a directory"):
+            add_root(a_file, allowlist_path=toml_path)
+
+    def test_rejects_dotenv_dir(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "secret_proj"
+        project.mkdir()
+        (project / ".env").write_text("TOKEN=xxx", encoding="utf-8")
+        with pytest.raises(DeniedPathError, match=r"\.env"):
+            add_root(project, allowlist_path=toml_path)
+
+    def test_expands_tilde_in_path(self, tmp_path):
+        """Path with ~ must expand to an absolute path (no literal ~ stored)."""
+        toml_path = tmp_path / "indexes.toml"
+        # Use a real directory under $HOME for this test.
+        project = Path.home() / ".cache"
+        if not project.is_dir():
+            pytest.skip("~/.cache does not exist on this machine")
+
+        # ~/.cache itself is not in the denylist — safe to register
+        try:
+            add_root("~/.cache", allowlist_path=toml_path)
+        except Exception:
+            pytest.skip("~/.cache refused by denylist on this machine")
+
+        entries = _read_toml(toml_path)
+        assert entries[0]["root_path"] == str(project.resolve())
+        assert "~" not in entries[0]["root_path"], (
+            "Tilde must be expanded before storing"
+        )
+
+    def test_does_not_touch_real_allowlist(self, tmp_path, monkeypatch):
+        """Critical: add_root with injected path must NOT write the real file."""
+        real_path = default_allowlist_path()
+        real_existed_before = real_path.exists()
+
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "safe_proj"
+        project.mkdir()
+        add_root(project, allowlist_path=toml_path)
+
+        # The real file state must be unchanged.
+        if not real_existed_before:
+            assert not real_path.exists(), "add_root must not create the real allowlist"
+
+
+# ---------------------------------------------------------------------------
+# list_roots
+# ---------------------------------------------------------------------------
+
+
+class TestListRoots:
+    def test_empty_when_file_missing(self, tmp_path):
+        result = list_roots(allowlist_path=tmp_path / "indexes.toml")
+        assert result == []
+
+    def test_returns_all_entries(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        entries = [
+            {"id": "a", "root_path": "/a", "colocated": True},
+            {"id": "b", "root_path": "/b", "colocated": False},
+        ]
+        _write_toml(toml_path, entries)
+        result = list_roots(allowlist_path=toml_path)
+        assert len(result) == 2
+        assert result[0]["id"] == "a"
+        assert result[1]["id"] == "b"
+
+    def test_does_not_touch_real_allowlist(self, tmp_path):
+        """list_roots with injected path reads only that path."""
+        real_path = default_allowlist_path()
+        # Call with non-existent injected path — should return [] without
+        # ever consulting the real file.
+        result = list_roots(allowlist_path=tmp_path / "indexes.toml")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# remove_root
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveRoot:
+    def test_removes_existing_entry(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "proj"
+        project.mkdir()
+        add_root(project, allowlist_path=toml_path)
+
+        removed, msg = remove_root(project, allowlist_path=toml_path)
+
+        assert removed is True
+        assert str(project.resolve()) in msg
+        entries = _read_toml(toml_path)
+        assert entries == []
+
+    def test_noop_when_not_found(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        removed, msg = remove_root(project, allowlist_path=toml_path)
+
+        assert removed is False
+        assert "not found" in msg
+
+    def test_leaves_other_entries_intact(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        proj_a = tmp_path / "a"
+        proj_b = tmp_path / "b"
+        proj_a.mkdir()
+        proj_b.mkdir()
+
+        add_root(proj_a, allowlist_path=toml_path)
+        add_root(proj_b, allowlist_path=toml_path)
+        remove_root(proj_a, allowlist_path=toml_path)
+
+        entries = _read_toml(toml_path)
+        assert len(entries) == 1
+        assert entries[0]["root_path"] == str(proj_b.resolve())
+
+    def test_resolves_path_before_matching(self, tmp_path):
+        """Remove with a trailing slash or relative form should still match."""
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "proj"
+        project.mkdir()
+        add_root(project, allowlist_path=toml_path)
+
+        # Pass path as string with trailing slash
+        removed, _ = remove_root(str(project) + "/", allowlist_path=toml_path)
+        assert removed is True
+
+    def test_does_not_touch_real_allowlist(self, tmp_path):
+        real_path = default_allowlist_path()
+        real_existed_before = real_path.exists()
+
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "proj"
+        project.mkdir()
+        remove_root(project, allowlist_path=toml_path)
+
+        if not real_existed_before:
+            assert not real_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Integration: add → list → remove round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_add_list_remove_full_cycle(self, tmp_path):
+        toml_path = tmp_path / "indexes.toml"
+        projects = [tmp_path / f"proj{i}" for i in range(3)]
+        for p in projects:
+            p.mkdir()
+
+        # Add all three
+        for p in projects:
+            added, _ = add_root(p, allowlist_path=toml_path)
+            assert added is True
+
+        # List should show 3
+        entries = list_roots(allowlist_path=toml_path)
+        assert len(entries) == 3
+
+        # Remove middle one
+        removed, _ = remove_root(projects[1], allowlist_path=toml_path)
+        assert removed is True
+
+        entries = list_roots(allowlist_path=toml_path)
+        assert len(entries) == 2
+        roots = {e["root_path"] for e in entries}
+        assert str(projects[1].resolve()) not in roots
+
+    def test_schema_matches_live_format(self, tmp_path):
+        """The TOML produced must match the schema confirmed from the live
+        ~/Library/Application Support/trusty-search/indexes.toml:
+          [[index]]
+          id = "..."
+          root_path = "..."
+          colocated = true
+        """
+        toml_path = tmp_path / "indexes.toml"
+        project = tmp_path / "myapp"
+        project.mkdir()
+        add_root(project, allowlist_path=toml_path)
+
+        content = toml_path.read_text(encoding="utf-8")
+        # Must produce [[index]] header (array-of-tables)
+        assert "[[index]]" in content
+        # id, root_path, colocated must all appear
+        assert 'id = "myapp"' in content
+        assert f'root_path = "{project.resolve()}"' in content
+        assert "colocated = true" in content


### PR DESCRIPTION
## Summary

- Adds `claude-mpm search-index` (alias `si`) CLI command with `add`, `list`, and `remove` sub-commands for managing the trusty-search opt-in `indexes.toml` allowlist
- Introduces `trusty_search_allowlist` service layer that handles path normalization, denylist enforcement, idempotent TOML writes, and atomic file replacement
- Fixes a latent bug where `DeniedPathError(ValueError)` was silently swallowed by its own `except ValueError: pass` guard in `_check_denylist` (denylist never actually fired for `~/.ssh`, `~/.aws`, etc.)

## TOML schema (confirmed against live file)

```toml
[[index]]
id = "my-project"
root_path = "/abs/resolved/path"
colocated = true
```

Schema was **confirmed** by reading `~/Library/Application Support/trusty-search/indexes.toml` (macOS live location from trusty-search's `dirs::data_local_dir()` mapping).

## Key design decisions

- **Never auto-indexes**: `add_root` is only called from the explicit CLI handler — no startup hooks, no cwd detection
- **Denylist** refuses: `$HOME`, `/tmp`, `/`, `/etc`, `/var`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker`, any dir containing a top-level `.env` file
- **Idempotent add**: same `root_path` → no-op with a yellow "already registered" message
- **Atomic write**: tmp file + rename so the daemon never sees a half-written file
- **Path**: `TRUSTY_DATA_DIR` env var overrides platform default (mirrors Rust `data_local_dir()`)

## Test plan

- [x] 45 unit tests in `tests/services/test_trusty_search_allowlist.py` — all green
- [x] All tests use injected `allowlist_path=tmp_path/...` — real `indexes.toml` is **never touched**
- [x] `test_schema_matches_live_format` asserts exact `[[index]]` / `id` / `root_path` / `colocated = true` output
- [x] `ruff format` + `ruff check` pass clean
- [x] `bandit` passes (added `# nosec B108` on `/tmp` denylist string with explanation)
- [x] `search-index` and `si` aliases appear in `all_commands` for "did you mean?" suggestions

Closes #668