### PR TITLE
fix: suppress stray .claude-mpm/ creation for read-only commands (closes #703)

### DIFF
--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -30,6 +30,11 @@ import time
 from pathlib import Path
 from typing import Any
 
+from claude_mpm.cli.command_config import (
+    is_lightweight_command,
+    needs_project_workspace,
+)
+
 # Functions exported for use by tests and other modules. The underscore prefix
 # is retained for internal-use convention, but these symbols are part of the
 # module's public API for testing purposes.
@@ -867,8 +872,6 @@ def should_skip_background_services(args, processed_argv):
         command = args.command
 
         # Skip background services for lightweight commands
-        from claude_mpm.cli.command_config import is_lightweight_command
-
         if is_lightweight_command(command):
             return True
 
@@ -878,8 +881,6 @@ def should_skip_background_services(args, processed_argv):
         # WHY: monitor status/port only reads daemon state; agents list/skills list
         # only read from ~/.claude-mpm/cache/ — none of them write to the project dir
         # and all of them must not trigger sync_deployment_on_startup (issue #703).
-        from claude_mpm.cli.command_config import needs_project_workspace
-
         if not needs_project_workspace(args):
             return True
 

--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -872,17 +872,16 @@ def should_skip_background_services(args, processed_argv):
         if is_lightweight_command(command):
             return True
 
-        # Skip background services for read-only subcommands
-        # These only read from cached data in ~/.claude-mpm/cache/
-        # Format: each command has its own {command}_command attribute (e.g., agents_command, skills_command)
-        if command == "agents":
-            agents_cmd = getattr(args, "agents_command", None)
-            if agents_cmd == "list":
-                return True
-        elif command == "skills":
-            skills_cmd = getattr(args, "skills_command", None)
-            if skills_cmd == "list":
-                return True
+        # Skip background services for read-only subcommands.
+        # Delegates to needs_project_workspace() via the shared _READ_ONLY_SUBCOMMANDS
+        # registry so the two gate functions stay in sync automatically.
+        # WHY: monitor status/port only reads daemon state; agents list/skills list
+        # only read from ~/.claude-mpm/cache/ — none of them write to the project dir
+        # and all of them must not trigger sync_deployment_on_startup (issue #703).
+        from claude_mpm.cli.command_config import needs_project_workspace
+
+        if not needs_project_workspace(args):
+            return True
 
     return any(cmd in (processed_argv or sys.argv[1:]) for cmd in skip_commands)
 

--- a/src/claude_mpm/services/port_manager.py
+++ b/src/claude_mpm/services/port_manager.py
@@ -475,6 +475,10 @@ class PortManager:
 
     def load_instances(self) -> dict:
         """Load registered instances from file."""
+        # State dir may not exist yet (read-only commands no longer create it in
+        # __init__; see save_instances()). No dir → no registered instances.
+        if not self.state_dir.exists():
+            return {}
         try:
             if self.instances_file.exists():
                 with self.instances_file.open() as f:

--- a/src/claude_mpm/services/port_manager.py
+++ b/src/claude_mpm/services/port_manager.py
@@ -42,7 +42,10 @@ class PortManager:
         self.logger = get_logger(__name__ + ".PortManager")
         self.project_root = project_root or Path.cwd()
         self.state_dir = self.project_root / ".claude-mpm"
-        self.state_dir.mkdir(exist_ok=True)
+        # WHY: do NOT mkdir here — PortManager is constructed by read-only commands
+        # such as `doctor` and `monitor status` that must not create .claude-mpm/.
+        # The directory is created lazily in save_instances() when a write actually
+        # occurs (issue #703).
         self.instances_file = self.state_dir / "socketio-instances.json"
 
     def is_port_available(self, port: int) -> bool:
@@ -484,6 +487,10 @@ class PortManager:
     def save_instances(self, instances: dict) -> None:
         """Save registered instances to file."""
         try:
+            # Create the state dir lazily — only when we are about to write.
+            # This avoids creating .claude-mpm/ in read-only command paths
+            # (doctor, monitor status) where the dir is never actually needed.
+            self.state_dir.mkdir(exist_ok=True)
             with self.instances_file.open("w") as f:
                 json.dump(instances, f, indent=2)
         except Exception as e:

--- a/tests/cli/test_project_init_gating.py
+++ b/tests/cli/test_project_init_gating.py
@@ -506,3 +506,80 @@ class TestProjectDirNotCreatedForReadOnlyCommands:
 
         mock_user.assert_called_once()
         mock_project.assert_not_called()
+
+
+# ===========================================================================
+# 5. Unit tests for PortManager lazy mkdir (issue #703)
+# ===========================================================================
+
+
+class TestPortManagerLazyMkdir:
+    """Verify that PortManager.__init__ does NOT create .claude-mpm/ and that
+    save_instances() creates it lazily on first write."""
+
+    def test_constructor_does_not_create_state_dir(self, tmp_path):
+        """Constructing PortManager must NOT create the .claude-mpm/ directory."""
+        from claude_mpm.services.port_manager import PortManager
+
+        state_dir = tmp_path / ".claude-mpm"
+        assert not state_dir.exists(), "precondition: dir must not exist yet"
+
+        PortManager(project_root=tmp_path)
+
+        assert not state_dir.exists(), (
+            "PortManager.__init__ must not create .claude-mpm/ (issue #703)"
+        )
+
+    def test_save_instances_creates_state_dir(self, tmp_path):
+        """save_instances() must create the .claude-mpm/ directory lazily."""
+        from claude_mpm.services.port_manager import PortManager
+
+        state_dir = tmp_path / ".claude-mpm"
+        assert not state_dir.exists(), "precondition: dir must not exist yet"
+
+        pm = PortManager(project_root=tmp_path)
+        pm.save_instances({})
+
+        assert state_dir.exists(), (
+            "save_instances() must create .claude-mpm/ when writing (issue #703)"
+        )
+
+
+# ===========================================================================
+# 6. Unit tests for should_skip_background_services read-only delegation
+# ===========================================================================
+
+
+class TestShouldSkipBackgroundServices:
+    """Verify that should_skip_background_services() returns True for read-only
+    commands and False for workspace commands."""
+
+    def _skip(self, args) -> bool:
+        from claude_mpm.cli.startup import should_skip_background_services
+
+        # Pass a non-empty processed_argv with no skip flags so the final
+        # `any(cmd in processed_argv ...)` line cannot accidentally match
+        # pytest's own sys.argv (which contains '-v', a skip flag).
+        return should_skip_background_services(args, processed_argv=["__test__"])
+
+    # --- Read-only: must return True ----------------------------------------
+
+    def test_doctor_skips(self):
+        assert self._skip(_args("doctor")) is True
+
+    def test_monitor_status_skips(self):
+        assert self._skip(_args("monitor", monitor_command="status")) is True
+
+    def test_agents_list_skips(self):
+        assert self._skip(_args("agents", agents_command="list")) is True
+
+    def test_skills_list_skips(self):
+        assert self._skip(_args("skills", skills_command="list")) is True
+
+    # --- Workspace commands: must return False --------------------------------
+
+    def test_run_does_not_skip(self):
+        assert self._skip(_args("run")) is False
+
+    def test_monitor_start_does_not_skip(self):
+        assert self._skip(_args("monitor", monitor_command="start")) is False


### PR DESCRIPTION
## Summary
Completes #703. Read-only/informational CLI commands no longer create a stray project-level `.claude-mpm/` in the cwd. Builds on the init.py gate from #704 by fixing the two remaining creators found via runtime tracing:

1. **`PortManager.__init__`** eagerly `mkdir`'d `.claude-mpm/` — it's constructed by `doctor` and `monitor status`. Now a pure constructor; the dir is created lazily in `save_instances()` only on actual write.
2. **`should_skip_background_services`** only special-cased `agents list` / `skills list`. It now delegates to the shared `needs_project_workspace()` gate, so all read-only commands (incl. `monitor status`) skip the deployment-on-startup that wrote `PM_INSTRUCTIONS_DEPLOYED.md` + agent templates into the cwd.

## Verification
- Unit: `tests/cli/test_project_init_gating.py` extended — PortManager constructor creates nothing / `save_instances` creates lazily; `should_skip_background_services` True for doctor/monitor status/agents list/skills list, False for run/monitor start. Full `tests/cli/` suite green (1024 passed).
- **Live trace** (monkeypatched `Path.mkdir`, fresh temp cwd per command): `monitor status`, `monitor status --port 8765`, `doctor`, `agents list`, `skills list`, `--version` → ZERO project-level `.claude-mpm/` created (only the correct user-level `~/.claude-mpm/`). `mpm-init` still creates the project dir (workspace not regressed). `doctor` / `agents list` / `monitor status` still produce correct output (no crash).

Closes #703

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)