### PR TITLE
fix(daemon): exec-based subprocess daemonization — real macOS SIGSEGV fix (#693)

### DIFF
--- a/docs/developer/daemon-fork-safety.md
+++ b/docs/developer/daemon-fork-safety.md
@@ -1,0 +1,185 @@
+# Daemon Fork Safety on macOS
+
+## The Problem: `EXC_BAD_ACCESS` / `SIGSEGV` after `os.fork()`
+
+### Root cause
+
+macOS uses CoreFoundation (CF) internally for logging, Objective-C runtime
+bookkeeping, and operating-system services.  CoreFoundation registers
+thread-local allocators, port rights, and dispatch sources at process startup.
+
+When a Python process that has multiple threads (e.g. an asyncio event loop,
+a uvicorn server, or any `threading.Thread`) calls `os.fork()`, the child
+process inherits the **address space snapshot** of the parent but only the
+**single calling thread**.  All other threads cease to exist in the child, but
+the CF data structures they owned are now dangling — the locks are held by
+threads that no longer exist, and the port rights point to Mach ports that the
+kernel has already torn down.
+
+The first time the child touches CF-backed functionality — writing to `os_log`,
+calling `setproctitle`, initialising a new `NSRunLoop`, or even calling
+`logging.getLogger(...)` which may internally use CF — the kernel delivers
+`EXC_BAD_ACCESS (SIGSEGV)` because the child is accessing deallocated or
+corrupted memory.
+
+This is documented in Apple's own POSIX fork(2) man page supplement:
+
+> After a fork() in a multithreaded program, the child can safely call
+> only async-signal-safe functions (see signal(3)) until it calls exec(2).
+
+Python's `os.fork()` makes no special effort to satisfy this constraint.
+
+### Why PR #691 (`fork_safety.py` / `multiprocessing.set_start_method`) was not the real fix
+
+PR #691 added `claude_mpm/mcp/fork_safety.py` and called
+`multiprocessing.set_start_method("spawn")`.  This guards
+`multiprocessing.Process(...)` usages.  However:
+
+1. `multiprocessing.set_start_method` has no effect on **raw `os.fork()`
+   calls** — they remain fork-based regardless.
+2. The daemon managers in `services/` used raw `os.fork()` directly (not
+   `multiprocessing.Process`), so they were completely unaffected.
+3. macOS has defaulted `multiprocessing` to `"spawn"` since Python 3.8, so
+   the call was largely a no-op on the target platform anyway.
+
+The `fork_safety.py` module is harmless defense-in-depth for edge cases where
+the default is overridden, but it was not and cannot be the fix for the daemon
+SIGSEGV.
+
+---
+
+## The Fix: exec-based daemon spawn (issue #693)
+
+### Pattern
+
+Replace every raw `os.fork()` double-fork daemonization with
+`subprocess.Popen(start_new_session=True)`:
+
+```python
+import os, subprocess, sys
+
+# Parent: spawn a fresh interpreter (no fork, no CF state inheritance)
+process = subprocess.Popen(
+    [sys.executable, "-m", "my_package.my_daemon_entry"],
+    stdin=subprocess.DEVNULL,
+    stdout=open("/path/to/daemon.log", "a"),
+    stderr=subprocess.STDOUT,
+    start_new_session=True,          # ← replaces the double-fork + os.setsid()
+    env={**os.environ, "MY_DAEMON_CHILD": "1"},
+)
+
+# Child (detected by env var): runs the daemon loop in the foreground.
+# It was exec'd from scratch — no CF state, no dangling threads.
+```
+
+`start_new_session=True` instructs the OS (both macOS and Linux) to call
+`setsid()` before `exec()`, which:
+
+- Creates a new process group and session (detaches from the terminal).
+- Is the exact session-detachment that the old `os.setsid()` call in the
+  first-fork child was providing.
+
+Because `subprocess.Popen` always `exec()`s a new interpreter image, the child
+process starts with a clean, single-threaded CF state — no inherited kqueue
+descriptors, no dangling Mach ports, no locked CF allocators.
+
+### What the double-fork provided and how `Popen` preserves it
+
+| Double-fork behaviour | `subprocess.Popen` equivalent |
+|---|---|
+| Session detachment (`os.setsid()`) | `start_new_session=True` |
+| `stdin` closed / `/dev/null` | `stdin=subprocess.DEVNULL` |
+| `stdout`/`stderr` → log file | `stdout=open(log, "a"), stderr=subprocess.STDOUT` |
+| Working directory (`os.chdir("/")`) | `cwd="/"` if needed (current modules omit this; daemon-relative paths resolve correctly) |
+| `umask(0)` | Child inherits parent umask; daemons that need specific permissions set `umask` themselves after startup |
+| PID file written by daemon | Child writes PID file after starting (`os.getpid()`) |
+| Parent returns immediately | Parent gets child `pid = process.pid` and optionally polls for the PID file |
+
+### Recursion guard
+
+Because the parent calls itself (re-invokes `sys.executable -m
+my_package.cli ...`), the child would loop forever without a guard.  Every
+daemon uses an environment variable to break the recursion:
+
+| Daemon | Guard variable |
+|---|---|
+| `SocketIODaemonManager` | `CLAUDE_MPM_SOCKETIO_DAEMON=1` |
+| `MessageConsumer --daemon` | `CLAUDE_MPM_MSG_CONSUMER_DAEMON=1` |
+| `DaemonLifecycle` / monitor | `CLAUDE_MPM_SUBPROCESS_DAEMON=1` |
+| `DaemonManager` (monitor) | `CLAUDE_MPM_SUBPROCESS_DAEMON=1` |
+
+When the child detects its guard variable it skips spawning another subprocess
+and runs the daemon loop directly in the foreground.
+
+---
+
+## Files changed in issue #693
+
+| File | Change |
+|---|---|
+| `src/claude_mpm/services/infrastructure/daemon_manager.py` | Replaced `os.fork()` single-fork with `_start_subprocess_daemon()` + `_SOCKETIO_DAEMON_ENV_KEY` guard |
+| `src/claude_mpm/services/communication/message_consumer.py` | Replaced double-fork `--daemon` path with `subprocess.Popen(start_new_session=True)` |
+| `src/claude_mpm/services/monitor/management/lifecycle.py` | Replaced double-fork `daemonize()` with `subprocess.Popen(start_new_session=True)` |
+| `src/claude_mpm/services/monitor/daemon_manager.py` | Removed double-fork body from `daemonize()`; method now returns `False` with an error log (callers use `start_daemon_subprocess()`) |
+| `tests/services/test_daemon_fork_safety.py` | New: AST no-fork invariant + per-daemon Popen/PID/stop/restart/idempotency tests |
+| `docs/developer/daemon-fork-safety.md` | This file |
+
+---
+
+## Inherited in-memory state: what had to be reconstructed
+
+The old double-fork inherited everything from the parent in-memory because it
+shared the parent's address space.  The exec-based child gets a fresh
+interpreter and must reconstruct all runtime state from config/args/env.
+
+**`SocketIODaemonManager`**: The parent passes `host` and `port` as Python
+literals embedded in the `-c` command string.  The child instantiates a fresh
+`SocketIODaemonManager` and calls `start()`, which detects the env flag and
+runs `_run_server()` directly.  No stateful objects are inherited.
+
+**`MessageConsumer`**: Stateless — the child re-imports `MessageBus` from
+scratch and creates a new `Consumer`.  Queue state lives in SQLite
+(`~/.claude-mpm/message_queue.db`) which is on disk, not in memory.
+
+**`DaemonLifecycle`**: The parent passes `--port`, `--pid-file`, and
+`--log-file` as CLI arguments.  The startup-status-file path is passed via
+`CLAUDE_MPM_STARTUP_STATUS_FILE`.  The child reconstructs a `DaemonLifecycle`
+instance from CLI args and calls `write_pid_file()` + `_report_startup_success()`
+itself.
+
+**`DaemonManager`**: Identical pattern to `DaemonLifecycle`.  Port, host,
+pid-file, and log-file are forwarded as CLI args.  The child writes its own
+PID file after binding the port.
+
+---
+
+## Checklist for adding future daemons safely
+
+1. **Never call `os.fork()` from a multithreaded Python parent on macOS.**
+   If you must fork, ensure `exec()` happens as the very next system call with
+   no CF/logging/Python-runtime touches in between.
+
+2. **Use `subprocess.Popen([sys.executable, ...], start_new_session=True)`**
+   to spawn daemon processes.  Pass `stdin=subprocess.DEVNULL` and redirect
+   `stdout`/`stderr` to a log file.
+
+3. **Choose a unique environment variable** as a recursion guard (e.g.
+   `MY_DAEMON_CHILD=1`).  The child detects this and runs in foreground mode
+   without spawning another subprocess.
+
+4. **Pass all required configuration** as CLI arguments or environment
+   variables — the child cannot inherit in-memory objects.
+
+5. **Write the PID file in the child** (after startup), not in the parent.
+   The parent waits for the PID file to appear (or polls a status file) to
+   confirm startup.
+
+6. **Add a test** in `tests/services/test_daemon_fork_safety.py` that:
+   - Patches `os.fork` to raise and asserts your start path never calls it.
+   - Asserts `subprocess.Popen` is called with `start_new_session=True`.
+   - Tests PID file write/cleanup.
+   - Tests stop/restart.
+
+7. **On Linux**, `start_new_session=True` behaves identically to macOS —
+   it calls `setsid(2)` before `execve(2)`.  Your daemon will work on both
+   platforms without platform-specific branches.

--- a/src/claude_mpm/scripts/socketio_daemon.py
+++ b/src/claude_mpm/scripts/socketio_daemon.py
@@ -23,10 +23,11 @@ from claude_mpm.core.logging_config import get_logger
 from claude_mpm.services.monitor.daemon import UnifiedMonitorDaemon
 from claude_mpm.services.port_manager import PortManager
 
-# Default paths
-DEFAULT_PID_FILE = Path.home() / ".claude-mpm" / "socketio-server.pid"
-DEFAULT_LOG_FILE = Path.home() / ".claude-mpm" / "logs" / "socketio" / "daemon.log"
+# Default paths — PID file is port-keyed to match SocketIODaemonManager convention
+# so that two instances on different ports never clobber each other.
 DEFAULT_PORT = 8765
+DEFAULT_PID_FILE = Path.home() / ".claude-mpm" / f"socketio-server-{DEFAULT_PORT}.pid"
+DEFAULT_LOG_FILE = Path.home() / ".claude-mpm" / "logs" / "socketio" / "daemon.log"
 
 logger = get_logger(__name__)
 
@@ -52,7 +53,8 @@ def is_running(pid_file: Path) -> bool:
 
 def start_server(port: int = DEFAULT_PORT, daemon: bool = True) -> bool:
     """Start the Socket.IO server."""
-    pid_file = DEFAULT_PID_FILE
+    # PID file is port-keyed so multiple instances on different ports don't collide.
+    pid_file = Path.home() / ".claude-mpm" / f"socketio-server-{port}.pid"
     log_file = DEFAULT_LOG_FILE
 
     # Ensure directories exist
@@ -69,6 +71,8 @@ def start_server(port: int = DEFAULT_PORT, daemon: bool = True) -> bool:
 
     if actual_port != port:
         logger.info(f"Port {port} is in use, using port {actual_port} instead")
+        # Recompute PID file for the actual port in use
+        pid_file = Path.home() / ".claude-mpm" / f"socketio-server-{actual_port}.pid"
 
     # Create and start daemon
     monitor_daemon = UnifiedMonitorDaemon(

--- a/src/claude_mpm/services/communication/message_consumer.py
+++ b/src/claude_mpm/services/communication/message_consumer.py
@@ -117,36 +117,43 @@ def main():
     args = parser.parse_args()
 
     if args.daemon:
-        # Re-invoke this module as a detached subprocess (exec-based, no fork).
-        # subprocess.Popen with start_new_session=True provides the same
-        # session-detachment as the old double-fork + os.setsid() without
-        # inheriting the parent's multithreaded CoreFoundation state.
-        # Note: no PID file — callers (e.g. message_queue.py CLI) already use
-        # subprocess.Popen themselves; this path handles direct --daemon usage.
-        cmd = [
-            sys.executable,
-            "-m",
-            "claude_mpm.services.communication.message_consumer",
-            "--workers",
-            str(args.workers),
-        ]
-        if args.quiet:
-            cmd.append("--quiet")
+        # Recursion guard: if we are already the exec'd daemon child, skip the
+        # re-spawn and fall through to the foreground run path below.
+        if os.environ.get("CLAUDE_MPM_MSG_CONSUMER_DAEMON") == "1":
+            args.daemon = (
+                False  # already the daemon child; run foreground, do not re-spawn
+            )
+        else:
+            # Re-invoke this module as a detached subprocess (exec-based, no fork).
+            # subprocess.Popen with start_new_session=True provides the same
+            # session-detachment as the old double-fork + os.setsid() without
+            # inheriting the parent's multithreaded CoreFoundation state.
+            # Note: no PID file — callers (e.g. message_queue.py CLI) already use
+            # subprocess.Popen themselves; this path handles direct --daemon usage.
+            cmd = [
+                sys.executable,
+                "-m",
+                "claude_mpm.services.communication.message_consumer",
+                "--workers",
+                str(args.workers),
+            ]
+            if args.quiet:
+                cmd.append("--quiet")
 
-        # Env marker prevents the child from recursing into daemon mode again
-        env = os.environ.copy()
-        env["CLAUDE_MPM_MSG_CONSUMER_DAEMON"] = "1"
+            # Env marker is read at entry to prevent the child recursing into daemon mode.
+            env = os.environ.copy()
+            env["CLAUDE_MPM_MSG_CONSUMER_DAEMON"] = "1"
 
-        subprocess.Popen(  # nosec B603
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            env=env,
-        )
-        # Parent exits immediately; child is fully detached
-        return
+            subprocess.Popen(  # nosec B603
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                env=env,
+            )
+            # Parent exits immediately; child is fully detached
+            return
 
     # Run the consumer (foreground or exec'd daemon child)
     consumer = MessageConsumer(workers=args.workers, quiet=args.quiet)

--- a/src/claude_mpm/services/communication/message_consumer.py
+++ b/src/claude_mpm/services/communication/message_consumer.py
@@ -7,11 +7,20 @@ It should be started as a daemon or system service in production.
 
 Usage:
     python -m claude_mpm.services.communication.message_consumer
+
+WHAT: Exec-based background spawn for the Huey message-queue consumer,
+      replacing raw os.fork() double-fork that is unsafe in multithreaded
+      Python parents on macOS (EXC_BAD_ACCESS / SIGSEGV).
+WHY:  See docs/developer/daemon-fork-safety.md — subprocess.Popen with
+      start_new_session=True provides equivalent session-detachment without
+      inheriting the parent's CoreFoundation / thread-local state.
 """
 
 import argparse
 import logging
+import os
 import signal
+import subprocess
 import sys
 
 from huey.consumer import Consumer
@@ -108,26 +117,38 @@ def main():
     args = parser.parse_args()
 
     if args.daemon:
-        # Daemonize the process
-        import os
+        # Re-invoke this module as a detached subprocess (exec-based, no fork).
+        # subprocess.Popen with start_new_session=True provides the same
+        # session-detachment as the old double-fork + os.setsid() without
+        # inheriting the parent's multithreaded CoreFoundation state.
+        # Note: no PID file — callers (e.g. message_queue.py CLI) already use
+        # subprocess.Popen themselves; this path handles direct --daemon usage.
+        cmd = [
+            sys.executable,
+            "-m",
+            "claude_mpm.services.communication.message_consumer",
+            "--workers",
+            str(args.workers),
+        ]
+        if args.quiet:
+            cmd.append("--quiet")
 
-        # Fork and detach
-        if os.fork() > 0:
-            sys.exit(0)
+        # Env marker prevents the child from recursing into daemon mode again
+        env = os.environ.copy()
+        env["CLAUDE_MPM_MSG_CONSUMER_DAEMON"] = "1"
 
-        os.setsid()
+        subprocess.Popen(  # nosec B603
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=env,
+        )
+        # Parent exits immediately; child is fully detached
+        return
 
-        if os.fork() > 0:
-            sys.exit(0)
-
-        # Redirect stdio to /dev/null
-        with open("/dev/null") as devnull:
-            os.dup2(devnull.fileno(), sys.stdin.fileno())
-        with open("/dev/null", "a+") as devnull:
-            os.dup2(devnull.fileno(), sys.stdout.fileno())
-            os.dup2(devnull.fileno(), sys.stderr.fileno())
-
-    # Run the consumer
+    # Run the consumer (foreground or exec'd daemon child)
     consumer = MessageConsumer(workers=args.workers, quiet=args.quiet)
     consumer.run()
 

--- a/src/claude_mpm/services/infrastructure/daemon_manager.py
+++ b/src/claude_mpm/services/infrastructure/daemon_manager.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 #!/usr/bin/env python3
 """
 Daemon Management Service for Socket.IO Server
@@ -14,6 +12,13 @@ This service handles:
 - Signal handling for graceful shutdown
 - Conflict detection with other server instances
 - Status monitoring and health checks
+
+WHAT: Exec-based daemon spawn for the Socket.IO server, replacing raw
+      os.fork() daemonization that causes EXC_BAD_ACCESS / SIGSEGV on macOS
+      multithreaded parents (CoreFoundation touched after fork, before exec).
+WHY:  See docs/developer/daemon-fork-safety.md — subprocess.Popen with
+      start_new_session=True gives the same session-detachment semantics as
+      the double-fork, without inheriting poisoned CF state.
 """
 
 import os
@@ -21,6 +26,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 try:
@@ -35,6 +41,9 @@ from claude_mpm.core.logging_utils import get_logger
 from claude_mpm.services.socketio.server.main import SocketIOServer
 
 logger = get_logger(__name__)
+
+# Environment variable that signals "I am the exec'd daemon child — run foreground"
+_SOCKETIO_DAEMON_ENV_KEY = "CLAUDE_MPM_SOCKETIO_DAEMON"
 
 
 class SocketIODaemonManager:
@@ -115,6 +124,10 @@ class SocketIODaemonManager:
         """
         Start the Socket.IO server as a daemon.
 
+        Uses exec-based spawning via subprocess.Popen(start_new_session=True)
+        instead of raw os.fork(), which is unsafe in multithreaded Python
+        parents on macOS (EXC_BAD_ACCESS from CoreFoundation after fork).
+
         Returns:
             True if started successfully, False otherwise
         """
@@ -130,37 +143,101 @@ class SocketIODaemonManager:
             )
             return False
 
-        try:
-            # Fork to create daemon process
-            pid = os.fork()
-            if pid > 0:
-                # Parent process - save PID and exit
-                with self.pid_file.open("w") as f:
-                    f.write(str(pid))
-                logger.info(f"Socket.IO server started as daemon (PID: {pid})")
-                return True
-
-            # Child process - become daemon
-            self._daemonize()
+        # If we are already the exec'd daemon child, run foreground directly.
+        if os.environ.get(_SOCKETIO_DAEMON_ENV_KEY) == "1":
             self._run_server()
+            return True
 
+        try:
+            return self._start_subprocess_daemon()
         except Exception as e:
             logger.error(f"Failed to start daemon: {e}")
             return False
 
-    def _daemonize(self) -> None:
-        """Convert the current process into a daemon."""
-        # Create new session
-        os.setsid()
-        os.umask(0)
+    def _start_subprocess_daemon(self) -> bool:
+        """Spawn the daemon as a detached subprocess (exec-based, no fork).
 
-        # Redirect stdout/stderr to log file
-        with self.log_file.open("a") as log:
-            os.dup2(log.fileno(), sys.stdout.fileno())
-            os.dup2(log.fileno(), sys.stderr.fileno())
+        The child detects _SOCKETIO_DAEMON_ENV_KEY=1 and calls _run_server()
+        directly in foreground mode.  start_new_session=True provides the
+        session-detachment that the old double-fork used to provide.  The PID
+        file is written by the child after startup (preserving original
+        semantics: PID file contains the actual running process's PID).
+
+        Returns:
+            True if daemon started and PID file appeared within timeout.
+        """
+        cmd = [
+            sys.executable,
+            "-c",
+            (
+                "from claude_mpm.services.infrastructure.daemon_manager import "
+                "SocketIODaemonManager; "
+                f"m = SocketIODaemonManager(host={self.host!r}, port={self.port}); "
+                "m.start()"
+            ),
+        ]
+
+        env = os.environ.copy()
+        env[_SOCKETIO_DAEMON_ENV_KEY] = "1"
+
+        log_file_handle = self.log_file.open("a")
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=False,
+                env=env,
+            )
+        finally:
+            log_file_handle.close()
+
+        pid = process.pid
+        logger.info(f"Socket.IO server subprocess started with PID {pid}")
+
+        # Wait for child to write PID file (max 15s)
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            if process.poll() is not None:
+                logger.error(
+                    f"Socket.IO daemon subprocess exited prematurely "
+                    f"(code {process.returncode})"
+                )
+                return False
+            if self.pid_file.exists():
+                try:
+                    written_pid = int(self.pid_file.read_text().strip())
+                    if written_pid == pid:
+                        logger.info(f"Socket.IO server started as daemon (PID: {pid})")
+                        return True
+                except Exception:
+                    pass
+            time.sleep(0.2)
+
+        logger.error("Timeout waiting for Socket.IO daemon to write PID file")
+        if process.poll() is None:
+            process.terminate()
+        return False
 
     def _run_server(self) -> None:
-        """Run the Socket.IO server in daemon mode."""
+        """Run the Socket.IO server in the foreground (daemon child entry-point).
+
+        This is called either directly (foreground mode) or inside the exec'd
+        subprocess when _SOCKETIO_DAEMON_ENV_KEY=1.  It writes the PID file,
+        redirects stdio to the log file, installs signal handlers, and enters
+        the server loop — exactly as the old fork-based _daemonize() did.
+        """
+        # Write PID file with our actual PID
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+            self.pid_file.write_text(str(os.getpid()))
+        except Exception as e:
+            print(
+                f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] WARNING: could not write PID file: {e}"
+            )
+
         print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Starting Socket.IO server...")
 
         # Create and configure server

--- a/src/claude_mpm/services/infrastructure/daemon_manager.py
+++ b/src/claude_mpm/services/infrastructure/daemon_manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Daemon Management Service for Socket.IO Server
 ==============================================
@@ -66,10 +65,11 @@ class SocketIODaemonManager:
         self.host = host
         self.port = port
 
-        # Configuration paths
+        # Configuration paths — keyed by port so two instances on different ports
+        # never clobber each other's PID file or log file.
         self.config_dir = Path.home() / ".claude-mpm"
-        self.pid_file = self.config_dir / "socketio-server.pid"
-        self.log_file = self.config_dir / "socketio-server.log"
+        self.pid_file = self.config_dir / f"socketio-server-{self.port}.pid"
+        self.log_file = self.config_dir / f"socketio-server-{self.port}.log"
 
         # Ensure directories exist
         self._ensure_directories()
@@ -188,16 +188,18 @@ class SocketIODaemonManager:
                 stdout=log_file_handle,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
-                close_fds=False,
                 env=env,
             )
         finally:
             log_file_handle.close()
 
-        pid = process.pid
-        logger.info(f"Socket.IO server subprocess started with PID {pid}")
+        logger.info(f"Socket.IO server subprocess started with PID {process.pid}")
 
-        # Wait for child to write PID file (max 15s)
+        # Wait for child to write PID file (max 15s).
+        # The child is the authority on its own PID — it writes os.getpid() which
+        # may differ from process.pid (e.g. if the child is a thin launcher).
+        # Accept any valid positive integer as success; the process.poll() guard
+        # below already catches a dead child before we check the file.
         deadline = time.time() + 15.0
         while time.time() < deadline:
             if process.poll() is not None:
@@ -209,8 +211,10 @@ class SocketIODaemonManager:
             if self.pid_file.exists():
                 try:
                     written_pid = int(self.pid_file.read_text().strip())
-                    if written_pid == pid:
-                        logger.info(f"Socket.IO server started as daemon (PID: {pid})")
+                    if written_pid > 0:
+                        logger.info(
+                            f"Socket.IO server started as daemon (PID: {written_pid})"
+                        )
                         return True
                 except Exception:
                     pass

--- a/src/claude_mpm/services/infrastructure/daemon_manager.py
+++ b/src/claude_mpm/services/infrastructure/daemon_manager.py
@@ -191,6 +191,8 @@ class SocketIODaemonManager:
                 env=env,
             )
         finally:
+            # Safe to close the parent's handle: Popen has already dup'd the fd into the
+            # child (exempt from close_fds), so the daemon keeps writing to the log.
             log_file_handle.close()
 
         logger.info(f"Socket.IO server subprocess started with PID {process.pid}")

--- a/src/claude_mpm/services/monitor/daemon.py
+++ b/src/claude_mpm/services/monitor/daemon.py
@@ -212,12 +212,12 @@ class UnifiedMonitorDaemon:
             # This branch is unreachable: use_subprocess_daemon() always returns True
             # (it only returns False when CLAUDE_MPM_SUBPROCESS_DAEMON=1, in which case
             # the block above already handled the subprocess path and returned).
-            raise AssertionError(
-                "unreachable: subprocess daemon path is mandatory — "
-                "use_subprocess_daemon() must have returned False AND "
-                "CLAUDE_MPM_SUBPROCESS_DAEMON must be unset simultaneously, "
-                "which cannot happen by construction."
+            self.logger.error(
+                "Unreachable daemon path hit: subprocess daemon path is mandatory "
+                "(use_subprocess_daemon() returned False without the subprocess sentinel set). "
+                "Refusing to fall back to unsafe os.fork() daemonization."
             )
+            return False
 
     def _start_foreground(self, force_restart: bool = False) -> bool:
         """Start in foreground mode.

--- a/src/claude_mpm/services/monitor/daemon.py
+++ b/src/claude_mpm/services/monitor/daemon.py
@@ -209,38 +209,15 @@ class UnifiedMonitorDaemon:
                 )
                 raise
         else:
-            # Legacy fork approach (kept for compatibility but not used by default)
-            # Wait for any pre-warming threads to complete before forking
-            self._wait_for_prewarm_completion()
-
-            # Use daemon manager's daemonize which includes cleanup
-            # DO NOT reset startup_status_file - it's needed for parent-child communication!
-            # self.daemon_manager.startup_status_file = None  # BUG: This breaks communication
-            success = self.daemon_manager.daemonize()
-            if not success:
-                return False
-
-            # We're now in the daemon process
-            # Update our PID references and status file
-            self.lifecycle.pid_file = self.daemon_manager.pid_file
-            self.lifecycle.startup_status_file = self.daemon_manager.startup_status_file
-
-            # Start the server in daemon mode
-            try:
-                result = self._run_server()
-                if not result:
-                    # Report failure before exiting
-                    self.daemon_manager._report_startup_error("Failed to start server")
-                else:
-                    # Report success
-                    self.daemon_manager._report_startup_success()
-                return result
-            except Exception as e:
-                # Report any exceptions during startup
-                self.daemon_manager._report_startup_error(
-                    f"Server startup exception: {e}"
-                )
-                raise
+            # This branch is unreachable: use_subprocess_daemon() always returns True
+            # (it only returns False when CLAUDE_MPM_SUBPROCESS_DAEMON=1, in which case
+            # the block above already handled the subprocess path and returned).
+            raise AssertionError(
+                "unreachable: subprocess daemon path is mandatory — "
+                "use_subprocess_daemon() must have returned False AND "
+                "CLAUDE_MPM_SUBPROCESS_DAEMON must be unset simultaneously, "
+                "which cannot happen by construction."
+            )
 
     def _start_foreground(self, force_restart: bool = False) -> bool:
         """Start in foreground mode.

--- a/src/claude_mpm/services/monitor/daemon_manager.py
+++ b/src/claude_mpm/services/monitor/daemon_manager.py
@@ -25,7 +25,6 @@ import signal
 import socket
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -762,80 +761,27 @@ class DaemonManager:
             return False
 
     def daemonize(self) -> bool:
-        """Daemonize the current process.
+        """Legacy daemonize — now an error guard; use start_daemon_subprocess().
+
+        The raw os.fork() double-fork that used to live here was unsafe in
+        multithreaded Python parents on macOS (EXC_BAD_ACCESS / SIGSEGV from
+        CoreFoundation after fork, before exec).  It has been removed as part
+        of the fix for issue #693.
+
+        This method is only reachable when CLAUDE_MPM_SUBPROCESS_DAEMON=1,
+        i.e. when we are already the exec'd daemon child — forking again from
+        inside the child would be doubly wrong.  The correct path is for the
+        child to call _run_server() / _start_foreground() directly.
 
         Returns:
-            True if successful (in parent), doesn't return in child
+            False always — callers should not reach this path.
         """
-        # Guard against re-entrant execution after fork
-        if hasattr(self, "_forking_in_progress"):
-            self.logger.error(
-                "CRITICAL: Detected re-entrant daemonize call after fork!"
-            )
-            return False
-
-        self._forking_in_progress = True
-
-        try:
-            # Clean up asyncio event loops before forking
-            self._cleanup_event_loops()
-
-            # Create status file for communication
-            with tempfile.NamedTemporaryFile(
-                mode="w", delete=False, suffix=".status"
-            ) as f:
-                self.startup_status_file = f.name
-                f.write("starting")
-
-            # First fork
-            pid = os.fork()
-            if pid > 0:
-                # Parent process - wait for child to confirm startup
-                del self._forking_in_progress  # Clean up in parent
-                return self._parent_wait_for_startup(pid)
-
-        except OSError as e:
-            self.logger.error(f"First fork failed: {e}")
-            return False
-
-        # Child process continues...
-
-        # Decouple from parent
-        os.chdir("/")
-        os.setsid()
-        os.umask(0)
-
-        try:
-            # Second fork
-            pid = os.fork()
-            if pid > 0:
-                # First child exits
-                sys.exit(0)
-        except OSError as e:
-            self.logger.error(f"Second fork failed: {e}")
-            self._report_startup_error(f"Second fork failed: {e}")
-            sys.exit(1)
-
-        # Grandchild process - the actual daemon
-
-        # Write PID file
-        self.write_pid_file()
-
-        # Redirect streams
-        self._redirect_streams()
-
-        # Setup signal handlers
-        self._setup_signal_handlers()
-
-        self.logger.info(f"Daemon process started with PID {os.getpid()}")
-
-        # DO NOT report success here - let the caller report after starting the service
-        # This prevents race conditions where we report success before the server starts
-        # self._report_startup_success()  # REMOVED - caller must report
-
-        # Note: Daemon process continues running
-        # Caller is responsible for running the actual service AND reporting status
-        return True
+        self.logger.error(
+            "daemonize() called — this path was removed in fix/#693 because "
+            "raw os.fork() from a multithreaded parent causes EXC_BAD_ACCESS on macOS. "
+            "Use start_daemon_subprocess() instead."
+        )
+        return False
 
     def stop_daemon(self, timeout: int = 10) -> bool:
         """Stop the daemon process.

--- a/src/claude_mpm/services/monitor/management/lifecycle.py
+++ b/src/claude_mpm/services/monitor/management/lifecycle.py
@@ -130,6 +130,8 @@ class DaemonLifecycle:
                 )
             finally:
                 if log_file_handle and not log_file_handle.closed:
+                    # Safe to close the parent's handle: Popen has already dup'd the fd into the
+                    # child (exempt from close_fds), so the daemon keeps writing to the log.
                     log_file_handle.close()
 
             self.logger.info(

--- a/src/claude_mpm/services/monitor/management/lifecycle.py
+++ b/src/claude_mpm/services/monitor/management/lifecycle.py
@@ -60,7 +60,7 @@ class DaemonLifecycle:
         start_new_session=True) so a fresh interpreter is exec'd and never
         inherits the multithreaded parent's CoreFoundation / kqueue state.
 
-        The subprocess child detects CLAUDE_MPM_LIFECYCLE_DAEMON=1 and calls
+        The subprocess child detects CLAUDE_MPM_SUBPROCESS_DAEMON=1 and calls
         the server entry-point directly in foreground mode.  The caller must
         set this env var and run the server loop itself; this method only
         handles the *spawn* side.  The startup-status-file mechanism is
@@ -73,11 +73,12 @@ class DaemonLifecycle:
             that polling is done by _parent_wait_for_startup, called here.)
         """
         try:
-            # Create a temporary file for startup status communication
+            # Create a temporary file for startup status communication.
+            # Normalize to Path immediately so all call sites are consistent.
             with tempfile.NamedTemporaryFile(
                 mode="w", delete=False, suffix=".status"
             ) as f:
-                self.startup_status_file = f.name
+                self.startup_status_file = Path(f.name)
                 f.write("starting")
 
             # Build argv — re-invoke via the CLI monitor start command so the
@@ -102,7 +103,7 @@ class DaemonLifecycle:
             # the server in foreground without forking again.
             env["CLAUDE_MPM_SUBPROCESS_DAEMON"] = "1"
             # Pass the status-file path so the child can report back.
-            env["CLAUDE_MPM_STARTUP_STATUS_FILE"] = self.startup_status_file
+            env["CLAUDE_MPM_STARTUP_STATUS_FILE"] = str(self.startup_status_file)
 
             # Open log file for stdout/stderr redirection
             log_file_handle = None
@@ -125,7 +126,6 @@ class DaemonLifecycle:
                     stdout=log_target,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
-                    close_fds=False,
                     env=env,
                 )
             finally:
@@ -417,8 +417,8 @@ class DaemonLifecycle:
         while time.time() - start_time < timeout:
             try:
                 # Check if status file exists and read it
-                if self.startup_status_file and Path(self.startup_status_file).exists():
-                    with Path(self.startup_status_file).open() as f:
+                if self.startup_status_file and self.startup_status_file.exists():
+                    with self.startup_status_file.open() as f:
                         status = f.read().strip()
 
                     if status == OperationResult.SUCCESS:
@@ -470,8 +470,7 @@ class DaemonLifecycle:
         """Report successful startup to parent process."""
         if self.startup_status_file:
             try:
-                with Path(self.startup_status_file).open("w") as f:
-                    f.write(OperationResult.SUCCESS)
+                self.startup_status_file.write_text(OperationResult.SUCCESS)
             except Exception as e:
                 self.logger.error(f"Failed to report startup success: {e}")
 
@@ -483,8 +482,7 @@ class DaemonLifecycle:
         """
         if self.startup_status_file:
             try:
-                with Path(self.startup_status_file).open("w") as f:
-                    f.write(f"error:{error_msg}")
+                self.startup_status_file.write_text(f"error:{error_msg}")
             except Exception:
                 pass  # Can't report if file write fails
 
@@ -492,7 +490,7 @@ class DaemonLifecycle:
         """Clean up the temporary status file."""
         if self.startup_status_file:
             try:
-                Path(self.startup_status_file).unlink(missing_ok=True)
+                self.startup_status_file.unlink(missing_ok=True)
             except Exception:
                 pass  # Ignore cleanup errors
             finally:

--- a/src/claude_mpm/services/monitor/management/lifecycle.py
+++ b/src/claude_mpm/services/monitor/management/lifecycle.py
@@ -7,16 +7,21 @@ daemonization, PID file management, and graceful shutdown for the unified
 monitor daemon.
 
 DESIGN DECISIONS:
-- Standard Unix daemon patterns
+- Exec-based daemon spawn via subprocess.Popen(start_new_session=True) instead
+  of raw os.fork() double-fork, which causes EXC_BAD_ACCESS / SIGSEGV on macOS
+  when CoreFoundation is touched after fork in a multithreaded parent.
 - PID file management for process tracking
 - Proper signal handling for graceful shutdown
 - Log file redirection for daemon mode
+
+See docs/developer/daemon-fork-safety.md for the full rationale.
 """
 
 import json
 import os
 import signal
 import socket
+import subprocess
 import sys
 import tempfile
 import time
@@ -49,15 +54,25 @@ class DaemonLifecycle:
         self.startup_status_file = None
 
     def daemonize(self) -> bool:
-        """Daemonize the current process.
+        """Start the daemon as a detached subprocess (exec-based, no fork).
+
+        Replaces the old raw os.fork() double-fork with subprocess.Popen(
+        start_new_session=True) so a fresh interpreter is exec'd and never
+        inherits the multithreaded parent's CoreFoundation / kqueue state.
+
+        The subprocess child detects CLAUDE_MPM_LIFECYCLE_DAEMON=1 and calls
+        the server entry-point directly in foreground mode.  The caller must
+        set this env var and run the server loop itself; this method only
+        handles the *spawn* side.  The startup-status-file mechanism is
+        preserved: the parent writes "starting", then polls until the child
+        writes "success" or "error:<msg>".
 
         Returns:
-            True if daemonization successful, False otherwise
+            True if spawn succeeded and subprocess is running.
+            False on error.  (Does NOT block waiting for full server startup —
+            that polling is done by _parent_wait_for_startup, called here.)
         """
         try:
-            # Clean up any existing asyncio event loops before forking
-            self._cleanup_event_loops()
-
             # Create a temporary file for startup status communication
             with tempfile.NamedTemporaryFile(
                 mode="w", delete=False, suffix=".status"
@@ -65,53 +80,67 @@ class DaemonLifecycle:
                 self.startup_status_file = f.name
                 f.write("starting")
 
-            # First fork
-            pid = os.fork()
-            if pid > 0:
-                # Parent process - wait for child to confirm startup
-                return self._parent_wait_for_startup(pid)
-        except OSError as e:
-            self.logger.error(f"First fork failed: {e}")
-            self._report_startup_error(f"First fork failed: {e}")
-            return False
+            # Build argv — re-invoke via the CLI monitor start command so the
+            # child enters the same code path it would have post-fork.
+            cmd = [
+                sys.executable,
+                "-m",
+                "claude_mpm.cli",
+                "monitor",
+                "start",
+                "--background",
+                "--port",
+                str(self.port),
+            ]
+            if self.pid_file:
+                cmd += ["--pid-file", str(self.pid_file)]
+            if self.log_file:
+                cmd += ["--log-file", str(self.log_file)]
 
-        # Decouple from parent environment
-        os.chdir("/")
-        os.setsid()
-        os.umask(0)
+            env = os.environ.copy()
+            # Signal to the child that it is the daemon subprocess and must run
+            # the server in foreground without forking again.
+            env["CLAUDE_MPM_SUBPROCESS_DAEMON"] = "1"
+            # Pass the status-file path so the child can report back.
+            env["CLAUDE_MPM_STARTUP_STATUS_FILE"] = self.startup_status_file
 
-        try:
-            # Second fork
-            pid = os.fork()
-            if pid > 0:
-                # First child process exits
-                sys.exit(0)
-        except OSError as e:
-            self.logger.error(f"Second fork failed: {e}")
-            self._report_startup_error(f"Second fork failed: {e}")
-            return False
+            # Open log file for stdout/stderr redirection
+            log_file_handle = None
+            if self.log_file:
+                Path(self.log_file).parent.mkdir(parents=True, exist_ok=True)
+                log_file_handle = Path(self.log_file).open("a")
+                log_target = log_file_handle
+            else:
+                default_log = (
+                    Path.home() / ".claude-mpm" / "logs" / "monitor-daemon.log"
+                )
+                default_log.parent.mkdir(parents=True, exist_ok=True)
+                log_file_handle = default_log.open("a")
+                log_target = log_file_handle
 
-        # Set up error logging before redirecting streams
-        self._setup_early_error_logging()
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_target,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    close_fds=False,
+                    env=env,
+                )
+            finally:
+                if log_file_handle and not log_file_handle.closed:
+                    log_file_handle.close()
 
-        # Write PID file first (before stream redirection)
-        try:
-            self.write_pid_file()
+            self.logger.info(
+                f"Monitor daemon subprocess started with PID {process.pid}"
+            )
+            return self._parent_wait_for_startup(process.pid)
+
         except Exception as e:
-            self._report_startup_error(f"Failed to write PID file: {e}")
+            self.logger.error(f"Failed to start daemon subprocess: {e}")
+            self._report_startup_error(str(e))
             return False
-
-        # Redirect standard file descriptors
-        self._redirect_streams()
-
-        # Setup signal handlers
-        self._setup_signal_handlers()
-
-        self.logger.info(f"Daemon process started with PID {os.getpid()}")
-
-        # Report successful startup (after basic setup but before server start)
-        self._report_startup_success()
-        return True
 
     def _redirect_streams(self):
         """Redirect standard streams for daemon mode."""
@@ -389,7 +418,7 @@ class DaemonLifecycle:
             try:
                 # Check if status file exists and read it
                 if self.startup_status_file and Path(self.startup_status_file).exists():
-                    with self.startup_status_file.open() as f:
+                    with Path(self.startup_status_file).open() as f:
                         status = f.read().strip()
 
                     if status == OperationResult.SUCCESS:
@@ -441,7 +470,7 @@ class DaemonLifecycle:
         """Report successful startup to parent process."""
         if self.startup_status_file:
             try:
-                with self.startup_status_file.open("w") as f:
+                with Path(self.startup_status_file).open("w") as f:
                     f.write(OperationResult.SUCCESS)
             except Exception as e:
                 self.logger.error(f"Failed to report startup success: {e}")
@@ -454,7 +483,7 @@ class DaemonLifecycle:
         """
         if self.startup_status_file:
             try:
-                with self.startup_status_file.open("w") as f:
+                with Path(self.startup_status_file).open("w") as f:
                     f.write(f"error:{error_msg}")
             except Exception:
                 pass  # Can't report if file write fails

--- a/tests/services/test_daemon_fork_safety.py
+++ b/tests/services/test_daemon_fork_safety.py
@@ -130,9 +130,6 @@ class TestSocketIODaemonManagerExecSpawn:
         assert result is True
         mock_popen.assert_called_once()
         _call = mock_popen.call_args
-        assert _call.kwargs.get("start_new_session") is True or (
-            len(_call.args) >= 1 and _call.args[0] and True
-        ), "start_new_session=True must be passed to Popen"
         assert _call.kwargs.get("start_new_session") is True
 
     def test_start_passes_daemon_env_key(self, tmp_path: Path) -> None:

--- a/tests/services/test_daemon_fork_safety.py
+++ b/tests/services/test_daemon_fork_safety.py
@@ -1,0 +1,773 @@
+"""Tests for exec-based daemon fork safety (issue #693).
+
+WHAT: Verifies that every refactored daemon manager in claude_mpm uses
+      exec-based subprocess.Popen(start_new_session=True) rather than raw
+      os.fork(), and that PID-file lifecycle, stdio redirection, stop/restart,
+      and idempotency semantics are all preserved.
+
+WHY:  raw os.fork() from a multithreaded Python parent on macOS causes
+      EXC_BAD_ACCESS / SIGSEGV when CoreFoundation is touched after fork but
+      before exec.  The fix (issue #693) replaces every double-fork path with
+      subprocess.Popen(start_new_session=True).  These tests guard against
+      regression on both macOS and Linux.
+
+Reference: docs/developer/daemon-fork-safety.md
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_SRC))
+
+_SERVICES = _SRC / "claude_mpm" / "services"
+
+
+def _source_has_no_fork(module_path: Path) -> bool:
+    """AST-based check that a Python file contains no os.fork() call."""
+    source = module_path.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        # Match: os.fork()
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "fork"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "os"
+        ):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# No-fork invariant: static AST check
+# ---------------------------------------------------------------------------
+
+
+class TestNoForkInvariant:
+    """Verify that no os.fork() call appears in any refactored daemon module."""
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "infrastructure/daemon_manager.py",
+            "communication/message_consumer.py",
+            "monitor/management/lifecycle.py",
+            "monitor/daemon_manager.py",
+        ],
+    )
+    def test_no_os_fork_call(self, rel_path: str) -> None:
+        """Module must not contain any os.fork() call (AST-verified)."""
+        module_path = _SERVICES / rel_path
+        assert module_path.exists(), f"Module not found: {module_path}"
+        assert _source_has_no_fork(module_path), (
+            f"{rel_path} still contains an os.fork() call — "
+            "this is the regression that caused EXC_BAD_ACCESS on macOS "
+            "(see issue #693 and docs/developer/daemon-fork-safety.md)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# infrastructure/daemon_manager.py — SocketIODaemonManager
+# ---------------------------------------------------------------------------
+
+
+class TestSocketIODaemonManagerExecSpawn:
+    """Exec-based spawn semantics for SocketIODaemonManager."""
+
+    def _make_manager(self, tmp_path: Path) -> Any:
+        """Return a SocketIODaemonManager with paths redirected to tmp_path."""
+        from claude_mpm.services.infrastructure.daemon_manager import (
+            SocketIODaemonManager,
+        )
+
+        m = SocketIODaemonManager(host="localhost", port=19765)
+        m.config_dir = tmp_path
+        m.pid_file = tmp_path / "socketio-server.pid"
+        m.log_file = tmp_path / "socketio-server.log"
+        return m
+
+    def test_start_calls_popen_with_start_new_session(self, tmp_path: Path) -> None:
+        """start() must call subprocess.Popen(start_new_session=True) — not os.fork()."""
+        m = self._make_manager(tmp_path)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 42
+        fake_proc.poll.return_value = None  # still running
+
+        def _write_pid_side_effect(*args, **kwargs) -> MagicMock:
+            # Simulate the child writing the PID file
+            m.pid_file.write_text("42")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("os.fork must not be called")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid_side_effect,
+            ) as mock_popen,
+        ):
+            result = m.start()
+
+        assert result is True
+        mock_popen.assert_called_once()
+        _call = mock_popen.call_args
+        assert _call.kwargs.get("start_new_session") is True or (
+            len(_call.args) >= 1 and _call.args[0] and True
+        ), "start_new_session=True must be passed to Popen"
+        assert _call.kwargs.get("start_new_session") is True
+
+    def test_start_passes_daemon_env_key(self, tmp_path: Path) -> None:
+        """start() must pass CLAUDE_MPM_SOCKETIO_DAEMON=1 in the child env."""
+        from claude_mpm.services.infrastructure.daemon_manager import (
+            _SOCKETIO_DAEMON_ENV_KEY,
+        )
+
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 99
+        fake_proc.poll.return_value = None
+
+        def _write_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("99")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid,
+            ) as mock_popen,
+        ):
+            m.start()
+
+        env_passed = mock_popen.call_args.kwargs.get("env", {})
+        assert env_passed.get(_SOCKETIO_DAEMON_ENV_KEY) == "1", (
+            f"Child env must contain {_SOCKETIO_DAEMON_ENV_KEY}=1"
+        )
+
+    def test_start_uses_devnull_stdin(self, tmp_path: Path) -> None:
+        """Popen must receive stdin=DEVNULL (detached from terminal)."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 7
+        fake_proc.poll.return_value = None
+
+        def _write_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("7")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid,
+            ) as mock_popen,
+        ):
+            m.start()
+
+        assert mock_popen.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+    def test_start_returns_false_when_already_running(self, tmp_path: Path) -> None:
+        """start() must return False if is_running() is True (idempotent)."""
+        m = self._make_manager(tmp_path)
+
+        with patch.object(m, "is_running", return_value=True):
+            with patch("os.fork", side_effect=AssertionError("no fork")):
+                result = m.start()
+
+        assert result is False
+
+    def test_pid_file_lifecycle(self, tmp_path: Path) -> None:
+        """stop() reads PID file, sends SIGTERM, and PID file is cleaned up."""
+        m = self._make_manager(tmp_path)
+        pid_file = m.pid_file
+
+        # Write a fake PID
+        test_pid = 12345
+        pid_file.write_text(str(test_pid))
+
+        with (
+            patch("os.kill") as mock_kill,
+            patch.object(m, "is_running", side_effect=[True, False]),
+        ):
+            result = m.stop()
+
+        assert result is True
+        mock_kill.assert_any_call(test_pid, signal.SIGTERM)
+
+    def test_stop_handles_missing_pid_file(self, tmp_path: Path) -> None:
+        """stop() returns False gracefully if no PID file exists."""
+        m = self._make_manager(tmp_path)
+        # Ensure no PID file
+        m.pid_file.unlink(missing_ok=True)
+
+        with patch.object(m, "is_running", return_value=False):
+            result = m.stop()
+
+        # stop() returns False when not running
+        assert result is False
+
+    def test_restart_calls_stop_then_start(self, tmp_path: Path) -> None:
+        """restart() delegates to stop() then start() in order."""
+        m = self._make_manager(tmp_path)
+        calls: list[str] = []
+
+        with (
+            patch.object(m, "stop", side_effect=lambda: calls.append("stop")),
+            patch.object(m, "start", side_effect=lambda: calls.append("start") or True),
+            patch("time.sleep"),
+        ):
+            m.restart()
+
+        assert calls == ["stop", "start"], f"Expected stop then start, got {calls}"
+
+    def test_daemon_child_runs_foreground_on_env_flag(self, tmp_path: Path) -> None:
+        """When CLAUDE_MPM_SOCKETIO_DAEMON=1 is set, start() calls _run_server() directly."""
+        from claude_mpm.services.infrastructure.daemon_manager import (
+            _SOCKETIO_DAEMON_ENV_KEY,
+        )
+
+        m = self._make_manager(tmp_path)
+
+        with (
+            patch.dict(os.environ, {_SOCKETIO_DAEMON_ENV_KEY: "1"}),
+            patch.object(m, "is_running", return_value=False),
+            patch.object(m, "_check_port_conflict", return_value=None),
+            patch.object(m, "_run_server") as mock_run,
+        ):
+            result = m.start()
+
+        mock_run.assert_called_once()
+        assert result is True
+
+    def test_start_new_session_cross_platform(self, tmp_path: Path) -> None:
+        """start_new_session=True must be set regardless of platform (Linux and macOS)."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 55
+        fake_proc.poll.return_value = None
+
+        def _write_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("55")
+            return fake_proc
+
+        for platform_str in ("darwin", "linux"):
+            with (
+                patch("sys.platform", platform_str),
+                patch("os.fork", side_effect=AssertionError("no fork")),
+                patch(
+                    "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                    side_effect=_write_pid,
+                ) as mock_popen,
+            ):
+                m.pid_file.unlink(missing_ok=True)
+                m.start()
+            assert mock_popen.call_args.kwargs.get("start_new_session") is True, (
+                f"start_new_session must be True on {platform_str}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# communication/message_consumer.py — --daemon mode
+# ---------------------------------------------------------------------------
+
+
+class TestMessageConsumerExecSpawn:
+    """Exec-based --daemon spawn for MessageConsumer.main()."""
+
+    def _run_main_daemon(self) -> tuple[MagicMock, dict[str, Any]]:
+        """Invoke main() with --daemon and capture Popen call."""
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd, **kwargs) -> MagicMock:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        with (
+            patch("os.fork", side_effect=AssertionError("os.fork must not be called")),
+            patch(
+                "claude_mpm.services.communication.message_consumer.subprocess.Popen",
+                side_effect=_fake_popen,
+            ) as mock_popen,
+            patch("sys.argv", ["message_consumer", "--daemon"]),
+        ):
+            from claude_mpm.services.communication import message_consumer
+
+            message_consumer.main()
+
+        return mock_popen, captured
+
+    def test_daemon_flag_uses_popen_not_fork(self) -> None:
+        """--daemon must call subprocess.Popen, never os.fork()."""
+        mock_popen, _captured = self._run_main_daemon()
+        mock_popen.assert_called_once()
+
+    def test_daemon_flag_sets_start_new_session(self) -> None:
+        """Popen call must include start_new_session=True."""
+        _, captured = self._run_main_daemon()
+        assert captured["kwargs"].get("start_new_session") is True
+
+    def test_daemon_flag_sets_stdin_devnull(self) -> None:
+        """Popen call must route stdin to DEVNULL (detached)."""
+        _, captured = self._run_main_daemon()
+        assert captured["kwargs"].get("stdin") == subprocess.DEVNULL
+
+    def test_daemon_flag_sets_recursion_guard_env(self) -> None:
+        """Child env must contain CLAUDE_MPM_MSG_CONSUMER_DAEMON=1."""
+        _, captured = self._run_main_daemon()
+        env = captured["kwargs"].get("env", {})
+        assert env.get("CLAUDE_MPM_MSG_CONSUMER_DAEMON") == "1"
+
+    def test_daemon_cmd_includes_module_flag(self) -> None:
+        """Child argv must re-invoke the same module with -m."""
+        _, captured = self._run_main_daemon()
+        cmd = captured["cmd"]
+        assert "-m" in cmd
+        assert "claude_mpm.services.communication.message_consumer" in cmd
+
+    def test_daemon_workers_forwarded(self) -> None:
+        """--workers N must appear in child argv."""
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd, **kwargs) -> MagicMock:
+            captured["cmd"] = cmd
+            return MagicMock()
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.communication.message_consumer.subprocess.Popen",
+                side_effect=_fake_popen,
+            ),
+            patch("sys.argv", ["message_consumer", "--daemon", "--workers", "4"]),
+        ):
+            from claude_mpm.services.communication import message_consumer
+
+            message_consumer.main()
+
+        assert "4" in captured.get("cmd", [])
+
+
+# ---------------------------------------------------------------------------
+# monitor/management/lifecycle.py — DaemonLifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonLifecycleExecSpawn:
+    """Exec-based spawn semantics for DaemonLifecycle."""
+
+    def _make_lifecycle(self, tmp_path: Path) -> Any:
+        from claude_mpm.services.monitor.management.lifecycle import DaemonLifecycle
+
+        lc = DaemonLifecycle(
+            pid_file=str(tmp_path / "monitor.pid"),
+            log_file=str(tmp_path / "monitor.log"),
+            port=19766,
+        )
+        return lc
+
+    def test_daemonize_uses_popen_not_fork(self, tmp_path: Path) -> None:
+        """daemonize() must use subprocess.Popen, not os.fork()."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 200
+
+        with (
+            patch("os.fork", side_effect=AssertionError("os.fork must not be called")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            result = lc.daemonize()
+
+        assert result is True
+        mock_popen.assert_called_once()
+
+    def test_daemonize_sets_start_new_session(self, tmp_path: Path) -> None:
+        """Popen must receive start_new_session=True."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 201
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+    def test_daemonize_stdin_devnull(self, tmp_path: Path) -> None:
+        """Popen must receive stdin=DEVNULL."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 202
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        assert mock_popen.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+    def test_daemonize_env_marks_subprocess_daemon(self, tmp_path: Path) -> None:
+        """Child env must carry CLAUDE_MPM_SUBPROCESS_DAEMON=1."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 203
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        env = mock_popen.call_args.kwargs.get("env", {})
+        assert env.get("CLAUDE_MPM_SUBPROCESS_DAEMON") == "1"
+
+    def test_daemonize_passes_startup_status_file_env(self, tmp_path: Path) -> None:
+        """Child env must carry CLAUDE_MPM_STARTUP_STATUS_FILE so it can report back."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 204
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        env = mock_popen.call_args.kwargs.get("env", {})
+        assert "CLAUDE_MPM_STARTUP_STATUS_FILE" in env
+
+    def test_daemonize_redirects_stdout_to_log_file(self, tmp_path: Path) -> None:
+        """Popen stdout must be redirected to the log file, not DEVNULL."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 205
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        # stdout must not be DEVNULL — it should be the opened log file handle
+        stdout_arg = mock_popen.call_args.kwargs.get("stdout")
+        assert stdout_arg != subprocess.DEVNULL, (
+            "Log output must be redirected to a file, not discarded"
+        )
+
+    def test_stop_daemon_signals_correct_pid(self, tmp_path: Path) -> None:
+        """stop_daemon() sends SIGTERM to the PID from the PID file."""
+        lc = self._make_lifecycle(tmp_path)
+        pid_path = Path(lc.pid_file)
+        test_pid = 55555
+        pid_path.parent.mkdir(parents=True, exist_ok=True)
+        pid_path.write_text(str(test_pid))
+
+        with (
+            patch("os.kill") as mock_kill,
+            patch.object(lc, "is_running", side_effect=[True, False]),
+        ):
+            result = lc.stop_daemon()
+
+        assert result is True
+        mock_kill.assert_any_call(test_pid, signal.SIGTERM)
+
+    def test_pid_file_written_and_cleaned(self, tmp_path: Path) -> None:
+        """write_pid_file() writes current PID; cleanup() removes it."""
+        lc = self._make_lifecycle(tmp_path)
+        pid_path = Path(lc.pid_file)
+        pid_path.parent.mkdir(parents=True, exist_ok=True)
+
+        lc.write_pid_file()
+        assert pid_path.exists()
+        written_pid = int(pid_path.read_text().strip())
+        assert written_pid == os.getpid()
+
+        lc.cleanup()
+        assert not pid_path.exists()
+
+    def test_is_running_false_without_pid_file(self, tmp_path: Path) -> None:
+        """is_running() returns False when PID file is absent."""
+        lc = self._make_lifecycle(tmp_path)
+        Path(lc.pid_file).unlink(missing_ok=True)
+        assert lc.is_running() is False
+
+    def test_report_startup_success_writes_status_file(self, tmp_path: Path) -> None:
+        """_report_startup_success() writes 'success' to the status file."""
+        from claude_mpm.core.enums import OperationResult
+
+        lc = self._make_lifecycle(tmp_path)
+        status_file = tmp_path / "startup.status"
+        status_file.write_text("starting")
+        lc.startup_status_file = str(status_file)
+
+        lc._report_startup_success()
+        assert status_file.read_text().strip() == OperationResult.SUCCESS
+
+    def test_report_startup_error_writes_status_file(self, tmp_path: Path) -> None:
+        """_report_startup_error() writes 'error:<msg>' to the status file."""
+        lc = self._make_lifecycle(tmp_path)
+        status_file = tmp_path / "startup.status"
+        status_file.write_text("starting")
+        lc.startup_status_file = str(status_file)
+
+        lc._report_startup_error("port in use")
+        content = status_file.read_text().strip()
+        assert content.startswith("error:")
+        assert "port in use" in content
+
+
+# ---------------------------------------------------------------------------
+# monitor/daemon_manager.py — DaemonManager (legacy fork removed)
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorDaemonManagerExecSpawn:
+    """Exec-based spawn for monitor/daemon_manager.py DaemonManager."""
+
+    def _make_manager(self, tmp_path: Path) -> Any:
+        from claude_mpm.services.monitor.daemon_manager import DaemonManager
+
+        m = DaemonManager(
+            port=19767,
+            host="localhost",
+            pid_file=str(tmp_path / "monitor-daemon-19767.pid"),
+            log_file=str(tmp_path / "monitor-daemon-19767.log"),
+        )
+        return m
+
+    def test_start_daemon_subprocess_uses_popen_not_fork(self, tmp_path: Path) -> None:
+        """start_daemon_subprocess() must use Popen, not os.fork()."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 300
+        fake_proc.poll.return_value = None  # still running
+
+        # Simulate PID file written + port becomes bound
+        def _fake_popen(cmd, **kwargs) -> MagicMock:
+            Path(m.pid_file).write_text("300")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("os.fork must not be called")),
+            patch(
+                "claude_mpm.services.monitor.daemon_manager.subprocess.Popen",
+                side_effect=_fake_popen,
+            ) as mock_popen,
+            patch.object(m, "_is_port_available", return_value=False),
+            patch.object(m, "_verify_daemon_health", return_value=True),
+        ):
+            result = m.start_daemon_subprocess()
+
+        assert result is True
+        mock_popen.assert_called_once()
+
+    def test_start_daemon_subprocess_start_new_session(self, tmp_path: Path) -> None:
+        """Popen must include start_new_session=True."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 301
+        fake_proc.poll.return_value = None
+
+        def _fake_popen(cmd, **kwargs) -> MagicMock:
+            Path(m.pid_file).write_text("301")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.daemon_manager.subprocess.Popen",
+                side_effect=_fake_popen,
+            ) as mock_popen,
+            patch.object(m, "_is_port_available", return_value=False),
+            patch.object(m, "_verify_daemon_health", return_value=True),
+        ):
+            m.start_daemon_subprocess()
+
+        assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+    def test_start_daemon_subprocess_passes_recursion_guard(
+        self, tmp_path: Path
+    ) -> None:
+        """Child env must contain CLAUDE_MPM_SUBPROCESS_DAEMON=1."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 302
+        fake_proc.poll.return_value = None
+
+        def _fake_popen(cmd, **kwargs) -> MagicMock:
+            Path(m.pid_file).write_text("302")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.daemon_manager.subprocess.Popen",
+                side_effect=_fake_popen,
+            ) as mock_popen,
+            patch.object(m, "_is_port_available", return_value=False),
+            patch.object(m, "_verify_daemon_health", return_value=True),
+        ):
+            m.start_daemon_subprocess()
+
+        env = mock_popen.call_args.kwargs.get("env", {})
+        assert env.get("CLAUDE_MPM_SUBPROCESS_DAEMON") == "1"
+
+    def test_daemonize_legacy_path_returns_false(self, tmp_path: Path) -> None:
+        """daemonize() (legacy stub) must return False and log an error."""
+        m = self._make_manager(tmp_path)
+        with patch.object(m.logger, "error") as mock_error:
+            result = m.daemonize()
+        assert result is False
+        mock_error.assert_called_once()
+        logged = mock_error.call_args[0][0]
+        assert "os.fork" in logged or "daemonize" in logged
+
+    def test_use_subprocess_daemon_returns_true_without_env(
+        self, tmp_path: Path
+    ) -> None:
+        """use_subprocess_daemon() returns True unless already inside a subprocess."""
+        m = self._make_manager(tmp_path)
+        env_backup = os.environ.pop("CLAUDE_MPM_SUBPROCESS_DAEMON", None)
+        try:
+            assert m.use_subprocess_daemon() is True
+        finally:
+            if env_backup is not None:
+                os.environ["CLAUDE_MPM_SUBPROCESS_DAEMON"] = env_backup
+
+    def test_use_subprocess_daemon_returns_false_when_child(
+        self, tmp_path: Path
+    ) -> None:
+        """use_subprocess_daemon() returns False when already the exec'd child."""
+        m = self._make_manager(tmp_path)
+        with patch.dict(os.environ, {"CLAUDE_MPM_SUBPROCESS_DAEMON": "1"}):
+            assert m.use_subprocess_daemon() is False
+
+    def test_stop_daemon_signals_pid_from_file(self, tmp_path: Path) -> None:
+        """stop_daemon() reads PID file and sends SIGTERM."""
+        m = self._make_manager(tmp_path)
+        Path(m.pid_file).write_text("77777")
+
+        with (
+            patch("os.kill") as mock_kill,
+        ):
+            # Simulate process disappearing after SIGTERM
+            mock_kill.side_effect = [None, ProcessLookupError]
+            result = m.stop_daemon()
+
+        assert result is True
+        first_call_args = mock_kill.call_args_list[0]
+        assert first_call_args[0][0] == 77777
+        assert first_call_args[0][1] == signal.SIGTERM
+
+    def test_write_and_cleanup_pid_file(self, tmp_path: Path) -> None:
+        """write_pid_file() writes current PID; cleanup_pid_file() removes it."""
+        m = self._make_manager(tmp_path)
+
+        m.write_pid_file()
+        assert Path(m.pid_file).exists()
+        assert int(Path(m.pid_file).read_text().strip()) == os.getpid()
+
+        m.cleanup_pid_file()
+        assert not Path(m.pid_file).exists()
+
+    def test_is_running_false_for_nonexistent_process(self, tmp_path: Path) -> None:
+        """is_running() returns False if PID file references a dead process."""
+        m = self._make_manager(tmp_path)
+        # Use a PID that almost certainly does not exist
+        Path(m.pid_file).write_text("999999999")
+        assert m.is_running() is False
+        # Stale PID file must be removed
+        assert not Path(m.pid_file).exists()
+
+    def test_already_running_idempotent(self, tmp_path: Path) -> None:
+        """start_daemon() returns True immediately if daemon is already running."""
+        m = self._make_manager(tmp_path)
+        with patch.object(m, "is_running", return_value=True):
+            with patch("os.fork", side_effect=AssertionError("no fork")):
+                result = m.start_daemon()
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: verify no os.fork in the broader services package
+# ---------------------------------------------------------------------------
+
+
+class TestNoForkInServicesPackage:
+    """Grep-level check: no os.fork( in the services subtree."""
+
+    def test_grep_no_raw_fork(self) -> None:
+        """AST-based check: no live os.fork() call exists in services/ Python files.
+
+        We intentionally use the AST (not grep) so that os.fork() appearing only
+        in comments, docstrings, or string literals does not trip the check.
+        """
+        live_forks: list[str] = []
+        for py_file in _SERVICES.rglob("*.py"):
+            try:
+                source = py_file.read_text()
+                tree = ast.parse(source, filename=str(py_file))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "fork"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "os"
+                ):
+                    live_forks.append(f"{py_file}:{node.lineno}")
+
+        assert live_forks == [], (
+            "Found live os.fork() AST call-sites in services/:\n"
+            + "\n".join(live_forks)
+            + "\n\nSee issue #693 — raw os.fork() in a multithreaded Python parent "
+            "causes EXC_BAD_ACCESS / SIGSEGV on macOS."
+        )

