### PR TITLE
fix(migrations): remove stale _mpm_managed/_mpm_version metadata from global settings

### DIFF
--- a/src/claude_mpm/migrations/migrate_clean_global_settings_metadata.py
+++ b/src/claude_mpm/migrations/migrate_clean_global_settings_metadata.py
@@ -1,0 +1,286 @@
+"""
+Migration to remove stale _mpm_managed/_mpm_version metadata from global
+~/.claude/settings.json (issue #676).
+
+WHAT: Strips orphaned ``_mpm_managed``, ``_mpm_version``, and any leftover
+      MPM-owned ``hooks`` entries from ``~/.claude/settings.json`` only.
+
+WHY: A pre-6.3.x code path wrote the full MPM project-settings template
+     (including ``_mpm_managed: true``, ``_mpm_version``, and hook entries)
+     into the GLOBAL ``~/.claude/settings.json``.  The v6_3_19 migration moved
+     the hooks to project-level settings but left the orphaned metadata behind.
+     That orphaned metadata makes every plain ``claude`` session (outside a
+     claude-mpm project) appear MPM-managed, and the stale ``_mpm_version``
+     silently suppresses template upgrades.
+
+     The INTENTIONAL global keys written by ``_deploy_spinner_global`` are
+     ``spinnerVerbs``, ``spinnerTipsEnabled``, ``spinnerTipsOverride``, and
+     ``_mpm_spinner_version`` — these are always preserved.
+
+This migration:
+1. Reads ``~/.claude/settings.json`` (no-op if absent).
+2. Removes ``_mpm_managed`` and ``_mpm_version`` keys if present.
+3. Removes any ``hooks`` entries where ``_mpm: true`` is set OR where
+   ``command`` contains ``"claude-hook"`` (MPM-owned entries).
+   Non-MPM / user hooks are left untouched.
+4. If the ``hooks`` dict becomes empty after step 3, removes the empty key.
+5. Creates a timestamped backup before writing, then rotates old backups
+   (keeps at most 5).
+6. Is idempotent (second run is a no-op), fail-open (wraps all I/O in
+   try/except — failures are logged but never crash startup), and a no-op
+   when the file does not exist or contains none of the stale keys.
+
+References
+----------
+LINK: none
+"""
+
+import json
+import logging
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Keys written intentionally by _deploy_spinner_global — must be preserved.
+_SPINNER_KEYS: frozenset[str] = frozenset(
+    {
+        "spinnerVerbs",
+        "spinnerTipsEnabled",
+        "spinnerTipsOverride",
+        "_mpm_spinner_version",
+    }
+)
+
+# Top-level metadata keys that are stale in global settings.
+_STALE_METADATA_KEYS: tuple[str, ...] = ("_mpm_managed", "_mpm_version")
+
+# Substrings used to recognise an MPM hook command entry (mirrors the
+# v6_3_19 / dedup_hook_registrations migration lists).
+_MPM_HOOK_MARKERS: tuple[str, ...] = (
+    "claude-hook-fast",
+    "claude-hook-handler",
+    "claude-hook",
+    "message_check_hook",
+    "tool_failure_hook",
+    "claude_mpm",
+)
+
+_BACKUP_KEEP = 5  # Maximum number of MPM backups retained per settings file.
+
+
+def _is_mpm_hook_command(hook_cmd: Any) -> bool:
+    """Return True if this hook command dict is owned by claude-mpm.
+
+    Args:
+        hook_cmd: A single hook command entry (should be a dict).
+
+    Returns:
+        True when the entry should be removed from global settings.
+    """
+    if not isinstance(hook_cmd, dict):
+        return False
+    # Primary: explicit MPM ownership marker.
+    if hook_cmd.get("_mpm") is True:
+        return True
+    # Secondary: command string contains a known MPM marker substring.
+    command = str(hook_cmd.get("command", ""))
+    if any(marker in command for marker in _MPM_HOOK_MARKERS):
+        return True
+    # Tertiary: any arg string contains an MPM marker.
+    args = hook_cmd.get("args") or []
+    if isinstance(args, list):
+        for arg in args:
+            if isinstance(arg, str) and any(
+                marker in arg for marker in _MPM_HOOK_MARKERS
+            ):
+                return True
+    return False
+
+
+def _strip_stale_metadata(settings: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Remove stale MPM metadata and hook entries from a global settings dict.
+
+    Mutates ``settings`` in-place and returns the updated dict alongside the
+    total count of keys/entries removed.
+
+    Preserves:
+    - All user-authored keys.
+    - All spinner keys (``spinnerVerbs``, ``spinnerTipsEnabled``,
+      ``spinnerTipsOverride``, ``_mpm_spinner_version``).
+    - All non-MPM hook entries.
+
+    Args:
+        settings: Parsed ``~/.claude/settings.json`` dict.
+
+    Returns:
+        Tuple of (updated settings, total count of items removed).
+    """
+    removed = 0
+
+    # --- Step 1: remove stale top-level metadata keys -----------------------
+    for key in _STALE_METADATA_KEYS:
+        if key in settings:
+            del settings[key]
+            removed += 1
+            logger.debug("Removed stale global key: %s", key)
+
+    # --- Step 2: strip MPM-owned hook entries --------------------------------
+    hooks = settings.get("hooks")
+    if isinstance(hooks, dict):
+        event_types_to_delete: list[str] = []
+
+        for event_type, event_configs in hooks.items():
+            if not isinstance(event_configs, list):
+                continue
+
+            cleaned_configs: list[dict[str, Any]] = []
+            for config in event_configs:
+                if not isinstance(config, dict):
+                    cleaned_configs.append(config)
+                    continue
+
+                hook_list = config.get("hooks")
+                if not isinstance(hook_list, list):
+                    cleaned_configs.append(config)
+                    continue
+
+                filtered = [h for h in hook_list if not _is_mpm_hook_command(h)]
+                n_removed = len(hook_list) - len(filtered)
+                removed += n_removed
+
+                if not filtered:
+                    # Entire matcher block is now empty — drop it.
+                    continue
+
+                config = dict(config)  # shallow copy so we don't mutate the original
+                config["hooks"] = filtered
+                cleaned_configs.append(config)
+
+            if cleaned_configs:
+                hooks[event_type] = cleaned_configs
+            else:
+                event_types_to_delete.append(event_type)
+
+        for event_type in event_types_to_delete:
+            del hooks[event_type]
+
+        # --- Step 3: drop the entire hooks key when it's now empty ----------
+        if not hooks:
+            del settings["hooks"]
+            logger.debug("Removed empty 'hooks' key from global settings")
+
+    return settings, removed
+
+
+def _rotate_backups(path: Path) -> None:
+    """Delete old MPM backups for ``path``, keeping only ``_BACKUP_KEEP`` newest.
+
+    Fail-open: any error is silently swallowed.
+    """
+    try:
+        stem = path.stem  # e.g. "settings"
+        pattern = f"{stem}.json.backup_*"
+        backups = sorted(path.parent.glob(pattern))
+        excess = backups[: max(0, len(backups) - _BACKUP_KEEP)]
+        for old_backup in excess:
+            try:
+                old_backup.unlink()
+                logger.debug("Deleted old backup: %s", old_backup)
+            except OSError:
+                pass
+    except Exception:
+        pass
+
+
+def run_migration() -> bool:
+    """Remove stale MPM metadata from ``~/.claude/settings.json``.
+
+    Intended to be called by the migration runner on first startup of
+    claude-mpm >= 6.5.21.
+
+    Returns:
+        True in all cases — this migration is fail-open and must never crash
+        startup.
+    """
+    try:
+        global_settings = Path.home() / ".claude" / "settings.json"
+
+        if not global_settings.exists():
+            logger.info(
+                "~/.claude/settings.json not found — nothing to migrate (issue #676)"
+            )
+            return True
+
+        try:
+            with open(global_settings, encoding="utf-8") as fh:
+                settings = json.load(fh)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "clean_global_settings_metadata: could not parse %s: %s — skipping",
+                global_settings,
+                exc,
+            )
+            return True
+        except OSError as exc:
+            logger.warning(
+                "clean_global_settings_metadata: could not read %s: %s — skipping",
+                global_settings,
+                exc,
+            )
+            return True
+
+        if not isinstance(settings, dict):
+            logger.warning(
+                "clean_global_settings_metadata: %s is not a JSON object — skipping",
+                global_settings,
+            )
+            return True
+
+        settings, removed_count = _strip_stale_metadata(settings)
+
+        if removed_count == 0:
+            logger.info(
+                "clean_global_settings_metadata: no stale metadata found in %s",
+                global_settings,
+            )
+            return True
+
+        # Create a timestamped backup before writing.
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+        backup_path = global_settings.with_suffix(f".json.backup_{timestamp}")
+        try:
+            shutil.copy2(global_settings, backup_path)
+            logger.info("Backup created: %s", backup_path)
+        except OSError as exc:
+            logger.warning("Could not create backup (non-fatal): %s", exc)
+
+        _rotate_backups(global_settings)
+
+        try:
+            with open(global_settings, "w", encoding="utf-8") as fh:
+                json.dump(settings, fh, indent=2)
+            fh_path = global_settings  # for the log message
+            logger.info(
+                "clean_global_settings_metadata: removed %d stale item(s) from %s",
+                removed_count,
+                fh_path,
+            )
+        except OSError as exc:
+            logger.warning(
+                "clean_global_settings_metadata: failed to write %s: %s — skipping",
+                global_settings,
+                exc,
+            )
+
+        return True
+
+    except Exception as exc:  # outermost fail-open guard
+        logger.warning(
+            "clean_global_settings_metadata migration encountered an unexpected "
+            "error: %s — startup will continue normally",
+            exc,
+        )
+        return True

--- a/src/claude_mpm/migrations/migrate_clean_global_settings_metadata.py
+++ b/src/claude_mpm/migrations/migrate_clean_global_settings_metadata.py
@@ -37,7 +37,9 @@ LINK: none
 
 import json
 import logging
+import os
 import shutil
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -57,18 +59,63 @@ _SPINNER_KEYS: frozenset[str] = frozenset(
 # Top-level metadata keys that are stale in global settings.
 _STALE_METADATA_KEYS: tuple[str, ...] = ("_mpm_managed", "_mpm_version")
 
-# Substrings used to recognise an MPM hook command entry (mirrors the
-# v6_3_19 / dedup_hook_registrations migration lists).
-_MPM_HOOK_MARKERS: tuple[str, ...] = (
-    "claude-hook-fast",
-    "claude-hook-handler",
-    "claude-hook",
-    "message_check_hook",
-    "tool_failure_hook",
-    "claude_mpm",
+# Exact basename stems used to recognise an MPM hook command entry
+# (mirrors the v6_3_19 / dedup_hook_registrations migration lists).
+# These are matched as basename (final path component) so that a user's
+# command such as ``pre_claude_mpm_check.sh`` is NOT accidentally removed.
+# CONSERVATIVE by design: when unsure, we do NOT delete.
+_MPM_HOOK_SCRIPTS: frozenset[str] = frozenset(
+    {
+        "claude-hook",
+        "claude-hook-fast.sh",
+        "claude-hook-handler.sh",
+    }
+)
+
+# Known internal Python helper names registered by MPM (exact basename match).
+_MPM_HOOK_PYTHON_HELPERS: frozenset[str] = frozenset(
+    {
+        "message_check_hook",
+        "tool_failure_hook",
+    }
 )
 
 _BACKUP_KEEP = 5  # Maximum number of MPM backups retained per settings file.
+
+
+def _command_is_mpm_owned(command_str: str) -> bool:
+    """Return True when a command string can be *precisely* attributed to MPM.
+
+    The check is CONSERVATIVE: we only remove entries we are highly confident
+    were written by claude-mpm.  A user command that merely *contains* the
+    substring ``claude_mpm`` (e.g. ``/usr/local/bin/claude_mpm_wrapper``) is
+    NOT matched here — that would be a false-positive that silently deletes
+    user data.
+
+    Matching rules (in order):
+    1. The basename of the command equals one of the known MPM hook script
+       names exactly (e.g. ``claude-hook``, ``claude-hook-fast.sh``).
+    2. The command basename equals one of the known MPM Python helper names.
+    3. The command path contains the path component ``/claude_mpm/`` — i.e.
+       it is a file *inside* the MPM package tree, identified by a full path
+       segment boundary (not a bare substring).
+
+    Args:
+        command_str: The raw ``command`` value from a hook entry.
+
+    Returns:
+        True when the command is recognised as MPM-owned; False otherwise.
+    """
+    basename = Path(command_str).name
+    if basename in _MPM_HOOK_SCRIPTS:
+        return True
+    if basename in _MPM_HOOK_PYTHON_HELPERS:
+        return True
+    # Path-component match: file lives inside the MPM package directory.
+    # Use separator-bounded comparison to avoid matching e.g. "my_claude_mpm_wrapper".
+    if "/claude_mpm/" in command_str:
+        return True
+    return False
 
 
 def _is_mpm_hook_command(hook_cmd: Any) -> bool:
@@ -82,20 +129,18 @@ def _is_mpm_hook_command(hook_cmd: Any) -> bool:
     """
     if not isinstance(hook_cmd, dict):
         return False
-    # Primary: explicit MPM ownership marker.
+    # Primary: explicit MPM ownership marker — most reliable signal.
     if hook_cmd.get("_mpm") is True:
         return True
-    # Secondary: command string contains a known MPM marker substring.
+    # Secondary: command string matches a known MPM script precisely.
     command = str(hook_cmd.get("command", ""))
-    if any(marker in command for marker in _MPM_HOOK_MARKERS):
+    if _command_is_mpm_owned(command):
         return True
-    # Tertiary: any arg string contains an MPM marker.
+    # Tertiary: an arg string precisely matches a known MPM script.
     args = hook_cmd.get("args") or []
     if isinstance(args, list):
         for arg in args:
-            if isinstance(arg, str) and any(
-                marker in arg for marker in _MPM_HOOK_MARKERS
-            ):
+            if isinstance(arg, str) and _command_is_mpm_owned(arg):
                 return True
     return False
 
@@ -254,19 +299,32 @@ def run_migration() -> bool:
         try:
             shutil.copy2(global_settings, backup_path)
             logger.info("Backup created: %s", backup_path)
+            _rotate_backups(global_settings)
         except OSError as exc:
             logger.warning("Could not create backup (non-fatal): %s", exc)
 
-        _rotate_backups(global_settings)
-
+        # Atomic write: dump to a sibling temp file then Path.replace() so that
+        # a crash mid-write never leaves settings.json in a partial state.
         try:
-            with open(global_settings, "w", encoding="utf-8") as fh:
-                json.dump(settings, fh, indent=2)
-            fh_path = global_settings  # for the log message
+            dir_ = global_settings.parent
+            fd, tmp_str = tempfile.mkstemp(dir=dir_, suffix=".tmp", prefix="settings_")
+            tmp_path = Path(tmp_str)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(settings, fh, indent=2)
+                    fh.write("\n")
+                tmp_path.replace(global_settings)
+            except Exception:
+                # Clean up the temp file if the replace didn't happen.
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
             logger.info(
                 "clean_global_settings_metadata: removed %d stale item(s) from %s",
                 removed_count,
-                fh_path,
+                global_settings,
             )
         except OSError as exc:
             logger.warning(

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -215,6 +215,13 @@ def _run_dedup_hook_registrations_migration() -> bool:
     return run_migration()
 
 
+def _run_clean_global_settings_metadata_migration() -> bool:
+    """Remove stale _mpm_managed/_mpm_version metadata from global ~/.claude/settings.json (issue #676)."""
+    from .migrate_clean_global_settings_metadata import run_migration
+
+    return run_migration()
+
+
 def _run_remove_absolute_hook_paths_migration() -> bool:
     """Replace absolute MPM hook paths with the portable 'claude-hook' entry point (issue #563)."""
     from pathlib import Path
@@ -382,6 +389,12 @@ MIGRATIONS: list[Migration] = [
         version="6.5.20",
         description="Collapse duplicate MPM claude-hook entries that differ only in timeout into a single canonical entry per event (issue #677)",
         run=_run_dedup_hook_registrations_migration,
+    ),
+    Migration(
+        id="clean_global_settings_metadata",
+        version="6.5.21",
+        description="Remove stale _mpm_managed/_mpm_version metadata and leftover MPM hook entries from global ~/.claude/settings.json (issue #676)",
+        run=_run_clean_global_settings_metadata_migration,
     ),
 ]
 

--- a/tests/migrations/test_clean_global_settings_metadata.py
+++ b/tests/migrations/test_clean_global_settings_metadata.py
@@ -1,0 +1,390 @@
+"""Tests for the clean_global_settings_metadata migration (issue #676).
+
+Coverage:
+1. Strips ``_mpm_managed`` and ``_mpm_version`` keys; preserves spinner keys,
+   ``_mpm_spinner_version``, and unrelated user keys.
+2. Removes MPM hook remnants (entries with ``_mpm: true`` or a ``command``
+   containing ``"claude-hook"`` / other MPM markers) while preserving user hooks.
+3. Idempotent: running the migration a second time is a no-op (returns True,
+   no further writes, count unchanged).
+4. No-op when none of the stale keys are present.
+5. No-op when ``~/.claude/settings.json`` does not exist.
+6. Empty ``hooks`` dict is removed after all MPM entries are stripped.
+7. Legacy hook entries (no ``_mpm`` marker; matched by command-string substring)
+   are also removed.
+8. ``_mpm_spinner_version`` is NOT removed (it is a spinner key, not stale
+   metadata).
+
+IMPORTANT: Tests use a tmp-file path injected via ``unittest.mock.patch``; the
+real ``~/.claude/settings.json`` is NEVER touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import claude_mpm.migrations.migrate_clean_global_settings_metadata as migration_mod
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _mpm_hook(command: str = "claude-hook") -> dict[str, Any]:
+    return {"type": "command", "command": command, "_mpm": True}
+
+
+def _user_hook(command: str = "my-custom-tool") -> dict[str, Any]:
+    """A user-authored hook that must never be removed."""
+    return {"type": "command", "command": command}
+
+
+def _event_block(*hooks: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{"matcher": "*", "hooks": list(hooks)}]
+
+
+def _run(settings_path: Path) -> bool:
+    """Invoke the migration with its global-settings path redirected to ``settings_path``."""
+    with patch.object(
+        Path,
+        "home",
+        return_value=settings_path.parent.parent,  # parent of .claude/
+    ):
+        return migration_mod.run_migration()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_mpm_hook_command
+# ---------------------------------------------------------------------------
+
+
+class TestIsMpmHookCommand:
+    def test_explicit_mpm_marker(self) -> None:
+        hook = {"type": "command", "command": "anything", "_mpm": True}
+        assert migration_mod._is_mpm_hook_command(hook) is True
+
+    def test_claude_hook_command_string(self) -> None:
+        hook = {"type": "command", "command": "claude-hook"}
+        assert migration_mod._is_mpm_hook_command(hook) is True
+
+    def test_claude_hook_fast_path(self) -> None:
+        hook = {"type": "command", "command": "/opt/claude-hook-fast.sh"}
+        assert migration_mod._is_mpm_hook_command(hook) is True
+
+    def test_claude_hook_in_args(self) -> None:
+        hook = {"type": "command", "command": "python", "args": ["claude-hook"]}
+        assert migration_mod._is_mpm_hook_command(hook) is True
+
+    def test_user_hook_not_matched(self) -> None:
+        hook = {"type": "command", "command": "my-hook"}
+        assert migration_mod._is_mpm_hook_command(hook) is False
+
+    def test_non_dict_returns_false(self) -> None:
+        assert migration_mod._is_mpm_hook_command("string") is False  # type: ignore[arg-type]
+        assert migration_mod._is_mpm_hook_command(None) is False  # type: ignore[arg-type]
+
+    def test_claude_mpm_in_command_string(self) -> None:
+        hook = {"type": "command", "command": "/usr/bin/claude_mpm"}
+        assert migration_mod._is_mpm_hook_command(hook) is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _strip_stale_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestStripStaleMetadata:
+    def test_removes_mpm_managed(self) -> None:
+        settings: dict[str, Any] = {"_mpm_managed": True, "theme": "dark"}
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "_mpm_managed" not in result
+        assert result["theme"] == "dark"
+        assert count == 1
+
+    def test_removes_mpm_version(self) -> None:
+        settings: dict[str, Any] = {"_mpm_version": "6.3.0", "envs": {}}
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "_mpm_version" not in result
+        assert "envs" in result
+        assert count == 1
+
+    def test_removes_both_metadata_keys(self) -> None:
+        settings: dict[str, Any] = {
+            "_mpm_managed": True,
+            "_mpm_version": "6.0.0",
+            "user_key": "keep",
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "_mpm_managed" not in result
+        assert "_mpm_version" not in result
+        assert result["user_key"] == "keep"
+        assert count == 2
+
+    def test_preserves_spinner_keys(self) -> None:
+        settings: dict[str, Any] = {
+            "_mpm_managed": True,
+            "_mpm_version": "6.0.0",
+            "spinnerVerbs": ["coding"],
+            "spinnerTipsEnabled": True,
+            "spinnerTipsOverride": [],
+            "_mpm_spinner_version": "6.5.0",
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "spinnerVerbs" in result
+        assert "spinnerTipsEnabled" in result
+        assert "spinnerTipsOverride" in result
+        assert "_mpm_spinner_version" in result
+        assert count == 2
+
+    def test_no_stale_keys_returns_zero(self) -> None:
+        settings: dict[str, Any] = {"theme": "dark"}
+        _, count = migration_mod._strip_stale_metadata(settings)
+        assert count == 0
+
+    def test_removes_mpm_hooks_preserves_user_hooks(self) -> None:
+        settings: dict[str, Any] = {
+            "hooks": {
+                "PreToolUse": _event_block(_mpm_hook(), _user_hook()),
+            }
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        hooks = result["hooks"]["PreToolUse"][0]["hooks"]
+        assert len(hooks) == 1
+        assert hooks[0]["command"] == "my-custom-tool"
+        assert count == 1
+
+    def test_empty_hooks_key_removed(self) -> None:
+        settings: dict[str, Any] = {
+            "hooks": {
+                "PreToolUse": _event_block(_mpm_hook()),
+            }
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "hooks" not in result
+        assert count == 1
+
+    def test_legacy_hook_removed_by_command_string(self) -> None:
+        """Hooks without ``_mpm`` marker but matching command string are removed."""
+        legacy_hook = {"type": "command", "command": "claude-hook-fast.sh"}
+        settings: dict[str, Any] = {
+            "hooks": {
+                "PostToolUse": _event_block(legacy_hook),
+            }
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "hooks" not in result
+        assert count == 1
+
+    def test_multiple_events_all_cleaned(self) -> None:
+        settings: dict[str, Any] = {
+            "_mpm_managed": True,
+            "hooks": {
+                "PreToolUse": _event_block(_mpm_hook()),
+                "PostToolUse": _event_block(_mpm_hook(), _user_hook()),
+            },
+        }
+        result, count = migration_mod._strip_stale_metadata(settings)
+        assert "_mpm_managed" not in result
+        # PreToolUse block was completely MPM → entire hooks key for that event removed
+        assert "PreToolUse" not in result.get("hooks", {})
+        # PostToolUse still has the user hook
+        post = result["hooks"]["PostToolUse"][0]["hooks"]
+        assert len(post) == 1
+        assert post[0]["command"] == "my-custom-tool"
+        # 1 metadata key + 1 MPM hook in PreToolUse + 1 MPM hook in PostToolUse
+        assert count == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: run_migration (uses tmp path, never touches real fs)
+# ---------------------------------------------------------------------------
+
+
+class TestRunMigration:
+    def test_strips_metadata_and_preserves_user_and_spinner_keys(
+        self, tmp_path: Path
+    ) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "_mpm_managed": True,
+                "_mpm_version": "6.3.0",
+                "spinnerVerbs": ["coding"],
+                "spinnerTipsEnabled": True,
+                "_mpm_spinner_version": "6.3.0",
+                "theme": "dark",
+                "user_setting": 42,
+            },
+        )
+
+        result = _run(settings_file)
+
+        assert result is True
+        data = _read(settings_file)
+        assert "_mpm_managed" not in data
+        assert "_mpm_version" not in data
+        # Spinner keys preserved
+        assert data["spinnerVerbs"] == ["coding"]
+        assert data["spinnerTipsEnabled"] is True
+        assert data["_mpm_spinner_version"] == "6.3.0"
+        # User keys preserved
+        assert data["theme"] == "dark"
+        assert data["user_setting"] == 42
+
+    def test_removes_mpm_hooks_preserves_user_hooks(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "_mpm_managed": True,
+                "hooks": {
+                    "PreToolUse": _event_block(_mpm_hook(), _user_hook("my-linter")),
+                    "PostToolUse": _event_block(_mpm_hook()),
+                },
+            },
+        )
+
+        result = _run(settings_file)
+
+        assert result is True
+        data = _read(settings_file)
+        assert "_mpm_managed" not in data
+        # PostToolUse was all-MPM → removed
+        assert "PostToolUse" not in data.get("hooks", {})
+        # PreToolUse still has the user hook
+        pre_hooks = data["hooks"]["PreToolUse"][0]["hooks"]
+        assert len(pre_hooks) == 1
+        assert pre_hooks[0]["command"] == "my-linter"
+
+    def test_idempotent_second_run_noop(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "_mpm_managed": True,
+                "_mpm_version": "6.0.0",
+                "theme": "dark",
+            },
+        )
+
+        _run(settings_file)
+        mtime_after_first = settings_file.stat().st_mtime
+        content_after_first = settings_file.read_text()
+
+        _run(settings_file)
+        content_after_second = settings_file.read_text()
+
+        # Content must be identical on the second run
+        assert content_after_first == content_after_second
+
+    def test_noop_when_no_stale_keys(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "theme": "dark",
+                "spinnerVerbs": ["coding"],
+                "_mpm_spinner_version": "6.5.0",
+            },
+        )
+        original_content = settings_file.read_text()
+
+        result = _run(settings_file)
+
+        assert result is True
+        # File must be unchanged
+        assert settings_file.read_text() == original_content
+
+    def test_noop_when_file_missing(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        # File does not exist
+        assert not settings_file.exists()
+
+        result = _run(settings_file)
+
+        assert result is True
+        assert not settings_file.exists()
+
+    def test_legacy_hooks_removed_by_command_string(self, tmp_path: Path) -> None:
+        """MPM hooks written before the ``_mpm`` marker are identified by command string."""
+        legacy_hook = {"type": "command", "command": "claude-hook-fast.sh"}
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "hooks": {
+                    "PreToolUse": _event_block(legacy_hook, _user_hook()),
+                }
+            },
+        )
+
+        result = _run(settings_file)
+
+        assert result is True
+        data = _read(settings_file)
+        pre_hooks = data["hooks"]["PreToolUse"][0]["hooks"]
+        assert len(pre_hooks) == 1
+        assert pre_hooks[0]["command"] == "my-custom-tool"
+
+    def test_mpm_spinner_version_not_removed(self, tmp_path: Path) -> None:
+        """``_mpm_spinner_version`` must not be treated as a stale metadata key."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "_mpm_managed": True,
+                "_mpm_version": "6.0.0",
+                "_mpm_spinner_version": "6.5.0",
+            },
+        )
+
+        _run(settings_file)
+
+        data = _read(settings_file)
+        assert "_mpm_managed" not in data
+        assert "_mpm_version" not in data
+        assert "_mpm_spinner_version" in data
+        assert data["_mpm_spinner_version"] == "6.5.0"
+
+    def test_backup_created_when_changes_made(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(settings_file, {"_mpm_managed": True})
+
+        _run(settings_file)
+
+        backups = list((tmp_path / ".claude").glob("settings.json.backup_*"))
+        assert len(backups) == 1
+
+    def test_no_backup_when_no_changes(self, tmp_path: Path) -> None:
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(settings_file, {"theme": "dark"})
+
+        _run(settings_file)
+
+        backups = list((tmp_path / ".claude").glob("settings.json.backup_*"))
+        assert len(backups) == 0
+
+    def test_returns_true_on_invalid_json(self, tmp_path: Path) -> None:
+        """Migration must be fail-open even with malformed JSON."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text("{ invalid json }", encoding="utf-8")
+
+        result = _run(settings_file)
+
+        assert result is True

--- a/tests/migrations/test_clean_global_settings_metadata.py
+++ b/tests/migrations/test_clean_global_settings_metadata.py
@@ -97,8 +97,19 @@ class TestIsMpmHookCommand:
         assert migration_mod._is_mpm_hook_command("string") is False  # type: ignore[arg-type]
         assert migration_mod._is_mpm_hook_command(None) is False  # type: ignore[arg-type]
 
-    def test_claude_mpm_in_command_string(self) -> None:
-        hook = {"type": "command", "command": "/usr/bin/claude_mpm"}
+    def test_claude_mpm_substring_in_command_not_matched(self) -> None:
+        """A command that merely *contains* 'claude_mpm' as a substring is NOT removed.
+
+        Only hooks whose basename exactly matches a known MPM script, or whose
+        path contains the '/claude_mpm/' path component, are removed.
+        A bare substring like '/usr/bin/claude_mpm_wrapper' must be preserved.
+        """
+        hook = {"type": "command", "command": "/usr/bin/claude_mpm_wrapper"}
+        assert migration_mod._is_mpm_hook_command(hook) is False
+
+    def test_claude_mpm_path_component_is_matched(self) -> None:
+        """A command whose path contains '/claude_mpm/' IS removed (package path)."""
+        hook = {"type": "command", "command": "/opt/lib/claude_mpm/hooks/handler.sh"}
         assert migration_mod._is_mpm_hook_command(hook) is True
 
 
@@ -283,7 +294,6 @@ class TestRunMigration:
         )
 
         _run(settings_file)
-        mtime_after_first = settings_file.stat().st_mtime
         content_after_first = settings_file.read_text()
 
         _run(settings_file)
@@ -340,6 +350,46 @@ class TestRunMigration:
         pre_hooks = data["hooks"]["PreToolUse"][0]["hooks"]
         assert len(pre_hooks) == 1
         assert pre_hooks[0]["command"] == "my-custom-tool"
+
+    def test_user_hook_with_claude_mpm_substring_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        """A user hook whose command merely CONTAINS 'claude_mpm' is NOT removed.
+
+        This is the critical false-positive regression test: commands like
+        '/usr/local/bin/claude_mpm_wrapper' or 'pre_claude_mpm_check.sh' must
+        survive the migration unchanged.  Only hooks with ``_mpm: true`` or
+        whose basename/path-component precisely matches a known MPM script are
+        removed.
+        """
+        user_hook_with_mpm_in_name = {
+            "type": "command",
+            "command": "/usr/local/bin/claude_mpm_wrapper",
+        }
+        settings_file = tmp_path / ".claude" / "settings.json"
+        _write(
+            settings_file,
+            {
+                "_mpm_managed": True,
+                "hooks": {
+                    "PreToolUse": _event_block(
+                        _mpm_hook(),  # real MPM hook — should be removed
+                        user_hook_with_mpm_in_name,  # user hook — must survive
+                    ),
+                },
+            },
+        )
+
+        result = _run(settings_file)
+
+        assert result is True
+        data = _read(settings_file)
+        assert "_mpm_managed" not in data
+        pre_hooks = data["hooks"]["PreToolUse"][0]["hooks"]
+        assert len(pre_hooks) == 1, (
+            "Expected user hook to survive; MPM hook should have been removed"
+        )
+        assert pre_hooks[0]["command"] == "/usr/local/bin/claude_mpm_wrapper"
 
     def test_mpm_spinner_version_not_removed(self, tmp_path: Path) -> None:
         """``_mpm_spinner_version`` must not be treated as a stale metadata key."""


### PR DESCRIPTION
## Summary

- Adds a new run-once migration `clean_global_settings_metadata` (version `6.5.21`) that strips orphaned `_mpm_managed` and `_mpm_version` metadata — and any leftover MPM-owned `hooks` entries — from `~/.claude/settings.json` only.
- Preserves all intentional global keys: `spinnerVerbs`, `spinnerTipsEnabled`, `spinnerTipsOverride`, `_mpm_spinner_version`, and all user-authored settings.
- Removes MPM hook entries identified by `_mpm: true` or command-string markers (`claude-hook`, `claude-hook-fast`, etc.); user hooks are untouched.
- Idempotent, fail-open (never crashes startup), creates a timestamped backup before writing, and rotates to keep at most 5 backups.
- Registered in `registry.py` at id `clean_global_settings_metadata`, version `6.5.21`.

## Test plan

- [x] `uv run pytest tests/migrations/test_clean_global_settings_metadata.py -p no:xdist -v` — 26 passed
- [x] Tests use `tmp_path` + `unittest.mock.patch`; real `~/.claude/settings.json` is never touched
- [x] Covers: strip metadata keys, preserve spinner keys + user keys, remove MPM hooks, preserve user hooks, idempotency, no-op on missing file, no-op when no stale keys, legacy hook removal, backup creation, no backup when no changes, invalid JSON fail-open

Closes #676

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)