### PR TITLE
feat: redact secrets from session-analyzer reports (#738)

### DIFF
--- a/src/claude_mpm/cli/commands/session_report.py
+++ b/src/claude_mpm/cli/commands/session_report.py
@@ -78,8 +78,17 @@ def run_session_report(args: argparse.Namespace) -> int:
     # signature change is out of scope here; the window is benign in practice
     # because transcripts are write-once JSONL files that never move or vanish
     # mid-session.
+    no_redact: bool = getattr(args, "no_redact", False)
+    if no_redact:
+        import sys as _sys
+
+        print(
+            "Warning: --no-redact is active. The report may contain live credentials. "
+            "Use only for trusted local-only inspection.",
+            file=_sys.stderr,
+        )
     try:
-        report = parse_session(session_id, cwd)
+        report = parse_session(session_id, cwd, redact=not no_redact)
     except (FileNotFoundError, ValueError) as exc:
         # Expected user-facing errors: transcript missing or malformed content.
         print(f"Failed to parse session transcript: {exc}", file=sys.stderr)
@@ -164,6 +173,18 @@ def add_session_report_parser(subparsers: argparse.ArgumentParser) -> None:
             "Output file path.  "
             "Use '-' for stdout.  "
             "Default: docs/reporting/session-tracker/{session_id}.md"
+        ),
+    )
+    parser.add_argument(
+        "--no-redact",
+        dest="no_redact",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable secret redaction and reproduce transcript text verbatim.  "
+            "**Trusted local-only use only** — the report may contain live API "
+            "tokens, private keys, or other credentials that appeared in the "
+            "session.  Never commit or share a --no-redact report."
         ),
     )
     parser.set_defaults(command="session-report")

--- a/src/claude_mpm/services/session_analysis/transcript_parser.py
+++ b/src/claude_mpm/services/session_analysis/transcript_parser.py
@@ -352,6 +352,132 @@ _COMMAND_TAG_RE = re.compile(
 )
 
 
