### PR TITLE
fix: align use_matcher for Stop/SubagentStop in HookInstallerService

### DIFF
--- a/src/claude_mpm/services/hook_installer_service.py
+++ b/src/claude_mpm/services/hook_installer_service.py
@@ -381,6 +381,9 @@ class HookInstallerService:
                 return cmd
 
             # Add hooks for all event types - MERGE instead of overwrite
+            # Stop/SubagentStop are simple events with no tool subtype — no matcher needed.
+            # PreToolUse/PostToolUse/UserPromptSubmit use matcher="*" to catch all tools.
+            _EVENTS_WITH_MATCHER = {"UserPromptSubmit", "PreToolUse", "PostToolUse"}
             for event_type in [
                 "UserPromptSubmit",
                 "PreToolUse",
@@ -390,7 +393,11 @@ class HookInstallerService:
             ]:
                 existing = settings["hooks"].get(event_type, [])
                 settings["hooks"][event_type] = _merge_hooks_for_event(
-                    existing, _make_hook_command(event_type), _is_our_hook, self.logger
+                    existing,
+                    _make_hook_command(event_type),
+                    _is_our_hook,
+                    self.logger,
+                    use_matcher=event_type in _EVENTS_WITH_MATCHER,
                 )
 
             # Write settings


### PR DESCRIPTION
## Summary

`HookInstallerService` was calling `merge_hooks_for_event` without `use_matcher`, defaulting to `True` for all events including `Stop` and `SubagentStop`. This produced `{"matcher": "*", "hooks": [...]}` blocks for those events, while `HookInstaller` correctly produces `{"hooks": [...]}` (no matcher).

## Change

Added `_EVENTS_WITH_MATCHER` set; passes `use_matcher=False` for `Stop`/`SubagentStop`, `True` for `PreToolUse`/`PostToolUse`/`UserPromptSubmit`. Mirrors the explicit per-event logic in `installer.py`.

## Test plan
- [ ] `test_hook_installer.py` passes (35/35)
- [ ] Ruff clean

Closes #725

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)