### PR TITLE
fix(branding): standardize AI-attribution footer to "🤖👥 Generated with Claude MPM"

### DIFF
--- a/docs/guides/doctor-command.md
+++ b/docs/guides/doctor-command.md
@@ -670,7 +670,7 @@ Reports include:
 
 ---
 
-🤖 *Generated with [Claude Code](https://claude.com/claude-code)*
+🤖👥 *Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)*
 ```
 
 ### Report Organization

--- a/plugin/skills/mpm-bug-reporting/SKILL.md
+++ b/plugin/skills/mpm-bug-reporting/SKILL.md
@@ -92,7 +92,15 @@ Always include:
 
 ## Impact
 [How this affects users/workflow]
+
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 ```
+
+**Footer rule**: Always append the canonical MPM footer
+(`🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)`) to
+the issue body. Never use Claude Code's default `🤖 Generated with [Claude Code]`
+footer — MPM only overrides the commit trailer, so the "Generated with" footer
+must be set explicitly or the Claude Code default leaks into GitHub issues.
 
 ## Using gh CLI
 

--- a/plugin/skills/mpm-git-file-tracking/SKILL.md
+++ b/plugin/skills/mpm-git-file-tracking/SKILL.md
@@ -55,7 +55,7 @@ git commit -m "feat: add {description}
 - Includes {key_features}
 - Part of {initiative}
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
@@ -94,7 +94,7 @@ git commit -m "feat: add OAuth2 authentication
 - Added authentication routes
 - Part of user login feature
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -63,6 +63,20 @@ Always delegate to version-control agent with strategy parameters.
 
 ## PR Creation Workflow
 
+### Footer Branding (required)
+
+Always append the canonical MPM footer to PR bodies and commit messages:
+
+```
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
+
+Never use Claude Code's default `🤖 Generated with [Claude Code]` footer. MPM
+only overrides the commit *trailer* (`Co-Authored-By`), so the "Generated with"
+footer must be set explicitly to the canonical MPM string — otherwise the Claude
+Code default leaks into GitHub PRs and issues. The `Co-Authored-By: Claude MPM
+<https://github.com/bobmatnyc/claude-mpm>` trailer is separate and stays as-is.
+
 When creating PRs, delegate to version-control agent with:
 
 ```

--- a/plugin/skills/mpm-tool-usage-guide/SKILL.md
+++ b/plugin/skills/mpm-tool-usage-guide/SKILL.md
@@ -192,7 +192,7 @@ git commit -m "feat: add OAuth2 authentication
 - Added authentication routes
 - Part of user login feature
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```

--- a/scripts/gh-claude-mpm
+++ b/scripts/gh-claude-mpm
@@ -2,6 +2,19 @@
 # Claude MPM GitHub CLI Wrapper
 # Customizes PR messages with Claude MPM branding
 
