### PR TITLE
feat: worktree-first workflow as framework default

### DIFF
--- a/docs/releases/worktree-workflow.md
+++ b/docs/releases/worktree-workflow.md
@@ -4,7 +4,7 @@
 
 Starting from this release, all issue-linked work in claude-mpm uses git
 worktrees by default. Each GitHub issue gets its own `worktree` directory
-under `.worktrees/`; the source repository stays pinned to `HEAD` throughout
+under `.claude/worktrees/`; the source repository stays pinned to `HEAD` throughout
 the entire development cycle.
 
 This is an **opt-out** change: no existing config files need to be edited.
@@ -16,7 +16,7 @@ To disable the feature set `workflow.worktree.enabled: false` in
 | Problem with plain branch checkout | How worktrees solve it |
 |------------------------------------|------------------------|
 | Source directory changes with the branch — agents lose their HEAD reference | Source dir is always on `main`; worktrees are fully independent |
-| Parallel agents on different issues risk conflicts inside the same working tree | Each issue lives in `.worktrees/issue-N-<slug>/` — completely isolated |
+| Parallel agents on different issues risk conflicts inside the same working tree | Each issue lives in `.claude/worktrees/issue-N-<slug>/` — completely isolated |
 | Switching branches requires stashing or committing WIP | No stash/checkout gymnastics; each worktree has its own index |
 | `isolation: "worktree"` on Agent tool calls requires an actual worktree | Native alignment: same directory layout the Agent tool expects |
 
@@ -40,17 +40,17 @@ git branch -d feat/N-<slug>
 
 ```
 repo/                          ← always main, always at HEAD
-  .worktrees/
+  .claude/worktrees/
     issue-N-<slug>/            ← git worktree, feat/N-<slug> branch
     issue-M-<other>/           ← another issue, fully independent
 ```
 
 ```bash
-git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>
-# work inside .worktrees/issue-N-<slug>/
+git worktree add .claude/worktrees/issue-N-<slug> -b feat/N-<slug>
+# work inside .claude/worktrees/issue-N-<slug>/
 gh pr create
 # after squash-merge:
-git worktree remove .worktrees/issue-N-<slug> --force
+git worktree remove .claude/worktrees/issue-N-<slug> --force
 git pull
 ```
 
@@ -75,8 +75,8 @@ The following files were changed as part of this feature:
 
 | File | Change |
 |------|--------|
-| `src/claude_mpm/services/project/gitignore_manager.py` | Added `.worktrees/` to `STANDARD_GITIGNORE_PATTERNS` (bare `worktrees/` was intentionally excluded as too broad) |
-| `src/claude_mpm/cli/commands/config.py` | Added `.worktrees/` to the `config gitignore` recommendation output (bare `worktrees/` excluded) |
+| `src/claude_mpm/services/project/gitignore_manager.py` | Added `.claude/worktrees/` to `STANDARD_GITIGNORE_PATTERNS` (bare `worktrees/` was intentionally excluded as too broad) |
+| `src/claude_mpm/cli/commands/config.py` | Added `.claude/worktrees/` to the `config gitignore` recommendation output (bare `worktrees/` excluded) |
 | `src/claude_mpm/core/config.py` | Added `workflow.worktree` sub-key to `_apply_defaults()` with `enabled: true` |
 | `src/claude_mpm/agents/WORKFLOW.md` | Added **Worktree Workflow (default)** section documenting the 8-step model |
 | `plugin/skills/mpm-pr-workflow/SKILL.md` | Added **Worktree-First Branch Setup** section with worktree commands and post-merge cleanup |

--- a/docs/releases/worktree-workflow.md
+++ b/docs/releases/worktree-workflow.md
@@ -75,8 +75,8 @@ The following files were changed as part of this feature:
 
 | File | Change |
 |------|--------|
