### PR TITLE
fix(hooks): robust worktree token attribution + doc drift in commit cost tracker (#696)

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -225,7 +225,7 @@ The PM **owns** verification. Delegation to QA is a mechanism, not a handoff of 
 When delegating to QA, the PM must state **exactly what QA must observe and report back**:
 
 > ❌ "Verify the commit_cost_tracker works"  
-> ✅ "Make a real git commit in this repo and paste the full output of `git log -1 --format='%B'`. I need to see X-AI-Tokens-In, X-AI-Tokens-Out, X-AI-Cache-Read, X-AI-Cache-Write, X-AI-Cache-Ratio, and X-AI-Est-Cost-USD trailers present."
+> ✅ "Make a real git commit in this repo and paste the full output of `git log -1 --format='%B'`. I need to see X-AI-Tokens-In, X-AI-Tokens-Out, and X-AI-Model trailers present."
 
 ### QA report is not done until
 

--- a/src/claude_mpm/hooks/commit_cost_tracker.py
+++ b/src/claude_mpm/hooks/commit_cost_tracker.py
@@ -19,6 +19,14 @@ DESIGN DECISIONS:
   session transcript directly (the most-recently-modified JSONL in
   ~/.claude/projects/{encoded_cwd}/) to obtain live cumulative token counts.
   Falls back to context-usage.json when no transcript is found.
+- WORKTREE / SUBAGENT FALLBACK (fix for #696): When a subagent commit runs in a
+  linked worktree, git's cwd is the worktree root (e.g.
+  .claude/worktrees/agent-XXXX), NOT the main working tree. The parent session
+  transcript lives under the main tree's encoded path. resolve_main_working_tree()
+  finds the main tree via ``git worktree list --porcelain`` (or the parent of
+  ``git rev-parse --git-common-dir`` as fallback), then get_token_delta() retries
+  the lookup with that canonical cwd. Baseline reads and writes also use the
+  canonical cwd so the delta is always consistent.
 - Atomic file I/O (write-to-temp, then rename) prevents corruption when hooks
   run concurrently across worktrees.
 - All subprocess calls use stdlib only; no new dependencies.
@@ -27,6 +35,9 @@ DESIGN DECISIONS:
 - The amend uses --no-verify to avoid triggering hooks recursively.
 - Trailers emitted: X-AI-Tokens-In, X-AI-Tokens-Out, and conditionally
   X-AI-Model / X-AI-Models.  Cost and cache trailers have been removed.
+- ZERO-SKIP (fix for #696): When the resolved delta is still 0/0 after all
+  fallbacks, the X-AI-Tokens-In / X-AI-Tokens-Out trailers are omitted entirely
+  rather than emitting useless zeros.
 """
 
 from __future__ import annotations
@@ -98,7 +109,7 @@ _COAUTHORED_CANONICAL_RE = re.compile(
 )
 
 # Regex to strip X-AI-* trailers that already exist so we never duplicate them.
-# Matches lines like "X-AI-Tokens-In: 123" or "X-AI-Est-Cost-USD: 0.000012".
+# Matches lines like "X-AI-Tokens-In: 123" or "X-AI-Model: claude-opus-4-8".
 # The pattern anchors at line start (MULTILINE) and matches any content on the
 # line.  Using .*  rather than [^\n]+ to ensure blank-value lines are stripped.
 _XAI_TRAILER_RE = re.compile(r"^X-AI-[A-Za-z-]+:.*$", re.MULTILINE)
@@ -111,6 +122,73 @@ _SHA_RE = re.compile(r"\[.*?\s+([a-f0-9]{7,40})\]")
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def resolve_main_working_tree(cwd: str) -> str:
+    """Return the main git working tree path for *cwd*, handling linked worktrees.
+
+    WHY: When a subagent commit runs inside a linked worktree (e.g.
+    ``.claude/worktrees/agent-XXXX``), the parent session transcript lives under
+    the MAIN working tree's encoded path in ``~/.claude/projects/``.  Using the
+    worktree cwd as-is yields no transcript match (issue #696).
+
+    WHAT: Runs ``git worktree list --porcelain`` from *cwd* and returns the
+    ``worktree`` path from the FIRST entry (the main working tree).  Falls back
+    to deriving the parent of ``git rev-parse --git-common-dir`` (which points to
+    ``.git`` inside the main tree).  If both git calls fail, returns *cwd*
+    unchanged.
+
+    TEST: In a temp repo with one linked worktree, call from the worktree dir
+    and assert the returned path equals the main repo root, not the worktree.
+    Call from the main repo dir itself and assert it is returned unchanged.
+
+    Args:
+        cwd: Absolute path string for the commit's working directory.
+
+    Returns:
+        Absolute path string of the main working tree, or *cwd* on failure.
+    """
+    _debug(f"resolve_main_working_tree: cwd={cwd}")
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if line.startswith("worktree "):
+                    main_tree = line[len("worktree ") :]
+                    _debug(f"  resolve_main_working_tree: first entry = {main_tree!r}")
+                    return main_tree
+    except Exception as exc:
+        _debug(f"  resolve_main_working_tree: worktree list failed: {exc}")
+
+    # Fallback: parent of git-common-dir (works even without porcelain support).
+    try:
+        result2 = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result2.returncode == 0:
+            git_common = Path(result2.stdout.strip()).resolve()
+            # git-common-dir is the shared .git dir; its parent is the main tree.
+            main_tree = str(git_common.parent)
+            _debug(f"  resolve_main_working_tree: from git-common-dir => {main_tree}")
+            return main_tree
+    except Exception as exc2:
+        _debug(f"  resolve_main_working_tree: git-common-dir failed: {exc2}")
+
+    _debug(f"  resolve_main_working_tree: fallback to cwd={cwd}")
+    return cwd
 
 
 def _read_live_cumulative(cwd: str) -> tuple[dict[str, int], dict[str, dict[str, int]]]:
@@ -203,10 +281,16 @@ def get_token_delta(cwd: str) -> dict[str, Any]:
     WHY: Every commit needs the incremental token usage since the previous commit
     so that X-AI-* trailers reflect only the work done for that commit.  The
     live transcript lookup (see _read_live_cumulative) fixes issue #601 where
-    stale context-usage.json caused all-zero deltas.
+    stale context-usage.json caused all-zero deltas.  The main-working-tree
+    fallback (see resolve_main_working_tree) fixes issue #696 where subagent
+    commits in linked worktrees always produced zero deltas because the transcript
+    was stored under the main tree's path, not the worktree path.
 
-    WHAT: Reads live cumulative + baseline files, returns delta dict with integer
-    token fields plus a per-model ``models`` dict for the same delta window.  The
+    WHAT: Resolves the canonical project cwd ONCE via resolve_main_working_tree(),
+    then uses that canonical path consistently for transcript lookup, baseline
+    read, and baseline write — preventing any baseline/transcript cwd mismatch.
+    Reads live cumulative + baseline files, returns delta dict with integer token
+    fields plus a per-model ``models`` dict for the same delta window.  The
     per-model delta is computed independently for each model: if a model appears
     in the snapshot but not the baseline it gets its full snapshot value; if it
     only appears in the baseline it contributes zero (clamped).
@@ -223,16 +307,22 @@ def get_token_delta(cwd: str) -> dict[str, Any]:
         cache_write_tokens (all non-negative integers) plus ``models`` — a dict
         mapping model name to per-model token delta (same four keys).
     """
-    project_root = Path(cwd).resolve()
+    # Resolve the canonical project cwd ONCE.  For a linked-worktree subagent
+    # commit, this maps the worktree path back to the main working tree so the
+    # transcript lookup, baseline read, AND baseline write all use the same path.
+    canonical_cwd = resolve_main_working_tree(cwd)
+    _debug(f"get_token_delta: cwd={cwd} canonical_cwd={canonical_cwd}")
+
+    project_root = Path(canonical_cwd).resolve()
     baseline_file = (
         project_root / ".claude-mpm" / "state" / "commit-token-baseline.json"
     )
 
-    _debug(f"get_token_delta: cwd={cwd}")
     _debug(f"  baseline_file={baseline_file} exists={baseline_file.exists()}")
 
-    # Read live cumulative totals (transcript preferred, snapshot as fallback).
-    cumulative, cumulative_models = _read_live_cumulative(cwd)
+    # Read live cumulative totals using the CANONICAL cwd (transcript preferred,
+    # snapshot as fallback).
+    cumulative, cumulative_models = _read_live_cumulative(canonical_cwd)
     _debug(f"  cumulative={cumulative}")
     _debug(f"  cumulative_models keys={list(cumulative_models.keys())}")
 
@@ -420,12 +510,24 @@ def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> No
         primary_model = _primary_model(model_delta)
         models_trailer = _format_models_trailer(model_delta)
 
-        trailers = [
+        tokens_in = delta.get("input_tokens", 0)
+        tokens_out = delta.get("output_tokens", 0)
+        has_token_data = tokens_in != 0 or tokens_out != 0
+
+        trailers: list[str] = [
             "",  # blank line before trailers
             _COAUTHORED_CANONICAL,
-            f"X-AI-Tokens-In: {delta.get('input_tokens', 0)}",
-            f"X-AI-Tokens-Out: {delta.get('output_tokens', 0)}",
         ]
+
+        if has_token_data:
+            trailers.append(f"X-AI-Tokens-In: {tokens_in}")
+            trailers.append(f"X-AI-Tokens-Out: {tokens_out}")
+        else:
+            _debug(
+                "amend_commit_message: skipping X-AI-Tokens-In/Out trailers "
+                "— no token data resolved (delta is 0/0 after all fallbacks)"
+            )
+
         if primary_model:
             trailers.append(f"X-AI-Model: {primary_model}")
         if models_trailer:

--- a/src/claude_mpm/hooks/commit_cost_tracker.py
+++ b/src/claude_mpm/hooks/commit_cost_tracker.py
@@ -132,15 +132,21 @@ def resolve_main_working_tree(cwd: str) -> str:
     the MAIN working tree's encoded path in ``~/.claude/projects/``.  Using the
     worktree cwd as-is yields no transcript match (issue #696).
 
-    WHAT: Runs ``git worktree list --porcelain`` from *cwd* and returns the
-    ``worktree`` path from the FIRST entry (the main working tree).  Falls back
-    to deriving the parent of ``git rev-parse --git-common-dir`` (which points to
-    ``.git`` inside the main tree).  If both git calls fail, returns *cwd*
-    unchanged.
+    WHAT: Short-circuits immediately when ``git rev-parse --git-dir`` equals
+    ``--git-common-dir`` (cwd is already the main tree) to avoid spawning
+    ``git worktree list`` on every non-worktree commit.  Otherwise runs
+    ``git worktree list --porcelain`` and returns the ``worktree`` path from
+    the FIRST entry.  Falls back to deriving the parent of
+    ``git rev-parse --git-common-dir`` (which points to ``.git`` inside the
+    main tree).  Relative paths from ``--git-common-dir`` are resolved relative
+    to *cwd* (not the process cwd) so ``../.git`` resolves correctly.  If all
+    git calls fail, returns *cwd* unchanged.
 
     TEST: In a temp repo with one linked worktree, call from the worktree dir
     and assert the returned path equals the main repo root, not the worktree.
     Call from the main repo dir itself and assert it is returned unchanged.
+    Pass a mocked relative path (``../.git``) as ``--git-common-dir`` output and
+    assert it resolves relative to *cwd*, not the process cwd.
 
     Args:
         cwd: Absolute path string for the commit's working directory.
@@ -149,6 +155,39 @@ def resolve_main_working_tree(cwd: str) -> str:
         Absolute path string of the main working tree, or *cwd* on failure.
     """
     _debug(f"resolve_main_working_tree: cwd={cwd}")
+
+    # --- Fast path: if git-dir == git-common-dir, cwd is already the main tree.
+    # This avoids spawning git worktree list on every normal (non-worktree) commit.
+    try:
+        r_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        r_common = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if r_dir.returncode == 0 and r_common.returncode == 0:
+            git_dir_path = (Path(cwd) / r_dir.stdout.strip()).resolve()
+            git_common_path = (Path(cwd) / r_common.stdout.strip()).resolve()
+            if git_dir_path == git_common_path:
+                # Already in the main working tree — no worktree lookup needed.
+                _debug(
+                    f"  resolve_main_working_tree: fast-path — "
+                    f"git-dir == git-common-dir ({git_common_path}), returning cwd"
+                )
+                return cwd
+    except Exception as exc_fast:
+        _debug(f"  resolve_main_working_tree: fast-path check failed: {exc_fast}")
+
     try:
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
@@ -169,6 +208,8 @@ def resolve_main_working_tree(cwd: str) -> str:
         _debug(f"  resolve_main_working_tree: worktree list failed: {exc}")
 
     # Fallback: parent of git-common-dir (works even without porcelain support).
+    # Resolve relative to *cwd* (not the process cwd) so a relative output like
+    # ``../.git`` resolves correctly inside the worktree directory.
     try:
         result2 = subprocess.run(
             ["git", "rev-parse", "--git-common-dir"],
@@ -179,7 +220,7 @@ def resolve_main_working_tree(cwd: str) -> str:
             check=False,
         )
         if result2.returncode == 0:
-            git_common = Path(result2.stdout.strip()).resolve()
+            git_common = (Path(cwd) / result2.stdout.strip()).resolve()
             # git-common-dir is the shared .git dir; its parent is the main tree.
             main_tree = str(git_common.parent)
             _debug(f"  resolve_main_working_tree: from git-common-dir => {main_tree}")
@@ -512,7 +553,7 @@ def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> No
 
         tokens_in = delta.get("input_tokens", 0)
         tokens_out = delta.get("output_tokens", 0)
-        has_token_data = tokens_in != 0 or tokens_out != 0
+        has_token_data = tokens_in > 0 or tokens_out > 0
 
         trailers: list[str] = [
             "",  # blank line before trailers

--- a/tests/test_commit_cost_tracker.py
+++ b/tests/test_commit_cost_tracker.py
@@ -1,4 +1,4 @@
-"""Unit tests for commit_cost_tracker module (issue #600 / #601).
+"""Unit tests for commit_cost_tracker module (issue #600 / #601 / #696).
 
 Covers:
 - get_token_delta(): reading context-usage.json, first-call zero baseline,
@@ -13,6 +13,13 @@ Covers:
     context-usage.json so the git post-commit hook sees non-zero deltas.
   - CHANGE 1: commit hook parses live transcript JSONL directly and produces
     non-zero delta even when context-usage.json is stale / zero.
+- Worktree / subagent attribution (issue #696):
+  - resolve_main_working_tree() returns the main repo root when called from a
+    linked worktree.
+  - get_token_delta() uses the main-tree transcript when the worktree transcript
+    is missing.
+  - amend_commit_message() skips X-AI-Tokens-In/Out when delta is 0/0.
+  - Normal (non-worktree) commit path regression.
 """
 
 from __future__ import annotations
@@ -38,6 +45,7 @@ from claude_mpm.hooks.commit_cost_tracker import (
     amend_commit_message,
     extract_commit_sha,
     get_token_delta,
+    resolve_main_working_tree,
     write_cost_log,
 )
 from claude_mpm.services.infrastructure.context_usage_tracker import (
@@ -872,3 +880,316 @@ class TestMultipleStopEventsDoNotAccumulate:
             "(double-counting bug — each Stop event should replace, not add)"
         )
         assert raw["cumulative_output_tokens"] == 3_500
+
+
+# ---------------------------------------------------------------------------
+# Issue #696: Worktree / subagent attribution fixes
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMainWorkingTree:
+    """Tests for resolve_main_working_tree() helper (fix for #696).
+
+    All git subprocess calls are monkeypatched so tests never touch real git.
+    """
+
+    def _make_run(self, stdout: str, returncode: int = 0):
+        """Return a mock subprocess.run result."""
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = stdout
+        m.stderr = ""
+        return m
+
+    def test_linked_worktree_returns_main_tree(self, tmp_path: Path) -> None:
+        """When called from a linked worktree, returns the first worktree entry."""
+        main_tree = str(tmp_path / "main-repo")
+        worktree_path = str(
+            tmp_path / "main-repo" / ".claude" / "worktrees" / "agent-abc"
+        )
+        porcelain_output = (
+            f"worktree {main_tree}\nHEAD abc123\nbranch refs/heads/main\n\n"
+            f"worktree {worktree_path}\nHEAD def456\nbranch refs/heads/worktree-agent-abc\n"
+        )
+
+        with patch("subprocess.run", return_value=self._make_run(porcelain_output)):
+            result = resolve_main_working_tree(worktree_path)
+
+        assert result == main_tree, (
+            f"Expected main tree {main_tree!r}, got {result!r} — "
+            "worktree resolution broken"
+        )
+
+    def test_main_repo_returns_itself(self, tmp_path: Path) -> None:
+        """When called from the main repo root, the main tree is returned unchanged."""
+        main_tree = str(tmp_path / "main-repo")
+        porcelain_output = (
+            f"worktree {main_tree}\nHEAD abc123\nbranch refs/heads/main\n"
+        )
+
+        with patch("subprocess.run", return_value=self._make_run(porcelain_output)):
+            result = resolve_main_working_tree(main_tree)
+
+        assert result == main_tree
+
+    def test_fallback_to_git_common_dir_when_porcelain_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Falls back to git-common-dir parent when worktree list fails."""
+        main_tree = tmp_path / "main-repo"
+        main_tree.mkdir()
+        git_dir = main_tree / ".git"
+        git_dir.mkdir()
+        worktree_path = str(tmp_path / "worktree")
+
+        fail_result = self._make_run("", returncode=128)
+        # git rev-parse --git-common-dir returns the shared .git path
+        git_common_result = self._make_run(str(git_dir))
+
+        with patch("subprocess.run", side_effect=[fail_result, git_common_result]):
+            result = resolve_main_working_tree(worktree_path)
+
+        assert result == str(main_tree), (
+            f"Expected {main_tree!r}, got {result!r} — git-common-dir fallback broken"
+        )
+
+    def test_both_git_calls_fail_returns_original_cwd(self, tmp_path: Path) -> None:
+        """When both git calls fail, the original cwd is returned unchanged."""
+        worktree_path = str(tmp_path / "worktree")
+        fail_result = self._make_run("", returncode=128)
+
+        with patch("subprocess.run", side_effect=[fail_result, fail_result]):
+            result = resolve_main_working_tree(worktree_path)
+
+        assert result == worktree_path, (
+            "Should return cwd unchanged when git resolution fails"
+        )
+
+    def test_exception_during_subprocess_returns_cwd(self, tmp_path: Path) -> None:
+        """If subprocess.run raises, falls back gracefully to original cwd."""
+        worktree_path = str(tmp_path / "worktree")
+
+        with patch("subprocess.run", side_effect=OSError("no git")):
+            result = resolve_main_working_tree(worktree_path)
+
+        assert result == worktree_path
+
+
+class TestGetTokenDeltaWorktreeFallback:
+    """Test that get_token_delta() uses the main-tree transcript when the
+    worktree's own transcript directory is missing (issue #696).
+    """
+
+    def _patch_home(self, fake_home: Path):
+        """Patch Path.home() inside transcript_usage to use fake_home."""
+        return patch(
+            "claude_mpm.hooks.transcript_usage.Path.home",
+            return_value=fake_home,
+        )
+
+    def _patch_resolve_main(self, canonical_cwd: str):
+        """Patch resolve_main_working_tree to return canonical_cwd."""
+        return patch(
+            "claude_mpm.hooks.commit_cost_tracker.resolve_main_working_tree",
+            return_value=canonical_cwd,
+        )
+
+    def test_worktree_cwd_misses_but_main_tree_transcript_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """When transcript is absent for worktree cwd but present for main tree,
+        get_token_delta() returns the real non-zero delta from main tree.
+        """
+        main_tree = str(tmp_path / "main-repo")
+        Path(main_tree).mkdir(parents=True)
+        state_dir = Path(main_tree) / ".claude-mpm" / "state"
+        state_dir.mkdir(parents=True)
+
+        worktree_cwd = str(tmp_path / "main-repo" / ".claude" / "worktrees" / "agent-x")
+
+        # Transcript exists ONLY for main_tree, not for worktree_cwd.
+        fake_home = tmp_path / "fake_home"
+        _create_fake_transcript_for_cwd(
+            fake_home,
+            main_tree,
+            input_tokens=20_000,
+            output_tokens=4_500,
+            model="claude-sonnet-4-6",
+        )
+        # No transcript for worktree_cwd (nothing created there).
+
+        with self._patch_home(fake_home), self._patch_resolve_main(main_tree):
+            delta = get_token_delta(worktree_cwd)
+
+        assert delta["input_tokens"] == 20_000, (
+            f"Expected 20000 from main-tree transcript, got {delta['input_tokens']} — "
+            "worktree fallback not working (issue #696)"
+        )
+        assert delta["output_tokens"] == 4_500
+
+    def test_baseline_written_to_canonical_cwd(self, tmp_path: Path) -> None:
+        """Baseline is written under the canonical (main-tree) cwd, not the worktree."""
+        main_tree = str(tmp_path / "main-repo")
+        Path(main_tree).mkdir(parents=True)
+        (Path(main_tree) / ".claude-mpm" / "state").mkdir(parents=True)
+
+        worktree_cwd = str(tmp_path / "main-repo" / ".claude" / "worktrees" / "agent-y")
+
+        fake_home = tmp_path / "fake_home"
+        _create_fake_transcript_for_cwd(
+            fake_home,
+            main_tree,
+            input_tokens=8_000,
+            output_tokens=1_200,
+        )
+
+        with self._patch_home(fake_home), self._patch_resolve_main(main_tree):
+            get_token_delta(worktree_cwd)
+
+        # Baseline must be at the main-tree path, NOT the worktree path.
+        baseline_path = (
+            Path(main_tree) / ".claude-mpm" / "state" / "commit-token-baseline.json"
+        )
+        assert baseline_path.exists(), (
+            f"Baseline file missing at {baseline_path} — "
+            "was written to worktree path instead of main-tree path"
+        )
+        baseline = json.loads(baseline_path.read_text())
+        assert baseline["input_tokens"] == 8_000
+        assert baseline["output_tokens"] == 1_200
+
+    def test_normal_non_worktree_commit_still_works(self, tmp_path: Path) -> None:
+        """Regression: a normal main-repo commit (no worktree) still gets the correct delta."""
+        main_tree = str(tmp_path / "main-repo")
+        Path(main_tree).mkdir(parents=True)
+        (Path(main_tree) / ".claude-mpm" / "state").mkdir(parents=True)
+
+        fake_home = tmp_path / "fake_home"
+        _create_fake_transcript_for_cwd(
+            fake_home,
+            main_tree,
+            input_tokens=12_000,
+            output_tokens=2_500,
+            model="claude-opus-4-8",
+        )
+
+        # resolve_main_working_tree returns cwd unchanged for a normal repo.
+        with self._patch_home(fake_home), self._patch_resolve_main(main_tree):
+            delta = get_token_delta(main_tree)
+
+        assert delta["input_tokens"] == 12_000, (
+            "Normal (non-worktree) commit regression: wrong token count"
+        )
+        assert delta["output_tokens"] == 2_500
+        assert "claude-opus-4-8" in delta.get("models", {})
+
+
+class TestAmendCommitMessageZeroSkip:
+    """Test that amend_commit_message() omits X-AI-Tokens-In/Out when delta is 0/0
+    (fix for #696 zero-skip requirement).
+    """
+
+    def _make_log_result(self, message: str) -> MagicMock:
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = message
+        r.stderr = ""
+        return r
+
+    def _make_amend_result(self) -> MagicMock:
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = ""
+        r.stderr = ""
+        return r
+
+    def test_zero_delta_skips_token_trailers(self) -> None:
+        """When both input_tokens and output_tokens are 0, token trailers are omitted."""
+        zero_delta: dict = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "models": {},
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_log_result("feat: some change\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", zero_delta, "/tmp")
+
+        amend_call = mock_run.call_args_list[1]
+        new_msg = amend_call[0][0][amend_call[0][0].index("-m") + 1]
+
+        assert "X-AI-Tokens-In:" not in new_msg, (
+            "X-AI-Tokens-In must be omitted when delta is 0"
+        )
+        assert "X-AI-Tokens-Out:" not in new_msg, (
+            "X-AI-Tokens-Out must be omitted when delta is 0"
+        )
+
+    def test_zero_delta_still_emits_coauthoredby(self) -> None:
+        """Co-Authored-By is always emitted even when token delta is 0."""
+        zero_delta: dict = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "models": {},
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_log_result("fix: something\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", zero_delta, "/tmp")
+
+        amend_call = mock_run.call_args_list[1]
+        new_msg = amend_call[0][0][amend_call[0][0].index("-m") + 1]
+
+        assert _COAUTHORED_CANONICAL in new_msg, (
+            "Co-Authored-By must be preserved even when token delta is 0"
+        )
+
+    def test_nonzero_out_only_still_emits_trailers(self) -> None:
+        """If output_tokens is nonzero (input=0), token trailers are still emitted."""
+        delta: dict = {
+            "input_tokens": 0,
+            "output_tokens": 50,
+            "models": {},
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_log_result("chore: update\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", delta, "/tmp")
+
+        amend_call = mock_run.call_args_list[1]
+        new_msg = amend_call[0][0][amend_call[0][0].index("-m") + 1]
+
+        assert "X-AI-Tokens-In: 0" in new_msg
+        assert "X-AI-Tokens-Out: 50" in new_msg
+
+    def test_nonzero_tokens_still_emits_trailers(self) -> None:
+        """Regression: normal non-zero delta still produces token trailers."""
+        delta: dict = {
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "models": {},
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_log_result("feat: new feature\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", delta, "/tmp")
+
+        amend_call = mock_run.call_args_list[1]
+        new_msg = amend_call[0][0][amend_call[0][0].index("-m") + 1]
+
+        assert "X-AI-Tokens-In: 1000" in new_msg
+        assert "X-AI-Tokens-Out: 200" in new_msg

--- a/tests/test_commit_cost_tracker.py
+++ b/tests/test_commit_cost_tracker.py
@@ -912,7 +912,17 @@ class TestResolveMainWorkingTree:
             f"worktree {worktree_path}\nHEAD def456\nbranch refs/heads/worktree-agent-abc\n"
         )
 
-        with patch("subprocess.run", return_value=self._make_run(porcelain_output)):
+        # Fast-path calls: --git-dir != --git-common-dir so we do NOT short-circuit.
+        # The worktree's .git is a file (or .git/worktrees/agent-abc), while the
+        # shared git-common-dir is the main repo's .git.  Provide distinct outputs.
+        fast_dir = self._make_run(".git/worktrees/agent-abc")  # worktree-specific
+        fast_common = self._make_run("../../.git")  # shared main .git
+        porcelain_result = self._make_run(porcelain_output)
+
+        with patch(
+            "subprocess.run",
+            side_effect=[fast_dir, fast_common, porcelain_result],
+        ):
             result = resolve_main_working_tree(worktree_path)
 
         assert result == main_tree, (
@@ -921,13 +931,17 @@ class TestResolveMainWorkingTree:
         )
 
     def test_main_repo_returns_itself(self, tmp_path: Path) -> None:
-        """When called from the main repo root, the main tree is returned unchanged."""
-        main_tree = str(tmp_path / "main-repo")
-        porcelain_output = (
-            f"worktree {main_tree}\nHEAD abc123\nbranch refs/heads/main\n"
-        )
+        """When called from the main repo root, the main tree is returned unchanged.
 
-        with patch("subprocess.run", return_value=self._make_run(porcelain_output)):
+        The fast-path short-circuits when git-dir == git-common-dir (both return
+        ``.git``), so git worktree list is never spawned.
+        """
+        main_tree = str(tmp_path / "main-repo")
+
+        # Fast-path: git-dir == git-common-dir → both return ".git".
+        fast_same = self._make_run(".git")
+
+        with patch("subprocess.run", side_effect=[fast_same, fast_same]):
             result = resolve_main_working_tree(main_tree)
 
         assert result == main_tree
@@ -942,11 +956,26 @@ class TestResolveMainWorkingTree:
         git_dir.mkdir()
         worktree_path = str(tmp_path / "worktree")
 
-        fail_result = self._make_run("", returncode=128)
-        # git rev-parse --git-common-dir returns the shared .git path
-        git_common_result = self._make_run(str(git_dir))
+        # Fast-path: --git-dir (worktree-specific) != --git-common-dir (shared)
+        # so the fast path does NOT short-circuit.
+        fast_dir_result = self._make_run(".git/worktrees/wt1")  # worktree-specific
+        fast_common_result = self._make_run(str(git_dir))  # shared .git (absolute)
 
-        with patch("subprocess.run", side_effect=[fail_result, git_common_result]):
+        # git worktree list --porcelain fails
+        worktree_list_fail = self._make_run("", returncode=128)
+
+        # Fallback git rev-parse --git-common-dir returns the shared .git path
+        fallback_common_result = self._make_run(str(git_dir))
+
+        with patch(
+            "subprocess.run",
+            side_effect=[
+                fast_dir_result,
+                fast_common_result,
+                worktree_list_fail,
+                fallback_common_result,
+            ],
+        ):
             result = resolve_main_working_tree(worktree_path)
 
         assert result == str(main_tree), (
@@ -954,11 +983,19 @@ class TestResolveMainWorkingTree:
         )
 
     def test_both_git_calls_fail_returns_original_cwd(self, tmp_path: Path) -> None:
-        """When both git calls fail, the original cwd is returned unchanged."""
+        """When all git calls fail, the original cwd is returned unchanged.
+
+        The fast-path makes two calls (--git-dir, --git-common-dir), then
+        git worktree list is attempted, then the --git-common-dir fallback.
+        All four must fail to reach the final ``return cwd`` safety net.
+        """
         worktree_path = str(tmp_path / "worktree")
         fail_result = self._make_run("", returncode=128)
 
-        with patch("subprocess.run", side_effect=[fail_result, fail_result]):
+        with patch(
+            "subprocess.run",
+            side_effect=[fail_result, fail_result, fail_result, fail_result],
+        ):
             result = resolve_main_working_tree(worktree_path)
 
         assert result == worktree_path, (
@@ -973,6 +1010,70 @@ class TestResolveMainWorkingTree:
             result = resolve_main_working_tree(worktree_path)
 
         assert result == worktree_path
+
+    def test_relative_git_common_dir_resolved_against_cwd_not_process_cwd(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: a relative --git-common-dir output is resolved relative to the
+        worktree cwd, not the process cwd.
+
+        WHY: git rev-parse --git-common-dir can return a relative path such as
+        ``../.git`` when run from a linked worktree.  Before the fix, the code
+        called Path(output).resolve() with no base, anchoring to the process cwd
+        instead of the worktree directory.  This test asserts that ``../.git``
+        returned while cwd=``<tmp>/worktree/sub`` resolves to
+        ``<tmp>/worktree/.git`` (relative to the worktree, not the process cwd).
+
+        HOW: Build a real on-disk layout — main_repo/.git + worktree/sub — then
+        mock the two subprocess calls so they behave as a real linked worktree
+        would (git-dir != git-common-dir for the fast-path, then worktree list
+        fails, then git-common-dir returns a relative path pointing to main_repo/.git).
+        Assert the resolved parent equals main_repo.
+        """
+        # Create the real directory tree so Path.resolve() works correctly.
+        main_repo = tmp_path / "main_repo"
+        main_git = main_repo / ".git"
+        main_git.mkdir(parents=True)
+
+        # Simulate a linked worktree at main_repo/.clone_worktrees/sub.
+        worktree_dir = main_repo / ".clone_worktrees" / "sub"
+        worktree_dir.mkdir(parents=True)
+        worktree_cwd = str(worktree_dir)
+
+        # git rev-parse --git-common-dir returns "../../.git" (relative to worktree_dir).
+        relative_git_common = "../../.git"
+
+        # Fast-path calls: make --git-dir != --git-common-dir so the fast path
+        # does NOT short-circuit (we need to reach the fallback).
+        fast_dir_result = self._make_run(
+            ".git/worktrees/sub"
+        )  # git-dir (worktree-specific)
+        fast_common_result = self._make_run(
+            relative_git_common
+        )  # git-common-dir (shared)
+
+        # worktree list call fails so we fall through to the --git-common-dir fallback.
+        worktree_list_fail = self._make_run("", returncode=128)
+
+        # Fallback --git-common-dir call returns the same relative path.
+        fallback_common_result = self._make_run(relative_git_common)
+
+        side_effects = [
+            fast_dir_result,  # git rev-parse --git-dir  (fast-path)
+            fast_common_result,  # git rev-parse --git-common-dir  (fast-path)
+            worktree_list_fail,  # git worktree list --porcelain  (fails → fallback)
+            fallback_common_result,  # git rev-parse --git-common-dir  (fallback)
+        ]
+
+        with patch("subprocess.run", side_effect=side_effects):
+            result = resolve_main_working_tree(worktree_cwd)
+
+        expected = str(main_repo)
+        assert result == expected, (
+            f"Expected main_repo={expected!r}, got {result!r}.\n"
+            "Relative git-common-dir must be resolved relative to the worktree cwd, "
+            "not the process cwd (regression guard for trusty-review item #1 on #696)."
+        )
 
 
 class TestGetTokenDeltaWorktreeFallback:


### PR DESCRIPTION
## Summary
Closes #696. Two fixes to the `post-commit` token/cost trailer hook (`commit_cost_tracker.py`). Does NOT restore the cache/cost trailers — those remain removed by design (per maintainer).

## Fix 1 — Robust token attribution for subagent / worktree commits
The hook read token counts from `~/.claude/projects/{cwd_encoded}/` transcripts. When a subagent commits from a **linked git worktree**, `git rev-parse --show-toplevel` returns the worktree root, whose encoded path has no transcript → every such commit got useless `X-AI-Tokens-In: 0 / X-AI-Tokens-Out: 0` blocks (visible after squash-merge).
- New `resolve_main_working_tree(cwd)` derives the MAIN working tree via `git worktree list --porcelain` (first entry), falling back to `parent(git rev-parse --git-common-dir)`, then to `cwd`.
- `get_token_delta()` resolves the canonical cwd **once** and uses it consistently for transcript lookup, baseline read, and baseline write (no baseline/transcript mismatch).
- **Zero-skip**: when no token data resolves, the `X-AI-Tokens-In/Out` trailers are omitted entirely rather than writing zeros.

## Fix 2 — Doc drift
`PM_INSTRUCTIONS.md` listed four trailers (`X-AI-Cache-Read/Write/Ratio`, `X-AI-Est-Cost-USD`) that were removed from the tracker on 2026-06-02 — causing verification false-negatives. Corrected to the actually-emitted set: `X-AI-Tokens-In`, `X-AI-Tokens-Out`, `X-AI-Model`.

## Tests
`tests/hooks/` — worktree main-tree resolver, missing-primary-transcript fallback, zero-skip, and non-worktree regression. 54 passed.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