+# ---------------------------------------------------------------------------
+# Secret redaction patterns
+#
+# Applied to ALL ingested text before it is stored in any TimelineEvent field
+# (title, detail, call inputs/outputs, subagent prompt/response, outcome text).
+# This prevents live credentials from leaking into report .md files, .jsx data,
+# or <!-- meta --> blocks.
+#
+# Pattern order is intentional: specific prefixed patterns run FIRST so they
+# match before the generic "high-entropy assignment" rule at the bottom.
+# The function is idempotent: ``[REDACTED:...]`` placeholders never match any
+# live-credential pattern, so re-running on already-redacted text is a no-op.
+# ---------------------------------------------------------------------------
+
+# (pattern, replacement_label) — compiled once at module load
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # npm tokens:  npm_<36 alphanum>
+    (re.compile(r"npm_[A-Za-z0-9]{36}"), "npm_token"),
+    # GitHub tokens:  ghp_ / gho_ / ghu_ / ghs_ / ghr_  followed by 36+ alphanum
+    (re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"), "github_token"),
+    # AWS access key ID:  AKIA followed by 16 uppercase+digits
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "aws_key"),
+    # OpenAI / Anthropic-style API keys:  sk-  followed by 20+ alphanum/_/-
+    (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "api_key"),
+    # Slack tokens:  xoxb / xoxa / xoxp / xoxr / xoxs  followed by 10+ alphanum/-
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "slack_token"),
+    # PEM private-key blocks (DOTALL — may span multiple lines)
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        "private_key",
+    ),
+    # Generic high-entropy assignment:
+    #   token/password/passwd/secret/api_key/apikey/access_key
+    #   followed by =, :, or => (with optional surrounding whitespace)
+    #   followed by an optional quote and a value of 16+ chars
+    #
+    # Only the VALUE portion is replaced; the key name is preserved so the
+    # report still shows context like ``api_key = [REDACTED:api_key]``.
+    #
+    # Negative lookahead ``(?!\[REDACTED:)`` prevents double-redaction of values
+    # that a specific pattern has already replaced (e.g. when ``npm_<token>``
+    # was first turned into ``[REDACTED:npm_token]``, the ``TOKEN=`` prefix in
+    # ``NPM_TOKEN=`` would otherwise re-fire this rule on the placeholder).
+    (
+        re.compile(
+            r"""(?ix)
+            (?:token|password|passwd|secret|api[_\-]?key|apikey|access[_\-]key)  # key name
+            \s*(?:=>|[:=])\s*                                                      # separator
+            (?P<q>["\']?)                                                           # optional quote
+            (?!\[REDACTED:)                                                         # not already redacted
+            (?P<val>[A-Za-z0-9+/=_\-!@#$%^&*()\[\]{}<>.,;:~]{16,})               # value (≥16 chars)
+            (?P=q)                                                                  # close quote
+            """,
+        ),
+        "api_key",
+    ),
+]
+
+# Pre-compiled: already-redacted placeholder — never re-redact these
+_ALREADY_REDACTED_RE = re.compile(r"\[REDACTED:[a-z_]+\]")
+
+
+def _redact_secrets(text: str) -> str:
+    """Remove live credential strings from *text*, replacing them with labelled placeholders.
+
+    WHAT: Scans *text* for known secret patterns (npm tokens, GitHub tokens,
+          AWS access keys, OpenAI/Anthropic-style ``sk-`` API keys, Slack
+          tokens, PEM private-key blocks, and generic high-entropy assignments
+          to credential-like keys) and replaces each match with a
+          ``[REDACTED:<type>]`` sentinel.
+    WHY:  ``session-report`` reproduces transcript text verbatim.  Without
+          scrubbing, real tokens that appeared in tool inputs, shell output, or
+          assistant responses would propagate into the report ``.md``, ``.jsx``
+          data files, and ``<!-- meta -->`` blocks — exactly the npm-token
+          leak described in issue #738.
+
+    Pattern order
+    -------------
+    Specific prefixed patterns (npm, GitHub, AWS, sk-, Slack, PEM) run before
+    the generic high-entropy-assignment rule so they always win on any value
+    that starts with a recognisable prefix.
+
+    Idempotency
+    -----------
+    ``[REDACTED:<type>]`` placeholders do not match any live-credential regex,
+    so calling this function on already-redacted text is always a no-op.
+
+    Scope
+    -----
+    Normal prose (sentences, code identifiers, URLs) is not affected unless
+    it accidentally matches a secret pattern — which is extremely unlikely
+    given the minimum-length constraints and required prefixes.
+
+    Parameters
+    ----------
+    text:
+        Arbitrary UTF-8 string ingested from a JSONL transcript.
+
+    Returns
+    -------
+    str
+        *text* with all matched secrets replaced by ``[REDACTED:<label>]``.
+    """
+    for pattern, label in _SECRET_PATTERNS:
+        replacement = f"[REDACTED:{label}]"
+        # For the generic assignment rule the named group ``val`` covers only
+        # the value portion; we splice the replacement into the full match so
+        # the key name is preserved.
+        if pattern.groupindex.get("val"):
+            # Build a replacement that keeps everything except the ``val`` group
+            def _replace_val(m: re.Match[str], _label: str = label) -> str:
+                start, end = m.span("val")
+                rel_start = start - m.start()
+                rel_end = end - m.start()
+                full = m.group(0)
+                return full[:rel_start] + f"[REDACTED:{_label}]" + full[rel_end:]
+
+            text = pattern.sub(_replace_val, text)
+        else:
+            text = pattern.sub(replacement, text)
+    return text
+
+
 def _strip_control_tags(text: str) -> str:
     """Remove Claude Code harness control tags from *text*.
 
@@ -671,6 +797,7 @@ def parse_session(
     cwd: str,
     *,
     include_subagents: bool = True,
+    redact: bool = True,
 ) -> SessionReport:
     """Parse a full session into a SessionReport.
 
