### PR TITLE
refactor: extract shared merge_hooks_for_event helper

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/hook_merge.py
+++ b/src/claude_mpm/hooks/claude_hooks/hook_merge.py
@@ -1,0 +1,156 @@
+"""Shared hook-merge helper used by both HookInstaller and HookInstallerService.
+
+WHAT: Exports ``merge_hooks_for_event`` — a standalone two-pass deduplication
+      function that reconciles MPM hook entries in a Claude Code settings block
+      and guarantees exactly one MPM hook entry per event after every call.
+
+WHY: The same two-pass dedup algorithm was duplicated verbatim in
+     ``HookInstaller._update_claude_settings`` (installer.py) and
+     ``HookInstallerService.install_hooks`` (hook_installer_service.py).
+     Keeping two copies creates divergence risk: a bug fix or timeout change
+     applied to one site can easily be missed in the other, reproducing the
+     class of drift that caused issue #677.  A single shared module eliminates
+     that risk and makes future changes a single-line edit.
+
+References
+----------
+SPEC-HOOKS-04~1 : docs/specs/hooks.md#SPEC-HOOKS-04~1
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
+
+
+def merge_hooks_for_event(
+    existing_hooks: list,
+    new_hook_command: dict,
+    is_our_hook: Callable[[dict], bool],
+    logger: logging.Logger,
+    use_matcher: bool = True,
+) -> list:
+    """Merge new_hook_command into existing_hooks, deduplicating MPM entries.
+
+    WHAT: Two-pass idempotent merge that guarantees exactly one MPM hook entry
+          per event block regardless of how many times the installer has run.
+
+    WHY: Both HookInstaller and HookInstallerService need identical dedup
+         semantics.  Sharing a single implementation prevents the two sites
+         from drifting (the root cause of issue #677 follow-up bugs).
+
+    Two-pass algorithm:
+
+    - Pass 1: find the first MPM hook (via ``is_our_hook``), reconcile it to
+      canonical values (command, timeout, _mpm), store object identity via
+      ``id(hook)`` so Pass 2 can skip it safely even if block/hook indices
+      shift due to future list mutations.
+
+    - Pass 2: purge every OTHER MPM hook entry so that re-running the
+      installer any number of times converges to exactly one MPM hook per
+      event.  User-owned hooks (not recognised by ``is_our_hook``) are never
+      touched.
+
+    When no MPM hook exists, appends ``new_hook_command`` to the first block
+    whose ``matcher`` satisfies the ``use_matcher`` policy, or creates a new
+    block if none exists.
+
+    Args:
+        existing_hooks: Current hooks config list for an event type.
+        new_hook_command: The canonical MPM hook dict to add/reconcile.
+            Must contain at minimum ``"command"``, ``"timeout"``, and
+            ``"_mpm": True``.
+        is_our_hook: Predicate that returns True for MPM-owned hook dicts.
+            Typically ``claude_mpm.hooks.hook_identity.is_our_hook``.
+        logger: Logger for debug messages.
+        use_matcher: When True (default), the append path looks for a block
+            with ``matcher == "*"`` and creates one if missing.  When False,
+            the append path looks for a block with no ``matcher`` key and
+            creates one without a matcher.  Has no effect when an existing
+            MPM hook is found in Pass 1 (the reconcile-then-dedup path).
+
+    Returns:
+        Updated hooks list with exactly one MPM hook entry, duplicates removed.
+        The same list object is returned (mutated in-place).
+    """
+    # ------------------------------------------------------------------
+    # Pass 1: find the first MPM hook and reconcile it to canonical values.
+    #
+    # We store the Python object identity (id) of the found hook rather than
+    # its (block_idx, hook_idx) coordinates.  Object identity is more robust:
+    # if list mutations ever shift indices between Pass 1 and Pass 2, the id
+    # still uniquely identifies the one hook we want to keep.
+    # ------------------------------------------------------------------
+    canonical_hook_id: int | None = None
+
+    for hook_config in existing_hooks:
+        if "hooks" in hook_config and isinstance(hook_config["hooks"], list):
+            for hook in hook_config["hooks"]:
+                if is_our_hook(hook):
+                    # Reconcile the FULL entry (command + timeout + _mpm) to the
+                    # canonical desired value — not just command.  This prevents
+                    # a stale timeout from persisting after an upgrade (issue #677).
+                    hook["command"] = new_hook_command["command"]
+                    hook["timeout"] = new_hook_command["timeout"]
+                    hook["_mpm"] = True
+                    canonical_hook_id = id(hook)
+                    break
+        if canonical_hook_id is not None:
+            break
+
+    if canonical_hook_id is not None:
+        # ------------------------------------------------------------------
+        # Pass 2: purge every OTHER MPM hook entry so that re-running the
+        # installer any number of times converges to exactly one entry.
+        # We iterate all blocks and filter out MPM entries whose object id
+        # does not match the canonical hook we just reconciled above.
+        # ------------------------------------------------------------------
+        for hook_config in existing_hooks:
+            if "hooks" not in hook_config or not isinstance(hook_config["hooks"], list):
+                continue
+            kept: list = []
+            for hook in hook_config["hooks"]:
+                if is_our_hook(hook) and id(hook) != canonical_hook_id:
+                    # Extra duplicate — drop it.
+                    logger.debug("Removing duplicate MPM hook: %s", hook.get("command"))
+                else:
+                    kept.append(hook)
+            hook_config["hooks"] = kept
+        return existing_hooks
+
+    # ------------------------------------------------------------------
+    # No MPM hook found — append new_hook_command to an appropriate block,
+    # or create a new block if none exists.
+    # ------------------------------------------------------------------
+    added = False
+
+    for hook_config in existing_hooks:
+        matcher = hook_config.get("matcher")
+        if use_matcher:
+            # Look for an existing wildcard-matcher block.
+            if matcher == "*":
+                if "hooks" not in hook_config:
+                    hook_config["hooks"] = []
+                hook_config["hooks"].append(new_hook_command)
+                added = True
+                break
+        # Simple events have no matcher key.
+        elif matcher is None:
+            if "hooks" not in hook_config:
+                hook_config["hooks"] = []
+            hook_config["hooks"].append(new_hook_command)
+            added = True
+            break
+
+    if not added:
+        # No suitable block found — create a new one.
+        if use_matcher:
+            new_config: dict = {"matcher": "*", "hooks": [new_hook_command]}
+        else:
+            new_config = {"hooks": [new_hook_command]}
+        existing_hooks.append(new_config)
+
+    return existing_hooks

--- a/src/claude_mpm/hooks/claude_hooks/hook_merge.py
+++ b/src/claude_mpm/hooks/claude_hooks/hook_merge.py
@@ -129,16 +129,12 @@ def merge_hooks_for_event(
 
     for hook_config in existing_hooks:
         matcher = hook_config.get("matcher")
-        if use_matcher:
-            # Look for an existing wildcard-matcher block.
-            if matcher == "*":
-                if "hooks" not in hook_config:
-                    hook_config["hooks"] = []
-                hook_config["hooks"].append(new_hook_command)
-                added = True
-                break
-        # Simple events have no matcher key.
-        elif matcher is None:
+        # Accept a block when:
+        #  - use_matcher=True  → block has matcher == "*"
+        #  - use_matcher=False → block has matcher == "*" OR no matcher key
+        #    (simple events like Stop have no matcher, but if a wildcard block
+        #    happens to exist we can reuse it rather than creating a new one)
+        if matcher == "*" or (not use_matcher and matcher is None):
             if "hooks" not in hook_config:
                 hook_config["hooks"] = []
             hook_config["hooks"].append(new_hook_command)

--- a/src/claude_mpm/hooks/claude_hooks/installer.py
+++ b/src/claude_mpm/hooks/claude_hooks/installer.py
@@ -13,6 +13,9 @@ import stat
 import subprocess  # nosec B404 - Safe: only uses hardcoded 'claude' CLI command, no user input
 from pathlib import Path
 
+from claude_mpm.hooks.claude_hooks.hook_merge import (
+    merge_hooks_for_event as _merge_hooks_for_event,
+)
 from claude_mpm.hooks.hook_identity import is_our_hook as _is_our_hook
 from claude_mpm.hooks.timeout_constants import canonical_timeout as _canonical_timeout
 
@@ -883,103 +886,6 @@ main "$@"
         # merge_hooks_for_event.
         hook_command_base = {"type": "command", "command": hook_cmd, "_mpm": True}
 
-        def merge_hooks_for_event(
-            existing_hooks: list, new_hook_command: dict, use_matcher: bool = True
-        ) -> list:
-            """Merge new hook command into existing hooks without duplication.
-
-            Why: Re-running the installer must converge to exactly one MPM hook
-            per event, regardless of how many times it has run before or how many
-            legacy/duplicate entries have accumulated from previous installs.
-            What: Finds the first MPM hook in any block, reconciles it to the
-            canonical command/timeout/_mpm values, then purges every additional
-            MPM hook entry across all blocks (idempotent dedup). When no MPM hook
-            exists, appends one to the matching block or creates a new block.
-            Test: Install twice into a temp settings.json; assert exactly one MPM
-            hook entry per event and that user-owned hooks are untouched.
-
-            Args:
-                existing_hooks: Current hooks configuration for an event type
-                new_hook_command: The claude-mpm hook command to add
-                use_matcher: Whether to include matcher: "*" in the config
-
-            Returns:
-                Updated hooks list with our hook merged in, duplicates removed
-            """
-            # Pass 1: find the first MPM hook and reconcile it to the canonical
-            # values.  Track which (block_idx, hook_idx) it lives at so Pass 2
-            # can skip it when removing extras.
-            canonical_location: tuple[int, int] | None = None
-
-            for block_idx, hook_config in enumerate(existing_hooks):
-                if "hooks" in hook_config and isinstance(hook_config["hooks"], list):
-                    for hook_idx, hook in enumerate(hook_config["hooks"]):
-                        if _is_our_hook(hook):
-                            # Reconcile the FULL entry (command + timeout + _mpm)
-                            # to the canonical desired value — not just command.
-                            # This prevents a stale timeout from persisting after
-                            # an upgrade (issue #677).
-                            hook["command"] = new_hook_command["command"]
-                            hook["timeout"] = new_hook_command["timeout"]
-                            hook["_mpm"] = True
-                            canonical_location = (block_idx, hook_idx)
-                            break
-                if canonical_location is not None:
-                    break
-
-            if canonical_location is not None:
-                # Pass 2: purge every OTHER MPM hook entry so that re-running the
-                # installer any number of times converges to exactly one entry.
-                # We iterate all blocks and filter out MPM entries that are not
-                # the canonical one we just reconciled above.
-                canon_block, canon_hook = canonical_location
-                for block_idx, hook_config in enumerate(existing_hooks):
-                    if "hooks" not in hook_config or not isinstance(
-                        hook_config["hooks"], list
-                    ):
-                        continue
-                    kept: list = []
-                    for hook_idx, hook in enumerate(hook_config["hooks"]):
-                        if _is_our_hook(hook) and (block_idx, hook_idx) != (
-                            canon_block,
-                            canon_hook,
-                        ):
-                            # Extra duplicate — drop it.
-                            self.logger.debug(
-                                "Removing duplicate MPM hook at block %d, hook %d",
-                                block_idx,
-                                hook_idx,
-                            )
-                        else:
-                            kept.append(hook)
-                    hook_config["hooks"] = kept
-                return existing_hooks
-
-            # Our hook doesn't exist - need to add it
-            # Strategy: Add our hook to the first "*" matcher config, or create new config
-            added = False
-
-            for hook_config in existing_hooks:
-                # Check if this config has matcher: "*" (or no matcher for simple events)
-                matcher = hook_config.get("matcher")
-                if matcher == "*" or (not use_matcher and matcher is None):
-                    # Add our hook to this config's hooks array
-                    if "hooks" not in hook_config:
-                        hook_config["hooks"] = []
-                    hook_config["hooks"].append(new_hook_command)
-                    added = True
-                    break
-
-            if not added:
-                # No suitable config found, create a new one
-                if use_matcher:
-                    new_config = {"matcher": "*", "hooks": [new_hook_command]}
-                else:
-                    new_config = {"hooks": [new_hook_command]}
-                existing_hooks.append(new_config)
-
-            return existing_hooks
-
         def _make_hook_command(event_type: str) -> dict:
             """Build a canonical hook command dict for the given event type.
 
@@ -995,8 +901,12 @@ main "$@"
         tool_events = ["PreToolUse", "PostToolUse"]
         for event_type in tool_events:
             existing = settings["hooks"].get(event_type, [])
-            settings["hooks"][event_type] = merge_hooks_for_event(
-                existing, _make_hook_command(event_type), use_matcher=True
+            settings["hooks"][event_type] = _merge_hooks_for_event(
+                existing,
+                _make_hook_command(event_type),
+                _is_our_hook,
+                self.logger,
+                use_matcher=True,
             )
 
         # Simple events (no subtypes, no matcher needed).
@@ -1004,8 +914,12 @@ main "$@"
         simple_events_core = ["Stop", "SubagentStop"]
         for event_type in simple_events_core:
             existing = settings["hooks"].get(event_type, [])
-            settings["hooks"][event_type] = merge_hooks_for_event(
-                existing, _make_hook_command(event_type), use_matcher=False
+            settings["hooks"][event_type] = _merge_hooks_for_event(
+                existing,
+                _make_hook_command(event_type),
+                _is_our_hook,
+                self.logger,
+                use_matcher=False,
             )
 
         # v2.1.47+ hook events: only install if Claude Code version supports them.
@@ -1023,13 +937,21 @@ main "$@"
             # Install newer hook types
             for event_type in new_hook_events_simple:
                 existing = settings["hooks"].get(event_type, [])
-                settings["hooks"][event_type] = merge_hooks_for_event(
-                    existing, _make_hook_command(event_type), use_matcher=False
+                settings["hooks"][event_type] = _merge_hooks_for_event(
+                    existing,
+                    _make_hook_command(event_type),
+                    _is_our_hook,
+                    self.logger,
+                    use_matcher=False,
                 )
             for event_type in new_hook_events_matcher:
                 existing = settings["hooks"].get(event_type, [])
-                settings["hooks"][event_type] = merge_hooks_for_event(
-                    existing, _make_hook_command(event_type), use_matcher=True
+                settings["hooks"][event_type] = _merge_hooks_for_event(
+                    existing,
+                    _make_hook_command(event_type),
+                    _is_our_hook,
+                    self.logger,
+                    use_matcher=True,
                 )
         else:
             # Older Claude Code: remove any stale entries that would cause warnings
@@ -1042,14 +964,22 @@ main "$@"
 
         # SessionStart needs matcher for subtypes (startup, resume)
         existing = settings["hooks"].get("SessionStart", [])
-        settings["hooks"]["SessionStart"] = merge_hooks_for_event(
-            existing, _make_hook_command("SessionStart"), use_matcher=True
+        settings["hooks"]["SessionStart"] = _merge_hooks_for_event(
+            existing,
+            _make_hook_command("SessionStart"),
+            _is_our_hook,
+            self.logger,
+            use_matcher=True,
         )
 
         # UserPromptSubmit needs matcher for potential subtypes
         existing = settings["hooks"].get("UserPromptSubmit", [])
-        settings["hooks"]["UserPromptSubmit"] = merge_hooks_for_event(
-            existing, _make_hook_command("UserPromptSubmit"), use_matcher=True
+        settings["hooks"]["UserPromptSubmit"] = _merge_hooks_for_event(
+            existing,
+            _make_hook_command("UserPromptSubmit"),
+            _is_our_hook,
+            self.logger,
+            use_matcher=True,
         )
 
         # Fix statusLine command to handle both output style schemas

--- a/src/claude_mpm/services/hook_installer_service.py
+++ b/src/claude_mpm/services/hook_installer_service.py
@@ -18,6 +18,9 @@ from pathlib import Path
 from typing import Any
 
 from ..core.logging_config import get_logger
+from ..hooks.claude_hooks.hook_merge import (
+    merge_hooks_for_event as _merge_hooks_for_event,
+)
 from ..hooks.hook_identity import is_our_hook as _is_our_hook
 from ..hooks.timeout_constants import canonical_timeout as _canonical_timeout
 
@@ -371,98 +374,6 @@ class HookInstallerService:
             if "hooks" not in settings:
                 settings["hooks"] = {}
 
-            def merge_hooks_for_event(
-                existing_hooks: list, hook_command: dict[str, Any]
-            ) -> list:
-                """Merge new hook command into existing hooks without duplication.
-
-                Why: Re-running the installer must converge to exactly one MPM hook
-                per event, regardless of how many times it has run before or how many
-                legacy/duplicate entries have accumulated from previous installs.
-                What: Finds the first MPM hook in any block, reconciles it to the
-                canonical command/timeout/_mpm values, then purges every additional
-                MPM hook entry across all blocks (idempotent dedup). When no MPM hook
-                exists, appends one to the first matcher="*" block or creates a new one.
-                Test: Install twice into a temp settings.json; assert exactly one MPM
-                hook entry per event and that user-owned hooks are untouched.
-
-                Args:
-                    existing_hooks: Current hooks configuration for an event type
-                    hook_command: The claude-mpm hook command to add
-
-                Returns:
-                    Updated hooks list with our hook merged in, duplicates removed
-                """
-                # Pass 1: find the first MPM hook and reconcile it to the canonical
-                # values.  Track which (block_idx, hook_idx) it lives at so Pass 2
-                # can skip it when removing extras.
-                canonical_location: tuple[int, int] | None = None
-
-                for block_idx, hook_config in enumerate(existing_hooks):
-                    if "hooks" in hook_config and isinstance(
-                        hook_config["hooks"], list
-                    ):
-                        for hook_idx, hook in enumerate(hook_config["hooks"]):
-                            if _is_our_hook(hook):
-                                # Reconcile the FULL entry (command + timeout + _mpm)
-                                # to the canonical desired value — not just command.
-                                # This prevents a stale timeout from persisting after
-                                # an upgrade (issue #677).
-                                hook["command"] = hook_command["command"]
-                                hook["timeout"] = hook_command["timeout"]
-                                hook["_mpm"] = True
-                                canonical_location = (block_idx, hook_idx)
-                                break
-                    if canonical_location is not None:
-                        break
-
-                if canonical_location is not None:
-                    # Pass 2: purge every OTHER MPM hook entry so that re-running
-                    # the installer any number of times converges to exactly one entry.
-                    canon_block, canon_hook = canonical_location
-                    for block_idx, hook_config in enumerate(existing_hooks):
-                        if "hooks" not in hook_config or not isinstance(
-                            hook_config["hooks"], list
-                        ):
-                            continue
-                        kept: list = []
-                        for hook_idx, hook in enumerate(hook_config["hooks"]):
-                            if _is_our_hook(hook) and (block_idx, hook_idx) != (
-                                canon_block,
-                                canon_hook,
-                            ):
-                                # Extra duplicate — drop it.
-                                self.logger.debug(
-                                    "Removing duplicate MPM hook at block %d, hook %d",
-                                    block_idx,
-                                    hook_idx,
-                                )
-                            else:
-                                kept.append(hook)
-                        hook_config["hooks"] = kept
-                    return existing_hooks
-
-                # Our hook doesn't exist - need to add it
-                # Strategy: Add our hook to the first "*" matcher config, or create new
-                added = False
-
-                for hook_config in existing_hooks:
-                    # Check if this config has matcher: "*"
-                    if hook_config.get("matcher") == "*":
-                        # Add our hook to this config's hooks array
-                        if "hooks" not in hook_config:
-                            hook_config["hooks"] = []
-                        hook_config["hooks"].append(hook_command)
-                        added = True
-                        break
-
-                if not added:
-                    # No suitable config found, create a new one
-                    new_config = {"matcher": "*", "hooks": [hook_command]}
-                    existing_hooks.append(new_config)
-
-                return existing_hooks
-
             def _make_hook_command(event_type: str) -> dict[str, Any]:
                 """Build a canonical hook command dict for the given event type."""
                 cmd = dict(new_hook_command_base)
@@ -478,8 +389,8 @@ class HookInstallerService:
                 "SubagentStop",
             ]:
                 existing = settings["hooks"].get(event_type, [])
-                settings["hooks"][event_type] = merge_hooks_for_event(
-                    existing, _make_hook_command(event_type)
+                settings["hooks"][event_type] = _merge_hooks_for_event(
+                    existing, _make_hook_command(event_type), _is_our_hook, self.logger
                 )
 
             # Write settings


### PR DESCRIPTION
## Summary

- Extracts the duplicated two-pass hook-dedup algorithm into `src/claude_mpm/hooks/claude_hooks/hook_merge.py`
- Both `HookInstaller` (`installer.py`) and `HookInstallerService` (`hook_installer_service.py`) now call the shared helper
- Uses object identity (`id(hook)`) instead of `(block_idx, hook_idx)` for canonical tracking — more robust against future list mutations

## Why

PR #722 fixed hook installer idempotency but applied the same two-pass algorithm verbatim to two files. A future divergence between the copies would silently re-introduce the duplicate-hooks bug in one path.

## Changes

| File | Change |
|------|--------|
| `src/claude_mpm/hooks/claude_hooks/hook_merge.py` | New — shared `merge_hooks_for_event` function |
| `src/claude_mpm/hooks/claude_hooks/installer.py` | Removed ~95-line inline impl, now calls shared helper |
| `src/claude_mpm/services/hook_installer_service.py` | Removed ~80-line inline impl, now calls shared helper |

## Test plan
- [ ] 35/35 `test_hook_installer.py` tests pass
- [ ] Full suite passes
- [ ] No behaviour change

Closes #723

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)