### PR TITLE
test(fixtures): align mpm-agent-manager snapshot with canonical name

### DIFF
--- a/tests/fixtures/agent_name_snapshot.json
+++ b/tests/fixtures/agent_name_snapshot.json
@@ -18,7 +18,7 @@
     "java-engineer": "Java Engineer",
     "javascript-engineer": "Javascript Engineer",
     "memory-manager-agent": "Memory Manager",
-    "mpm-agent-manager": "mpm_agent_manager",
+    "mpm-agent-manager": "MPM Agent Manager",
     "mpm-skills-manager": "MPM Skills Manager",
     "nextjs-engineer": "Nextjs Engineer",
     "ops": "Ops",


### PR DESCRIPTION
## Summary

The `mpm-agent-manager` entry in `tests/fixtures/agent_name_snapshot.json` was stale: it mapped to the old `mpm_agent_manager`, while the deployed agent `.claude/agents/mpm-agent-manager.md` declares `name: MPM Agent Manager`. This aligns the fixture with the canonical deployed name.

### Change
```diff
-    "mpm-agent-manager": "mpm_agent_manager",
+    "mpm-agent-manager": "MPM Agent Manager",
```

One line, one file. No other keys touched, no golden fixture regenerated, no instruction (`.md`) files modified.

## Relationship to #674

Supersedes the fixture-staleness fix from #674 with a minimal, scoped change. The CB#11 instruction addition and golden regeneration from #674 are intentionally NOT included (unrequested/unvetted).

## Validation

- `uv run pytest tests/test_agent_name_drift.py -p no:xdist` → 3 passed, 1 skipped (skip is environmental: no cached agents on disk, unrelated to this change)
- `uv run pytest tests/test_assembled_prompt_snapshot.py -p no:xdist` → 20 passed
- `uv run ruff format . && uv run ruff check --fix .` → no changes, all checks passed

Note: no test currently loads this fixture (it appears orphaned), so this is a correctness/hygiene fix with no behavioral impact.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)