--- a/tests/services/test_daemon_fork_safety.py
+++ b/tests/services/test_daemon_fork_safety.py
@@ -92,16 +92,17 @@ class TestNoForkInvariant:
 class TestSocketIODaemonManagerExecSpawn:
     """Exec-based spawn semantics for SocketIODaemonManager."""
 
-    def _make_manager(self, tmp_path: Path) -> Any:
+    def _make_manager(self, tmp_path: Path, port: int = 19765) -> Any:
         """Return a SocketIODaemonManager with paths redirected to tmp_path."""
         from claude_mpm.services.infrastructure.daemon_manager import (
             SocketIODaemonManager,
         )
 
-        m = SocketIODaemonManager(host="localhost", port=19765)
+        m = SocketIODaemonManager(host="localhost", port=port)
         m.config_dir = tmp_path
-        m.pid_file = tmp_path / "socketio-server.pid"
-        m.log_file = tmp_path / "socketio-server.log"
+        # Use port-keyed names matching the production logic
+        m.pid_file = tmp_path / f"socketio-server-{port}.pid"
+        m.log_file = tmp_path / f"socketio-server-{port}.log"
         return m
 
     def test_start_calls_popen_with_start_new_session(self, tmp_path: Path) -> None:
@@ -284,6 +285,105 @@ class TestSocketIODaemonManagerExecSpawn:
                 f"start_new_session must be True on {platform_str}"
             )
 
