### PR TITLE
feat: framework workflow rules — ticket updates + worktree branches (#733)

### DIFF
--- a/docs/workflow/PM_WORKFLOW.md
+++ b/docs/workflow/PM_WORKFLOW.md
@@ -24,16 +24,20 @@ No direct commits to `main`. Substantive work lands on `main` only via a squash-
 
 ## Ticket Progress & Failure Updates (MANDATORY)
 
+<!-- Canonical copy in src/claude_mpm/agents/WORKFLOW.md — keep in sync -->
+
 When work is associated with a ticket or GitHub issue, the PM MUST post progress updates to that ticket as work progresses:
 
 - **On start**: Post plan and scope
 - **At each milestone**: Post when phases complete
-- **On failure/blocker**: Report within 5 minutes with remediation plan
+- **On failure/blocker**: Report promptly with remediation plan
 - **At completion**: Post summary and merge status
 
 **Delegation**: All ticket operations are delegated to the Ticketing agent. PM never calls ticketing/gh MCP tools directly.
 
 ## Worktree-Based Branch Workflow (CRITICAL)
+
+<!-- Canonical copy in src/claude_mpm/agents/WORKFLOW.md — keep in sync -->
 
 Feature/fix work uses git worktrees; the PRIMARY checkout stays on `main`/HEAD:
 

--- a/docs/workflow/PM_WORKFLOW.md
+++ b/docs/workflow/PM_WORKFLOW.md
@@ -22,6 +22,29 @@ No direct commits to `main`. Substantive work lands on `main` only via a squash-
 
 **Branch hygiene:** delete feature branches after squash-merge; never run parallel agents on the same branch; keep `main` clean (no throwaway commits).
 
+## Ticket Progress & Failure Updates (MANDATORY)
+
+When work is associated with a ticket or GitHub issue, the PM MUST post progress updates to that ticket as work progresses:
+
+- **On start**: Post plan and scope
+- **At each milestone**: Post when phases complete
+- **On failure/blocker**: Report within 5 minutes with remediation plan
+- **At completion**: Post summary and merge status
+
+**Delegation**: All ticket operations are delegated to the Ticketing agent. PM never calls ticketing/gh MCP tools directly.
+
+## Worktree-Based Branch Workflow (CRITICAL)
+
+Feature/fix work uses git worktrees; the PRIMARY checkout stays on `main`/HEAD:
+
+1. **Create per-issue worktree**: `git worktree add .claude/worktrees/issue-<N>-<slug> -b feat/<N>-<slug>`
+2. **Never switch primary checkout for feature work** — causes stash/WIP contention; always use worktrees
+3. **No concurrent branch mutations in same tree** — serialization prevents ref conflicts
+4. **Parallel agents use worktree isolation** — each gets its own worktree
+5. **Cleanup after merge**: `git worktree remove .claude/worktrees/issue-<N>-<slug>` (only after squash-merge lands)
+
+**Rationale**: Eliminates checkout contention, enables safe parallelism, keeps stable HEAD.
+
 ## Mandatory 5-Phase Sequence
 
 ### Phase 1: Research (CONDITIONAL)

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -208,7 +208,7 @@ When work is associated with a ticket or GitHub issue (issue number, PROJ-123, o
 
 - **On start**: Post plan, scope, and approach to the ticket
 - **At each phase/milestone**: Post when research, code analysis, implementation, or QA completes
-- **On ANY failure/blocker/course-correction**: State what failed, impact, and remediation plan within 5 minutes
+- **On ANY failure/blocker/course-correction**: State what failed, impact, and remediation plan promptly
 - **At completion**: Post summary, PR link, and merge status
 
 **Rationale**: Ticket visibility prevents stakeholder surprises; failures are reported promptly and recorded for retrospectives.

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -54,6 +54,39 @@ repo/                          ← main, always at HEAD
 
 To opt out: set `workflow.worktree.enabled: false` in `.claude-mpm/config.yaml`.
 
+## Worktree-Based Branch Workflow (CRITICAL)
+
+Feature/fix work uses git worktrees; the PRIMARY checkout stays on the default branch (`main`/HEAD):
+
+### Rules
+1. **Per-issue worktree creation** — For each ticketed change, create an isolated worktree:
+   ```bash
+   git worktree add .claude/worktrees/issue-<N>-<slug> <branch>
+   # Or create the branch in one step:
+   git worktree add .claude/worktrees/issue-<N>-<slug> -b feat/<N>-<slug>
+   ```
+   Then do all build, test, commit, and push operations inside the worktree.
+
+2. **Never switch primary checkout for feature work** — Do NOT check out a feature branch in the primary working tree; this causes stash/WIP contention with concurrent agents. When creating a new branch, always create it in a worktree (using `-b` flag above).
+
+3. **No concurrent branch mutations in one tree** — Never run two branch-mutating git operations concurrently in the same working tree (primary or worktree). Serialization prevents ref conflicts.
+
+4. **Parallel agents use worktree isolation** — When delegating to multiple agents that mutate files, each must use its own worktree. File mutations must never be concurrent in the same tree.
+
+5. **Cleanup after merge** — After the feature branch is squash-merged to `main`, remove the worktree from the source dir:
+   ```bash
+   git worktree remove .claude/worktrees/issue-<N>-<slug>
+   git branch -d feat/<N>-<slug>   # delete local tracking branch
+   git pull                        # advance source dir to HEAD
+   ```
+   Only run after confirming squash-merge has landed on main. If the worktree has untracked files, inspect with `git -C .claude/worktrees/issue-<N>-<slug> status` first; commit or stash anything you want to keep, then retry removal (or use `--force` only if files are disposable).
+
+### Rationale
+- **Eliminates checkout contention**: No competing branch switches in the primary tree
+- **Enables safe parallelism**: Multiple agents work on separate issues without file-system conflicts
+- **Consistent with isolation patterns**: Aligns with the `isolation: "worktree"` pattern on Agent tool calls
+- **Keeps stable HEAD**: Primary tree always points to `main` for reliable reference pulls and deployments
+
 ## Mandatory 5-Phase Sequence
 
 ### Phase 1: Research (CONDITIONAL)
@@ -168,6 +201,19 @@ Return: Clean or list of blocked items
 **Note**: Release workflows are project-specific and should be customized per project. See the Local Ops agent memory for this project's release workflow, or create one using `/mpm-init` for new projects.
 
 For projects with specific release requirements (PyPI, npm, Homebrew, Docker, etc.), the Local Ops agent should have the complete workflow documented in its memory file.
+
+## Ticket Progress & Failure Updates (MANDATORY)
+
+When work is associated with a ticket or GitHub issue (issue number, PROJ-123, or issue/PR URL), the PM MUST post progress updates to that ticket as work progresses — not only at completion:
+
+- **On start**: Post plan, scope, and approach to the ticket
+- **At each phase/milestone**: Post when research, code analysis, implementation, or QA completes
+- **On ANY failure/blocker/course-correction**: State what failed, impact, and remediation plan within 5 minutes
+- **At completion**: Post summary, PR link, and merge status
+
+**Rationale**: Ticket visibility prevents stakeholder surprises; failures are reported promptly and recorded for retrospectives.
+
+**Delegation**: All ticket comment operations (including failure reports) are delegated to the Ticketing agent or Version Control for GitHub PR/issue comments. The PM never calls ticketing/gh MCP tools directly.
 
 ## Ticketing Integration
 


### PR DESCRIPTION
Add two critical workflow rules to the framework default workflow:

## Rule A: Ticket Progress & Failure Updates (MANDATORY)
- PM posts progress updates to tickets as work progresses (not just at completion)
- Covers start, milestones, failures/blockers, and completion
- All operations delegated to Ticketing agent or Version Control

## Rule B: Worktree-Based Branch Workflow (CRITICAL)  
- Feature/fix work uses per-issue worktrees; primary checkout stays on main/HEAD
- Never switch primary checkout for feature branches (eliminates stash/WIP contention)
- No concurrent branch mutations in same tree; parallel agents use worktree isolation
- Cleanup worktree after squash-merge lands

Rationale: Eliminates checkout contention, enables safe parallelism, keeps stable HEAD.

Both rules added to `src/claude_mpm/agents/WORKFLOW.md` (canonical framework default) and mirrored in `docs/workflow/PM_WORKFLOW.md` (docs mirror).

Closes #733