@@ -688,12 +815,23 @@ def parse_session(
         Absolute path of the project directory that owns the session.
     include_subagents:
         If ``False``, skip subagent JSONL files (useful for tests).
+    redact:
+        If ``True`` (default), apply :func:`_redact_secrets` to every text
+        field as it is ingested so that live credentials (API tokens, private
+        keys, etc.) never reach any output stage.  Pass ``redact=False`` only
+        for trusted local-only use where the raw transcript text must be
+        preserved verbatim (e.g. ``--no-redact`` CLI flag).
 
     Returns
     -------
     SessionReport
         Fully populated report (may have empty events if transcript missing).
     """
+    # Local helper: apply redaction only when the redact flag is True.
+    # Using a local alias keeps all call-sites terse and makes the flag
+    # easy to thread through without touching every leaf expression.
+    _scrub: Any = _redact_secrets if redact else (lambda t: t)
+
     transcript_path = locate_transcript(session_id, cwd)
     report = SessionReport(
         session_id=session_id,
@@ -706,12 +844,31 @@ def parse_session(
 
     lines = _parse_jsonl(transcript_path)
     tool_result_index = _build_tool_result_index(lines)
+    # Redact tool-result texts immediately after building the index so every
+    # downstream consumer (response_text on CallDetail, outcome events) sees
+    # scrubbed output.
+    if redact:
+        tool_result_index = {
+            k: _redact_secrets(v) for k, v in tool_result_index.items()
+        }
 
     # Parse subagent files first so we can correlate
     subagent_summaries: list[_SubagentSummary] = []
     if include_subagents:
         for sa_path in _list_subagent_files(session_id, cwd):
-            subagent_summaries.append(_parse_subagent_transcript(sa_path))
+            sa = _parse_subagent_transcript(sa_path)
+            if redact:
+                # Scrub the two text fields that flow into output stages
+                sa.prompt_text = _redact_secrets(sa.prompt_text)
+                sa.response_text = _redact_secrets(sa.response_text)
+                # Scrub all per-turn events inside the subagent summary
+                for sa_ev in sa.all_events:
+                    sa_ev.title = _redact_secrets(sa_ev.title)
+                    sa_ev.detail = _redact_secrets(sa_ev.detail)
+                    for sa_cd in sa_ev.calls:
+                        sa_cd.input_summary = _redact_secrets(sa_cd.input_summary)
+                        sa_cd.response_text = _redact_secrets(sa_cd.response_text)
+            subagent_summaries.append(sa)
 
     # Collect PM-side Agent tool_use timestamps for correlation
     pm_agent_calls: list[tuple[datetime, str]] = []  # (ts, tool_use_id)
@@ -748,6 +905,10 @@ def parse_session(
             if not clean_text:
                 # After stripping, if nothing human-readable remains, skip.
                 continue
+
+            # Redact secrets AFTER stripping control tags (so we don't waste
+            # effort scanning injected harness content that gets removed anyway).
+            clean_text = _scrub(clean_text)
 
             if not first_user_text:
                 first_user_text = clean_text
@@ -786,7 +947,7 @@ def parse_session(
                     if btype == "text":
                         t = block.get("text", "")
                         if t.strip():
-                            text_parts.append(t)
+                            text_parts.append(_scrub(t))
                     elif btype == "tool_use":
                         tid = block.get("id", "")
                         name = block.get("name", "")
@@ -796,20 +957,20 @@ def parse_session(
                         cd = CallDetail(
                             tool_name=name,
                             tool_use_id=tid,
-                            input_summary=_summarise_input(inp),
-                            response_text=response_text[:500],
+                            input_summary=_scrub(_summarise_input(inp)),
+                            response_text=_scrub(response_text[:500]),
                         )
 
                         if name == "Agent":
                             has_agent = True
                             cd.subagent_type = inp.get("subagent_type", "")
                             cd.subagent_model = inp.get("model", "")
-                            cd.subagent_description = inp.get("description", "")
+                            cd.subagent_description = _scrub(inp.get("description", ""))
                             pm_agent_calls.append((ts, tid))
                         elif name == "Skill":
                             has_skill = True
                             cd.skill_name = inp.get("skill", "")
-                            cd.skill_args = str(inp.get("args", ""))
+                            cd.skill_args = _scrub(str(inp.get("args", "")))
                         elif name.startswith("mcp__"):
                             has_mcp = True
 
@@ -945,6 +1106,7 @@ def parse_session(
                         if summary.all_events
                         else event.timestamp
                     )
+                    # response_text was already scrubbed above when redact=True
                     outcome_event = TimelineEvent(
                         uuid=f"{cd.tool_use_id}-{summary.agent_id}-outcome",
                         timestamp=outcome_ts,

--- a/tests/services/session_analysis/test_session_analysis.py
+++ b/tests/services/session_analysis/test_session_analysis.py
@@ -40,6 +40,7 @@ from claude_mpm.services.session_analysis.transcript_parser import (
     _last_line_timestamp,
     _parse_jsonl,
     _parse_subagent_transcript,
+    _redact_secrets,
     _SubagentSummary,
     find_most_recent_session,
     locate_transcript,
@@ -1630,3 +1631,376 @@ class TestJsxFilterBarSyntax:
             "Expected '})}'  as the FILTERS.map close, but found '}}' or did not find it. "
             "The JSX filter-bar .map callback is not properly closed."
         )
+
+
+# ===========================================================================
+# Issue #738 — _redact_secrets: secret scrubbing in session reports
+# ===========================================================================
+
+
+class TestRedactSecrets:
+    """Unit tests for the _redact_secrets helper (Issue #738).
+
+    Each test checks ONE specific secret pattern: the literal secret must be
+    absent from the output and the matching [REDACTED:<label>] sentinel must
+    be present.
+    """
+
+    def test_npm_token_redacted(self) -> None:
+        """npm_ followed by 36 alphanum characters is replaced."""
+        token = "npm_" + "A" * 36
+        result = _redact_secrets(f"NPM_TOKEN={token}")
+        assert token not in result
+        assert "[REDACTED:npm_token]" in result
+
+    def test_github_token_ghp_redacted(self) -> None:
+        """ghp_ GitHub tokens are replaced."""
+        token = "ghp_" + "B" * 36
+        result = _redact_secrets(f"export GH_TOKEN={token}")
+        assert token not in result
+        assert "[REDACTED:github_token]" in result
+
+    def test_github_token_gho_redacted(self) -> None:
+        """gho_ GitHub tokens are replaced."""
+        token = "gho_" + "C" * 36
+        result = _redact_secrets(token)
+        assert token not in result
+        assert "[REDACTED:github_token]" in result
+
+    def test_github_token_ghu_redacted(self) -> None:
+        """ghu_ GitHub tokens are replaced."""
+        token = "ghu_" + "D" * 36
+        result = _redact_secrets(f"GITHUB_TOKEN={token}")
+        assert token not in result
+        assert "[REDACTED:github_token]" in result
+
+    def test_github_token_ghs_redacted(self) -> None:
+        """ghs_ GitHub tokens are replaced."""
+        token = "ghs_" + "E" * 36
+        result = _redact_secrets(token)
+        assert token not in result
+        assert "[REDACTED:github_token]" in result
+
+    def test_github_token_ghr_redacted(self) -> None:
+        """ghr_ GitHub tokens are replaced."""
+        token = "ghr_" + "F" * 36
+        result = _redact_secrets(token)
+        assert token not in result
+        assert "[REDACTED:github_token]" in result
+
+    def test_aws_access_key_redacted(self) -> None:
+        """AKIA followed by 16 uppercase/digit chars is replaced."""
+        key = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret  # 20 chars total: AKIA + 16
+        result = _redact_secrets(f"AWS_ACCESS_KEY_ID={key}")
+        assert key not in result
+        assert "[REDACTED:aws_key]" in result
+
+    def test_openai_style_api_key_redacted(self) -> None:
+        """sk- followed by 20+ alphanum/_/- chars is replaced."""
+        key = "sk-" + "x" * 48  # well over the 20-char minimum
+        result = _redact_secrets(f"OPENAI_API_KEY={key}")
+        assert key not in result
+        assert "[REDACTED:api_key]" in result
+
+    def test_anthropic_style_api_key_redacted(self) -> None:
+        """Anthropic keys also use the sk- prefix."""
+        key = "sk-ant-api03-" + "y" * 80
+        result = _redact_secrets(f"ANTHROPIC_API_KEY={key}")
+        assert key not in result
+        assert "[REDACTED:api_key]" in result
+
+    def test_slack_token_xoxb_redacted(self) -> None:
+        """xoxb- Slack bot tokens are replaced."""
+        token = "xoxb-123456789012-123456789012-" + "z" * 24
+        result = _redact_secrets(f"SLACK_BOT_TOKEN={token}")
+        assert token not in result
+        assert "[REDACTED:slack_token]" in result
+
+    def test_slack_token_xoxa_redacted(self) -> None:
+        """xoxa- Slack app tokens are replaced."""
+        token = "xoxa-2-" + "a" * 20
+        result = _redact_secrets(token)
+        assert token not in result
+        assert "[REDACTED:slack_token]" in result
+
+    def test_slack_token_xoxp_redacted(self) -> None:
+        """xoxp- Slack user tokens are replaced."""
+        token = "xoxp-" + "b" * 20
+        result = _redact_secrets(token)
+        assert token not in result
+        assert "[REDACTED:slack_token]" in result
+
+    def test_pem_private_key_block_redacted(self) -> None:
+        """PEM private key blocks spanning multiple lines are replaced."""
+        pem = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"  # pragma: allowlist secret
+            "MIIEowIBAAKCAQEA" + "X" * 64 + "\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        result = _redact_secrets(f"Key material:\n{pem}\nEnd.")
+        assert "MIIEowIBAAKCAQEA" not in result
+        assert "[REDACTED:private_key]" in result
+        # Surrounding text is preserved
+        assert "Key material:" in result
+        assert "End." in result
+
+    def test_ec_private_key_block_redacted(self) -> None:
+        """PRIVATE KEY (EC / PKCS#8) blocks are also scrubbed."""
+        pem = (
+            "-----BEGIN PRIVATE KEY-----\n"  # pragma: allowlist secret
+            + "G" * 64
+            + "\n-----END PRIVATE KEY-----"
+        )
+        result = _redact_secrets(pem)
+        assert "G" * 64 not in result
+        assert "[REDACTED:private_key]" in result
+
+    def test_generic_token_assignment_redacted(self) -> None:
+        """token=<16+ chars> is redacted; key name is preserved."""
+        text = "token=abcdefghijklmnop"  # 16-char value
+        result = _redact_secrets(text)
+        assert "abcdefghijklmnop" not in result
+        assert "token=" in result  # key name preserved
+        assert "[REDACTED:api_key]" in result
+
+    def test_generic_password_assignment_redacted(self) -> None:
+        """password=<16+ chars> value is redacted."""
+        text = "password=hunter2hunter2hunter2"
+        result = _redact_secrets(text)
+        assert "hunter2hunter2hunter2" not in result
+        assert "password=" in result
+        assert "[REDACTED:api_key]" in result
+
+    def test_generic_secret_assignment_quoted_redacted(self) -> None:
+        """secret='<16+ chars>' — quoted value is redacted."""
+        text = "secret='my_super_secret_key_here'"  # pragma: allowlist secret
+        result = _redact_secrets(text)
+        assert "my_super_secret_key_here" not in result
+        assert "secret=" in result
+        assert "[REDACTED:api_key]" in result
+
+    def test_generic_api_key_colon_separator_redacted(self) -> None:
+        """api_key: <16+ chars> (YAML-style) value is redacted."""
+        text = "api_key: abcdefghijklmnopqrst"  # 20-char value
+        result = _redact_secrets(text)
+        assert "abcdefghijklmnopqrst" not in result
+        assert "api_key" in result
+
+    def test_idempotent_on_already_redacted_text(self) -> None:
+        """Re-running _redact_secrets on already-redacted output is a no-op."""
+        already = "[REDACTED:npm_token] and [REDACTED:github_token]"
+        result = _redact_secrets(already)
+        assert result == already
+
+    def test_idempotent_double_pass_npm(self) -> None:
+        """Two passes on an npm-token-bearing string yield the same result."""
+        token = "npm_" + "Z" * 36
+        first = _redact_secrets(token)
+        second = _redact_secrets(first)
+        assert first == second
+
+    def test_normal_prose_unchanged(self) -> None:
+        """Ordinary sentences are not modified."""
+        prose = "The quick brown fox jumps over the lazy dog."
+        assert _redact_secrets(prose) == prose
+
+    def test_normal_code_unchanged(self) -> None:
+        """Short variable assignments and identifiers are not affected."""
+        code = "token = 'short'"  # 5-char value — below the 16-char threshold
+        assert _redact_secrets(code) == code
+
+    def test_url_with_token_query_param_is_safe(self) -> None:
+        """Ordinary URLs without long credential strings pass through."""
+        url = "https://api.example.com/v1/resource?limit=10&offset=0"
+        assert _redact_secrets(url) == url
+
+    def test_multiple_secrets_all_redacted(self) -> None:
+        """When multiple different secret types appear, all are scrubbed."""
+        npm = "npm_" + "N" * 36
+        aws = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
+        text = f"NPM={npm} AWS={aws}"
+        result = _redact_secrets(text)
+        assert npm not in result
+        assert aws not in result
+        assert "[REDACTED:npm_token]" in result
+        assert "[REDACTED:aws_key]" in result
+
+
+class TestRedactSecretsInReport:
+    """Integration tests: secrets injected into JSONL transcripts must not appear
+    in the rendered Markdown or JSX output when redact=True (the default).
+
+    Each test builds a minimal synthetic session with a specific secret embedded
+    in the user prompt or assistant text, then asserts:
+      - the raw secret string is absent from the rendered Markdown, AND
+      - the matching [REDACTED:<label>] sentinel is present.
+    A parallel --no-redact / redact=False test verifies the opt-out path
+    preserves the raw text.
+    """
+
+    def _build_minimal_jsonl_with_secret(
+        self, tmp_path: Path, secret_text: str, session_id: str = "sec-test-01"
+    ) -> tuple[str, str]:
+        """Write a fake JSONL with *secret_text* in the user message and return
+        (session_id, fake_cwd).
+        """
+        fake_cwd = str(tmp_path / "fake" / "proj")
+        encoded = _encode_cwd(fake_cwd)
+        session_dir = tmp_path / ".claude" / "projects" / encoded
+        session_dir.mkdir(parents=True)
+
+        line = {
+            "uuid": "u-sec-001",
+            "timestamp": "2025-06-10T10:00:00.000Z",
+            "message": {"role": "user", "content": secret_text},
+            "sessionId": session_id,
+        }
+        (session_dir / f"{session_id}.jsonl").write_text(
+            json.dumps(line) + "\n", encoding="utf-8"
+        )
+        return session_id, fake_cwd
+
+    def _render(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        secret_text: str,
+        redact: bool = True,
+        session_id: str = "sec-test-01",
+    ) -> tuple[str, str]:
+        """Parse + render to Markdown AND produce JSX-ready event list.
+
+        Returns (md_text, events_json_str).
+        """
+        sid, cwd = self._build_minimal_jsonl_with_secret(
+            tmp_path, secret_text, session_id
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        report = parse_session(sid, cwd, include_subagents=False, redact=redact)
+        md = render_markdown(report)
+        # Simulate what the JSX converter does: serialize the events list
+        events_data = [
+            {
+                "title": e.title,
+                "detail": e.detail,
+                "actor": e.actor,
+            }
+            for e in report.events
+        ]
+        jsx_like = json.dumps(events_data)
+        return md, jsx_like
+
+    def test_npm_token_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """npm token in user prompt does not reach md or jsx output."""
+        token = "npm_" + "T" * 36
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"Install token: {token}", session_id="npm-test-01"
+        )
+        assert token not in md, "npm token must not appear in Markdown output"
+        assert token not in jsx, "npm token must not appear in JSX-like event data"
+        assert "[REDACTED:npm_token]" in md
+
+    def test_github_token_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GitHub ghp_ token does not leak into any output stage."""
+        token = "ghp_" + "G" * 36
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"GH_TOKEN={token}", session_id="ghp-test-01"
+        )
+        assert token not in md
+        assert token not in jsx
+        assert "[REDACTED:github_token]" in md
+
+    def test_aws_key_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AWS access key does not leak into any output stage."""
+        key = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"AWS_KEY={key}", session_id="aws-test-01"
+        )
+        assert key not in md
+        assert key not in jsx
+        assert "[REDACTED:aws_key]" in md
+
+    def test_openai_api_key_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """sk- API key does not leak into any output stage."""
+        key = "sk-" + "K" * 48
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"key={key}", session_id="sk-test-01"
+        )
+        assert key not in md
+        assert key not in jsx
+        assert "[REDACTED:api_key]" in md
+
+    def test_slack_token_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Slack xoxb- token does not leak into any output stage."""
+        token = "xoxb-123456789012-123456789012-" + "S" * 24
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"SLACK={token}", session_id="slack-test-01"
+        )
+        assert token not in md
+        assert token not in jsx
+        assert "[REDACTED:slack_token]" in md
+
+    def test_pem_key_absent_from_md_and_jsx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PEM private key block does not leak into any output stage."""
+        pem = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"  # pragma: allowlist secret
+            "MIIEowIBAAKCAQEA" + "P" * 64 + "\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        md, jsx = self._render(
+            tmp_path, monkeypatch, f"Key:\n{pem}", session_id="pem-test-01"
+        )
+        assert "MIIEowIBAAKCAQEA" not in md
+        assert "MIIEowIBAAKCAQEA" not in jsx
+        assert "[REDACTED:private_key]" in md
+
+    def test_generic_secret_assignment_absent_from_md(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Generic token=<value> assignment is scrubbed in rendered output."""
+        text = "access_key=verylongsecretvaluethatexceeds16chars"
+        md, jsx = self._render(
+            tmp_path, monkeypatch, text, session_id="generic-test-01"
+        )
+        assert "verylongsecretvaluethatexceeds16chars" not in md
+        assert "verylongsecretvaluethatexceeds16chars" not in jsx
+        assert "[REDACTED:api_key]" in md
+
+    def test_no_redact_preserves_raw_text(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """redact=False (--no-redact) leaves raw text intact in the report."""
+        token = "npm_" + "R" * 36
+        md, _jsx = self._render(
+            tmp_path,
+            monkeypatch,
+            f"token={token}",
+            redact=False,
+            session_id="noredact-test-01",
+        )
+        assert token in md, "With redact=False the raw token must survive into Markdown"
+        assert "[REDACTED:npm_token]" not in md
+
+    def test_title_derivation_also_redacted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Session title (derived from first user message) is also scrubbed."""
+        token = "npm_" + "U" * 36
+        md, _jsx = self._render(
+            tmp_path, monkeypatch, token, session_id="title-test-01"
+        )
+        # The report title appears in the YAML frontmatter
+        assert token not in md
+        assert "[REDACTED:npm_token]" in md


### PR DESCRIPTION
## Summary
Closes #738. Adds a secret-scrubbing pass to the session-analyzer so generated reports (`.md`, `.jsx`, `<!-- meta -->`) never contain live credentials.

## Changes
- `_redact_secrets()` in `transcript_parser.py`, applied to all ingested text → replaces secrets with `[REDACTED:<type>]`. Covers npm tokens, GitHub tokens, AWS keys, OpenAI/Anthropic `sk-` keys, Slack tokens, PEM private-key blocks, and generic `token/password/secret/api_key=<high-entropy>` assignments.
- `--no-redact` opt-out flag on `session-report` (default = redaction ON; opt-out for trusted local-only use).
- Tests covering each pattern + idempotency + `--no-redact`.

## Verification
- 127 tests passing.
- Live-verified against the real session that originally leaked tokens (`692a072a`): combined secret scan of the generated `.md` + `.jsx` returns ZERO matches; `[REDACTED:npm_token]` present.

## Context
Found when a generated report contained two live npm tokens and the pre-commit scanner blocked the commit. This makes the `docs/session-reports/` preservation workflow safe.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)