### PR TITLE
fix: show (stdio) label for trusty-search when both stdio and HTTP active

### DIFF
--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -637,6 +637,7 @@ def get_trusty_status(service: str) -> tuple[str, str]:
                     line = f"{emoji} {service}: on (stdio)   palace: {palace}"
             elif is_healthy:
                 if is_stdio:
+                    # brackets signal HTTP sidecar is secondary/informational; stdio is the primary transport
                     line = f"{emoji} {service}: on (stdio)   [{host_port}]"
                 else:
                     line = f"{emoji} {service}: on   {host_port}"

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -636,7 +636,10 @@ def get_trusty_status(service: str) -> tuple[str, str]:
                     # stdio connected but HTTP unreachable (port informational only)
                     line = f"{emoji} {service}: on (stdio)   palace: {palace}"
             elif is_healthy:
-                line = f"{emoji} {service}: on   {host_port}"
+                if is_stdio:
+                    line = f"{emoji} {service}: on (stdio)   [{host_port}]"
+                else:
+                    line = f"{emoji} {service}: on   {host_port}"
             else:
                 line = f"{emoji} {service}: on (stdio)"
             return ("on", line)


### PR DESCRIPTION
## Summary
- When a trusty service is both stdio-configured **and** has a healthy HTTP sidecar, show `(stdio)` as the primary label and demote the HTTP address to a bracketed hint.
- Fixes the visual asymmetry in the startup banner where trusty-search appeared to use a different transport than trusty-memory and trusty-review.

**Before:**
\`\`\`
🧠 trusty-memory: on (stdio)
🔍 trusty-search: on   127.0.0.1:7878
📝 trusty-review: on (stdio)
\`\`\`

**After:**
\`\`\`
🧠 trusty-memory: on (stdio)
🔍 trusty-search: on (stdio)   [127.0.0.1:7878]
📝 trusty-review: on (stdio)
\`\`\`

## Test plan
- [ ] All existing tests pass (\`make test\`)
- [ ] Ruff format/lint clean

Closes #716

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)