-| `src/claude_mpm/services/project/gitignore_manager.py` | Added `.worktrees/` and `worktrees/` to `STANDARD_GITIGNORE_PATTERNS` |
-| `src/claude_mpm/cli/commands/config.py` | Added `.worktrees/` and `worktrees/` to the `config gitignore` recommendation output |
+| `src/claude_mpm/services/project/gitignore_manager.py` | Added `.worktrees/` to `STANDARD_GITIGNORE_PATTERNS` (bare `worktrees/` was intentionally excluded as too broad) |
+| `src/claude_mpm/cli/commands/config.py` | Added `.worktrees/` to the `config gitignore` recommendation output (bare `worktrees/` excluded) |
 | `src/claude_mpm/core/config.py` | Added `workflow.worktree` sub-key to `_apply_defaults()` with `enabled: true` |
 | `src/claude_mpm/agents/WORKFLOW.md` | Added **Worktree Workflow (default)** section documenting the 8-step model |
 | `plugin/skills/mpm-pr-workflow/SKILL.md` | Added **Worktree-First Branch Setup** section with worktree commands and post-merge cleanup |

--- a/docs/releases/worktree-workflow.md
+++ b/docs/releases/worktree-workflow.md
@@ -1,0 +1,82 @@
+# Worktree-first workflow is now the default
+
+## Summary
+
+Starting from this release, all issue-linked work in claude-mpm uses git
+worktrees by default. Each GitHub issue gets its own `worktree` directory
+under `.worktrees/`; the source repository stays pinned to `HEAD` throughout
+the entire development cycle.
+
+This is an **opt-out** change: no existing config files need to be edited.
+To disable the feature set `workflow.worktree.enabled: false` in
+`.claude-mpm/config.yaml`.
+
+## Rationale
+
+| Problem with plain branch checkout | How worktrees solve it |
+|------------------------------------|------------------------|
+| Source directory changes with the branch — agents lose their HEAD reference | Source dir is always on `main`; worktrees are fully independent |
+| Parallel agents on different issues risk conflicts inside the same working tree | Each issue lives in `.worktrees/issue-N-<slug>/` — completely isolated |
+| Switching branches requires stashing or committing WIP | No stash/checkout gymnastics; each worktree has its own index |
+| `isolation: "worktree"` on Agent tool calls requires an actual worktree | Native alignment: same directory layout the Agent tool expects |
+
+## What the new workflow looks like
+
+### Before (plain branch checkout)
+
+```
+repo/                  ← switches between main / feature branches
+```
+
+```bash
+git checkout -b feat/N-<slug>
+# ... work here ...
+gh pr create
+git checkout main
+git branch -d feat/N-<slug>
+```
+
+### After (worktree-first, default)
+
+```
+repo/                          ← always main, always at HEAD
+  .worktrees/
+    issue-N-<slug>/            ← git worktree, feat/N-<slug> branch
+    issue-M-<other>/           ← another issue, fully independent
+```
+
+```bash
+git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>
+# work inside .worktrees/issue-N-<slug>/
+gh pr create
+# after squash-merge:
+git worktree remove .worktrees/issue-N-<slug> --force
+git pull
+```
+
+## Migration / opt-out
+
+To revert to the plain branch-checkout model for a project, add to
+`.claude-mpm/config.yaml`:
+
+```yaml
+workflow:
+  worktree:
+    enabled: false
+```
+
+No other changes are needed. All other workflow steps (branch naming,
+commit conventions, PR footer, trusty-review gate, squash-merge) remain
+identical.
+
+## Technical details
+
+The following files were changed as part of this feature:
+
+| File | Change |
+|------|--------|
+| `src/claude_mpm/services/project/gitignore_manager.py` | Added `.worktrees/` and `worktrees/` to `STANDARD_GITIGNORE_PATTERNS` |
+| `src/claude_mpm/cli/commands/config.py` | Added `.worktrees/` and `worktrees/` to the `config gitignore` recommendation output |
+| `src/claude_mpm/core/config.py` | Added `workflow.worktree` sub-key to `_apply_defaults()` with `enabled: true` |
+| `src/claude_mpm/agents/WORKFLOW.md` | Added **Worktree Workflow (default)** section documenting the 8-step model |
+| `plugin/skills/mpm-pr-workflow/SKILL.md` | Added **Worktree-First Branch Setup** section with worktree commands and post-merge cleanup |

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -59,11 +59,13 @@ directory advances on the feature branch.
 
 ```bash
 # Remove the worktree
-git worktree remove .worktrees/issue-N-<slug> --force
+git worktree remove .worktrees/issue-N-<slug>
 
 # Pull latest main in the source dir
 git pull
 ```
