### PR TITLE
docs: align PM worktree guidance with default-worktree workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,33 @@ Closes #447"
 
 ---
 
+## 🟡 Worktree Development Workflow
+
+Keep the primary checkout on `main`/HEAD at all times — never check out a feature branch in it.
+
+**Per-issue worktree:**
+
+```bash
+git worktree add .claude/worktrees/issue-<N>-<slug> -b feat/<N>-<slug>
+# All build, test, and commit operations happen inside the worktree
+```
+
+`.claude/worktrees/` is gitignored; each issue gets its own tree. Parallel agents or parallel issues use separate worktrees — never run concurrent branch mutations in one tree.
+
+**Cleanup after squash-merge:**
+
+```bash
+git worktree remove .claude/worktrees/issue-<N>-<slug>
+git branch -d feat/<N>-<slug>
+git pull
+```
+
+Only run after confirming the squash-merge has landed on `main`.
+
+> **Note:** The MPM PM enforces this automatically via the Agent tool's `isolation: "worktree"` parameter. Canonical rules live in `src/claude_mpm/agents/WORKFLOW.md`.
+
+---
+
 ## 🔴 Release Workflow
 
 `claude-mpm gh switch` first (must be bobmatnyc, not bob-duetto) → `make release-patch|minor|major` → `make release-publish`. Never call `./scripts/publish_to_pypi.sh` directly.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -10,6 +10,7 @@ Technical documentation for contributors and extenders.
 - **Skills Versioning**: [skills-versioning.md](skills-versioning.md)
 - **Structured Questions Integration**: [integrating-structured-questions.md](integrating-structured-questions.md)
 - **Code Formatting**: [CODE_FORMATTING.md](CODE_FORMATTING.md)
+- **Worktree Workflow**: canonical rules in [`src/claude_mpm/agents/WORKFLOW.md`](../../src/claude_mpm/agents/WORKFLOW.md); developer quick-start in the [CLAUDE.md § Worktree Development Workflow](../../CLAUDE.md) section
 
 ## Deep Dives
 

--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -339,9 +339,11 @@ Default `docs_path`: `docs/research/`. Configurable via `.claude-mpm/config.yaml
 
 > **PM-ONLY.** `isolation: "worktree"` and `run_in_background: true` are Agent-tool parameters available exclusively to the top-level PM orchestrator. Subagents do not have access to the Agent tool and must not attempt to spawn agents.
 
-Use `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents that modify files.
-Not needed for: sequential agents, read-only research, separate file trees.
+**Default rule: ALL file-modifying work uses worktree isolation** — including single and sequential agents, not just parallel ones. The primary checkout MUST stay pinned to `main`/HEAD; never run `git checkout -b` or `git switch` a feature branch in the primary working tree. Delegate every file-modifying agent call with `isolation: "worktree"`, which automatically creates the worktree under `.claude/worktrees/<name>` (gitignored). The PM retains only read-only git operations and branch/PR coordination on `main`.
+
 Use `run_in_background: true` for fire-and-forget parallel work.
+
+For the canonical step-by-step worktree workflow see `WORKFLOW.md` → "Worktree Workflow (default)" and "Worktree-Based Branch Workflow (CRITICAL)".
 
 **Worktree isolation constraints:**
 - **Never** use `isolation: "worktree"` for ops/restart/deployment tasks — these are stateless, not file-modification tasks.

--- a/tests/fixtures/assembled_prompt_golden.txt
+++ b/tests/fixtures/assembled_prompt_golden.txt
@@ -333,9 +333,11 @@ Default `docs_path`: `docs/research/`. Configurable via `.claude-mpm/config.yaml
 
 > **PM-ONLY.** `isolation: "worktree"` and `run_in_background: true` are Agent-tool parameters available exclusively to the top-level PM orchestrator. Subagents do not have access to the Agent tool and must not attempt to spawn agents.
 
-Use `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents that modify files.
-Not needed for: sequential agents, read-only research, separate file trees.
+**Default rule: ALL file-modifying work uses worktree isolation** — including single and sequential agents, not just parallel ones. The primary checkout MUST stay pinned to `main`/HEAD; never run `git checkout -b` or `git switch` a feature branch in the primary working tree. Delegate every file-modifying agent call with `isolation: "worktree"`, which automatically creates the worktree under `.claude/worktrees/<name>` (gitignored). The PM retains only read-only git operations and branch/PR coordination on `main`.
+
 Use `run_in_background: true` for fire-and-forget parallel work.
+
+For the canonical step-by-step worktree workflow see `WORKFLOW.md` → "Worktree Workflow (default)" and "Worktree-Based Branch Workflow (CRITICAL)".
 
 **Worktree isolation constraints:**
 - **Never** use `isolation: "worktree"` for ops/restart/deployment tasks — these are stateless, not file-modification tasks.


### PR DESCRIPTION
## Summary
Fixes a stale instruction that caused the PM to skip worktrees for sequential file-modifying work.

## Problem
`src/claude_mpm/agents/PM_INSTRUCTIONS.md` (always inlined into the PM prompt) said worktree isolation was only for "2+ parallel agents" and "not needed for sequential agents" — contradicting the newer `WORKFLOW.md` "Worktree Workflow (default)". As a result the PM ran sequential work on branches in the primary checkout / sibling dirs instead of `.claude/worktrees/`.

## Changes
- `PM_INSTRUCTIONS.md`: rewrite the "Worktree Isolation" section — ALL file-modifying work (single/sequential included) uses worktree isolation under `.claude/worktrees/`; primary checkout stays pinned to `main`/HEAD; cross-references the canonical `WORKFLOW.md` sections. Valid constraints (PM-only, no worktree for stateless ops, requires git repo) retained.
- `tests/fixtures/assembled_prompt_golden.txt`: updated golden to match.
- `CLAUDE.md`: new "🟡 Worktree Development Workflow" section (developer-facing).
- `docs/developer/README.md`: link to the workflow.

Deployed PM instructions rebuild from source on startup (`_rebuild_pm_instructions_deployed`), so this propagates automatically.

## Verification
221 passed, 4 skipped (pre-existing) for instruction/deployer/golden tests.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)