+    def test_popen_never_uses_pipe_for_stdout_stderr(self, tmp_path: Path) -> None:
+        """Popen must NOT route stdout or stderr to subprocess.PIPE (would buffer without consumer)."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 66
+        fake_proc.poll.return_value = None
+
+        def _write_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("66")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid,
+            ) as mock_popen,
+        ):
+            m.start()
+
+        assert mock_popen.call_args.kwargs.get("stdout") != subprocess.PIPE, (
+            "stdout must not be subprocess.PIPE — daemon output would buffer without a consumer"
+        )
+        assert mock_popen.call_args.kwargs.get("stderr") != subprocess.PIPE, (
+            "stderr must not be subprocess.PIPE — daemon output would buffer without a consumer"
+        )
+
+    def test_popen_close_fds_not_false(self, tmp_path: Path) -> None:
+        """Popen must not pass close_fds=False — that leaks all parent fds into the daemon."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 67
+        fake_proc.poll.return_value = None
+
+        def _write_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("67")
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid,
+            ) as mock_popen,
+        ):
+            m.start()
+
+        # close_fds should not be explicitly False; absent or True are both acceptable.
+        assert mock_popen.call_args.kwargs.get("close_fds") is not False, (
+            "close_fds must not be False — that leaks parent fds into the daemon child"
+        )
+
+    def test_two_instances_have_distinct_pid_files(self, tmp_path: Path) -> None:
+        """Two SocketIODaemonManagers on different ports must use different PID file paths."""
+        m_a = self._make_manager(tmp_path, port=19765)
+        m_b = self._make_manager(tmp_path, port=19766)
+
+        assert m_a.pid_file != m_b.pid_file, (
+            "Managers on different ports must use different PID files to avoid clobbering"
+        )
+        assert str(m_a.port) in str(m_a.pid_file), (
+            "PID file path must contain the port number"
+        )
+        assert str(m_b.port) in str(m_b.pid_file), (
+            "PID file path must contain the port number"
+        )
+        # Log files too
+        assert m_a.log_file != m_b.log_file
+        assert str(m_a.port) in str(m_a.log_file)
+        assert str(m_b.port) in str(m_b.log_file)
+
+    def test_pid_file_validated_by_positive_integer_not_exact_match(
+        self, tmp_path: Path
+    ) -> None:
+        """Parent accepts any valid positive PID written by the child, not only process.pid."""
+        m = self._make_manager(tmp_path)
+        fake_proc = MagicMock()
+        # process.pid is 100, but child writes its own os.getpid() = 101
+        fake_proc.pid = 100
+        fake_proc.poll.return_value = None
+
+        def _write_pid_with_different_pid(*a, **kw) -> MagicMock:
+            m.pid_file.write_text("101")  # child's actual PID differs from process.pid
+            return fake_proc
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.infrastructure.daemon_manager.subprocess.Popen",
+                side_effect=_write_pid_with_different_pid,
+            ),
+        ):
+            result = m.start()
+
+        assert result is True, (
+            "Parent must accept any valid positive PID written by the child, "
+            "not require it to exactly match process.pid"
+        )
+
 
 # ---------------------------------------------------------------------------
 # communication/message_consumer.py — --daemon mode
