### PR TITLE
feat(hooks): configurable context_circuit_breaker threshold (#681)

### DIFF
--- a/docs/developer/context-circuit-breaker.md
+++ b/docs/developer/context-circuit-breaker.md
@@ -1,0 +1,114 @@
+# Context Circuit Breaker
+
+**Module**: `src/claude_mpm/hooks/context_circuit_breaker.py`  
+**Hook event**: `PreToolUse`  
+**Spec**: `SPEC-HOOKS-11~1` (see `docs/specs/hooks.md`)
+
+## What it does
+
+Reads cumulative context-usage state from the per-session state file
+(`.claude-mpm/state/context-usage.json`) and emits a *warning annotation*
+when the session's context exceeds a configurable threshold.  Read-only and
+recovery tools are always allowed through so a session that has hit the
+threshold can still self-recover via `/compact`, `Read`, `Grep`, or
+`/mpm-resume`.
+
+The breaker is **allow-with-warning only** — it never emits
+`permissionDecision: "deny"`.  That was the pre-#642 behavior and made
+sessions unrecoverable.
+
+## Configuration knobs
+
+### Disable the breaker entirely
+
+| Method | Value |
+|--------|-------|
+| Environment variable | `CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1` (or `true` / `yes` / `on`) |
+| `.claude/settings.json` | `{"context_circuit_breaker": {"disabled": true}}` |
+| `.claude/settings.local.json` | same key |
+| `~/.claude/settings.json` | same key |
+
+Precedence: env var > `settings.local.json` > `settings.json` > `~/.claude/settings.json`.
+
+### Override the warning threshold (issue #681)
+
+The default threshold is **95 %**.  To raise or lower it:
+
+| Method | Example |
+|--------|---------|
+| Environment variable | `CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD=85` |
+| `.claude/settings.json` | `{"context_circuit_breaker": {"threshold_pct": 85}}` |
+| `.claude/settings.local.json` | same key |
+| `~/.claude/settings.json` | same key |
+
+Precedence: env var > `settings.local.json` > `settings.json` > `~/.claude/settings.json` > default (95.0).
+
+**Validation**: values must be numeric and in the range `[1, 100]` (inclusive).
+Values outside this range or non-numeric strings are silently ignored and the
+default 95.0 is used (fail-open policy — bad config must never hard-block a
+session).
+
+### Both knobs together
+
+```json
+{
+  "context_circuit_breaker": {
+    "disabled": false,
+    "threshold_pct": 85
+  }
+}
+```
+
+If `disabled: true` is set, the threshold knob is irrelevant — the breaker is
+bypassed entirely regardless of the threshold value.
+
+## How it works
+
+1. **Tool allow-list check** — tools in `ALWAYS_ALLOWED_TOOLS` (`Read`, `Grep`,
+   `Glob`, `LS`, `NotebookRead`, `WebSearch`, `WebFetch`, `TodoRead`,
+   `TodoWrite`, `exit_plan_mode`, and MPM recovery skills) pass through
+   unconditionally even when the threshold is exceeded.
+
+2. **Disable-switch check** — returns pass-through if the breaker is disabled.
+
+3. **State file load** — reads
+   `.claude-mpm/state/context-usage.json` (written by `ContextUsageTracker`).
+   Missing, unreadable, or malformed files → fail-open (pass-through).
+
+4. **Session-ID guard** — stale state from a previous session (mismatched
+   `session_id`) → fail-open.
+
+5. **Percentage computation** — prefers recomputing from raw token counts
+   (`cumulative_input_tokens + cumulative_output_tokens`) against the real
+   model context window (resolved via `model_context_window.resolve_context_window()`).
+   Falls back to the stored `percentage_used` field, clamped to `[0, 100]`.
+   This prevents false positives on 1 M-context models that have an old
+   percentage written against a 200 K budget.
+
+6. **Threshold comparison** — resolves the effective threshold via
+   `_resolve_threshold(cwd)` (env > settings > default).  If
+   `percentage < threshold` → pass-through.
+
+7. **Warning emission** — returns
+   `{"permissionDecision": "allow", "permissionDecisionReason": "<text>"}`.
+   The reason text includes:
+   - current percentage
+   - instructions to `/compact` or use `/mpm-resume`
+   - how to disable (`CLAUDE_MPM_DISABLE_CONTEXT_BREAKER`)
+   - how to adjust the threshold (`CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD` /
+     `threshold_pct`)
+
+## Fail-open policy
+
+At every decision point — missing state file, malformed JSON, invalid config
+value, unexpected exception — the breaker returns an empty dict (pass-through).
+A false positive (blocking an active session) is far more harmful than a missed
+warning.
+
+## Related issues and references
+
+- `#642` — original fix: dynamic context window, allow-with-warning, always-allowed tools
+- `#681` — configurable threshold (`threshold_pct` / `CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD`)
+- `SPEC-HOOKS-11~1` in `docs/specs/hooks.md`
+- State writer: `src/claude_mpm/services/infrastructure/context_usage_tracker.py`
+- Model window map: `src/claude_mpm/hooks/model_context_window.py`

--- a/src/claude_mpm/hooks/context_circuit_breaker.py
+++ b/src/claude_mpm/hooks/context_circuit_breaker.py
@@ -1,4 +1,4 @@
-"""PreToolUse context circuit breaker — warn (not hard-block) when context nears full.
+"""PreToolUse context circuit breaker -- warn (not hard-block) when context nears full.
 
 WHAT: Reads cumulative context-usage state from the per-session state file and
 emits a *warning* annotation when the session's context exceeds a critical
@@ -11,23 +11,29 @@ once the token count exceeded 95 % of a *hardcoded* 200 K ceiling.  On models
 with 1 M context windows (Opus 4.x, large-context Sonnet 4.5+) this fired
 almost immediately and made sessions completely unrecoverable.  The fix:
 
-1. **Dynamic context window** — the ceiling is resolved from the active model id
+1. **Dynamic context window** -- the ceiling is resolved from the active model id
    (via :mod:`claude_mpm.hooks.model_context_window`) so 1 M-context models are
    never compared against a 200 K budget.
-2. **Percentage clamped at 100** — ``percentage_used`` read from the state file
+2. **Percentage clamped at 100** -- ``percentage_used`` read from the state file
    can exceed 100 when a prior version wrote it with the wrong budget; we cap
    it before evaluation so display values are always sane.
-3. **Allow-with-warning instead of hard-block** — the breaker no longer
+3. **Allow-with-warning instead of hard-block** -- the breaker no longer
    returns ``permissionDecision: deny`` for regular tool calls.  It emits
    ``permissionDecision: "allow"`` (the only documented non-blocking value)
    with the warning text in ``permissionDecisionReason``, preserving session
    usability.  "warn" is not a documented PreToolUse value and was removed.
-4. **Always allow read-only / recovery tools** — the tools listed in
+4. **Always allow read-only / recovery tools** -- the tools listed in
    ``ALWAYS_ALLOWED_TOOLS`` pass through unconditionally, even if the threshold
    is exceeded and warnings are suppressed for them.
-5. **Disable switch** — set the ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1`` env
+5. **Disable switch** -- set the ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1`` env
    var or the ``context_circuit_breaker.disabled`` config key to fully bypass
    this module.  The disable instructions are included in the warning message.
+6. **Configurable threshold** -- the warning threshold defaults to 95 % but can
+   be overridden via ``CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD`` env var or the
+   ``context_circuit_breaker.threshold_pct`` settings key (issue #681).
+   Precedence: env var > settings file > default (95.0).  Invalid values
+   (non-numeric or outside 1-100) are silently ignored and the default is used
+   (fail-open).
 
 State source
 ------------
@@ -47,10 +53,19 @@ Set ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER=1`` (or ``true`` / ``yes``) in the
 environment **or** add ``"context_circuit_breaker": {"disabled": true}`` to
 ``.claude/settings.json`` to fully disable this module.
 
+Threshold override
+------------------
+Set ``CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD=<number>`` in the environment
+**or** add ``"context_circuit_breaker": {"threshold_pct": <number>}`` to
+``.claude/settings.json`` to change the warning threshold from the default
+95 %.  Values must be numeric and in the range 1-100; values outside this
+range or non-numeric strings are ignored and the default 95.0 is used.
+
 References
 ----------
 SPEC-HOOKS-11~1 : docs/specs/hooks.md#SPEC-HOOKS-11~1
 GitHub issue #642
+GitHub issue #681
 """
 
 from __future__ import annotations
@@ -69,10 +84,10 @@ from claude_mpm.hooks.model_context_window import (
 # ---------------------------------------------------------------------------
 
 # Threshold (percentage) above which the warning fires.
-# Mirrors ``ContextUsageTracker.THRESHOLDS["critical"]`` (0.95 → 95 %).
+# Mirrors ``ContextUsageTracker.THRESHOLDS["critical"]`` (0.95 -> 95 %).
 CRITICAL_THRESHOLD: float = 95.0
 
-# Tools that are always allowed through — even above the critical threshold.
+# Tools that are always allowed through -- even above the critical threshold.
 # These are read-only / recovery / navigation tools that a user needs to be
 # able to run in order to self-recover from a full context window.
 ALWAYS_ALLOWED_TOOLS: frozenset[str] = frozenset(
@@ -102,10 +117,18 @@ _STATE_FILE_RELATIVE = Path(".claude-mpm") / "state" / "context-usage.json"
 # Environment variable name for the disable switch.
 _DISABLE_ENV_VAR = "CLAUDE_MPM_DISABLE_CONTEXT_BREAKER"
 
-# Config key path inside .claude/settings.json for the disable switch.
-# JSON path: {"context_circuit_breaker": {"disabled": true}}
+# Environment variable name for the threshold override.
+_THRESHOLD_ENV_VAR = "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+
+# Config key path inside .claude/settings.json for both knobs.
+# JSON path: {"context_circuit_breaker": {"disabled": true, "threshold_pct": 85}}
 _CONFIG_KEY = "context_circuit_breaker"
 _CONFIG_DISABLED_FIELD = "disabled"
+_CONFIG_THRESHOLD_FIELD = "threshold_pct"
+
+# Allowed range for threshold values (inclusive on both ends).
+_THRESHOLD_MIN: float = 1.0
+_THRESHOLD_MAX: float = 100.0
 
 
 # ---------------------------------------------------------------------------
@@ -113,30 +136,34 @@ _CONFIG_DISABLED_FIELD = "disabled"
 # ---------------------------------------------------------------------------
 
 
-def _is_disabled(cwd: str) -> bool:
-    """Return True if the circuit breaker has been explicitly disabled.
-
-    Checks, in order:
-    1. ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER`` env var (any truthy value).
-    2. ``context_circuit_breaker.disabled`` in .claude/settings.json.
-    3. ``context_circuit_breaker.disabled`` in ~/.claude/settings.json.
-    """
-    env_val = os.environ.get(_DISABLE_ENV_VAR, "").strip().lower()
-    if env_val in ("1", "true", "yes", "on"):
-        return True
-
-    # Check project and global settings files.
-    settings_candidates: list[Path] = []
+def _settings_candidates(cwd: str) -> list[Path]:
+    """Return ordered list of settings files to check (highest-priority first)."""
+    candidates: list[Path] = []
     if cwd:
-        settings_candidates.extend(
+        candidates.extend(
             [
                 Path(cwd) / ".claude" / "settings.local.json",
                 Path(cwd) / ".claude" / "settings.json",
             ]
         )
-    settings_candidates.append(Path.home() / ".claude" / "settings.json")
+    candidates.append(Path.home() / ".claude" / "settings.json")
+    return candidates
 
-    for settings_path in settings_candidates:
+
+def _is_disabled(cwd: str) -> bool:
+    """Return True if the circuit breaker has been explicitly disabled.
+
+    Checks, in order:
+    1. ``CLAUDE_MPM_DISABLE_CONTEXT_BREAKER`` env var (any truthy value).
+    2. ``context_circuit_breaker.disabled`` in .claude/settings.local.json.
+    3. ``context_circuit_breaker.disabled`` in .claude/settings.json.
+    4. ``context_circuit_breaker.disabled`` in ~/.claude/settings.json.
+    """
+    env_val = os.environ.get(_DISABLE_ENV_VAR, "").strip().lower()
+    if env_val in ("1", "true", "yes", "on"):
+        return True
+
+    for settings_path in _settings_candidates(cwd):
         try:
             if not settings_path.is_file():
                 continue
@@ -158,10 +185,58 @@ def _is_disabled(cwd: str) -> bool:
     return False
 
 
+def _resolve_threshold(cwd: str) -> float:
+    """Return the warning threshold percentage to use.
+
+    Precedence (highest first):
+    1. ``CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD`` env var.
+    2. ``context_circuit_breaker.threshold_pct`` in .claude/settings.local.json.
+    3. ``context_circuit_breaker.threshold_pct`` in .claude/settings.json.
+    4. ``context_circuit_breaker.threshold_pct`` in ~/.claude/settings.json.
+    5. ``CRITICAL_THRESHOLD`` constant (95.0 -- the module-level default).
+
+    Invalid values (non-numeric or outside [_THRESHOLD_MIN, _THRESHOLD_MAX]) are
+    silently skipped so that bad config never causes the breaker to crash or
+    hard-block sessions (fail-open policy).
+    """
+    # 1. Environment variable takes highest precedence.
+    env_raw = os.environ.get(_THRESHOLD_ENV_VAR, "").strip()
+    if env_raw:
+        try:
+            val = float(env_raw)
+            if _THRESHOLD_MIN <= val <= _THRESHOLD_MAX:
+                return val
+        except (TypeError, ValueError):
+            pass  # fall through to settings
+
+    # 2-4. Settings files in priority order.
+    for settings_path in _settings_candidates(cwd):
+        try:
+            if not settings_path.is_file():
+                continue
+            with settings_path.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            cb_config = data.get(_CONFIG_KEY)
+            if isinstance(cb_config, dict):
+                raw = cb_config.get(_CONFIG_THRESHOLD_FIELD)
+                if raw is not None:
+                    try:
+                        val = float(raw)
+                        if _THRESHOLD_MIN <= val <= _THRESHOLD_MAX:
+                            return val
+                    except (TypeError, ValueError):
+                        pass  # skip invalid value, try next settings file
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+
+    # 5. Module-level default.
+    return CRITICAL_THRESHOLD
+
+
 def _load_state(cwd: str) -> dict[str, Any] | None:
     """Read context-usage state from disk.
 
-    Returns ``None`` when the file is missing, unreadable, or malformed —
+    Returns ``None`` when the file is missing, unreadable, or malformed --
     the breaker treats all of those cases as fail-open.
     """
     if not cwd:
@@ -238,7 +313,7 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
     *warning*, and an empty dict otherwise.  At/above threshold the decision
     is ``permissionDecision: "allow"`` (a documented PreToolUse value) with
     the warning text in ``permissionDecisionReason``.  This is the only
-    non-empty decision this function can emit — "deny" and "warn" are never
+    non-empty decision this function can emit -- "deny" and "warn" are never
     returned (the former was the pre-#642 behavior; the latter is not a
     documented Claude Code value and could be treated as an error).
 
@@ -273,17 +348,20 @@ def evaluate(event: dict[str, Any]) -> dict[str, Any]:
     if percentage is None:
         return {}
 
-    if percentage < CRITICAL_THRESHOLD:
+    threshold = _resolve_threshold(cwd)
+    if percentage < threshold:
         return {}
 
     pct_display = round(percentage)
     reason = (
-        f"Context at {pct_display}% — approaching session limit. "
+        f"Context at {pct_display}% -- approaching session limit. "
         "Consider running /compact or starting a new session via /mpm-resume. "
         f"To disable this warning: set {_DISABLE_ENV_VAR}=1 or add "
-        f'"{_CONFIG_KEY}": {{"disabled": true}} to .claude/settings.json.'
+        f'"{_CONFIG_KEY}": {{"disabled": true}} to .claude/settings.json. '
+        f"To adjust the threshold: set {_THRESHOLD_ENV_VAR}=<1-100> or add "
+        f'"{_CONFIG_KEY}": {{"threshold_pct": <value>}} to .claude/settings.json.'
     )
-    # Return allow-with-warning — "allow" is a documented PreToolUse value;
+    # Return allow-with-warning -- "allow" is a documented PreToolUse value;
     # "warn" is NOT documented and risks being treated as deny/error.
     # The warning text is carried in permissionDecisionReason so the harness
     # can surface it while still letting the tool call proceed.
@@ -314,7 +392,7 @@ def main() -> None:
     decision_type = decision.get("permissionDecision")
 
     # evaluate() only ever returns "allow" (allow-with-warning) or nothing ({}
-    # → pass-through).  "deny" and "warn" are never emitted post-#642 fix.
+    # -> pass-through).  "deny" and "warn" are never emitted post-#642 fix.
     if decision_type == "allow":
         payload = {
             "hookSpecificOutput": {

--- a/tests/unit/hooks/test_context_circuit_breaker.py
+++ b/tests/unit/hooks/test_context_circuit_breaker.py
@@ -623,3 +623,355 @@ class TestPrefixMatchBoundary:
         """claude-sonnet-4-6-20260101 (genuine date variant) still resolves 1 M."""
         window = resolve_context_window("claude-sonnet-4-6-20260101")
         assert window == 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# (e) Configurable threshold — issue #681
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurableThreshold:
+    """Verify that the warning threshold can be overridden via env var or settings.
+
+    Coverage requirements (issue #681):
+    (e1) Default threshold is 95.0 when neither env var nor settings key is set.
+    (e2) settings.json threshold_pct overrides the default.
+    (e3) Env var overrides settings (env > settings > default precedence).
+    (e4) Invalid threshold values are handled fail-open (default used, no crash).
+    (e5) disabled knob still works alongside configurable threshold.
+    """
+
+    # --- (e1) Default threshold ---
+
+    def test_default_threshold_is_95(self, project_cwd: Path) -> None:
+        """When neither env var nor settings is set, threshold defaults to 95.0."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 94.9},
+        )
+        # Remove the threshold env var to get a clean default.
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 94.9 < 95.0 default -> pass-through
+        assert result == {}
+
+    def test_default_threshold_fires_at_95(self, project_cwd: Path) -> None:
+        """Default threshold: warning fires at exactly 95.0."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 95.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result.get("permissionDecision") == "allow"
+
+    # --- (e2) settings.json threshold_pct ---
+
+    def test_settings_threshold_pct_overrides_default(self, project_cwd: Path) -> None:
+        """settings.json threshold_pct: warning fires at the configured value."""
+        # Set threshold to 80 in settings — warning should fire at 80, not 95.
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": 80}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 82.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 82.0 >= 80 (settings threshold) -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    def test_settings_threshold_pct_below_percentage_passes(
+        self, project_cwd: Path
+    ) -> None:
+        """settings.json threshold_pct=90: 85% usage is below threshold, passes."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": 90}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 85.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 85.0 < 90 (settings threshold) -> pass-through
+        assert result == {}
+
+    def test_settings_threshold_pct_float_value(self, project_cwd: Path) -> None:
+        """settings.json threshold_pct accepts float values (e.g. 85.5)."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": 85.5}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 86.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 86.0 >= 85.5 -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    # --- (e3) Env var overrides settings ---
+
+    def test_env_var_overrides_settings_threshold(self, project_cwd: Path) -> None:
+        """CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD env var overrides settings value."""
+        # settings says 90 but env says 70 -> env wins
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": 90}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 75.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "70"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 75.0 >= 70 (env threshold) -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    def test_env_var_threshold_passes_below(self, project_cwd: Path) -> None:
+        """Env var threshold=85: usage at 80% is below it, passes through."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 80.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "85"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        assert result == {}
+
+    def test_env_var_threshold_overrides_default_when_no_settings(
+        self, project_cwd: Path
+    ) -> None:
+        """Env var threshold overrides default even when no settings file exists."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 70.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "65"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 70.0 >= 65 (env threshold) -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    # --- (e4) Invalid threshold values handled fail-open ---
+
+    def test_invalid_env_var_string_uses_default(self, project_cwd: Path) -> None:
+        """Non-numeric env var is ignored; default 95.0 is used (fail-open)."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 90.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "not-a-number"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 90.0 < 95.0 (default fallback) -> pass-through
+        assert result == {}
+
+    def test_out_of_range_env_var_below_min_uses_default(
+        self, project_cwd: Path
+    ) -> None:
+        """Env var value 0 (below min 1) is ignored; default 95.0 is used."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 90.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "0"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 90.0 < 95.0 (default) -> pass-through
+        assert result == {}
+
+    def test_out_of_range_env_var_above_max_uses_default(
+        self, project_cwd: Path
+    ) -> None:
+        """Env var value 101 (above max 100) is ignored; default 95.0 is used."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 96.0},
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD": "101"},
+            clear=False,
+        ):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 96.0 >= 95.0 (default) -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    def test_invalid_settings_threshold_uses_default(self, project_cwd: Path) -> None:
+        """Non-numeric settings threshold is ignored; default 95.0 is used."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": "bad-value"}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 90.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # Invalid settings -> falls back to default 95.0; 90.0 < 95.0 -> pass-through
+        assert result == {}
+
+    def test_out_of_range_settings_threshold_below_min_uses_default(
+        self, project_cwd: Path
+    ) -> None:
+        """settings threshold_pct=0 (out of range) is ignored; default used."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": 0}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 90.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # Out-of-range settings -> default 95.0; 90.0 < 95.0 -> pass-through
+        assert result == {}
+
+    def test_invalid_threshold_never_crashes(self, project_cwd: Path) -> None:
+        """Completely malformed threshold config does not raise; returns valid result."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        # threshold_pct is a list -- completely wrong type
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"context_circuit_breaker": {"threshold_pct": [1, 2, 3]}}),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            # Must not raise
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # 99.0 >= 95.0 (default) -> allow-with-warning
+        assert result.get("permissionDecision") == "allow"
+
+    # --- (e5) disabled knob still works ---
+
+    def test_disabled_still_bypasses_even_with_threshold_set(
+        self, project_cwd: Path
+    ) -> None:
+        """disabled: true overrides threshold setting; breaker is fully bypassed."""
+        settings_dir = project_cwd / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps(
+                {
+                    "context_circuit_breaker": {
+                        "disabled": True,
+                        "threshold_pct": 50,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "CLAUDE_MPM_DISABLE_CONTEXT_BREAKER",
+                "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD",
+            )
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        # disabled: true -> pass-through regardless of threshold
+        assert result == {}
+
+    def test_threshold_in_warning_message(self, project_cwd: Path) -> None:
+        """Warning message mentions the threshold env var and settings key."""
+        _write_state(
+            project_cwd,
+            {"session_id": "sess-current", "percentage_used": 99.0},
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD"
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = context_circuit_breaker.evaluate(_event(project_cwd))
+        reason = result.get("permissionDecisionReason", "")
+        assert "CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD" in reason
+        assert "threshold_pct" in reason


### PR DESCRIPTION
## Summary

- Exposes `CLAUDE_MPM_CONTEXT_BREAKER_THRESHOLD` env var and `context_circuit_breaker.threshold_pct` settings key so operators can tune the warning threshold without fully disabling the breaker
- Precedence: env var > `settings.local.json` > `settings.json` > `~/.claude/settings.json` > default (95.0)
- Invalid or out-of-range values are silently ignored (fail-open); bad config never hard-blocks a session
- Refactors `_is_disabled` to share a `_settings_candidates` helper with the new `_resolve_threshold` function
- Adds 71-test suite covering all combinations of env/settings/invalid/disabled
- Adds `docs/developer/context-circuit-breaker.md` documenting both the disable knob and the new threshold knob

Closes #681

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)