### PR TITLE
fix: require Authorization: prefix for token-keyword redaction

### DIFF
--- a/src/claude_mpm/services/session_analysis/transcript_parser.py
+++ b/src/claude_mpm/services/session_analysis/transcript_parser.py
@@ -378,20 +378,45 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "api_key"),
     # Slack tokens:  xoxb / xoxa / xoxp / xoxr / xoxs  followed by 10+ alphanum/-
     (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "slack_token"),
-    # Authorization / Bearer tokens appearing in headers or logs:
-    #   "Authorization: Bearer <token>", "Authorization: token <token>",
-    #   or bare "Bearer <token>" in log lines.
-    # Only the VALUE is replaced; the scheme word (Bearer / token) is kept so
-    # the line remains readable: "Authorization: Bearer [REDACTED:bearer_token]".
+    # Authorization / Bearer tokens appearing in headers or logs.
+    #
+    # Two sub-cases with different prefix requirements:
+    #
+    #   (a) bare "Bearer <token>" — unambiguous; no Authorization: prefix needed.
+    #       e.g. log line: "Sending request with Bearer eyJ..."
+    #
+    #   (b) "Authorization: token <token>" — requires the Authorization: prefix
+    #       because bare "token <word>" appears constantly in normal prose
+    #       (e.g. "The token abcde... was accepted") and would cause false positives.
+    #
+    # In both cases only the VALUE is replaced; the scheme word (bearer / token)
+    # is kept so the line stays readable:
+    #   "Authorization: Bearer [REDACTED:bearer_token]"
+    #   "token [REDACTED:bearer_token]"
     # Value charset covers JWTs (dots), base64 (+/=), URL-safe variants (-_).
-    # The ≥20-char minimum prevents false positives on ordinary prose such as
-    # "the bearer of bad news" (no long high-entropy value follows).
+    # The ≥20-char minimum prevents false positives on ordinary prose.
     # Negative lookahead ``(?!\[REDACTED:)`` ensures idempotency.
+    #
+    # Case (a): bare Bearer (no Authorization: prefix required)
     (
         re.compile(
             r"""(?ix)
             (?:Authorization\s*:\s*)?            # optional "Authorization:" prefix
-            (?:[Bb]earer|[Tt]oken)               # scheme keyword (case-insensitive)
+            bearer                               # scheme keyword (case-insensitive via (?i))
+            \s+                                   # required whitespace
+            (?!\[REDACTED:)                       # not already redacted
+            (?P<val>[A-Za-z0-9._\-+/=]{20,})     # value: ≥20 chars (JWTs, base64, etc.)
+            """,
+        ),
+        "bearer_token",
+    ),
+    # Case (b): "token" keyword — requires the Authorization: prefix to avoid
+    # redacting bare "token <word>" in ordinary prose.
+    (
+        re.compile(
+            r"""(?ix)
+            Authorization\s*:\s*                 # "Authorization:" prefix is REQUIRED
+            token                                # scheme keyword (case-insensitive via (?i))
             \s+                                   # required whitespace
             (?!\[REDACTED:)                       # not already redacted
             (?P<val>[A-Za-z0-9._\-+/=]{20,})     # value: ≥20 chars (JWTs, base64, etc.)

--- a/tests/services/session_analysis/test_session_analysis.py
+++ b/tests/services/session_analysis/test_session_analysis.py
@@ -1892,6 +1892,63 @@ class TestRedactSecrets:
         text = "Bearer abc123"  # only 9 chars — below the 20-char minimum
         assert _redact_secrets(text) == text
 
+    # ------------------------------------------------------------------
+    # Token-keyword prose over-match regression (#742)
+    # ------------------------------------------------------------------
+
+    def test_bare_token_keyword_in_prose_not_redacted(self) -> None:
+        """Bare 'token <long-value>' in prose (no Authorization: prefix) is NOT redacted.
+
+        This is the key regression guard: bare 'token' appears constantly in
+        natural-language text and must NOT trigger redaction unless preceded by
+        'Authorization:'.
+        """
+        prose = "The token abcdefghijklmnopqrstuvwxyz12 was accepted"
+        assert _redact_secrets(prose) == prose
+
+    def test_bare_token_prose_variant_not_redacted(self) -> None:
+        """Another prose variant to confirm the over-match is fully plugged."""
+        prose = "Refresh token abcdefghijklmnopqrstuvwxyzABCDEF and retry"
+        assert _redact_secrets(prose) == prose
+
+    def test_authorization_token_with_prefix_redacted(self) -> None:
+        """Authorization: token <value> (GitHub-style) IS redacted when the prefix is present."""
+        value = "abcdefghijklmnopqrst1234567890"  # pragma: allowlist secret  # 30 chars
+        text = f"Authorization: token {value}"
+        result = _redact_secrets(text)
+        assert value not in result
+        assert "[REDACTED:bearer_token]" in result
+        assert "token" in result
+        assert "Authorization" in result
+
+    def test_bare_bearer_still_redacted_after_split(self) -> None:
+        """Bare 'Bearer <token>' (no Authorization: prefix) must still be redacted.
+
+        Ensures the split into two patterns did not break the bearer case.
+        """
+        token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYm9iIn0.SflKxwRJSMeKKF2QT"  # pragma: allowlist secret
+        text = f"Bearer {token}"
+        result = _redact_secrets(text)
+        assert token not in result
+        assert "[REDACTED:bearer_token]" in result
+        assert "Bearer" in result
+
+    def test_authorization_bearer_still_redacted_after_split(self) -> None:
+        """Authorization: Bearer <token> continues to be redacted (regression guard)."""
+        token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signatureXYZ"  # pragma: allowlist secret
+        text = f"Authorization: Bearer {token}"
+        result = _redact_secrets(text)
+        assert token not in result
+        assert "[REDACTED:bearer_token]" in result
+        assert "Bearer" in result
+        assert "Authorization" in result
+
+    def test_bare_token_idempotency_guard(self) -> None:
+        """[REDACTED:bearer_token] placeholder in token position is not re-redacted."""
+        already = "Authorization: token [REDACTED:bearer_token]"
+        result = _redact_secrets(already)
+        assert result == already
+
 
 class TestRedactSecretsInReport:
     """Integration tests: secrets injected into JSONL transcripts must not appear


### PR DESCRIPTION
## Summary
Tightens the Bearer/token redaction from #742 to remove a prose over-match flagged in review: bare `token <20+ chars>` in ordinary text (e.g. "the token abc…xyz was accepted") was being redacted.

## Change
Split the `bearer_token` pattern into two:
- bare `Bearer <value>` — redacted (unambiguous), with or without `Authorization:` prefix.
- `token <value>` — redacted ONLY when preceded by `Authorization:`.
Also dropped redundant `[Bb]earer`/`[Tt]oken` char classes (the `(?i)` flag already handles case).

## Behavior
- `Authorization: Bearer <val>` → redacted ✓
- `Authorization: token <val>` → redacted ✓
- bare `Bearer <val>` → redacted ✓
- bare `token <val>` in prose → NOT redacted ✓ (the fix; regression-tested)

## Verification
141 tests passing (+6).

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)