### PR TITLE
fix(tests): restore /private/var/folders denylist entry stripped by tmp_path fixture

### DIFF
--- a/tests/services/test_trusty_search_allowlist.py
+++ b/tests/services/test_trusty_search_allowlist.py
@@ -392,12 +392,10 @@ class TestCheckDenylist:
         We restore the entry here (matching the /private/tmp test pattern) to
         verify that _check_denylist honours it when present in the set.
         """
-        import claude_mpm.services.trusty_search_allowlist as mod
-
         restored = _mod._DENYLIST_SUBTREE_ROOTS | frozenset(["/private/var/folders"])
-        monkeypatch.setattr(mod, "_DENYLIST_SUBTREE_ROOTS", restored)
+        monkeypatch.setattr(_mod, "_DENYLIST_SUBTREE_ROOTS", restored)
         with pytest.raises(DeniedPathError, match="ephemeral/system"):
-            mod._check_denylist(Path("/private/var/folders"))
+            _mod._check_denylist(Path("/private/var/folders"))
 
     def test_rejects_private_var_folders_subdirectory(self, monkeypatch):
         """Deep macOS temp path must be refused (kills removal mutants).
@@ -405,12 +403,10 @@ class TestCheckDenylist:
         See `test_rejects_private_var_folders_root` for why /private/var/folders
         is re-injected via monkeypatch.
         """
-        import claude_mpm.services.trusty_search_allowlist as mod
-
         restored = _mod._DENYLIST_SUBTREE_ROOTS | frozenset(["/private/var/folders"])
-        monkeypatch.setattr(mod, "_DENYLIST_SUBTREE_ROOTS", restored)
+        monkeypatch.setattr(_mod, "_DENYLIST_SUBTREE_ROOTS", restored)
         with pytest.raises(DeniedPathError, match="ephemeral/system"):
-            mod._check_denylist(Path("/private/var/folders/xx/abc123/T/myapp"))
+            _mod._check_denylist(Path("/private/var/folders/xx/abc123/T/myapp"))
 
     # --- Denylist constant integrity (kills set-to-empty mutants) -------------
 

--- a/tests/services/test_trusty_search_allowlist.py
+++ b/tests/services/test_trusty_search_allowlist.py
@@ -383,15 +383,34 @@ class TestCheckDenylist:
         with pytest.raises(DeniedPathError, match="ephemeral/system"):
             mod._check_denylist(Path("/private/tmp/myproject"))
 
-    def test_rejects_private_var_folders_root(self):
-        """`/private/var/folders` (macOS per-user temp) root must be refused."""
-        with pytest.raises(DeniedPathError, match="ephemeral/system"):
-            _check_denylist(Path("/private/var/folders"))
+    def test_rejects_private_var_folders_root(self, monkeypatch):
+        """`/private/var/folders` (macOS per-user temp) root must be refused.
 
-    def test_rejects_private_var_folders_subdirectory(self):
-        """Deep macOS temp path must be refused."""
+        The autouse fixture strips /private/var/folders from
+        _DENYLIST_SUBTREE_ROOTS because pytest's tmp_path on macOS resolves to
+        /private/var/folders/... — exactly the same pattern as /private/tmp.
+        We restore the entry here (matching the /private/tmp test pattern) to
+        verify that _check_denylist honours it when present in the set.
+        """
+        import claude_mpm.services.trusty_search_allowlist as mod
+
+        restored = _mod._DENYLIST_SUBTREE_ROOTS | frozenset(["/private/var/folders"])
+        monkeypatch.setattr(mod, "_DENYLIST_SUBTREE_ROOTS", restored)
         with pytest.raises(DeniedPathError, match="ephemeral/system"):
-            _check_denylist(Path("/private/var/folders/xx/abc123/T/myapp"))
+            mod._check_denylist(Path("/private/var/folders"))
+
+    def test_rejects_private_var_folders_subdirectory(self, monkeypatch):
+        """Deep macOS temp path must be refused (kills removal mutants).
+
+        See `test_rejects_private_var_folders_root` for why /private/var/folders
+        is re-injected via monkeypatch.
+        """
+        import claude_mpm.services.trusty_search_allowlist as mod
+
+        restored = _mod._DENYLIST_SUBTREE_ROOTS | frozenset(["/private/var/folders"])
+        monkeypatch.setattr(mod, "_DENYLIST_SUBTREE_ROOTS", restored)
+        with pytest.raises(DeniedPathError, match="ephemeral/system"):
+            mod._check_denylist(Path("/private/var/folders/xx/abc123/T/myapp"))
 
     # --- Denylist constant integrity (kills set-to-empty mutants) -------------
 


### PR DESCRIPTION
## Summary
Fixes 2 reproducible failures in `tests/services/test_trusty_search_allowlist.py` (`test_rejects_private_var_folders_root`, `test_rejects_private_var_folders_subdirectory`).

## Root cause — test bug, not a denylist gap
The source (`trusty_search_allowlist.py`) already correctly lists `/private/var/folders` in `_DENYLIST_SUBTREE_ROOTS`. The failure was caused by the autouse fixture `_patch_subtree_roots_for_tmp_path`, which strips any subtree root that covers `tmp_path`. On macOS `tmp_path` resolves under `/private/var/folders/...`, so the fixture removed the very entry these two tests assert on. The analogous `/private/tmp` tests already re-inject their root via `monkeypatch`; the `/private/var/folders` tests simply forgot to.

## Fix
Add the `monkeypatch` re-injection of `/private/var/folders` to both tests, matching the established `/private/tmp` pattern. Source unchanged (it was already correct).

## Tests
Full allowlist suite: **67 passed**.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
