### PR TITLE
fix: make monitor daemon PID/log paths CWD-invariant (#701)

### DIFF
--- a/src/claude_mpm/cli/commands/monitor.py
+++ b/src/claude_mpm/cli/commands/monitor.py
@@ -198,8 +198,14 @@ class MonitorCommand(BaseCommand):
     def _status_monitor(self, args) -> CommandResult:
         """Get unified monitor daemon status."""
 
+        # Get port from args, defaulting to 8765 to match the other subcommands
+        port = getattr(args, "port", None)
+        if port is None:
+            port = 8765
+        host = getattr(args, "host", "localhost")
+
         # Create daemon instance to check status
-        daemon = UnifiedMonitorDaemon()
+        daemon = UnifiedMonitorDaemon(host=host, port=port)
         status_data = daemon.status()
 
         # Format output message

--- a/src/claude_mpm/cli/commands/monitor.py
+++ b/src/claude_mpm/cli/commands/monitor.py
@@ -198,7 +198,8 @@ class MonitorCommand(BaseCommand):
     def _status_monitor(self, args) -> CommandResult:
         """Get unified monitor daemon status."""
 
-        # Get port from args, defaulting to 8765 to match the other subcommands
+        # Default port 8765 mirrors the literal used by _start_monitor/_stop_monitor;
+        # no shared constant is in play across those handlers.
         port = getattr(args, "port", None)
         if port is None:
             port = 8765

--- a/src/claude_mpm/cli/parsers/monitor_parser.py
+++ b/src/claude_mpm/cli/parsers/monitor_parser.py
@@ -109,6 +109,11 @@ def add_monitor_subparser(subparsers) -> argparse.ArgumentParser:
         MonitorCommands.STATUS.value, help="Check monitoring server status"
     )
     status_monitor_parser.add_argument(
+        "--port",
+        type=int,
+        help="Port of server to check (checks default port if not specified)",
+    )
+    status_monitor_parser.add_argument(
         "--verbose", action="store_true", help="Show detailed status information"
     )
     status_monitor_parser.add_argument(

--- a/src/claude_mpm/cli/parsers/monitor_parser.py
+++ b/src/claude_mpm/cli/parsers/monitor_parser.py
@@ -114,6 +114,9 @@ def add_monitor_subparser(subparsers) -> argparse.ArgumentParser:
         help="Port of server to check (checks default port if not specified)",
     )
     status_monitor_parser.add_argument(
+        "--host", default="localhost", help="Host to bind to (default: localhost)"
+    )
+    status_monitor_parser.add_argument(
         "--verbose", action="store_true", help="Show detailed status information"
     )
     status_monitor_parser.add_argument(

--- a/src/claude_mpm/services/monitor/daemon.py
+++ b/src/claude_mpm/services/monitor/daemon.py
@@ -19,7 +19,6 @@ import signal
 import sys
 import threading
 import time
-from pathlib import Path
 
 from ...core.logging_config import get_logger
 from ..hook_installer_service import HookInstallerService
@@ -92,12 +91,14 @@ class UnifiedMonitorDaemon:
         self.shutdown_event = threading.Event()
 
     def _get_default_pid_file(self) -> str:
-        """Get default PID file path with port number to support multiple daemons."""
-        project_root = Path.cwd()
-        claude_mpm_dir = project_root / ".claude-mpm"
-        claude_mpm_dir.mkdir(exist_ok=True)
-        # Include port in filename to support multiple daemon instances
-        return str(claude_mpm_dir / f"monitor-daemon-{self.port}.pid")
+        """Get default PID file path with port number to support multiple daemons.
+
+        Delegates to DaemonManager.get_pid_file_for_port so that ALL three
+        resolvers (DaemonManager.get_pid_file_for_port, DaemonManager._get_default_pid_file,
+        and this method) share a single CWD-invariant implementation (issue #701).
+        Directory creation is deferred to the write path (write_pid_file).
+        """
+        return str(DaemonManager.get_pid_file_for_port(self.port))
 
     def start(self, force_restart: bool = False) -> bool:
         """Start the unified monitor daemon.

--- a/src/claude_mpm/services/monitor/daemon_manager.py
+++ b/src/claude_mpm/services/monitor/daemon_manager.py
@@ -25,6 +25,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -36,6 +37,66 @@ from ...core.logging_config import get_logger
 EXIT_NORMAL = 0
 EXIT_SIGKILL = 137  # 128 + SIGKILL(9) - forced termination
 EXIT_SIGTERM = 143  # 128 + SIGTERM(15) - graceful shutdown
+
+
+def _find_project_root(start: Path | None = None) -> Path:
+    """Walk up from *start* (or cwd) to find the nearest project-root marker.
+
+    WHAT: Returns the closest ancestor directory that contains a project-root
+          marker, giving the monitor daemon a stable anchor for PID/log paths
+          that does not change when the caller's cwd is a subdirectory.
+    WHY:  Without this, ``get_pid_file_for_port`` and ``_get_default_log_file``
+          each call ``Path.cwd()`` independently.  A ``start`` from a project
+          subdirectory resolves a *different* ``.claude-mpm/`` than the project
+          root, so ``stop``/``status`` from a subdirectory find a different PID
+          file than ``start`` wrote (issue #701).
+
+    Markers used (priority order, most specific first):
+      1. ``.git`` entry (file or directory — git worktrees use a ``.git`` FILE)
+      2. ``pyproject.toml`` — Python project root
+
+    IMPORTANT — ``.claude-mpm/`` is deliberately NOT a marker here.
+    The framework's shared startup code (``ProjectInitializer.initialize_project_directory``
+    in ``src/claude_mpm/init.py``) creates a ``.claude-mpm/`` directory in the
+    current working directory on *every* CLI invocation — including read-only
+    commands like ``monitor status``.  Using ``.claude-mpm/`` as a marker would
+    cause the walk to anchor immediately to the cwd's stray ``.claude-mpm/``
+    instead of ascending to the real project root (issue #701 regression).
+
+    The OS temporary directory boundary is respected: the walk will not ascend
+    into or past ``tempfile.gettempdir()`` to avoid crossing into shared tmp
+    storage (matches the guard in UnifiedPathManager.project_root).
+
+    Fallback: if no marker is found (e.g. bare tmp dir, filesystem root), the
+    function returns ``start`` (or ``Path.cwd()``), preserving pre-fix behaviour
+    and preventing a crash.
+
+    :spec: none
+    """
+    anchor = (start or Path.cwd()).resolve()
+    _tmp_root = Path(tempfile.gettempdir()).resolve()
+
+    current = anchor
+    while True:
+        # Priority 1: .git entry (dir or file for git worktrees) — reliable VCS root
+        if (current / ".git").exists():
+            return current
+        # Priority 2: pyproject.toml — Python project root
+        if (current / "pyproject.toml").exists():
+            return current
+        # NOTE: .claude-mpm/ is intentionally NOT checked here — see docstring.
+
+        # Stop at OS temp root boundary; also stop when parent == current
+        # (filesystem root — further ascent would loop forever).
+        parent = current.parent
+        at_fs_root = parent == current
+        at_tmp_root = current == _tmp_root
+        if at_fs_root or at_tmp_root:
+            break
+        current = parent
+
+    # No marker found — return anchor unchanged (no regression for bare dirs)
+    return anchor
 
 
 class DaemonManager:
@@ -95,24 +156,31 @@ class DaemonManager:
               file (issue #695).  Centralising here means any future rename
               breaks both callers at once rather than silently.
 
+              This method is intentionally a PURE FUNCTION — it only computes
+              and returns a path; it never creates directories.  Read-only
+              callers (``status``, ``stop``) must not trigger mkdir side-effects
+              (issue #701).  Directory creation is the responsibility of WRITE
+              paths only (see ``write_pid_file`` and ``start_daemon_subprocess``).
+
         :spec: none
         """
-        project_root = Path.cwd()
-        claude_mpm_dir = project_root / ".claude-mpm"
-        claude_mpm_dir.mkdir(exist_ok=True)
-        return claude_mpm_dir / f"monitor-daemon-{port}.pid"
+        project_root = _find_project_root()
+        return project_root / ".claude-mpm" / f"monitor-daemon-{port}.pid"
 
     def _get_default_pid_file(self) -> Path:
         """Get default PID file path with port number to support multiple daemons."""
         return DaemonManager.get_pid_file_for_port(self.port)
 
     def _get_default_log_file(self) -> Path:
-        """Get default log file path with port number to support multiple daemons."""
-        project_root = Path.cwd()
-        logs_dir = project_root / ".claude-mpm" / "logs"
-        logs_dir.mkdir(parents=True, exist_ok=True)
+        """Get default log file path with port number to support multiple daemons.
+
+        Pure resolver — does NOT create directories.  The logs directory is
+        created by the write path (``start_daemon_subprocess``, ``_redirect_streams``)
+        immediately before opening the file (issue #701).
+        """
+        project_root = _find_project_root()
         # Include port in filename to support multiple daemon instances
-        return logs_dir / f"monitor-daemon-{self.port}.log"
+        return project_root / ".claude-mpm" / "logs" / f"monitor-daemon-{self.port}.log"
 
     def cleanup_port_conflicts(self, max_retries: int = 3) -> bool:
         """Clean up any processes using the daemon port.
@@ -632,9 +700,13 @@ class DaemonManager:
 
             self.logger.info(f"Starting monitor daemon via subprocess: {' '.join(cmd)}")
 
-            # Open log file for output redirection
+            # Open log file for output redirection.
+            # Create the parent directory here (write path) rather than in the
+            # path resolver, so that read-only callers (status/stop) never
+            # trigger a mkdir side-effect (issue #701).
             log_file_handle = None
             if self.log_file:
+                Path(self.log_file).parent.mkdir(parents=True, exist_ok=True)
                 log_file_handle = Path(self.log_file).open("a")
                 log_file = log_file_handle
             else:

--- a/tests/cli/commands/test_monitor_command.py
+++ b/tests/cli/commands/test_monitor_command.py
@@ -227,6 +227,26 @@ class TestMonitorCommand:
         assert result.success is True
         mock_daemon_class.assert_called_once_with(host="localhost", port=8765)
 
+    @patch("claude_mpm.cli.commands.monitor.UnifiedMonitorDaemon")
+    def test_status_with_explicit_host_and_port(self, mock_daemon_class):
+        """Test that --host and --port on status both flow through to UnifiedMonitorDaemon."""
+        mock_daemon = Mock()
+        mock_daemon_class.return_value = mock_daemon
+        mock_daemon.status.return_value = {
+            "running": False,
+            "host": "0.0.0.0",
+            "port": 9876,
+        }
+
+        args = Namespace(monitor_command="status", host="0.0.0.0", port=9876)
+
+        result = self.command.run(args)
+
+        assert isinstance(result, CommandResult)
+        assert result.success is True
+        mock_daemon_class.assert_called_once_with(host="0.0.0.0", port=9876)
+        mock_daemon.status.assert_called_once()
+
     def test_run_unknown_command(self):
         """Test handling of unknown monitor command."""
         args = Namespace(monitor_command="unknown")

--- a/tests/cli/commands/test_monitor_command.py
+++ b/tests/cli/commands/test_monitor_command.py
@@ -187,6 +187,46 @@ class TestMonitorCommand:
         assert result.success is True
         assert "not running" in result.message
 
+    @patch("claude_mpm.cli.commands.monitor.UnifiedMonitorDaemon")
+    def test_status_with_explicit_port(self, mock_daemon_class):
+        """Test that --port on status is forwarded to UnifiedMonitorDaemon."""
+        mock_daemon = Mock()
+        mock_daemon_class.return_value = mock_daemon
+        mock_daemon.status.return_value = {
+            "running": False,
+            "host": "localhost",
+            "port": 9999,
+        }
+
+        args = Namespace(monitor_command="status", port=9999)
+
+        result = self.command.run(args)
+
+        assert isinstance(result, CommandResult)
+        assert result.success is True
+        # Daemon must be constructed with the requested port
+        mock_daemon_class.assert_called_once_with(host="localhost", port=9999)
+        mock_daemon.status.assert_called_once()
+
+    @patch("claude_mpm.cli.commands.monitor.UnifiedMonitorDaemon")
+    def test_status_without_port_defaults_to_8765(self, mock_daemon_class):
+        """Test that omitting --port on status falls back to default port 8765."""
+        mock_daemon = Mock()
+        mock_daemon_class.return_value = mock_daemon
+        mock_daemon.status.return_value = {
+            "running": False,
+            "host": "localhost",
+            "port": 8765,
+        }
+
+        args = Namespace(monitor_command="status")  # no port attribute
+
+        result = self.command.run(args)
+
+        assert isinstance(result, CommandResult)
+        assert result.success is True
+        mock_daemon_class.assert_called_once_with(host="localhost", port=8765)
+
     def test_run_unknown_command(self):
         """Test handling of unknown monitor command."""
         args = Namespace(monitor_command="unknown")

--- a/tests/unit/services/monitor/test_daemon_cwd_invariant.py
+++ b/tests/unit/services/monitor/test_daemon_cwd_invariant.py
@@ -1,0 +1,360 @@
+"""Tests for CWD-invariant PID/log path resolution (issue #701).
+
+WHAT: Verifies that get_pid_file_for_port, _get_default_log_file, and
+      UnifiedMonitorDaemon._get_default_pid_file all anchor to the same
+      project root regardless of which subdirectory the caller's cwd is,
+      and that the resolver is a pure function (no mkdir side-effects).
+
+WHY:  Before the fix, each resolver called Path.cwd() independently.  A
+      ``start`` from the project root wrote the PID file to
+      ``<root>/.claude-mpm/``, but ``stop``/``status`` from a subdirectory
+      resolved a DIFFERENT ``.claude-mpm/``, causing false "not running" and
+      orphaned daemons (issue #701).
+
+IMPORTANT: Every test that calls into the resolvers MUST monkeypatch.chdir
+to a tmp_path first.  The real repo IS a project with .git and .claude-mpm,
+so calling the resolver without chdir would resolve the real repo root and
+potentially create real directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.services.monitor.daemon import UnifiedMonitorDaemon
+from claude_mpm.services.monitor.daemon_manager import DaemonManager, _find_project_root
+
+# ---------------------------------------------------------------------------
+# _find_project_root — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindProjectRoot:
+    """Unit tests for the module-level _find_project_root helper."""
+
+    def test_returns_git_root_from_subdir(self, tmp_path: Path, monkeypatch) -> None:
+        """Walking up from a subdirectory finds the nearest .git ancestor."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        subdir = proj / "src" / "deep"
+        subdir.mkdir(parents=True)
+
+        monkeypatch.chdir(subdir)
+        result = _find_project_root()
+        assert result == proj
+
+    def test_git_wins_over_colocated_claude_mpm(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """.git is the only root marker; .claude-mpm/ colocated with it is ignored as a marker.
+
+        Both .git and .claude-mpm/ are in the same directory.  The function
+        still returns that directory because .git is found — the result is
+        correct regardless, but we confirm .claude-mpm/ alone does NOT affect
+        the walk outcome.
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        (proj / ".claude-mpm").mkdir()
+
+        monkeypatch.chdir(proj)
+        result = _find_project_root()
+        assert result == proj
+
+    def test_git_ancestor_wins_over_stray_claude_mpm_in_cwd(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """.git ancestor must win even when cwd has a stray .claude-mpm/ dir.
+
+        This is the CORE regression for issue #701: the framework creates
+        .claude-mpm/ in the cwd on every CLI invocation (including read-only
+        commands like ``monitor status``).  If .claude-mpm/ were a marker, the
+        walk would anchor to the cwd (wrong) instead of ascending to the real
+        project root that contains .git.
+
+        Scenario:
+          tmp_path/proj/.git          ← real project root
+          tmp_path/proj/src/deep/     ← cwd when running `monitor status`
+          tmp_path/proj/src/deep/.claude-mpm/  ← spuriously created by framework
+
+        Expected: _find_project_root() returns tmp_path/proj  (the .git root)
+        Buggy behaviour (old code): returns tmp_path/proj/src/deep (stray .claude-mpm)
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        deep = proj / "src" / "deep"
+        deep.mkdir(parents=True)
+        # Simulate framework's stray .claude-mpm/ created in subdir cwd
+        (deep / ".claude-mpm").mkdir()
+
+        monkeypatch.chdir(deep)
+        result = _find_project_root()
+        assert result == proj, (
+            f"Expected real project root {proj}, got {result}.\n"
+            "A stray .claude-mpm/ in the cwd must NOT anchor the walk — "
+            "the .git ancestor must win (issue #701 regression guard)."
+        )
+
+    def test_pyproject_toml_found_when_no_git(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """pyproject.toml is used as fallback when no .git or .claude-mpm exists."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "pyproject.toml").touch()
+        subdir = proj / "src"
+        subdir.mkdir()
+
+        monkeypatch.chdir(subdir)
+        result = _find_project_root()
+        assert result == proj
+
+    def test_fallback_to_cwd_when_no_marker(self, tmp_path: Path, monkeypatch) -> None:
+        """Returns cwd unchanged when no project marker is found (no crash)."""
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        monkeypatch.chdir(bare)
+        result = _find_project_root()
+        assert result == bare, (
+            f"Expected fallback to cwd {bare}, got {result}. "
+            "No marker found should return anchor as-is."
+        )
+
+    def test_does_not_ascend_past_temp_dir(self, tmp_path: Path, monkeypatch) -> None:
+        """The walk must not ascend above tmp_path when there is no marker.
+
+        On macOS tmp_path lives under /private/var/folders/.../T/ which has no
+        project markers.  The walk should stop at the OS temp root boundary and
+        return the anchor (bare dir), not some ancestor outside the temp tree.
+        """
+        bare = tmp_path / "no_marker"
+        bare.mkdir()
+
+        monkeypatch.chdir(bare)
+        result = _find_project_root()
+
+        # The fallback must return the anchor (bare) unchanged — no marker means
+        # we return the starting directory, not some parent.
+        assert result == bare, (
+            f"Expected fallback to anchor {bare}, got {result}. "
+            "With no project markers, _find_project_root must return the anchor."
+        )
+
+    def test_start_parameter_overrides_cwd(self, tmp_path: Path, monkeypatch) -> None:
+        """Passing an explicit start path overrides Path.cwd()."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+
+        other = tmp_path / "other"
+        other.mkdir()
+
+        # chdir to 'other' which has no marker
+        monkeypatch.chdir(other)
+
+        # But pass proj explicitly
+        result = _find_project_root(start=proj)
+        assert result == proj
+
+
+# ---------------------------------------------------------------------------
+# get_pid_file_for_port — CWD-invariance
+# ---------------------------------------------------------------------------
+
+
+class TestGetPidFileForPortCwdInvariance:
+    """get_pid_file_for_port must return the same path from root and subdirs."""
+
+    def test_same_path_from_root_and_subdir(self, tmp_path: Path, monkeypatch) -> None:
+        """Path from project root equals path from a deep subdirectory."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        subdir = proj / "src" / "deep"
+        subdir.mkdir(parents=True)
+
+        monkeypatch.chdir(proj)
+        path_from_root = DaemonManager.get_pid_file_for_port(8765)
+
+        monkeypatch.chdir(subdir)
+        path_from_subdir = DaemonManager.get_pid_file_for_port(8765)
+
+        assert path_from_root == path_from_subdir, (
+            f"Path mismatch:\n  from root:   {path_from_root}\n"
+            f"  from subdir: {path_from_subdir}\n"
+            "Both must resolve to the same project root (issue #701)."
+        )
+
+    def test_both_paths_under_project_claude_mpm(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Resolved path is always under <project>/.claude-mpm/."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        subdir = proj / "src" / "deep"
+        subdir.mkdir(parents=True)
+
+        monkeypatch.chdir(subdir)
+        p = DaemonManager.get_pid_file_for_port(8765)
+
+        assert p.parts[-3] == "proj"
+        assert p.parts[-2] == ".claude-mpm"
+        assert p.name == "monitor-daemon-8765.pid"
+
+    def test_no_mkdir_side_effect(self, tmp_path: Path, monkeypatch) -> None:
+        """Calling get_pid_file_for_port must NOT create .claude-mpm/."""
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        monkeypatch.chdir(bare)
+        _ = DaemonManager.get_pid_file_for_port(8765)
+
+        assert not (bare / ".claude-mpm").exists(), (
+            "get_pid_file_for_port must be a pure resolver — it must not "
+            "create directories (issue #701 regression guard)."
+        )
+
+    def test_git_root_with_claude_mpm_subdir_anchors_correctly(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """PID file is under the .git root even when .claude-mpm/ also exists there.
+
+        With .git taking priority, a pre-existing .claude-mpm/ in the same
+        directory does not interfere — the result is the same project root.
+        Walking from a subdir with NO stray .claude-mpm/ must still land at proj.
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        (proj / ".claude-mpm").mkdir()
+
+        subdir = proj / "sub"
+        subdir.mkdir()
+
+        monkeypatch.chdir(subdir)
+        p = DaemonManager.get_pid_file_for_port(8765)
+
+        assert p.parent.parent == proj, (
+            f"Expected PID file under {proj}/.claude-mpm/, got {p}"
+        )
+
+    def test_stray_claude_mpm_in_subdir_does_not_defeat_git_root(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Critical regression: stray .claude-mpm/ in cwd must not defeat ancestor .git root.
+
+        Simulates the exact scenario that caused false "not running" in issue #701:
+        - Daemon was STARTED from project root (PID file → proj/.claude-mpm/monitor-daemon-8765.pid)
+        - `monitor status` is run from a subdirectory
+        - Framework startup creates subdir/.claude-mpm/ BEFORE the PID resolver runs
+        - Old code anchored to subdir and returned subdir/.claude-mpm/monitor-daemon-8765.pid → not found
+        - Fixed code ignores .claude-mpm/ as a marker and walks up to find .git
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        deep = proj / "src" / "deep"
+        deep.mkdir(parents=True)
+        # Framework-created stray dir in subdir cwd
+        (deep / ".claude-mpm").mkdir()
+
+        monkeypatch.chdir(deep)
+        p = DaemonManager.get_pid_file_for_port(8765)
+
+        assert p.parent.parent == proj, (
+            f"Expected PID file under {proj}/.claude-mpm/, got {p}.\n"
+            "Stray .claude-mpm/ in subdir cwd must NOT anchor the resolver "
+            "(issue #701 regression guard)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Three-resolver consistency
+# ---------------------------------------------------------------------------
+
+
+class TestThreeResolversAgree:
+    """All three resolvers must share the same project root."""
+
+    def test_pid_resolver_log_resolver_and_daemon_agree(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """get_pid_file_for_port, log resolver parent, and UnifiedMonitorDaemon all agree."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        subdir = proj / "a" / "b"
+        subdir.mkdir(parents=True)
+
+        monkeypatch.chdir(subdir)
+
+        pid_path = DaemonManager.get_pid_file_for_port(8765)
+        pid_root = (
+            pid_path.parent.parent
+        )  # strip monitor-daemon-8765.pid and .claude-mpm
+
+        mgr = DaemonManager(port=8765)
+        log_path = mgr._get_default_log_file()
+        log_root = log_path.parent.parent.parent  # strip filename, logs/, .claude-mpm/
+
+        daemon = UnifiedMonitorDaemon(port=8765)
+        daemon_pid_path = Path(daemon._get_default_pid_file())
+        daemon_pid_root = daemon_pid_path.parent.parent
+
+        assert pid_root == proj, f"PID resolver root {pid_root} != {proj}"
+        assert log_root == proj, f"Log resolver root {log_root} != {proj}"
+        assert daemon_pid_root == proj, f"Daemon pid root {daemon_pid_root} != {proj}"
+
+    def test_daemon_pid_file_delegates_to_static_resolver(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """UnifiedMonitorDaemon._get_default_pid_file must equal get_pid_file_for_port."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+
+        monkeypatch.chdir(proj)
+
+        static_path = DaemonManager.get_pid_file_for_port(8765)
+        daemon = UnifiedMonitorDaemon(port=8765)
+        daemon_path = Path(daemon._get_default_pid_file())
+
+        assert daemon_path == static_path, (
+            f"UnifiedMonitorDaemon._get_default_pid_file() returned {daemon_path}\n"
+            f"but DaemonManager.get_pid_file_for_port(8765) returned {static_path}\n"
+            "They must be equal (issue #701)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# socketio wrapper still agrees (regression guard for #695)
+# ---------------------------------------------------------------------------
+
+
+class TestSocketioDaemonWrapperStillAgrees:
+    """Confirm the socketio wrapper's _pid_file_for_port delegates to DaemonManager."""
+
+    @pytest.mark.parametrize("port", [8765, 8791, 9001, 19765])
+    def test_wrapper_equals_daemon_manager(
+        self, port: int, tmp_path: Path, monkeypatch
+    ) -> None:
+        """_pid_file_for_port(port) must equal DaemonManager.get_pid_file_for_port(port)."""
+        from claude_mpm.scripts.socketio_daemon import _pid_file_for_port
+
+        monkeypatch.chdir(tmp_path)
+
+        wrapper_path = _pid_file_for_port(port)
+        daemon_path = DaemonManager.get_pid_file_for_port(port)
+
+        assert wrapper_path == daemon_path, (
+            f"Port {port} path mismatch:\n"
+            f"  wrapper: {wrapper_path}\n"
+            f"  daemon:  {daemon_path}"
+        )


### PR DESCRIPTION
## Summary
Fixes #701 — `claude-mpm monitor start` from a project root then `status`/`stop` from a subdirectory resolved a *different* `.claude-mpm/` dir, falsely reporting "not running" and orphaning the daemon.

## Root cause
`get_pid_file_for_port()` anchored paths to `Path.cwd()`. A project-root walk was added — but the framework creates a `.claude-mpm/` in the cwd on **every** CLI invocation (`init.py:112`), so treating `.claude-mpm/` as a walk marker anchored the walk to the subdir and defeated the fix. The walk now anchors only on `.git` / `pyproject.toml`; `.claude-mpm/` is explicitly excluded.

## Changes
- `_find_project_root()` anchors daemon PID/log paths to the project root (`.git`/`pyproject.toml`), CWD-invariant.
- Removed the `mkdir()` side-effect from the resolver — read-only `status` no longer creates directories; dir creation moved to write paths.
- `UnifiedMonitorDaemon._get_default_pid_file` delegates to the canonical resolver so all three resolvers agree.
- Added `--port` to `monitor status` (parity with start/stop/restart) so non-default-port daemons can be queried.

## Verification
- Unit: new `test_daemon_cwd_invariant.py` (incl. regression: walk past a stray subdir `.claude-mpm/` to the real git root); socketio wrapper agreement tests stay green.
- **Live**: started daemon on port 8799 from project root; `status`/`stop` from `src/claude_mpm/services` subdir now correctly report RUNNING and kill the daemon; no stray pidfile written into the subdir; port fully released. All 6 runtime criteria PASS.

## Known follow-up (out of scope)
The framework still creates a bare `.claude-mpm/` in the cwd on every invocation (`init.py:112`, shared startup). The daemon resolver now walks past it correctly, but the spurious dir creation by read-only commands is a separate issue worth a future ticket.

Closes #701

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)