+# Force a UTF-8 locale for the emoji sed substitutions below. Under a non-UTF-8
+# locale (LANG=C / POSIX) some seds mis-parse the multi-byte 🤖👥 patterns and
+# silently skip the substitution. Probe for a UTF-8 locale that actually exists
+# (C.UTF-8/C.utf8 on Linux, en_US.UTF-8 on macOS) and fall back gracefully.
+_mpm_avail="$(locale -a 2>/dev/null)"
+for _mpm_locale in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
+    if printf '%s\n' "$_mpm_avail" | grep -qix "$_mpm_locale"; then
+        export LC_ALL="$_mpm_locale"
+        break
+    fi
+done
+unset _mpm_locale _mpm_avail
+
 # Function to modify PR body
 modify_pr_body() {
     local body="$1"

--- a/scripts/gh-claude-mpm
+++ b/scripts/gh-claude-mpm
@@ -27,7 +27,11 @@ modify_pr_body() {
     # Normalize the MPM footer icon to the canonical 🤖👥 (multi-agent)
     body=$(echo "$body" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
     body=$(echo "$body" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
-    body=$(echo "$body" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    # Only prefix the canonical icon onto a *bare* footer: the line must be the
+    # full footer (text + URL) with no preceding emoji, so we don't accidentally
+    # decorate an unrelated line that merely starts with "Generated with [Claude
+    # MPM]".
+    body=$(echo "$body" | sed 's#^Generated with \[Claude MPM\](https://github.com/bobmatnyc/claude-mpm)$#🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)#')
 
     echo "$body"
 }

--- a/scripts/gh-claude-mpm
+++ b/scripts/gh-claude-mpm
@@ -11,6 +11,11 @@ modify_pr_body() {
     body=$(echo "$body" | sed 's/Generated with \[Claude Code\]/Generated with [Claude MPM]/')
     body=$(echo "$body" | sed 's/Claude Code/Claude MPM/g')
 
+    # Normalize the MPM footer icon to the canonical 🤖👥 (multi-agent)
+    body=$(echo "$body" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    body=$(echo "$body" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    body=$(echo "$body" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+
     echo "$body"
 }
 

--- a/scripts/git-claude-mpm
+++ b/scripts/git-claude-mpm
@@ -11,6 +11,11 @@ modify_commit_message() {
     msg=$(echo "$msg" | sed 's/Generated with \[Claude Code\]/Generated with [Claude MPM]/')
     msg=$(echo "$msg" | sed 's/Claude Code/Claude MPM/g')
 
+    # Normalize the MPM footer icon to the canonical 🤖👥 (multi-agent)
+    msg=$(echo "$msg" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    msg=$(echo "$msg" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    msg=$(echo "$msg" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+
     echo "$msg"
 }
 

--- a/scripts/git-claude-mpm
+++ b/scripts/git-claude-mpm
@@ -2,6 +2,19 @@
 # Claude MPM Git Wrapper
 # Customizes git commit and PR messages with Claude MPM branding
 
+# Force a UTF-8 locale for the emoji sed substitutions below. Under a non-UTF-8
+# locale (LANG=C / POSIX) some seds mis-parse the multi-byte 🤖👥 patterns and
+# silently skip the substitution. Probe for a UTF-8 locale that actually exists
+# (C.UTF-8/C.utf8 on Linux, en_US.UTF-8 on macOS) and fall back gracefully.
+_mpm_avail="$(locale -a 2>/dev/null)"
+for _mpm_locale in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
+    if printf '%s\n' "$_mpm_avail" | grep -qix "$_mpm_locale"; then
+        export LC_ALL="$_mpm_locale"
+        break
+    fi
+done
+unset _mpm_locale _mpm_avail
+
 # Function to modify commit message
 modify_commit_message() {
     local msg="$1"

--- a/scripts/git-claude-mpm
+++ b/scripts/git-claude-mpm
@@ -27,7 +27,11 @@ modify_commit_message() {
     # Normalize the MPM footer icon to the canonical 🤖👥 (multi-agent)
     msg=$(echo "$msg" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
     msg=$(echo "$msg" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
-    msg=$(echo "$msg" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+    # Only prefix the canonical icon onto a *bare* footer: the line must be the
+    # full footer (text + URL) with no preceding emoji, so we don't accidentally
+    # decorate an unrelated line that merely starts with "Generated with [Claude
+    # MPM]".
+    msg=$(echo "$msg" | sed 's#^Generated with \[Claude MPM\](https://github.com/bobmatnyc/claude-mpm)$#🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)#')
 
     echo "$msg"
 }

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -62,7 +62,10 @@ MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/Generated with Claude Code/Generate
 # variant: bare (no icon), single 🤖, or doubled 🤖🤖.
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
-MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+# Only prefix the canonical icon onto a *bare* footer: the line must be the
+# full footer (text + URL) with no preceding emoji, so we don't accidentally
+# decorate an unrelated line that merely starts with "Generated with [Claude MPM]".
+MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's#^Generated with \[Claude MPM\](https://github.com/bobmatnyc/claude-mpm)$#🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)#')
 
 # Replace URLs
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/https:\/\/claude\.ai\/code/https:\/\/github.com\/bobmatnyc\/claude-mpm/g')

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -45,8 +45,11 @@ MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/Generated with \[Claude Code\](http
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/Generated with \[Claude Code\]/Generated with [Claude MPM]/')
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/Generated with Claude Code/Generated with Claude MPM/')
 
-# Replace if someone uses wrong emoji but right text
+# Normalize the icon to the canonical 🤖👥 (multi-agent) for any MPM footer
+# variant: bare (no icon), single 🤖, or doubled 🤖🤖.
+MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/🤖🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/🤖 Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
+MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/^Generated with \[Claude MPM\]/🤖👥 Generated with [Claude MPM]/')
 
 # Replace URLs
 MODIFIED_MSG=$(echo "$MODIFIED_MSG" | sed 's/https:\/\/claude\.ai\/code/https:\/\/github.com\/bobmatnyc\/claude-mpm/g')

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -24,6 +24,19 @@ cat > "$HOOKS_DIR/prepare-commit-msg" << 'EOF'
 # Claude MPM Custom Commit Message Hook
 # This hook modifies commit messages to use Claude MPM branding
 
+# Force a UTF-8 locale for the emoji sed substitutions below. Under a non-UTF-8
+# locale (LANG=C / POSIX) some seds mis-parse the multi-byte 🤖👥 patterns and
+# silently skip the substitution. Probe for a UTF-8 locale that actually exists
+# (C.UTF-8/C.utf8 on Linux, en_US.UTF-8 on macOS) and fall back gracefully.
+_mpm_avail="$(locale -a 2>/dev/null)"
+for _mpm_locale in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
+    if printf '%s\n' "$_mpm_avail" | grep -qix "$_mpm_locale"; then
+        export LC_ALL="$_mpm_locale"
+        break
+    fi
+done
+unset _mpm_locale _mpm_avail
+
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3

--- a/scripts/sync_agent_skills_repos.sh
+++ b/scripts/sync_agent_skills_repos.sh
@@ -162,7 +162,7 @@ sync_repo() {
 - Synchronized changes for release v$VERSION
 - Auto-committed by sync_agent_skills_repos.sh
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 

--- a/src/.claude/agents/ops.md
+++ b/src/.claude/agents/ops.md
@@ -318,7 +318,7 @@ find . -type f -size +1000k -not -path "./.git/*" -not -path "./node_modules/*"
    - Detail 1
    - Detail 2
    
-    🤖🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+    🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
    
    Co-Authored-By: Claude <noreply@anthropic.com>"
    ```

--- a/src/claude_mpm/agents/bundled/ticketing.md
+++ b/src/claude_mpm/agents/bundled/ticketing.md
@@ -65,6 +65,10 @@ Route issues to the correct repository:
 
 ### Issue Creation Commands
 
+**Footer rule**: Always append the canonical MPM footer to issue/PR bodies —
+`🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)`.
+Never use Claude Code's default `🤖 Generated with [Claude Code]` footer.
+
 ```bash
 # Core MPM bug
 gh issue create -R bobmatnyc/claude-mpm \
@@ -84,7 +88,7 @@ gh issue create -R bobmatnyc/claude-mpm \
 - Version: [version]
 - Component: [component]
 
-🤖 Reported by Claude MPM Agent
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 EOF
 )"
 

--- a/src/claude_mpm/cli/startup_migrations.py
+++ b/src/claude_mpm/cli/startup_migrations.py
@@ -1247,7 +1247,7 @@ _CLAUDE_CODE_FOOTER_OLD_ALT = (
     "Generated with [Claude Code](https://claude.com/claude-code)"
 )
 _CLAUDE_MPM_FOOTER_NEW = (
-    "🤖🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)"
+    "🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)"
 )
 
 
@@ -1282,7 +1282,7 @@ def _replace_claude_code_footers_in_agents() -> bool:
 
     Scans ~/.claude/agents/ and ~/.claude-mpm/cache/agents/ for agent markdown
     files containing the old "Generated with [Claude Code]" footer and replaces
-    them with "🤖🤖 Generated with [Claude MPM]".
+    them with "🤖👥 Generated with [Claude MPM]".
 
     Returns:
         True if migration succeeded (or no files needed updating).
@@ -1313,6 +1313,81 @@ def _replace_claude_code_footers_in_agents() -> bool:
                 logger.debug(f"Could not update {md_file}: {e}")
                 errors += 1
     logger.info(f"Footer migration: updated {updated} files, {errors} errors")
+    return errors == 0
+
+
+# =============================================================================
+# Migration: v6.5.24-unify-mpm-footer-icon
+# =============================================================================
+
+# Older deployments emitted the MPM "Generated with" footer with a single 🤖 or
+# a doubled 🤖🤖 icon. The canonical icon is 🤖👥 (multi-agent orchestration).
+_MPM_FOOTER_TAIL = (
+    "Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)"
+)
+_MPM_FOOTER_WRONG_ICONS = (
+    f"🤖🤖 {_MPM_FOOTER_TAIL}",
+    f"🤖 {_MPM_FOOTER_TAIL}",
+)
+_MPM_FOOTER_CANONICAL = f"🤖👥 {_MPM_FOOTER_TAIL}"
+
+
+def _check_mpm_footer_icon_needs_unify() -> bool:
+    """Check if any deployed agent file uses a non-canonical MPM footer icon.
+
+    Returns:
+        True if a single-🤖 or doubled-🤖🤖 MPM footer is found in any agent
+        markdown file under the deployed agent directories.
+    """
+    search_dirs = [
+        Path.home() / ".claude" / "agents",
+        Path.home() / ".claude-mpm" / "cache" / "agents",
+    ]
+    for search_dir in search_dirs:
+        if not search_dir.exists():
+            continue
+        for md_file in search_dir.glob("**/*.md"):
+            try:
+                content = md_file.read_text(encoding="utf-8", errors="ignore")
+                if any(wrong in content for wrong in _MPM_FOOTER_WRONG_ICONS):
+                    return True
+            except OSError:
+                continue
+    return False
+
+
+def _unify_mpm_footer_icon_in_agents() -> bool:
+    """Upgrade deployed MPM footers to the canonical 🤖👥 icon.
+
+    Replaces single-🤖 and doubled-🤖🤖 MPM "Generated with" footers with the
+    canonical 🤖👥 variant in deployed agent markdown files. Idempotent.
+
+    Returns:
+        True if migration succeeded (or no files needed updating).
+    """
+    search_dirs = [
+        Path.home() / ".claude" / "agents",
+        Path.home() / ".claude-mpm" / "cache" / "agents",
+    ]
+    updated = 0
+    errors = 0
+    for search_dir in search_dirs:
+        if not search_dir.exists():
+            continue
+        for md_file in search_dir.glob("**/*.md"):
+            try:
+                content = md_file.read_text(encoding="utf-8", errors="ignore")
+                new_content = content
+                for wrong in _MPM_FOOTER_WRONG_ICONS:
+                    new_content = new_content.replace(wrong, _MPM_FOOTER_CANONICAL)
+                if new_content != content:
+                    md_file.write_text(new_content, encoding="utf-8")
+                    updated += 1
+                    logger.debug(f"Unified footer icon in {md_file}")
+            except OSError as e:
+                logger.debug(f"Could not update {md_file}: {e}")
+                errors += 1
+    logger.info(f"Footer icon unification: updated {updated} files, {errors} errors")
     return errors == 0
 
 
@@ -1953,6 +2028,12 @@ MIGRATIONS: list[Migration] = [
         description="Deploy MPM spinner verbs/tips into ~/.claude/settings.json so they apply outside MPM projects",
         check=_check_spinner_global_needed,
         migrate=_deploy_spinner_global,
+    ),
+    Migration(
+        id="v6.5.24-unify-mpm-footer-icon",
+        description="Upgrade deployed MPM 'Generated with' footers from 🤖/🤖🤖 to canonical 🤖👥 icon",
+        check=_check_mpm_footer_icon_needs_unify,
+        migrate=_unify_mpm_footer_icon_in_agents,
     ),
 ]
 

--- a/src/claude_mpm/services/diagnostics/doctor_reporter.py
+++ b/src/claude_mpm/services/diagnostics/doctor_reporter.py
@@ -392,7 +392,7 @@ class DoctorReporter:
         print("---")
         print()
         print(
-            "🤖🤖 *Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)*"
+            "🤖👥 *Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)*"
         )
         print()
         print(

--- a/src/claude_mpm/services/pr/pr_template_service.py
+++ b/src/claude_mpm/services/pr/pr_template_service.py
@@ -151,7 +151,7 @@ class PRTemplateService:
 - [x] Documentation updated if needed
 
 ---
-🤖🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 """
 
@@ -217,7 +217,7 @@ Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 - [x] No conflicts with existing skills
 {related_section}
 ---
-🤖🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 """
 
@@ -330,5 +330,5 @@ Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 
 {detailed_changes}
 
-🤖🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 """

--- a/src/claude_mpm/skills/bundled/pm/mpm-bug-reporting/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-bug-reporting/SKILL.md
@@ -93,7 +93,15 @@ Always include:
 
 ## Impact
 [How this affects users/workflow]
+
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 ```
+
+**Footer rule**: Always append the canonical MPM footer
+(`🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)`) to
+the issue body. Never use Claude Code's default `🤖 Generated with [Claude Code]`
+footer — MPM only overrides the commit trailer, so the "Generated with" footer
+must be set explicitly or the Claude Code default leaks into GitHub issues.
 
 ## Using gh CLI
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-git-file-tracking/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-git-file-tracking/SKILL.md
@@ -56,7 +56,7 @@ git commit -m "feat: add {description}
 - Includes {key_features}
 - Part of {initiative}
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
@@ -95,7 +95,7 @@ git commit -m "feat: add OAuth2 authentication
 - Added authentication routes
 - Part of user login feature
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md
@@ -77,6 +77,20 @@ Always delegate to version-control agent with strategy parameters.
 
 ## PR Creation Workflow
 
+### Footer Branding (required)
+
+Always append the canonical MPM footer to PR bodies and commit messages:
+
+```
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
+
+Never use Claude Code's default `🤖 Generated with [Claude Code]` footer. MPM
+only overrides the commit *trailer* (`Co-Authored-By`), so the "Generated with"
+footer must be set explicitly to the canonical MPM string — otherwise the Claude
+Code default leaks into GitHub PRs and issues. The `Co-Authored-By: Claude MPM
+<https://github.com/bobmatnyc/claude-mpm>` trailer is separate and stays as-is.
+
 When creating PRs, delegate to version-control agent with:
 
 ```

--- a/src/claude_mpm/skills/bundled/pm/mpm-tool-usage-guide/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-tool-usage-guide/SKILL.md
@@ -190,7 +190,7 @@ git commit -m "feat: add OAuth2 authentication
 - Added authentication routes
 - Part of user login feature
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```

--- a/tools/dev/automated_release.py
+++ b/tools/dev/automated_release.py
@@ -349,7 +349,7 @@ def sync_agent_repositories(
 - Synchronized changes for release v{version}
 - Auto-committed by automated_release.py
 
-🤖 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"""
 


### PR DESCRIPTION
## Summary

Standardizes the AI-attribution footer to the canonical string everywhere an
agent/skill/script emits it onto GitHub issues, PRs, and commits:

```
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
```

Unifies all single-robot (`🤖`) and doubled-robot (`🤖🤖`) variants to the
multi-agent `🤖👥` icon, fixes the leak source, and corrects the footer
migration constant.

## Audit

Grepped the tracked repo for every AI-attribution string. Emitter files found
and normalized (worktrees, backups, `_archive/` historical snapshots, and
Claude Code *install-URL* references were correctly excluded):

- `src/claude_mpm/agents/bundled/ticketing.md` — `🤖 Reported by Claude MPM Agent` → canonical footer + "never use Claude Code default" directive
- `src/claude_mpm/skills/bundled/pm/mpm-git-file-tracking/SKILL.md` — `🤖` → `🤖👥`
- `src/claude_mpm/skills/bundled/pm/mpm-tool-usage-guide/SKILL.md` — `🤖` → `🤖👥`
- `src/claude_mpm/skills/bundled/pm/mpm-bug-reporting/SKILL.md` — added canonical footer to issue template + directive
- `src/claude_mpm/skills/bundled/pm/mpm-pr-workflow/SKILL.md` — added footer-branding section documenting the leak + directive
- `src/claude_mpm/cli/startup_migrations.py` — fixed REPLACEMENT constant `🤖🤖` → `🤖👥`; added migration `v6.5.24-unify-mpm-footer-icon`
- `src/claude_mpm/services/pr/pr_template_service.py` — `🤖🤖` → `🤖👥` (3 occurrences)
- `src/claude_mpm/services/diagnostics/doctor_reporter.py` — `🤖🤖` → `🤖👥`
- `src/.claude/agents/ops.md` — `🤖🤖` → `🤖👥`
- `scripts/setup-git-hooks.sh`, `scripts/gh-claude-mpm`, `scripts/git-claude-mpm` — added icon-normalization so bare/single/double variants all land on `🤖👥`
- `scripts/sync_agent_skills_repos.sh`, `tools/dev/automated_release.py` — `🤖` → `🤖👥`
- `docs/guides/doctor-command.md` — corrected example footer from `🤖 Claude Code` to `🤖👥 Claude MPM`
- `plugin/skills/{mpm-git-file-tracking,mpm-tool-usage-guide,mpm-bug-reporting,mpm-pr-workflow}` — distribution copies normalized to match bundled sources

The agent templates `git-file-tracking.md` and `circuit-breakers.md` already
used canonical `🤖👥` + repo link — no change needed.

## Leak root-cause

The most likely path emitting `🤖 Generated with Claude Code` into GitHub
issues/PRs: **MPM only overrides the commit *trailer* (`Co-Authored-By`), not
the "Generated with" footer.** When an agent creates a PR or issue and lets the
harness append Claude Code's built-in footer, that default footer leaks through
unchanged. The `gh-claude-mpm`/`git-claude-mpm`/`setup-git-hooks.sh` wrappers
only rewrite the footer *if* the message passes through them — direct
`gh issue create` / `gh pr create` calls bypass them.

Fix: every issue/PR/commit-creation instruction now carries an explicit
directive — "Always append the canonical MPM footer; never use the Claude Code
default footer" — in the ticketing agent, `mpm-bug-reporting`, and
`mpm-pr-workflow` skills (bundled + plugin copies).

## Migration

Fixed the existing `v5.9.57-update-claude-code-footers` REPLACEMENT constant
(was `🤖🤖`, now `🤖👥`). Added a new low-risk migration
`v6.5.24-unify-mpm-footer-icon` that upgrades already-deployed agent footers
from `🤖`/`🤖🤖` to `🤖👥` (idempotent, OSError-tolerant, same deployed-agent
dirs as the existing footer migration).

## Tests

`uv run pytest tests/ -k "skill or migration or footer" -p no:xdist`:
941 passed, 14 skipped (pre-existing, unrelated), 2 xpassed.
`uv run pytest tests/cli/test_startup_migrations.py`: 32 passed.
`uv run ruff format/check`: clean.

Closes #710

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