@@ -365,6 +465,39 @@ class TestMessageConsumerExecSpawn:
             message_consumer.main()
 
         assert "4" in captured.get("cmd", [])
+
+    def test_recursion_guard_prevents_respawn_when_already_child(self) -> None:
+        """When CLAUDE_MPM_MSG_CONSUMER_DAEMON=1 is set, --daemon must NOT spawn again."""
+        from claude_mpm.services.communication import message_consumer
+
+        consumer_instance = MagicMock()
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.communication.message_consumer.subprocess.Popen",
+                side_effect=AssertionError("must not spawn a second subprocess"),
+            ),
+            patch.dict(os.environ, {"CLAUDE_MPM_MSG_CONSUMER_DAEMON": "1"}),
+            patch("sys.argv", ["message_consumer", "--daemon"]),
+            patch(
+                "claude_mpm.services.communication.message_consumer.MessageConsumer",
+                return_value=consumer_instance,
+            ),
+        ):
+            message_consumer.main()
+
+        # Must have run the consumer directly (foreground), not spawned again
+        consumer_instance.run.assert_called_once()
+
+    def test_popen_never_uses_pipe_for_stdout_stderr(self) -> None:
+        """Popen must NOT route stdout or stderr to subprocess.PIPE."""
+        _, captured = self._run_main_daemon()
+        assert captured["kwargs"].get("stdout") != subprocess.PIPE, (
+            "stdout must not be PIPE — daemon output would buffer without a consumer"
+        )
+        assert captured["kwargs"].get("stderr") != subprocess.PIPE, (
+            "stderr must not be PIPE — daemon output would buffer without a consumer"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -539,27 +672,76 @@ class TestDaemonLifecycleExecSpawn:
 
     def test_report_startup_success_writes_status_file(self, tmp_path: Path) -> None:
         """_report_startup_success() writes 'success' to the status file."""
+        from pathlib import Path as _Path
+
         from claude_mpm.core.enums import OperationResult
 
         lc = self._make_lifecycle(tmp_path)
         status_file = tmp_path / "startup.status"
         status_file.write_text("starting")
-        lc.startup_status_file = str(status_file)
+        lc.startup_status_file = _Path(status_file)
 
         lc._report_startup_success()
         assert status_file.read_text().strip() == OperationResult.SUCCESS
 
     def test_report_startup_error_writes_status_file(self, tmp_path: Path) -> None:
         """_report_startup_error() writes 'error:<msg>' to the status file."""
+        from pathlib import Path as _Path
+
         lc = self._make_lifecycle(tmp_path)
         status_file = tmp_path / "startup.status"
         status_file.write_text("starting")
-        lc.startup_status_file = str(status_file)
+        lc.startup_status_file = _Path(status_file)
 
         lc._report_startup_error("port in use")
         content = status_file.read_text().strip()
         assert content.startswith("error:")
         assert "port in use" in content
+
+    def test_daemonize_popen_close_fds_not_false(self, tmp_path: Path) -> None:
+        """daemonize() Popen must not pass close_fds=False — that leaks all parent fds."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 206
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        assert mock_popen.call_args.kwargs.get("close_fds") is not False, (
+            "close_fds must not be False — that leaks parent fds into the daemon child"
+        )
+
+    def test_daemonize_popen_never_uses_pipe_for_stdout_stderr(
+        self, tmp_path: Path
+    ) -> None:
+        """daemonize() Popen must NOT route stdout or stderr to subprocess.PIPE."""
+        lc = self._make_lifecycle(tmp_path)
+        fake_proc = MagicMock()
+        fake_proc.pid = 207
+
+        with (
+            patch("os.fork", side_effect=AssertionError("no fork")),
+            patch(
+                "claude_mpm.services.monitor.management.lifecycle.subprocess.Popen",
+                return_value=fake_proc,
+            ) as mock_popen,
+            patch.object(lc, "_parent_wait_for_startup", return_value=True),
+        ):
+            lc.daemonize()
+
+        assert mock_popen.call_args.kwargs.get("stdout") != subprocess.PIPE, (
+            "stdout must not be PIPE — log output would buffer without a consumer"
+        )
+        assert mock_popen.call_args.kwargs.get("stderr") != subprocess.PIPE, (
+            "stderr must not be PIPE — log output would buffer without a consumer"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #693. The **real** fix for the macOS daemon `EXC_BAD_ACCESS / SIGSEGV` (follow-up to the no-op #690/#691). Replaces the remaining raw `os.fork()` double-fork daemonization in the four daemon managers with exec-based `subprocess.Popen(..., start_new_session=True)`, finishing a migration the monitor daemon already proved out in Sep 2025 (v4.2.40).

## Why os.fork() was unsafe
Forking from a multithreaded Python parent on macOS and touching CoreFoundation/os_log (setproctitle, logging) before `exec()` is undefined → kernel aborts. `multiprocessing.set_start_method("spawn")` does NOT affect raw `os.fork()`, so #691 never addressed this. Exec'ing a fresh interpreter avoids inheriting the poisoned CF state entirely.

## Changes
- `monitor/daemon_manager.py`, `monitor/management/lifecycle.py`, `communication/message_consumer.py`, `infrastructure/daemon_manager.py` — raw `os.fork()` replaced with exec-based subprocess spawn (unique env sentinel per daemon, child writes its own PID file, stdio → file/DEVNULL, `start_new_session=True`).
- `tests/services/test_daemon_fork_safety.py` — extensive per-daemon coverage + AST no-fork invariant.
- `docs/developer/daemon-fork-safety.md` — the hazard, the adopted pattern, and a safe-daemon checklist.

## Design constraints honored (distilled from prior fork+threading bugs)
Child writes own PID file · unique env sentinel per daemon · stdout/stderr never `PIPE` · `close_fds` correct · port-specific PID files · parent polls `process.poll()` during startup · child calls `ensure_spawn_on_darwin()` · MCP pre-warming left enabled.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
