### PR TITLE
fix: gate project-dir init for read-only commands (partial #703)

### DIFF
--- a/src/claude_mpm/cli/__init__.py
+++ b/src/claude_mpm/cli/__init__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ..constants import CLICommands
 from ..utils.progress import StartupProgressBar
+from .command_config import needs_project_workspace
 from .executor import ensure_run_attributes, execute_command
 
 # handle_missing_configuration, has_configuration_file, should_skip_config_check
@@ -103,7 +104,7 @@ def main(argv: list | None = None):
     # respect the user's logging preference (default: OFF)
     logger = setup_mcp_server_logging(args)
 
-    ensure_directories()
+    ensure_directories(project=needs_project_workspace(args))
 
     # Run migrations BEFORE banner (so we can show results in banner)
     # Migrations are quick and non-blocking, safe to run early

--- a/src/claude_mpm/cli/command_config.py
+++ b/src/claude_mpm/cli/command_config.py
@@ -60,23 +60,15 @@ _READ_ONLY_SUBCOMMANDS: dict[str, set[str]] = {
     "agents": {"list", "view"},
     # skills list is read-only; deploy needs workspace
     "skills": {"list"},
-    # memory status/show/view are read-only; init/add/build/clean need workspace
-    "memory": {"status", "show", "view", "optimize", "cross-ref", "route"},
+    # memory status/show/view are read-only; init/add/build/clean/optimize need workspace
+    # optimize: writes to .claude-mpm/memories/ via MemoryOptimizer — workspace required
+    # cross-ref: deprecated no-op (returns error dict, no writes) — read-only
+    # route: analyzes content only (MemoryRouter.analyze_and_route has no writes) — read-only
+    "memory": {"status", "show", "view", "cross-ref", "route"},
     # manifest validate/show are read-only; init needs workspace
     "manifest": {"validate", "show"},
     # dashboard status/open are read-only; start/stop need workspace
     "dashboard": {"status", "open"},
-}
-
-# Subcommand dest attribute names used by argparse for each parent command.
-# These are the names argparse stores the chosen subcommand in (e.g. args.monitor_command).
-_SUBCOMMAND_DEST: dict[str, str] = {
-    "monitor": "monitor_command",
-    "agents": "agents_command",
-    "skills": "skills_command",
-    "memory": "memory_command",
-    "manifest": "manifest_command",
-    "dashboard": "dashboard_command",
 }
 
 
@@ -142,8 +134,9 @@ def needs_project_workspace(args) -> bool:
 
     # Rule 3: commands that have mixed read-only / workspace subcommands
     if command in _READ_ONLY_SUBCOMMANDS:
-        dest_attr = _SUBCOMMAND_DEST.get(command)
-        subcommand = getattr(args, dest_attr, None) if dest_attr else None
+        # All parsers use "{command}_command" as the argparse dest uniformly.
+        dest_attr = f"{command}_command"
+        subcommand = getattr(args, dest_attr, None)
         if subcommand is None:
             # No subcommand given — bias toward creating (True)
             return True

--- a/src/claude_mpm/cli/command_config.py
+++ b/src/claude_mpm/cli/command_config.py
@@ -50,6 +50,35 @@ LIGHTWEIGHT_COMMANDS = {
     "update-statusline",
 }
 
+# Read-only subcommands that do NOT need the project workspace directory.
+# Keyed by parent command name, value is the set of read-only subcommand values.
+# Subcommands NOT listed here are treated as workspace-needing (safe default).
+_READ_ONLY_SUBCOMMANDS: dict[str, set[str]] = {
+    # monitor status/port only read state; start/stop/restart need the workspace
+    "monitor": {"status", "port"},
+    # agents list/view are read-only; deploy/force-deploy/fix/clean need workspace
+    "agents": {"list", "view"},
+    # skills list is read-only; deploy needs workspace
+    "skills": {"list"},
+    # memory status/show/view are read-only; init/add/build/clean need workspace
+    "memory": {"status", "show", "view", "optimize", "cross-ref", "route"},
+    # manifest validate/show are read-only; init needs workspace
+    "manifest": {"validate", "show"},
+    # dashboard status/open are read-only; start/stop need workspace
+    "dashboard": {"status", "open"},
+}
+
+# Subcommand dest attribute names used by argparse for each parent command.
+# These are the names argparse stores the chosen subcommand in (e.g. args.monitor_command).
+_SUBCOMMAND_DEST: dict[str, str] = {
+    "monitor": "monitor_command",
+    "agents": "agents_command",
+    "skills": "skills_command",
+    "memory": "memory_command",
+    "manifest": "manifest_command",
+    "dashboard": "dashboard_command",
+}
+
 
 def is_lightweight_command(command: str) -> bool:
     """Check if command should skip framework initialization.
@@ -68,3 +97,58 @@ def is_lightweight_command(command: str) -> bool:
         False
     """
     return command in LIGHTWEIGHT_COMMANDS
+
+
+def needs_project_workspace(args) -> bool:
+    """Return True if the given parsed args require the project-level .claude-mpm/ dir.
+
+    WHAT: Gate function that decides whether ``initialize_project_directory()``
+    should run for the current invocation.
+
+    WHY: The framework previously created a ``.claude-mpm/`` directory in the
+    current working directory on EVERY CLI invocation, including read-only
+    commands such as ``doctor``, ``monitor status``, and ``agents list``.  This
+    function allows the project-level init to be skipped for commands that only
+    read cached data from ``~/.claude-mpm/`` and never write to the project dir.
+
+    Classification rules (applied in order):
+    1. ``--version`` / ``--help`` flags (no ``args.command`` set): NO workspace.
+    2. Lightweight commands (``LIGHTWEIGHT_COMMANDS``): NO workspace.
+    3. Commands with read-only subcommands (``_READ_ONLY_SUBCOMMANDS``): only if
+       the chosen subcommand is in the read-only set.  Unknown/missing subcommands
+       ERR TOWARD creating (workspace=True) per the bias rule.
+    4. All other commands: YES workspace.
+
+    Bias rule: when in doubt, return True (create the dir).  A false positive is
+    a harmless stray directory; a false negative could break a workspace command.
+
+    Args:
+        args: Parsed argparse namespace (may lack ``command`` attribute for
+              bare ``--version`` / ``--help`` invocations).
+
+    Returns:
+        True  — run ``initialize_project_directory()`` (workspace command).
+        False — skip project-dir init (read-only / informational command).
+    """
+    command = getattr(args, "command", None)
+
+    # Rule 1: bare --version / --help — no command attribute set
+    if command is None:
+        return False
+
+    # Rule 2: lightweight commands never need the project workspace
+    if is_lightweight_command(command):
+        return False
+
+    # Rule 3: commands that have mixed read-only / workspace subcommands
+    if command in _READ_ONLY_SUBCOMMANDS:
+        dest_attr = _SUBCOMMAND_DEST.get(command)
+        subcommand = getattr(args, dest_attr, None) if dest_attr else None
+        if subcommand is None:
+            # No subcommand given — bias toward creating (True)
+            return True
+        # If the subcommand is in the read-only set, skip project init
+        return subcommand not in _READ_ONLY_SUBCOMMANDS[command]
+
+    # Rule 4: everything else needs the workspace
+    return True

--- a/src/claude_mpm/cli/utils.py
+++ b/src/claude_mpm/cli/utils.py
@@ -192,18 +192,27 @@ def setup_logging(args) -> logging.Logger:
     return logger
 
 
-def ensure_directories() -> None:
-    """
-    Ensure required directories exist on first run.
+def ensure_directories(project: bool = True) -> None:
+    """Ensure required directories exist on first run.
 
     WHY: Claude-mpm needs certain directories to function properly. Rather than
     failing when they don't exist, we create them automatically for a better
     user experience.
+
+    The user-level ``~/.claude-mpm/`` tree is ALWAYS initialized regardless of
+    ``project``, because commands such as ``doctor`` and ``agents list`` read
+    from it.  Only the project-level ``.claude-mpm/`` in the current working
+    directory is gated by ``project``.
+
+    Args:
+        project: When True (default) also initialize the project-level
+                 ``.claude-mpm/`` directory in the cwd.  Pass False for
+                 read-only / informational commands that do not need it.
     """
     try:
         from ..init import ensure_directories as init_ensure_directories
 
-        init_ensure_directories()
+        init_ensure_directories(project=project)
     except Exception:  # nosec B110
         # Continue even if initialization fails
         # The individual commands will handle missing directories as needed

--- a/src/claude_mpm/init.py
+++ b/src/claude_mpm/init.py
@@ -616,10 +616,16 @@ class ProjectInitializer:
 
         return dependencies
 
-    def ensure_initialized(self) -> bool:
+    def ensure_initialized(self, include_project: bool = True) -> bool:
         """Ensure both user and project directories are initialized.
 
         Shows clear information about where directories are being created.
+
+        Args:
+            include_project: When True (default) also initialize the
+                project-level ``.claude-mpm/`` directory in the cwd.  Pass
+                False for read-only / informational commands so they do not
+                create a spurious directory in arbitrary working directories.
         """
         # Determine actual working directory
         user_pwd = os.environ.get("CLAUDE_MPM_USER_PWD")
@@ -635,8 +641,16 @@ class ProjectInitializer:
         framework_path = Path(__file__).parent.parent.parent
         self.logger.info(f"Framework path: {framework_path}")
 
-        # Initialize user directory (in home)
+        # Initialize user directory (in home) — always runs for every command
         user_ok = self.initialize_user_directory()
+
+        if not include_project:
+            # Skip project-level init for read-only / informational commands.
+            # User-dir init already ran above so diagnostics still work.
+            self.logger.debug(
+                "Skipping project-level .claude-mpm/ init (read-only command)"
+            )
+            return user_ok
 
         # Initialize project directory (in user's actual working directory)
         self.logger.info(f"Checking for .claude-mpm/ in {actual_wd}")
@@ -645,10 +659,16 @@ class ProjectInitializer:
         return user_ok and project_ok
 
 
-def ensure_directories():
-    """Convenience function to ensure directories are initialized."""
+def ensure_directories(project: bool = True):
+    """Convenience function to ensure directories are initialized.
+
+    Args:
+        project: When True (default) also initialize the project-level
+                 ``.claude-mpm/`` directory in the cwd.  Pass False for
+                 read-only / informational commands.
+    """
     initializer = ProjectInitializer()
-    return initializer.ensure_initialized()
+    return initializer.ensure_initialized(include_project=project)
 
 
 def validate_installation():

--- a/tests/cli/test_project_init_gating.py
+++ b/tests/cli/test_project_init_gating.py
@@ -109,6 +109,12 @@ class TestNeedsProjectWorkspace:
     def test_memory_clean_needs_workspace(self):
         assert needs_project_workspace(_args("memory", memory_command="clean")) is True
 
+    def test_memory_optimize_needs_workspace(self):
+        # optimize writes to .claude-mpm/memories/ via MemoryOptimizer — not read-only
+        assert (
+            needs_project_workspace(_args("memory", memory_command="optimize")) is True
+        )
+
     def test_manifest_init_needs_workspace(self):
         assert (
             needs_project_workspace(_args("manifest", manifest_command="init")) is True
@@ -207,6 +213,17 @@ class TestNeedsProjectWorkspace:
 
     def test_memory_view_no_workspace(self):
         assert needs_project_workspace(_args("memory", memory_command="view")) is False
+
+    def test_memory_cross_ref_no_workspace(self):
+        # cross-ref is deprecated and makes no writes — read-only
+        assert (
+            needs_project_workspace(_args("memory", memory_command="cross-ref"))
+            is False
+        )
+
+    def test_memory_route_no_workspace(self):
+        # route only runs MemoryRouter.analyze_and_route which has no writes — read-only
+        assert needs_project_workspace(_args("memory", memory_command="route")) is False
 
     def test_manifest_validate_no_workspace(self):
         assert (

--- a/tests/cli/test_project_init_gating.py
+++ b/tests/cli/test_project_init_gating.py
@@ -1,0 +1,491 @@
+"""Tests for project-level .claude-mpm/ directory creation gating.
+
+Verifies that ``initialize_project_directory()`` is only called for commands
+that actually need a project workspace, and that read-only / informational
+commands do NOT create a spurious ``.claude-mpm/`` directory in the cwd.
+
+See: GitHub issue #703
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_mpm.cli.command_config import needs_project_workspace
+
+# ---------------------------------------------------------------------------
+# Helper — build a minimal args namespace
+# ---------------------------------------------------------------------------
+
+
+def _args(command: str | None = None, **subcommands) -> SimpleNamespace:
+    """Build a SimpleNamespace that mimics argparse output.
+
+    Args:
+        command: The top-level command string (e.g. ``"run"``, ``"monitor"``).
+        **subcommands: Extra attributes such as ``monitor_command="status"``.
+    """
+    ns = SimpleNamespace(command=command, **subcommands)
+    return ns
+
+
+# ===========================================================================
+# 1. Unit tests for needs_project_workspace() gate helper
+# ===========================================================================
+
+
+class TestNeedsProjectWorkspace:
+    """Covers needs_project_workspace() for all relevant command shapes."""
+
+    # --- Workspace commands (must return True) ------------------------------
+
+    def test_run_needs_workspace(self):
+        assert needs_project_workspace(_args("run")) is True
+
+    def test_run_guarded_needs_workspace(self):
+        assert needs_project_workspace(_args("run-guarded")) is True
+
+    def test_tickets_needs_workspace(self):
+        assert needs_project_workspace(_args("tickets")) is True
+
+    def test_mpm_init_needs_workspace(self):
+        # mpm-init is explicitly a workspace command per the issue
+        assert needs_project_workspace(_args("mpm-init")) is True
+
+    def test_aggregate_needs_workspace(self):
+        assert needs_project_workspace(_args("aggregate")) is True
+
+    def test_analyze_needs_workspace(self):
+        assert needs_project_workspace(_args("analyze")) is True
+
+    def test_analyze_code_needs_workspace(self):
+        assert needs_project_workspace(_args("analyze-code")) is True
+
+    def test_cleanup_memory_needs_workspace(self):
+        assert needs_project_workspace(_args("cleanup-memory")) is True
+
+    def test_serve_needs_workspace(self):
+        assert needs_project_workspace(_args("serve")) is True
+
+    def test_monitor_start_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("monitor", monitor_command="start")) is True
+        )
+
+    def test_monitor_stop_needs_workspace(self):
+        assert needs_project_workspace(_args("monitor", monitor_command="stop")) is True
+
+    def test_monitor_restart_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("monitor", monitor_command="restart")) is True
+        )
+
+    def test_agents_deploy_needs_workspace(self):
+        assert needs_project_workspace(_args("agents", agents_command="deploy")) is True
+
+    def test_agents_force_deploy_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("agents", agents_command="force-deploy"))
+            is True
+        )
+
+    def test_agents_fix_needs_workspace(self):
+        assert needs_project_workspace(_args("agents", agents_command="fix")) is True
+
+    def test_agents_clean_needs_workspace(self):
+        assert needs_project_workspace(_args("agents", agents_command="clean")) is True
+
+    def test_memory_init_needs_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="init")) is True
+
+    def test_memory_add_needs_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="add")) is True
+
+    def test_memory_build_needs_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="build")) is True
+
+    def test_memory_clean_needs_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="clean")) is True
+
+    def test_manifest_init_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("manifest", manifest_command="init")) is True
+        )
+
+    def test_dashboard_start_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("dashboard", dashboard_command="start"))
+            is True
+        )
+
+    def test_dashboard_stop_needs_workspace(self):
+        assert (
+            needs_project_workspace(_args("dashboard", dashboard_command="stop"))
+            is True
+        )
+
+    def test_skills_deploy_needs_workspace(self):
+        assert needs_project_workspace(_args("skills", skills_command="deploy")) is True
+
+    # Bias rule: unknown subcommand should default to True
+    def test_monitor_unknown_subcommand_defaults_to_workspace(self):
+        assert (
+            needs_project_workspace(
+                _args("monitor", monitor_command="unknown-future-cmd")
+            )
+            is True
+        )
+
+    # Bias rule: no subcommand given — default to True
+    def test_monitor_no_subcommand_defaults_to_workspace(self):
+        assert needs_project_workspace(_args("monitor")) is True
+
+    def test_agents_no_subcommand_defaults_to_workspace(self):
+        assert needs_project_workspace(_args("agents")) is True
+
+    # --- Read-only commands (must return False) -----------------------------
+
+    def test_doctor_no_workspace(self):
+        assert needs_project_workspace(_args("doctor")) is False
+
+    def test_info_no_workspace(self):
+        assert needs_project_workspace(_args("info")) is False
+
+    def test_config_no_workspace(self):
+        assert needs_project_workspace(_args("config")) is False
+
+    def test_configure_no_workspace(self):
+        assert needs_project_workspace(_args("configure")) is False
+
+    def test_upgrade_no_workspace(self):
+        assert needs_project_workspace(_args("upgrade")) is False
+
+    def test_install_no_workspace(self):
+        assert needs_project_workspace(_args("install")) is False
+
+    def test_postmortem_no_workspace(self):
+        assert needs_project_workspace(_args("postmortem")) is False
+
+    def test_migrate_no_workspace(self):
+        assert needs_project_workspace(_args("migrate")) is False
+
+    def test_mcp_no_workspace(self):
+        # "mcp" is in LIGHTWEIGHT_COMMANDS (server management)
+        assert needs_project_workspace(_args("mcp")) is False
+
+    def test_slack_no_workspace(self):
+        assert needs_project_workspace(_args("slack")) is False
+
+    def test_monitor_status_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("monitor", monitor_command="status")) is False
+        )
+
+    def test_monitor_port_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("monitor", monitor_command="port")) is False
+        )
+
+    def test_agents_list_no_workspace(self):
+        assert needs_project_workspace(_args("agents", agents_command="list")) is False
+
+    def test_agents_view_no_workspace(self):
+        assert needs_project_workspace(_args("agents", agents_command="view")) is False
+
+    def test_skills_list_no_workspace(self):
+        assert needs_project_workspace(_args("skills", skills_command="list")) is False
+
+    def test_memory_status_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("memory", memory_command="status")) is False
+        )
+
+    def test_memory_show_no_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="show")) is False
+
+    def test_memory_view_no_workspace(self):
+        assert needs_project_workspace(_args("memory", memory_command="view")) is False
+
+    def test_manifest_validate_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("manifest", manifest_command="validate"))
+            is False
+        )
+
+    def test_manifest_show_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("manifest", manifest_command="show")) is False
+        )
+
+    def test_dashboard_status_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("dashboard", dashboard_command="status"))
+            is False
+        )
+
+    def test_dashboard_open_no_workspace(self):
+        assert (
+            needs_project_workspace(_args("dashboard", dashboard_command="open"))
+            is False
+        )
+
+    # --- bare --version / --help (no command attribute) --------------------
+
+    def test_no_command_attribute_no_workspace(self):
+        """Bare --version / --help have no args.command — must not create dir."""
+        assert needs_project_workspace(SimpleNamespace()) is False
+
+    def test_command_none_no_workspace(self):
+        assert needs_project_workspace(_args(command=None)) is False
+
+
+# ===========================================================================
+# 2. Unit tests for ProjectInitializer.ensure_initialized gating
+# ===========================================================================
+
+
+class TestEnsureInitializedGating:
+    """Verify that include_project=False skips initialize_project_directory."""
+
+    def test_include_project_false_skips_project_init(self):
+        from claude_mpm.init import ProjectInitializer
+
+        initializer = ProjectInitializer()
+        with (
+            patch.object(
+                initializer, "initialize_user_directory", return_value=True
+            ) as mock_user,
+            patch.object(
+                initializer, "initialize_project_directory", return_value=True
+            ) as mock_project,
+        ):
+            result = initializer.ensure_initialized(include_project=False)
+
+        mock_user.assert_called_once()
+        mock_project.assert_not_called()
+        assert result is True  # user_ok=True propagated
+
+    def test_include_project_true_calls_both(self):
+        from claude_mpm.init import ProjectInitializer
+
+        initializer = ProjectInitializer()
+        with (
+            patch.object(
+                initializer, "initialize_user_directory", return_value=True
+            ) as mock_user,
+            patch.object(
+                initializer, "initialize_project_directory", return_value=True
+            ) as mock_project,
+        ):
+            result = initializer.ensure_initialized(include_project=True)
+
+        mock_user.assert_called_once()
+        mock_project.assert_called_once()
+        assert result is True
+
+    def test_default_include_project_calls_both(self):
+        """Default behavior (no arg) must still call both — no regression."""
+        from claude_mpm.init import ProjectInitializer
+
+        initializer = ProjectInitializer()
+        with (
+            patch.object(
+                initializer, "initialize_user_directory", return_value=True
+            ) as mock_user,
+            patch.object(
+                initializer, "initialize_project_directory", return_value=True
+            ) as mock_project,
+        ):
+            initializer.ensure_initialized()
+
+        mock_user.assert_called_once()
+        mock_project.assert_called_once()
+
+
+# ===========================================================================
+# 3. Unit tests for init.ensure_directories() convenience wrapper
+# ===========================================================================
+
+
+class TestEnsureDirectoriesWrapper:
+    """Verify the module-level ensure_directories() threads project= correctly."""
+
+    def test_project_false_propagated(self):
+        from claude_mpm import init as init_module
+
+        mock_initializer = MagicMock()
+        mock_initializer.ensure_initialized.return_value = True
+
+        with patch.object(
+            init_module, "ProjectInitializer", return_value=mock_initializer
+        ):
+            init_module.ensure_directories(project=False)
+
+        mock_initializer.ensure_initialized.assert_called_once_with(
+            include_project=False
+        )
+
+    def test_project_true_propagated(self):
+        from claude_mpm import init as init_module
+
+        mock_initializer = MagicMock()
+        mock_initializer.ensure_initialized.return_value = True
+
+        with patch.object(
+            init_module, "ProjectInitializer", return_value=mock_initializer
+        ):
+            init_module.ensure_directories(project=True)
+
+        mock_initializer.ensure_initialized.assert_called_once_with(
+            include_project=True
+        )
+
+    def test_default_project_true(self):
+        """Calling ensure_directories() with no args must pass include_project=True."""
+        from claude_mpm import init as init_module
+
+        mock_initializer = MagicMock()
+        mock_initializer.ensure_initialized.return_value = True
+
+        with patch.object(
+            init_module, "ProjectInitializer", return_value=mock_initializer
+        ):
+            init_module.ensure_directories()
+
+        mock_initializer.ensure_initialized.assert_called_once_with(
+            include_project=True
+        )
+
+
+# ===========================================================================
+# 4. Integration-style tests using tmp_path
+# ===========================================================================
+
+
+class TestProjectDirNotCreatedForReadOnlyCommands:
+    """Integration-style: assert no .claude-mpm/ created in cwd for read-only commands."""
+
+    def _run_ensure_directories_for_args(
+        self, args: SimpleNamespace, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Helper: change cwd to tmp_path and run ensure_directories with the gate."""
+        monkeypatch.chdir(tmp_path)
+        # Also set CLAUDE_MPM_USER_PWD so initialize_project_directory uses tmp_path
+        monkeypatch.setenv("CLAUDE_MPM_USER_PWD", str(tmp_path))
+
+        from claude_mpm.cli import utils as cli_utils
+        from claude_mpm.cli.command_config import needs_project_workspace
+
+        wants_project = needs_project_workspace(args)
+
+        # Patch the user directory init so we don't actually touch ~/.claude-mpm
+        with patch(
+            "claude_mpm.init.ProjectInitializer.initialize_user_directory",
+            return_value=True,
+        ):
+            cli_utils.ensure_directories(project=wants_project)
+
+    # ---- READ-ONLY: must NOT create .claude-mpm/ --------------------------
+
+    def test_doctor_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(_args("doctor"), tmp_path, monkeypatch)
+        assert not (tmp_path / ".claude-mpm").exists(), (
+            "doctor must not create a project .claude-mpm/ directory"
+        )
+
+    def test_monitor_status_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("monitor", monitor_command="status"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists(), (
+            "monitor status must not create a project .claude-mpm/ directory"
+        )
+
+    def test_agents_list_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("agents", agents_command="list"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists(), (
+            "agents list must not create a project .claude-mpm/ directory"
+        )
+
+    def test_skills_list_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("skills", skills_command="list"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists()
+
+    def test_version_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        """Bare --version invocation (no command attribute) must not create dir."""
+        self._run_ensure_directories_for_args(SimpleNamespace(), tmp_path, monkeypatch)
+        assert not (tmp_path / ".claude-mpm").exists()
+
+    def test_manifest_validate_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("manifest", manifest_command="validate"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists()
+
+    def test_memory_status_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("memory", memory_command="status"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists()
+
+    def test_dashboard_status_does_not_create_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("dashboard", dashboard_command="status"), tmp_path, monkeypatch
+        )
+        assert not (tmp_path / ".claude-mpm").exists()
+
+    # ---- WORKSPACE: MUST create .claude-mpm/ ------------------------------
+
+    def test_run_creates_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(_args("run"), tmp_path, monkeypatch)
+        assert (tmp_path / ".claude-mpm").exists(), (
+            "run must create a project .claude-mpm/ directory"
+        )
+
+    def test_mpm_init_creates_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(_args("mpm-init"), tmp_path, monkeypatch)
+        assert (tmp_path / ".claude-mpm").exists(), (
+            "mpm-init must create a project .claude-mpm/ directory"
+        )
+
+    def test_monitor_start_creates_project_dir(self, tmp_path, monkeypatch):
+        self._run_ensure_directories_for_args(
+            _args("monitor", monitor_command="start"), tmp_path, monkeypatch
+        )
+        assert (tmp_path / ".claude-mpm").exists(), (
+            "monitor start must create a project .claude-mpm/ directory"
+        )
+
+    # ---- USER DIR init still runs for read-only commands ------------------
+
+    def test_user_dir_init_still_runs_for_doctor(self, tmp_path, monkeypatch):
+        """Even for read-only commands, initialize_user_directory must be called."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CLAUDE_MPM_USER_PWD", str(tmp_path))
+
+        from claude_mpm.init import ProjectInitializer
+
+        with (
+            patch.object(
+                ProjectInitializer,
+                "initialize_user_directory",
+                return_value=True,
+            ) as mock_user,
+            patch.object(
+                ProjectInitializer,
+                "initialize_project_directory",
+                return_value=True,
+            ) as mock_project,
+        ):
+            from claude_mpm import init as init_module
+
+            init_module.ensure_directories(project=False)
+
+        mock_user.assert_called_once()
+        mock_project.assert_not_called()