+
+Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
 
 ### When disabled (opt-out)
 

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -36,6 +36,44 @@ When non-privileged users request main branch operations:
 
 **Error Prevention**: PM proactively guides non-privileged users to correct workflow (don't wait for git errors).
 
+## Worktree-First Branch Setup
+
+Check `workflow.worktree.enabled` (default: `true`) before starting any issue branch.
+
+### When enabled (default)
+
+Replace the plain branch checkout with a git worktree:
+
+```bash
+# Create the worktree and branch in one step
+git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>
+
+# All engineering work happens inside the worktree
+cd .worktrees/issue-N-<slug>
+```
+
+The source directory (`repo/`) stays on `main` throughout; only the worktree
+directory advances on the feature branch.
+
+**Post-merge cleanup** (after squash-merge lands on main):
+
+```bash
+# Remove the worktree
+git worktree remove .worktrees/issue-N-<slug> --force
+
+# Pull latest main in the source dir
+git pull
+```
+
+### When disabled (opt-out)
+
+Set `workflow.worktree.enabled: false` in `.claude-mpm/config.yaml` to fall back
+to the standard branch checkout approach below:
+
+```bash
+git checkout -b feat/N-<slug>
+```
+
 ## PR Workflow Delegation
 
 **Default**: Main-based PRs (unless user explicitly requests stacked)

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -66,7 +66,9 @@ git branch -d feat/N-<slug>   # delete the local tracking branch
 git pull
 ```
 
-Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .claude/worktrees/issue-N-<slug> status` first.
+- Only run after confirming the squash-merge has landed on main.
+- If the worktree has untracked files git will refuse removal — inspect with `git -C .claude/worktrees/issue-N-<slug> status` first.
+- After inspecting: commit or stash any work you want to keep, then retry `git worktree remove`; or use `--force` only if you are certain the files are disposable.
 
 ### When disabled (opt-out)
 

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -60,6 +60,7 @@ directory advances on the feature branch.
 ```bash
 # Remove the worktree
 git worktree remove .worktrees/issue-N-<slug>
+git branch -d feat/N-<slug>   # delete the local tracking branch
 
 # Pull latest main in the source dir
 git pull

--- a/plugin/skills/mpm-pr-workflow/SKILL.md
+++ b/plugin/skills/mpm-pr-workflow/SKILL.md
@@ -46,10 +46,10 @@ Replace the plain branch checkout with a git worktree:
 
 ```bash
 # Create the worktree and branch in one step
-git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>
+git worktree add .claude/worktrees/issue-N-<slug> -b feat/N-<slug>
 
 # All engineering work happens inside the worktree
-cd .worktrees/issue-N-<slug>
+cd .claude/worktrees/issue-N-<slug>
 ```
 
 The source directory (`repo/`) stays on `main` throughout; only the worktree
@@ -59,14 +59,14 @@ directory advances on the feature branch.
 
 ```bash
 # Remove the worktree
-git worktree remove .worktrees/issue-N-<slug>
+git worktree remove .claude/worktrees/issue-N-<slug>
 git branch -d feat/N-<slug>   # delete the local tracking branch
 
 # Pull latest main in the source dir
 git pull
 ```
 
-Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
+Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .claude/worktrees/issue-N-<slug> status` first.
 
 ### When disabled (opt-out)
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -48,6 +48,7 @@ repo/                          ← main, always at HEAD
    git pull                        # advance source dir to HEAD
    ```
    Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .claude/worktrees/issue-N-<slug> status` first.
+   After inspecting: commit or stash any work you want to keep, then retry `git worktree remove`; or use `--force` only if you are certain the files are disposable.
 
 **Rationale:** Source dir stays clean at HEAD; multiple agents can work on separate issues without file conflicts; consistent with the `isolation: "worktree"` pattern on Agent tool calls; eliminates stash/checkout gymnastics.
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -41,8 +41,13 @@ repo/                          ← main, always at HEAD
 5. `gh pr create` from the worktree branch
 6. PR review (trusty-review gate)
 7. Squash-merge → main
-8. `git worktree remove .worktrees/issue-N-<slug>` + `git pull` in source dir
-   - Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
+8. After squash-merge lands on main, run in the source dir:
+   ```
+   git worktree remove .worktrees/issue-N-<slug>
+   git branch -d feat/N-<slug>   # delete the local tracking branch
+   git pull                        # advance source dir to HEAD
+   ```
+   Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
 
 **Rationale:** Source dir stays clean at HEAD; multiple agents can work on separate issues without file conflicts; consistent with the `isolation: "worktree"` pattern on Agent tool calls; eliminates stash/checkout gymnastics.
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -28,26 +28,26 @@ When `workflow.worktree.enabled: true` (the default), all issue-linked work uses
 
 ```
 repo/                          ← main, always at HEAD
-  .worktrees/
+  .claude/worktrees/
     issue-N-<slug>/            ← git worktree, issue branch
     issue-M-<other-slug>/      ← parallel branch, independent
 ```
 
 **Steps:**
 1. Create GitHub issue → get issue number N
-2. `git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>`
-3. Engineer works inside `.worktrees/issue-N-<slug>/`
+2. `git worktree add .claude/worktrees/issue-N-<slug> -b feat/N-<slug>`
+3. Engineer works inside `.claude/worktrees/issue-N-<slug>/`
 4. Commits include `Closes #N`
 5. `gh pr create` from the worktree branch
 6. PR review (trusty-review gate)
 7. Squash-merge → main
 8. After squash-merge lands on main, run in the source dir:
    ```
-   git worktree remove .worktrees/issue-N-<slug>
+   git worktree remove .claude/worktrees/issue-N-<slug>
    git branch -d feat/N-<slug>   # delete the local tracking branch
    git pull                        # advance source dir to HEAD
    ```
-   Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
+   Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .claude/worktrees/issue-N-<slug> status` first.
 
 **Rationale:** Source dir stays clean at HEAD; multiple agents can work on separate issues without file conflicts; consistent with the `isolation: "worktree"` pattern on Agent tool calls; eliminates stash/checkout gymnastics.
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -41,7 +41,8 @@ repo/                          ← main, always at HEAD
 5. `gh pr create` from the worktree branch
 6. PR review (trusty-review gate)
 7. Squash-merge → main
-8. `git worktree remove .worktrees/issue-N-<slug> --force` + `git pull` in source dir
+8. `git worktree remove .worktrees/issue-N-<slug>` + `git pull` in source dir
+   - Only run after confirming the squash-merge has landed on main. If the worktree has untracked files git will refuse removal — inspect with `git -C .worktrees/issue-N-<slug> status` first.
 
 **Rationale:** Source dir stays clean at HEAD; multiple agents can work on separate issues without file conflicts; consistent with the `isolation: "worktree"` pattern on Agent tool calls; eliminates stash/checkout gymnastics.
 

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -22,6 +22,31 @@ No direct commits to `main`. Substantive work lands on `main` only via a squash-
 
 **Branch hygiene:** delete feature branches after squash-merge; never run parallel agents on the same branch; keep `main` clean (no throwaway commits).
 
+### Worktree Workflow (default)
+
+When `workflow.worktree.enabled: true` (the default), all issue-linked work uses git worktrees:
+
+```
+repo/                          ← main, always at HEAD
+  .worktrees/
+    issue-N-<slug>/            ← git worktree, issue branch
+    issue-M-<other-slug>/      ← parallel branch, independent
+```
+
+**Steps:**
+1. Create GitHub issue → get issue number N
+2. `git worktree add .worktrees/issue-N-<slug> -b feat/N-<slug>`
+3. Engineer works inside `.worktrees/issue-N-<slug>/`
+4. Commits include `Closes #N`
+5. `gh pr create` from the worktree branch
+6. PR review (trusty-review gate)
+7. Squash-merge → main
+8. `git worktree remove .worktrees/issue-N-<slug> --force` + `git pull` in source dir
+
+**Rationale:** Source dir stays clean at HEAD; multiple agents can work on separate issues without file conflicts; consistent with the `isolation: "worktree"` pattern on Agent tool calls; eliminates stash/checkout gymnastics.
+
+To opt out: set `workflow.worktree.enabled: false` in `.claude-mpm/config.yaml`.
+
 ## Mandatory 5-Phase Sequence
 
 ### Phase 1: Research (CONDITIONAL)

--- a/src/claude_mpm/cli/commands/config.py
+++ b/src/claude_mpm/cli/commands/config.py
@@ -475,7 +475,11 @@ class ConfigCommand(BaseCommand):
 .claude-mpm/*
 !.claude-mpm/memories/
 .claude-mpm/memories/*
-!.claude-mpm/memories/*.md"""
+!.claude-mpm/memories/*.md
+
+# Git worktrees (worktree-first workflow — keep out of version control)
+.worktrees/
+worktrees/"""
 
         # Display in a panel for clarity
         from rich.panel import Panel

--- a/src/claude_mpm/cli/commands/config.py
+++ b/src/claude_mpm/cli/commands/config.py
@@ -478,8 +478,7 @@ class ConfigCommand(BaseCommand):
 !.claude-mpm/memories/*.md
 
 # Git worktrees (worktree-first workflow — keep out of version control)
-.worktrees/
-worktrees/"""
+.worktrees/"""
 
         # Display in a panel for clarity
         from rich.panel import Panel

--- a/src/claude_mpm/cli/commands/config.py
+++ b/src/claude_mpm/cli/commands/config.py
@@ -478,7 +478,7 @@ class ConfigCommand(BaseCommand):
 !.claude-mpm/memories/*.md
 
 # Git worktrees (worktree-first workflow — keep out of version control)
-.worktrees/"""
+.claude/worktrees/"""
 
         # Display in a panel for clarity
         from rich.panel import Panel

--- a/src/claude_mpm/core/config.py
+++ b/src/claude_mpm/core/config.py
@@ -613,11 +613,11 @@ class Config:
                         "enforcement": "baseline",
                     },
                 },
-                # Worktree-first workflow: each issue gets its own git worktree so the
-                # source directory stays pinned to HEAD while work proceeds in isolation.
+                # Worktree-first workflow: each issue gets its own git worktree under
+                # .claude/worktrees/ (aligns with Claude Code native convention).
                 # Opt-OUT: enabled by default; set to false to revert to plain branch checkout.
                 "worktree": {
-                    "enabled": True,  # opt-out: on by default; set false in .claude-mpm/config.yaml to disable
+                    "enabled": True,
                 },
             },
         }

--- a/src/claude_mpm/core/config.py
+++ b/src/claude_mpm/core/config.py
@@ -612,7 +612,16 @@ class Config:
                         # off | baseline | strict
                         "enforcement": "baseline",
                     },
-                }
+                },
+                # Worktree-first workflow: each issue gets its own git worktree so the
+                # source directory stays pinned to HEAD while work proceeds in isolation.
+                # Opt-OUT: enabled by default; set to false to revert to plain branch checkout.
+                "worktree": {
+                    "enabled": True,  # opt-out: on by default
+                    "location": ".worktrees",  # directory for worktrees (gitignored)
+                    "auto_setup": True,  # run uv sync / npm install in new worktree
+                    "verify_baseline": False,  # skip baseline test run by default
+                },
             },
         }
 

--- a/src/claude_mpm/core/config.py
+++ b/src/claude_mpm/core/config.py
@@ -618,7 +618,7 @@ class Config:
                 # Opt-OUT: enabled by default; set to false to revert to plain branch checkout.
                 "worktree": {
                     "enabled": True,  # opt-out: on by default
-                    "location": ".worktrees",  # gitignored directory for worktrees
+                    "location": ".worktrees",  # TODO: consumed by mpm-pr-workflow skill; runtime enforcement in future milestone
                 },
             },
         }

--- a/src/claude_mpm/core/config.py
+++ b/src/claude_mpm/core/config.py
@@ -618,9 +618,7 @@ class Config:
                 # Opt-OUT: enabled by default; set to false to revert to plain branch checkout.
                 "worktree": {
                     "enabled": True,  # opt-out: on by default
-                    "location": ".worktrees",  # directory for worktrees (gitignored)
-                    "auto_setup": True,  # run uv sync / npm install in new worktree
-                    "verify_baseline": False,  # skip baseline test run by default
+                    "location": ".worktrees",  # gitignored directory for worktrees
                 },
             },
         }

--- a/src/claude_mpm/core/config.py
+++ b/src/claude_mpm/core/config.py
@@ -617,8 +617,7 @@ class Config:
                 # source directory stays pinned to HEAD while work proceeds in isolation.
                 # Opt-OUT: enabled by default; set to false to revert to plain branch checkout.
                 "worktree": {
-                    "enabled": True,  # opt-out: on by default
-                    "location": ".worktrees",  # TODO: consumed by mpm-pr-workflow skill; runtime enforcement in future milestone
+                    "enabled": True,  # opt-out: on by default; set false in .claude-mpm/config.yaml to disable
                 },
             },
         }

--- a/src/claude_mpm/services/project/gitignore_manager.py
+++ b/src/claude_mpm/services/project/gitignore_manager.py
@@ -129,6 +129,9 @@ STANDARD_GITIGNORE_PATTERNS: frozenset[str] = frozenset(
         ".claude-mpm/tmp/",
         ".claude/sessions/",
         "*.mpm.tmp",
+        # Git worktrees (worktree-first workflow)
+        ".worktrees/",
+        "worktrees/",
         # Backup files
         "*.bak",
         "*.backup",

--- a/src/claude_mpm/services/project/gitignore_manager.py
+++ b/src/claude_mpm/services/project/gitignore_manager.py
@@ -129,10 +129,8 @@ STANDARD_GITIGNORE_PATTERNS: frozenset[str] = frozenset(
         ".claude-mpm/tmp/",
         ".claude/sessions/",
         "*.mpm.tmp",
-        # .worktrees/ is the canonical location (dot-prefix); worktrees/ covers
-        # projects that omit the dot — both are always local-only, never committed.
+        # .worktrees/ is the canonical location (dot-prefix); always local-only, never committed.
         ".worktrees/",
-        "worktrees/",
         # Backup files
         "*.bak",
         "*.backup",

--- a/src/claude_mpm/services/project/gitignore_manager.py
+++ b/src/claude_mpm/services/project/gitignore_manager.py
@@ -129,8 +129,8 @@ STANDARD_GITIGNORE_PATTERNS: frozenset[str] = frozenset(
         ".claude-mpm/tmp/",
         ".claude/sessions/",
         "*.mpm.tmp",
-        # .worktrees/ is the canonical location (dot-prefix); always local-only, never committed.
-        ".worktrees/",
+        # .claude/worktrees/ is the canonical location; always local-only, never committed.
+        ".claude/worktrees/",
         # Backup files
         "*.bak",
         "*.backup",

--- a/src/claude_mpm/services/project/gitignore_manager.py
+++ b/src/claude_mpm/services/project/gitignore_manager.py
@@ -129,7 +129,8 @@ STANDARD_GITIGNORE_PATTERNS: frozenset[str] = frozenset(
         ".claude-mpm/tmp/",
         ".claude/sessions/",
         "*.mpm.tmp",
-        # Git worktrees (worktree-first workflow)
+        # .worktrees/ is the canonical location (dot-prefix); worktrees/ covers
+        # projects that omit the dot — both are always local-only, never committed.
         ".worktrees/",
         "worktrees/",
         # Backup files


### PR DESCRIPTION
## Summary

- Makes git worktrees the default pattern for all issue-linked work (`workflow.worktree.enabled: true`)
- Source directory stays pinned to HEAD; each issue gets its own `.worktrees/issue-N-<slug>/` tree
- Adds `workflow.worktree` config key (opt-out via `workflow.worktree.enabled: false`)
- Updates `mpm-pr-workflow` skill with worktree steps and post-merge cleanup
- Adds `.worktrees/` and `worktrees/` to standard gitignore patterns
- Documents the new workflow in `WORKFLOW.md` and `docs/releases/worktree-workflow.md`

## New default model

\`\`\`
repo/                        ← main, always at HEAD
  .worktrees/
    issue-N-fix-foo/         ← git worktree, issue branch
    issue-M-add-bar/         ← parallel branch, independent
\`\`\`

## Why

- Parallel agent isolation: multiple engineers work on separate issues without file conflicts
- Source dir always at HEAD: agents have a stable reference point
- Consistent with existing `isolation: "worktree"` on Agent tool calls
- Eliminates stash/checkout gymnastics in engineer delegations

## Opt-out

Set in \`.claude-mpm/config.yaml\`:
\`\`\`yaml
workflow:
  worktree:
    enabled: false
\`\`\`

## Test plan
- [ ] 7277 tests pass (\`make test\`)
- [ ] Ruff format/lint clean
- [ ] Release notes in \`docs/releases/worktree-workflow.md\`

Closes #720

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)