### PR TITLE
fix: redact Authorization/Bearer tokens in session reports

### DIFF
--- a/src/claude_mpm/services/session_analysis/transcript_parser.py
+++ b/src/claude_mpm/services/session_analysis/transcript_parser.py
@@ -378,6 +378,27 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "api_key"),
     # Slack tokens:  xoxb / xoxa / xoxp / xoxr / xoxs  followed by 10+ alphanum/-
     (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "slack_token"),
+    # Authorization / Bearer tokens appearing in headers or logs:
+    #   "Authorization: Bearer <token>", "Authorization: token <token>",
+    #   or bare "Bearer <token>" in log lines.
+    # Only the VALUE is replaced; the scheme word (Bearer / token) is kept so
+    # the line remains readable: "Authorization: Bearer [REDACTED:bearer_token]".
+    # Value charset covers JWTs (dots), base64 (+/=), URL-safe variants (-_).
+    # The ≥20-char minimum prevents false positives on ordinary prose such as
+    # "the bearer of bad news" (no long high-entropy value follows).
+    # Negative lookahead ``(?!\[REDACTED:)`` ensures idempotency.
+    (
+        re.compile(
+            r"""(?ix)
+            (?:Authorization\s*:\s*)?            # optional "Authorization:" prefix
+            (?:[Bb]earer|[Tt]oken)               # scheme keyword (case-insensitive)
+            \s+                                   # required whitespace
+            (?!\[REDACTED:)                       # not already redacted
+            (?P<val>[A-Za-z0-9._\-+/=]{20,})     # value: ≥20 chars (JWTs, base64, etc.)
+            """,
+        ),
+        "bearer_token",
+    ),
     # PEM private-key blocks (DOTALL — may span multiple lines)
     (
         re.compile(
@@ -422,9 +443,9 @@ def _redact_secrets(text: str) -> str:
 
     WHAT: Scans *text* for known secret patterns (npm tokens, GitHub tokens,
           AWS access keys, OpenAI/Anthropic-style ``sk-`` API keys, Slack
-          tokens, PEM private-key blocks, and generic high-entropy assignments
-          to credential-like keys) and replaces each match with a
-          ``[REDACTED:<type>]`` sentinel.
+          tokens, Authorization/Bearer header tokens, PEM private-key blocks,
+          and generic high-entropy assignments to credential-like keys) and
+          replaces each match with a ``[REDACTED:<type>]`` sentinel.
     WHY:  ``session-report`` reproduces transcript text verbatim.  Without
           scrubbing, real tokens that appeared in tool inputs, shell output, or
           assistant responses would propagate into the report ``.md``, ``.jsx``

--- a/tests/services/session_analysis/test_session_analysis.py
+++ b/tests/services/session_analysis/test_session_analysis.py
@@ -1825,6 +1825,73 @@ class TestRedactSecrets:
         assert "[REDACTED:npm_token]" in result
         assert "[REDACTED:aws_key]" in result
 
+    # ------------------------------------------------------------------
+    # Bearer / Authorization token tests (Issue #738/#739 hardening)
+    # ------------------------------------------------------------------
+
+    def test_authorization_bearer_header_redacted(self) -> None:
+        """Authorization: Bearer <token> — value redacted, scheme word kept."""
+        token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0"  # pragma: allowlist secret
+        text = f"Authorization: Bearer {token}"
+        result = _redact_secrets(text)
+        assert token not in result
+        assert "[REDACTED:bearer_token]" in result
+        # Scheme word must be preserved for readability
+        assert "Bearer" in result
+        assert "Authorization" in result
+
+    def test_authorization_token_github_style_redacted(self) -> None:
+        """Authorization: token <value> (GitHub-style) — value redacted, label bearer_token."""
+        # Use a generic ≥20-char value (not a ghp_ prefix, which the github pattern handles)
+        value = "abcdefghijklmnopqrst1234567890"  # pragma: allowlist secret  # 30 chars, no specific prefix
+        text = f"Authorization: token {value}"
+        result = _redact_secrets(text)
+        assert value not in result
+        assert "[REDACTED:bearer_token]" in result
+        assert "token" in result
+        assert "Authorization" in result
+
+    def test_bare_bearer_in_log_line_redacted(self) -> None:
+        """Bare 'Bearer <token>' in a log line (no 'Authorization:' prefix) is redacted."""
+        token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"  # pragma: allowlist secret
+        text = f"Sending request with Bearer {token} to endpoint"
+        result = _redact_secrets(text)
+        assert token not in result
+        assert "[REDACTED:bearer_token]" in result
+        assert "Bearer" in result
+        # Surrounding prose is preserved
+        assert "Sending request with" in result
+        assert "to endpoint" in result
+
+    def test_bearer_token_idempotent(self) -> None:
+        """Re-running on already-redacted Bearer output is a no-op."""
+        already = "Authorization: Bearer [REDACTED:bearer_token]"
+        result = _redact_secrets(already)
+        assert result == already
+
+    def test_bearer_token_double_pass_idempotent(self) -> None:
+        """Two passes on a Bearer-token-bearing string yield the same result."""
+        token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature_here_abc"  # pragma: allowlist secret
+        text = f"Authorization: Bearer {token}"
+        first = _redact_secrets(text)
+        second = _redact_secrets(first)
+        assert first == second
+
+    def test_bearer_of_bad_news_not_redacted(self) -> None:
+        """'bearer' in ordinary prose without a long value following is unchanged."""
+        prose = "She was the bearer of bad news."
+        assert _redact_secrets(prose) == prose
+
+    def test_token_word_alone_not_redacted(self) -> None:
+        """The word 'token' alone (no long high-entropy value) is not redacted."""
+        text = "The CSRF token was invalid."
+        assert _redact_secrets(text) == text
+
+    def test_bearer_short_value_not_redacted(self) -> None:
+        """Bearer followed by a short value (<20 chars) is NOT redacted (avoids false positives)."""
+        text = "Bearer abc123"  # only 9 chars — below the 20-char minimum
+        assert _redact_secrets(text) == text
+
 
 class TestRedactSecretsInReport:
     """Integration tests: secrets injected into JSONL transcripts must not appear


### PR DESCRIPTION
## Summary
Follow-up hardening to #738/#739 (trusty-review advisory). Extends the session-analyzer secret scrubber to redact `Authorization: Bearer <token>`, `Authorization: token <value>`, and bare `Bearer <token>` log lines — a common credential-leak vector not covered by the prefixed token patterns.

## Changes
- New `bearer_token` pattern in `_SECRET_PATTERNS` (transcript_parser.py): keeps the scheme word, redacts only the value → `Authorization: Bearer [REDACTED:bearer_token]`. ≥20-char value requirement avoids false positives on prose ("the bearer of bad news"); idempotent.
- Tests: positive (Bearer/token/bare), idempotency, and negative (plain prose) cases.

## Verification
135 tests passing (+8).

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)