### PR DESCRIPTION
## Summary
Partial fix for #703. Read-only/informational CLI commands no longer trigger the heavy project-level `.claude-mpm/` initialization (`initialize_project_directory()` — which writes config/project.json, .gitignore, deploys PM skills, and runs security-hook setup) in the current working directory.

A new `needs_project_workspace(args)` gate (reusing `is_lightweight_command()` + read-only subcommand rules) decides whether to run project-dir init. The user-level `~/.claude-mpm/` init remains **unconditional** (every command needs it). For genuinely ambiguous subcommands the gate biases toward creating, so no workspace command is ever starved.

## Scope — this is a PARTIAL fix (#703 stays open)
Live testing confirmed `initialize_project_directory()` is **not the only** creator of a cwd `.claude-mpm/`. This PR gates that (the heaviest) creator. The following remain and are deferred (documented on #703):
- `monitor status` still deploys PM instructions / agent templates into `.claude-mpm/` via the agent-deployment path.
- `doctor` still creates an empty `.claude-mpm/` via a startup-logging / `claude_mpm_dir_hidden` path.

Fully suppressing the stray dir for every read-only command spans several subsystems and is tracked as remaining work on #703.

## Verification
- 69 new unit tests for the gate (`tests/cli/test_project_init_gating.py`); full `tests/cli/` suite green (1006 passed).
- Live: `--version` in a fresh dir creates no `.claude-mpm/`; `mpm-init` still creates the full structure. (`monitor status` / `doctor` still create dirs via the deferred paths above — expected, documented.)

Refs #703

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)