### PR TITLE
fix: session pause/resume on pipx installs + version-aware skill deploy (#735)

### DIFF
--- a/src/claude_mpm/services/cli/session_resume_helper.py
+++ b/src/claude_mpm/services/cli/session_resume_helper.py
@@ -49,6 +49,49 @@ class SessionResumeHelper:
         # Legacy location for backward compatibility (also project-local)
         self.legacy_pause_dir = self.project_path / ".claude-mpm" / "sessions" / "pause"
 
+    def check_session_dir_access(self) -> tuple[bool, str | None]:
+        """Probe the session directory and distinguish *denied* from *empty*.
+
+        WHAT: Attempts to list the project session directory and reports
+        whether the read was permission-denied versus the directory being
+        genuinely empty or absent.
+        WHY: Bug #735 — guidance like ``ls .claude-mpm/sessions/ 2>/dev/null``
+        swallows stderr, so a sandbox-denied read looks identical to "no
+        sessions" and resume wrongly concludes there is nothing to resume.
+        Callers must be able to tell "I could not read" from "there is nothing".
+
+        Returns:
+            A ``(accessible, error_message)`` tuple:
+            - ``(True, None)``  — directory readable (may be empty or absent).
+            - ``(False, msg)``  — directory exists but could not be read
+              (permission denied or other OS error); ``msg`` describes it.
+        """
+        directory = self.pause_dir
+
+        # An absent directory is NOT an error — it simply means no sessions
+        # have ever been saved for this project. Distinguish this from a
+        # directory that exists but cannot be read.
+        if not directory.exists():
+            return True, None
+
+        try:
+            # Force an actual read of the directory entries. iterdir() is lazy,
+            # so we materialise it to trigger any PermissionError now.
+            list(directory.iterdir())
+            return True, None
+        except PermissionError as e:
+            msg = (
+                f"Permission denied reading session directory {directory}: {e}. "
+                "Cannot determine whether paused sessions exist — this is NOT "
+                "the same as 'no sessions'. Check sandbox/filesystem permissions."
+            )
+            logger.warning(msg)
+            return False, msg
+        except OSError as e:
+            msg = f"Failed to read session directory {directory}: {e}"
+            logger.warning(msg)
+            return False, msg
+
     def _find_md_only_sessions(self, directory: Path) -> list[Path]:
         """Find timestamped .md session files lacking a .json counterpart.
 
@@ -487,6 +530,20 @@ class SessionResumeHelper:
         Returns:
             Session data if found and user should resume, None otherwise
         """
+        # BUG #735: before concluding "no sessions", make sure we could
+        # actually read the directory. A permission-denied read must surface
+        # an explicit error rather than masquerading as an empty directory.
+        accessible, access_error = self.check_session_dir_access()
+        if not accessible:
+            print(
+                "\n⚠️  Could not read the session directory — unable to "
+                "determine whether a paused session exists.\n"
+                f"{access_error}\n"
+                "This is NOT the same as 'no sessions found'. Resolve the "
+                "permission issue and retry /mpm-session-resume.\n"
+            )
+            return None
+
         if not self.has_paused_sessions():
             logger.debug("No paused sessions found")
             return None

--- a/src/claude_mpm/services/pm_skills_deployer.py
+++ b/src/claude_mpm/services/pm_skills_deployer.py
@@ -38,6 +38,7 @@ References:
 """
 
 import hashlib
+import re
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -51,6 +52,72 @@ from claude_mpm.core.mixins import LoggerMixin
 
 # Security constants
 MAX_YAML_SIZE = 10 * 1024 * 1024  # 10MB limit to prevent YAML bombs
+
+# Default version assumed for a deployed/bundled skill whose SKILL.md does not
+# declare a ``version:`` in its YAML frontmatter. Treated as the lowest version.
+DEFAULT_SKILL_VERSION = "0.0.0"
+
+# Matches a ``version:`` line inside YAML frontmatter, with or without quotes.
+# Example matches: ``version: "1.2.0"``, ``version: 1.0.0``, ``version: '2.0'``
+_FRONTMATTER_VERSION_RE = re.compile(
+    r"^version:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE
+)
+
+
+def _parse_version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a comparable integer tuple.
+
+    WHAT: Converts ``"1.2.0"`` -> ``(1, 2, 0)`` so versions sort numerically
+    rather than lexically (``"10.0.0" > "9.0.0"``).
+    WHY: Bug #735 — checksum-based redeploy silently reverted user-hardened
+    skills. Version comparison must be numeric to decide whether the bundled
+    skill is strictly newer than the deployed one.
+
+    Non-numeric or malformed segments degrade gracefully to ``0`` so a junk
+    version never raises and is simply treated as the lowest possible version.
+
+    Args:
+        version: Dotted version string (e.g. ``"1.2.0"``).
+
+    Returns:
+        Tuple of integers suitable for direct comparison.
+    """
+    parts: list[int] = []
+    for segment in str(version).strip().split("."):
+        # Keep only the leading numeric run of each segment (e.g. "0rc1" -> 0).
+        match = re.match(r"\d+", segment)
+        parts.append(int(match.group()) if match else 0)
+    return tuple(parts) or (0,)
+
+
+def _read_skill_version(file_path: Path) -> str:
+    """Read the ``version:`` from a SKILL.md YAML frontmatter block.
+
+    WHAT: Extracts the declared version string from the frontmatter of a
+    SKILL.md file, returning ``DEFAULT_SKILL_VERSION`` when absent/unreadable.
+    WHY: Bug #735 — version-aware deployment needs the bundled and deployed
+    versions to decide whether an overwrite is an upgrade or a clobber.
+
+    Args:
+        file_path: Path to a SKILL.md file.
+
+    Returns:
+        The version string declared in frontmatter, or
+        ``DEFAULT_SKILL_VERSION`` if none is found or the file cannot be read.
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            # Versions live in the frontmatter at the very top; reading the
+            # first ~4KB is sufficient and avoids loading large files fully.
+            head = f.read(4096)
+    except OSError:
+        return DEFAULT_SKILL_VERSION
+
+    match = _FRONTMATTER_VERSION_RE.search(head)
+    if match:
+        return match.group(1).strip()
+    return DEFAULT_SKILL_VERSION
+
 
 # Tier 1: Required PM skills that MUST be deployed for PM agent to function properly
 # These are core framework management skills for basic PM operation
@@ -562,8 +629,9 @@ class PMSkillsDeployerService(LoggerMixin):
                 if not self._validate_safe_path(deployment_dir, target_path):
                     raise ValueError(f"Path traversal attempt detected: {target_path}")
 
-                # Compute checksum of source
+                # Compute checksum and read declared version of source
                 checksum = self._compute_checksum(source_path)
+                bundled_version = _read_skill_version(source_path)
 
                 # Check if already deployed
                 if skill_name in existing_deployments and not force:
@@ -576,16 +644,60 @@ class PMSkillsDeployerService(LoggerMixin):
                         )
                         continue
 
-                # Deploy skill (overwrites if exists - mpm-* skills WIN)
+                    # BUG #735: content differs. Do NOT blindly overwrite —
+                    # that silently reverts user-hardened skills. Only overwrite
+                    # when the bundled skill is STRICTLY NEWER than the deployed
+                    # one. The deployed version is read from the actual file on
+                    # disk (authoritative) falling back to the registry entry.
+                    if target_path.exists():
+                        deployed_version = _read_skill_version(target_path)
+                    else:
+                        deployed_version = existing.get(
+                            "version", DEFAULT_SKILL_VERSION
+                        )
+
+                    if _parse_version_tuple(bundled_version) <= _parse_version_tuple(
+                        deployed_version
+                    ):
+                        skipped.append(skill_name)
+                        # Preserve the deployed file's real version + a fresh
+                        # checksum of what is actually on disk so the registry
+                        # reflects reality (not the bundled source).
+                        new_deployed_skills.append(
+                            {
+                                "name": skill_name,
+                                "version": deployed_version,
+                                "deployed_at": existing.get("deployed_at", timestamp),
+                                "checksum": (
+                                    self._compute_checksum(target_path)
+                                    if target_path.exists()
+                                    else existing.get("checksum", checksum)
+                                ),
+                            }
+                        )
+                        self.logger.info(
+                            f"Skipped {skill_name}: deployed version "
+                            f"{deployed_version} >= bundled {bundled_version} "
+                            f"(refusing to clobber user-modified skill)"
+                        )
+                        continue
+
+                    self.logger.info(
+                        f"Upgrading {skill_name}: {deployed_version} -> "
+                        f"{bundled_version} (bundled is newer)"
+                    )
+
+                # Deploy skill. Overwrites only when: forced, brand-new, or the
+                # bundled version is strictly newer (checked above).
                 shutil.copy2(source_path, target_path)
 
                 # Add to deployed list
                 deployed.append(skill_name)
 
-                # Update registry entry
+                # Update registry entry with the real bundled version.
                 skill_entry = {
                     "name": skill_name,
-                    "version": "1.0.0",  # PM templates don't have versions yet
+                    "version": bundled_version,
                     "deployed_at": timestamp,
                     "checksum": checksum,
                 }
@@ -706,16 +818,24 @@ class PMSkillsDeployerService(LoggerMixin):
                 corrupted_skills.append(required_skill)
                 continue
 
-            # Verify checksum
+            # Verify checksum.
+            #
+            # BUG #735: a registry-vs-disk checksum mismatch on a non-empty,
+            # readable file means the deployed skill was *modified* (e.g. a
+            # user hardened it), NOT that it is corrupt. Classifying it as
+            # corrupted previously triggered auto-repair force-redeploy, which
+            # silently reverted the user's changes. We now treat such files as
+            # "user-modified" — a warning only, never auto-repaired. Genuine
+            # corruption (empty/unreadable) is still caught above.
             deployed_skill = deployed_lookup[required_skill]
             current_checksum = self._compute_checksum(skill_file)
             expected_checksum = deployed_skill.get("checksum", "")
 
             if current_checksum != expected_checksum:
                 warnings.append(
-                    f"Required PM skill checksum mismatch: {required_skill} (file may be corrupted)"
+                    f"Required PM skill modified since deployment: {required_skill} "
+                    f"(file differs from registry checksum — leaving user changes intact)"
                 )
-                corrupted_skills.append(required_skill)
 
         # Check for available updates (bundled skills newer than deployed)
         bundled_skills = {s["name"]: s for s in self._discover_bundled_pm_skills()}
@@ -741,38 +861,32 @@ class PMSkillsDeployerService(LoggerMixin):
                     warnings.append(f"PM skill update available: {skill_name}")
                     outdated_skills.append(skill_name)
 
-        # Auto-repair if enabled and issues found
-        repaired_skills = []
+        # Auto-repair if enabled and issues found.
+        #
+        # BUG #735: auto-repair previously called deploy_pm_skills(force=True),
+        # which force-overwrites EVERY skill — clobbering unrelated
+        # user-modified skills. We now repair ONLY the specific
+        # missing/corrupt skills via a targeted copy, leaving every other
+        # deployed skill (including user-modified ones) untouched.
+        repaired_skills: list[str] = []
         if auto_repair and (missing_skills or corrupted_skills):
+            broken = list(dict.fromkeys(missing_skills + corrupted_skills))
             self.logger.info(
                 f"Auto-repairing PM skills: {len(missing_skills)} missing, "
-                f"{len(corrupted_skills)} corrupted"
+                f"{len(corrupted_skills)} corrupted (targeted)"
             )
+            repaired_skills = self._repair_specific_skills(project_dir, broken)
 
-            # Deploy missing and corrupted skills
-            repair_result = self.deploy_pm_skills(project_dir, force=True)
-
-            if repair_result.success:
-                repaired_skills = repair_result.deployed
+            if repaired_skills:
                 self.logger.info(f"Auto-repaired {len(repaired_skills)} PM skills")
-
                 # Remove repaired skills from missing/corrupted lists
                 missing_skills = [s for s in missing_skills if s not in repaired_skills]
                 corrupted_skills = [
                     s for s in corrupted_skills if s not in repaired_skills
                 ]
-
-                # Update warnings
-                if repaired_skills:
-                    warnings.append(
-                        f"Auto-repaired {len(repaired_skills)} PM skills: {', '.join(repaired_skills)}"
-                    )
-            else:
                 warnings.append(
-                    f"Auto-repair failed: {len(repair_result.errors)} errors"
-                )
-                self.logger.error(
-                    f"Auto-repair failed with errors: {repair_result.errors}"
+                    f"Auto-repaired {len(repaired_skills)} PM skills: "
+                    f"{', '.join(repaired_skills)}"
                 )
 
         # Determine verification status
@@ -797,6 +911,88 @@ class PMSkillsDeployerService(LoggerMixin):
             message=message,
             skill_count=len(deployed_skills_data),
         )
+
+    def _repair_specific_skills(
+        self, project_dir: Path, skill_names: list[str]
+    ) -> list[str]:
+        """Redeploy ONLY the named skills from their bundled sources.
+
+        WHAT: Copies the bundled SKILL.md for each named skill over the
+        deployed location and updates that skill's registry entry, leaving all
+        other deployed skills untouched.
+        WHY: Bug #735 — auto-repair must fix genuinely missing/empty/corrupt
+        files without force-redeploying (and thus clobbering) unrelated
+        user-modified skills. This is the surgical alternative to
+        ``deploy_pm_skills(force=True)``.
+
+        Args:
+            project_dir: Project root directory (for registry location).
+            skill_names: Names of skills to repair.
+
+        Returns:
+            List of skill names that were successfully repaired.
+        """
+        if not skill_names:
+            return []
+
+        bundled = {s["name"]: s for s in self._discover_bundled_pm_skills()}
+        deployment_dir = self._get_deployment_dir(project_dir)
+        deployment_dir.mkdir(parents=True, exist_ok=True)
+
+        registry = self._load_registry(project_dir)
+        deployed_skills = registry.get("skills", [])
+        registry_lookup = {s["name"]: s for s in deployed_skills}
+
+        timestamp = datetime.now(tz=UTC).isoformat()
+        repaired: list[str] = []
+
+        for skill_name in skill_names:
+            bundled_skill = bundled.get(skill_name)
+            if not bundled_skill:
+                self.logger.warning(
+                    f"Cannot repair {skill_name}: no bundled source found"
+                )
+                continue
+
+            source_path = bundled_skill["path"]
+            skill_dir = deployment_dir / skill_name
+            target_path = skill_dir / "SKILL.md"
+
+            # SECURITY: keep targets inside the deployment directory.
+            if not self._validate_safe_path(deployment_dir, target_path):
+                self.logger.error(
+                    f"Refusing to repair {skill_name}: unsafe target path"
+                )
+                continue
+
+            try:
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, target_path)
+            except OSError as e:
+                self.logger.error(f"Failed to repair {skill_name}: {e}")
+                continue
+
+            checksum = self._compute_checksum(target_path)
+            version = _read_skill_version(source_path)
+            registry_lookup[skill_name] = {
+                "name": skill_name,
+                "version": version,
+                "deployed_at": timestamp,
+                "checksum": checksum,
+            }
+            repaired.append(skill_name)
+            self.logger.debug(f"Repaired PM skill: {skill_name}")
+
+        if repaired:
+            updated_registry = {
+                "version": self.REGISTRY_VERSION,
+                "deployed_at": timestamp,
+                "skills": list(registry_lookup.values()),
+            }
+            if not self._save_registry(project_dir, updated_registry):
+                self.logger.error("Failed to save registry after targeted repair")
+
+        return repaired
 
     def get_deployed_skills(self, project_dir: Path) -> list[PMSkillInfo]:
         """Get list of deployed PM skills with metadata.

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-pause
 description: Pause session and save current work state for later resume
 user-invocable: true
-version: "1.0.0"
+version: "1.1.0"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 effort: medium
@@ -36,6 +36,38 @@ When invoked, this skill:
 
 ## Implementation
 
+### Step 0 — Resolve the correct Python interpreter (REQUIRED)
+
+`claude_mpm` may be installed in an **isolated** environment (pipx, `uv tool`,
+`pip --user`) that the system `python3` **cannot** import. Running bare
+`python3 -c "from claude_mpm..."` then fails with `ModuleNotFoundError`.
+
+**Before running any Python below, resolve the interpreter that owns the
+installed `claude-mpm`.** Run this shell snippet and use the captured value
+(`$MPM_PY`) as your interpreter:
+
+```bash
+# Honor an explicit override first, then ask claude_mpm to resolve itself,
+# then fall back to the venv python beside the claude-mpm console script.
+if [ -n "$CLAUDE_MPM_PYTHON" ]; then
+    MPM_PY="$CLAUDE_MPM_PYTHON"
+else
+    MPM_PY="$(python3 -m claude_mpm.utils.interpreter_resolver 2>/dev/null)"
+    if [ -z "$MPM_PY" ]; then
+        # Derive the venv python from the installed claude-mpm executable.
+        CMPM="$(command -v claude-mpm 2>/dev/null)"
+        if [ -n "$CMPM" ]; then
+            MPM_PY="$(dirname "$(readlink -f "$CMPM" 2>/dev/null || echo "$CMPM")")/python"
+        fi
+    fi
+    [ -x "$MPM_PY" ] || MPM_PY="$(command -v python3)"
+fi
+echo "Using interpreter: $MPM_PY"
+```
+
+Then run the pause code with **`$MPM_PY`** (NOT bare `python3`):
+`"$MPM_PY" - <<'PY' ... PY`
+
 **Execute the following Python code to pause the session:**
 
 ```python
@@ -46,11 +78,12 @@ try:
 except ImportError:
     print(
         "ERROR: claude_mpm is not importable in the current Python environment.\n"
-        "If you installed via 'uv tool install claude-mpm', run:\n"
-        "  uv run python -c 'from claude_mpm.services.cli.session_pause_manager "
+        "Resolve the correct interpreter first (see Step 0 above), e.g.:\n"
+        "  MPM_PY=\"$(python3 -m claude_mpm.utils.interpreter_resolver)\"\n"
+        "  \"$MPM_PY\" -c 'from claude_mpm.services.cli.session_pause_manager "
         "import SessionPauseManager'\n"
-        "Or invoke directly: claude-mpm session-pause\n"
-        "Alternatively, activate the virtual environment where claude-mpm is installed."
+        "Or set CLAUDE_MPM_PYTHON to the interpreter where claude-mpm is installed.\n"
+        "Alternatively, invoke directly: claude-mpm session-pause"
     )
     raise SystemExit(1)
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-resume
 description: Load context from paused session
 user-invocable: true
-version: "1.2.0"
+version: "1.3.0"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 effort: medium
@@ -50,13 +50,42 @@ When invoked, this skill:
 
 ## Implementation
 
-**Before executing, detect which Python runtime has `claude_mpm` installed, then use that runtime. Check in priority order:**
+### Step 0 — Resolve the correct Python interpreter (REQUIRED)
 
-1. `uv run python -c "import claude_mpm"` — preferred; claude-mpm is typically installed as a `uv tool`
-2. `.venv/bin/python -c "import claude_mpm"` — if the project venv has an editable install
-3. `python3 -c "import claude_mpm"` — if claude_mpm is on the system Python
+`claude_mpm` may be installed in an **isolated** environment (pipx, `uv tool`,
+`pip --user`) that the system `python3` **cannot** import — bare
+`python3 -c "import claude_mpm"` then fails with `ModuleNotFoundError`. Resolve
+the interpreter that owns the installed `claude-mpm` executable first:
 
-Run whichever passes first, then execute the code below with that runtime. Parse the user's invocation arguments first, then dispatch to the appropriate code path.
+```bash
+# Honor an explicit override, then ask claude_mpm to resolve itself, then
+# derive the venv python from the claude-mpm console script.
+if [ -n "$CLAUDE_MPM_PYTHON" ]; then
+    MPM_PY="$CLAUDE_MPM_PYTHON"
+else
+    MPM_PY="$(python3 -m claude_mpm.utils.interpreter_resolver 2>/dev/null)"
+    if [ -z "$MPM_PY" ]; then
+        CMPM="$(command -v claude-mpm 2>/dev/null)"
+        if [ -n "$CMPM" ]; then
+            MPM_PY="$(dirname "$(readlink -f "$CMPM" 2>/dev/null || echo "$CMPM")")/python"
+        fi
+    fi
+    [ -x "$MPM_PY" ] || MPM_PY="$(command -v python3)"
+fi
+echo "Using interpreter: $MPM_PY"
+```
+
+This works for pipx, `uv tool`, `pip --user`, and editable/dev installs. Run
+the code below with **`$MPM_PY`** (NOT bare `python3`). Parse the user's
+invocation arguments first, then dispatch to the appropriate code path.
+
+> **Permission note (Bug #735):** Do **not** probe for sessions with
+> `ls .claude-mpm/sessions/ 2>/dev/null` — that swallows stderr, so a
+> permission-denied read looks identical to "no sessions" and resume wrongly
+> reports nothing to resume. The helper's `check_and_display_resume_prompt()`
+> already distinguishes *denied* from *empty* via `check_session_dir_access()`
+> and prints an explicit warning on denial. Trust the helper; never blanket-
+> suppress stderr when checking the session directory.
 
 ```python
 import sys
@@ -67,11 +96,12 @@ try:
 except ImportError:
     print(
         "ERROR: claude_mpm is not importable in the current Python environment.\n"
-        "If you installed via 'uv tool install claude-mpm', run:\n"
-        "  uv run python -c 'from claude_mpm.services.cli.session_resume_helper "
+        "Resolve the correct interpreter first (see Step 0 above), e.g.:\n"
+        "  MPM_PY=\"$(python3 -m claude_mpm.utils.interpreter_resolver)\"\n"
+        "  \"$MPM_PY\" -c 'from claude_mpm.services.cli.session_resume_helper "
         "import SessionResumeHelper'\n"
-        "Or invoke directly: claude-mpm session-resume\n"
-        "Alternatively, activate the virtual environment where claude-mpm is installed."
+        "Or set CLAUDE_MPM_PYTHON to the interpreter where claude-mpm is installed.\n"
+        "Alternatively, invoke directly: claude-mpm session-resume"
     )
     raise SystemExit(1)
 

--- a/src/claude_mpm/utils/interpreter_resolver.py
+++ b/src/claude_mpm/utils/interpreter_resolver.py
@@ -1,0 +1,157 @@
+"""Resolve the Python interpreter that can import ``claude_mpm``.
+
+WHAT: Provides ``resolve_claude_mpm_python()`` which returns the path to a
+Python interpreter capable of ``import claude_mpm``, working across pipx,
+``pip --user``, ``uv tool``, and editable/dev installs.
+WHY: Bug #735 — the session skills told the harness to run
+``python3 -c "from claude_mpm..."``. On pipx (and ``uv tool``) installs,
+``claude_mpm`` lives in an isolated virtualenv that the *system* ``python3``
+cannot import, producing ``ModuleNotFoundError``. The skill must locate the
+interpreter that owns the installed ``claude-mpm`` executable instead of
+assuming bare ``python3`` works.
+
+Resolution order (first that works wins):
+1. ``$CLAUDE_MPM_PYTHON`` env override (explicit escape hatch).
+2. ``sys.executable`` — if this very process can already import claude_mpm,
+   that interpreter is correct (covers ``python -m claude_mpm`` and editable
+   installs running inside the right venv).
+3. The venv ``python`` next to the resolved ``claude-mpm`` executable on PATH
+   (covers pipx, ``uv tool``, ``pip --user`` console-script installs).
+4. Bare ``python3`` / ``python`` as a last resort.
+
+This module deliberately has NO dependency on the rest of ``claude_mpm`` so it
+can be imported (or run via ``python -m``) by the lightest possible runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - used only to probe candidate interpreters
+import sys
+from pathlib import Path
+
+#: Environment variable users can set to force a specific interpreter.
+ENV_OVERRIDE = "CLAUDE_MPM_PYTHON"
+
+#: Console-script name installed by the claude-mpm package.
+CONSOLE_SCRIPT = "claude-mpm"
+
+
+def _can_import_claude_mpm(python_path: str | Path) -> bool:
+    """Return True if ``python_path`` can ``import claude_mpm``.
+
+    Runs a tiny subprocess so we test the *candidate* interpreter, not the
+    current one. Failures (missing interpreter, import error, timeout) all
+    resolve to ``False`` so the caller simply moves to the next candidate.
+
+    Args:
+        python_path: Path to a Python interpreter to probe.
+
+    Returns:
+        True if the interpreter exists and can import ``claude_mpm``.
+    """
+    python_path = str(python_path)
+    if not python_path:
+        return False
+    try:
+        result = subprocess.run(  # nosec B603 - fixed args, no shell
+            [python_path, "-c", "import claude_mpm"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _venv_python_for_executable(executable: str | Path) -> Path | None:
+    """Given a console-script path, return the venv ``python`` beside it.
+
+    Console scripts (pipx, uv tool, pip) live in ``<venv>/bin/`` next to the
+    interpreter that runs them. We resolve symlinks first so a pipx shim in
+    ``~/.local/bin`` points at the real venv ``bin`` directory.
+
+    Args:
+        executable: Path to the ``claude-mpm`` console script.
+
+    Returns:
+        Path to the sibling ``python``/``python3`` if it exists, else ``None``.
+    """
+    try:
+        real = Path(executable).resolve()
+    except OSError:
+        return None
+
+    bin_dir = real.parent
+    # Windows venvs put python.exe in the same Scripts/ dir; POSIX uses bin/.
+    candidates = [
+        bin_dir / "python",
+        bin_dir / "python3",
+        bin_dir / "python.exe",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_claude_mpm_python() -> str:
+    """Resolve a Python interpreter that can import ``claude_mpm``.
+
+    WHAT: Returns the path/name of an interpreter able to ``import claude_mpm``.
+    WHY: Bug #735 — see module docstring. Bare ``python3`` fails on isolated
+    installs (pipx/uv tool); we must find the interpreter that owns the
+    installed ``claude-mpm`` executable.
+
+    Returns:
+        A string usable as the interpreter argument to ``subprocess`` or shell
+        (an absolute path when resolved, or a bare name as a last-resort
+        fallback).
+    """
+    # 1. Explicit override always wins.
+    override = os.environ.get(ENV_OVERRIDE)
+    if override and _can_import_claude_mpm(override):
+        return override
+
+    # 2. The current interpreter, if it can already import claude_mpm.
+    if sys.executable and _can_import_claude_mpm(sys.executable):
+        return sys.executable
+
+    # 3. The venv python beside the installed claude-mpm console script.
+    executable = shutil.which(CONSOLE_SCRIPT)
+    if executable:
+        venv_python = _venv_python_for_executable(executable)
+        if venv_python and _can_import_claude_mpm(venv_python):
+            return str(venv_python)
+
+    # 4. Last resort: bare python3 / python (works for system installs).
+    for fallback in ("python3", "python"):
+        resolved = shutil.which(fallback)
+        if resolved and _can_import_claude_mpm(resolved):
+            return resolved
+
+    # Nothing worked — return sys.executable so the caller gets a real path and
+    # a clear ModuleNotFoundError rather than a confusing "python3 not found".
+    return sys.executable or "python3"
+
+
+def main() -> int:
+    """Print the resolved interpreter path to stdout (for shell capture).
+
+    Usage from a skill::
+
+        MPM_PY="$(python3 -m claude_mpm.utils.interpreter_resolver \\
+                    2>/dev/null || command -v python3)"
+
+    Returns:
+        Process exit code (0 always; resolution never hard-fails).
+    """
+    print(resolve_claude_mpm_python())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/skills/test_pm_skills_deployer_version_aware.py
+++ b/tests/services/skills/test_pm_skills_deployer_version_aware.py
@@ -1,0 +1,279 @@
+"""Version-aware deployment tests for PMSkillsDeployerService (Bug #735).
+
+Guarantees:
+- A deployed skill whose version is >= bundled is NEVER overwritten on
+  redeploy / auto-repair (no silent revert of user-hardened skills).
+- A strictly-newer bundled version DOES upgrade the deployed skill.
+- Genuinely missing/empty skills are still auto-repaired, without clobbering
+  unrelated user-modified skills.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from claude_mpm.services import pm_skills_deployer as mod
+from claude_mpm.services.pm_skills_deployer import (
+    PMSkillsDeployerService,
+    _parse_version_tuple,
+    _read_skill_version,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _skill_md(version: str, body: str = "content") -> str:
+    return f'---\nname: test\nversion: "{version}"\n---\n\n# Test\n\n{body}\n'
+
+
+@pytest.fixture
+def deployer(tmp_path, monkeypatch):
+    """A deployer whose bundled source and ~/.claude/skills both live in tmp."""
+    # Bundled source dir.
+    bundled = tmp_path / "bundled" / "pm"
+    bundled.mkdir(parents=True)
+
+    # Deployment dir (stand-in for ~/.claude/skills/).
+    deploy_root = tmp_path / "home" / ".claude" / "skills"
+    deploy_root.mkdir(parents=True)
+
+    svc = PMSkillsDeployerService()
+    svc.bundled_pm_skills_path = bundled
+
+    # Force deployment + safe-path checks to use our temp deploy root.
+    monkeypatch.setattr(svc, "_get_deployment_dir", lambda project_dir: deploy_root)
+    monkeypatch.setattr(svc, "_validate_safe_path", lambda base, target: True)
+
+    svc._bundled = bundled  # convenience handle for tests
+    svc._deploy_root = deploy_root
+    return svc
+
+
+def _write_bundled(deployer, name: str, version: str, body: str = "bundled") -> Path:
+    d = deployer._bundled / name
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "SKILL.md"
+    p.write_text(_skill_md(version, body))
+    return p
+
+
+def _write_deployed(deployer, name: str, version: str, body: str = "deployed") -> Path:
+    d = deployer._deploy_root / name
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "SKILL.md"
+    p.write_text(_skill_md(version, body))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_version_tuple_numeric_ordering():
+    assert _parse_version_tuple("10.0.0") > _parse_version_tuple("9.9.9")
+    assert _parse_version_tuple("1.2.0") == (1, 2, 0)
+    assert _parse_version_tuple("2.0") < _parse_version_tuple("2.0.1")
+
+
+def test_parse_version_tuple_handles_junk():
+    # Never raises; junk segments degrade to 0.
+    assert _parse_version_tuple("not-a-version") == (0,)
+    assert _parse_version_tuple("1.x.3") == (1, 0, 3)
+
+
+def test_read_skill_version_reads_frontmatter(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text(_skill_md("3.4.5"))
+    assert _read_skill_version(f) == "3.4.5"
+
+
+def test_read_skill_version_defaults_when_missing(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("---\nname: x\n---\n# no version\n")
+    assert _read_skill_version(f) == mod.DEFAULT_SKILL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Deploy: version-aware overwrite policy
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_refuses_to_overwrite_newer_deployed_skill(deployer, tmp_path):
+    """Bundled 1.0.0 must NOT clobber a deployed 2.0.0 user-hardened skill."""
+    name = "mpm-session-resume"
+    _write_bundled(deployer, name, "1.0.0", body="bundled-original")
+    deployed = _write_deployed(deployer, name, "2.0.0", body="USER-HARDENED")
+
+    # Seed registry so the skill is "known deployed" with a stale checksum
+    # (simulating that the user edited it after deployment).
+    project = tmp_path / "proj"
+    project.mkdir()
+    deployer._save_registry(
+        project,
+        {
+            "version": deployer.REGISTRY_VERSION,
+            "skills": [
+                {
+                    "name": name,
+                    "version": "2.0.0",
+                    "deployed_at": "2020-01-01T00:00:00+00:00",
+                    "checksum": "stale-checksum-does-not-match",
+                }
+            ],
+        },
+    )
+
+    result = deployer.deploy_pm_skills(project, tier="minimal")
+
+    # The deployed file is untouched — user content preserved.
+    assert "USER-HARDENED" in deployed.read_text()
+    assert name in result.skipped
+    assert name not in result.deployed
+
+
+def test_deploy_refuses_when_versions_equal(deployer, tmp_path):
+    """Equal versions with differing content => keep deployed (do not clobber)."""
+    name = "mpm-session-resume"
+    _write_bundled(deployer, name, "1.5.0", body="bundled")
+    deployed = _write_deployed(deployer, name, "1.5.0", body="USER-EDIT")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    deployer._save_registry(
+        project,
+        {
+            "version": deployer.REGISTRY_VERSION,
+            "skills": [
+                {
+                    "name": name,
+                    "version": "1.5.0",
+                    "deployed_at": "2020-01-01T00:00:00+00:00",
+                    "checksum": "stale",
+                }
+            ],
+        },
+    )
+
+    result = deployer.deploy_pm_skills(project, tier="minimal")
+    assert "USER-EDIT" in deployed.read_text()
+    assert name in result.skipped
+
+
+def test_deploy_upgrades_when_bundled_strictly_newer(deployer, tmp_path):
+    """Bundled 2.0.0 DOES overwrite deployed 1.0.0."""
+    name = "mpm-session-resume"
+    _write_bundled(deployer, name, "2.0.0", body="NEW-BUNDLED")
+    deployed = _write_deployed(deployer, name, "1.0.0", body="old-deployed")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    deployer._save_registry(
+        project,
+        {
+            "version": deployer.REGISTRY_VERSION,
+            "skills": [
+                {
+                    "name": name,
+                    "version": "1.0.0",
+                    "deployed_at": "2020-01-01T00:00:00+00:00",
+                    "checksum": "stale",
+                }
+            ],
+        },
+    )
+
+    result = deployer.deploy_pm_skills(project, tier="minimal")
+    assert "NEW-BUNDLED" in deployed.read_text()
+    assert name in result.deployed
+
+
+def test_force_still_overwrites(deployer, tmp_path):
+    """force=True bypasses version gating (explicit operator intent)."""
+    name = "mpm-session-resume"
+    _write_bundled(deployer, name, "1.0.0", body="FORCED-BUNDLED")
+    deployed = _write_deployed(deployer, name, "9.9.9", body="user")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    deployer._save_registry(
+        project,
+        {
+            "version": deployer.REGISTRY_VERSION,
+            "skills": [
+                {
+                    "name": name,
+                    "version": "9.9.9",
+                    "deployed_at": "2020-01-01T00:00:00+00:00",
+                    "checksum": "stale",
+                }
+            ],
+        },
+    )
+
+    result = deployer.deploy_pm_skills(project, tier="minimal", force=True)
+    assert "FORCED-BUNDLED" in deployed.read_text()
+    assert name in result.deployed
+
+
+# ---------------------------------------------------------------------------
+# Auto-repair: surgical, version-aware
+# ---------------------------------------------------------------------------
+
+
+def test_targeted_repair_fixes_only_named_skills(deployer, tmp_path):
+    """_repair_specific_skills repairs the named skill, leaves others alone."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    # 'broken' has a bundled source; 'pristine' is a user-modified skill we must
+    # not touch.
+    _write_bundled(deployer, "mpm-status", "1.0.0", body="REPAIRED")
+    pristine = _write_deployed(deployer, "mpm-help", "5.0.0", body="USER-PRISTINE")
+
+    repaired = deployer._repair_specific_skills(project, ["mpm-status"])
+
+    assert repaired == ["mpm-status"]
+    # The repaired skill now exists with bundled content.
+    fixed = deployer._deploy_root / "mpm-status" / "SKILL.md"
+    assert "REPAIRED" in fixed.read_text()
+    # The unrelated user skill is untouched.
+    assert "USER-PRISTINE" in pristine.read_text()
+
+
+def test_verify_modified_skill_not_classified_corrupted(deployer, tmp_path):
+    """A non-empty user-modified file is a warning, not corruption.
+
+    Therefore auto-repair must NOT redeploy it, and its content survives.
+    """
+    name = "mpm-session-resume"
+    _write_bundled(deployer, name, "1.0.0", body="bundled")
+    deployed = _write_deployed(deployer, name, "1.0.0", body="USER-HARDENED")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    deployer._save_registry(
+        project,
+        {
+            "version": deployer.REGISTRY_VERSION,
+            "skills": [
+                {
+                    "name": name,
+                    "version": "1.0.0",
+                    "deployed_at": "2020-01-01T00:00:00+00:00",
+                    "checksum": "stale-so-it-looks-changed",
+                }
+            ],
+        },
+    )
+
+    result = deployer.verify_pm_skills(project, auto_repair=True)
+
+    # User content preserved — never reverted by auto-repair.
+    assert "USER-HARDENED" in deployed.read_text()
+    assert name not in result.corrupted_skills
+    # A "modified since deployment" warning is present.
+    assert any("modified since deployment" in w for w in result.warnings)

--- a/tests/unit/services/cli/test_session_resume_permission.py
+++ b/tests/unit/services/cli/test_session_resume_permission.py
@@ -1,0 +1,105 @@
+"""Tests for session-dir permission handling in SessionResumeHelper (Bug #735).
+
+A sandbox/permission-denied read of ``.claude-mpm/sessions/`` must NOT be
+silently treated as "no sessions". ``check_session_dir_access()`` distinguishes
+*denied* from *empty/absent*, and ``check_and_display_resume_prompt()`` surfaces
+an explicit warning on denial instead of returning a false "nothing to resume".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    return fake_home
+
+
+def _make_helper(tmp_path) -> SessionResumeHelper:
+    project = tmp_path / "project"
+    project.mkdir()
+    return SessionResumeHelper(project_path=project)
+
+
+def test_absent_dir_is_accessible_not_error(tmp_path):
+    """A never-created session dir is 'accessible' (empty), not an error."""
+    helper = _make_helper(tmp_path)
+    assert not helper.pause_dir.exists()
+    accessible, err = helper.check_session_dir_access()
+    assert accessible is True
+    assert err is None
+
+
+def test_empty_dir_is_accessible(tmp_path):
+    """An existing-but-empty session dir reads cleanly (accessible, no error)."""
+    helper = _make_helper(tmp_path)
+    helper.pause_dir.mkdir(parents=True)
+    accessible, err = helper.check_session_dir_access()
+    assert accessible is True
+    assert err is None
+
+
+def test_permission_denied_is_reported_distinctly(tmp_path, monkeypatch):
+    """A PermissionError on read yields (False, message) — NOT a silent empty."""
+    helper = _make_helper(tmp_path)
+    helper.pause_dir.mkdir(parents=True)
+
+    def boom(self):
+        raise PermissionError(13, "Permission denied")
+
+    # Patch Path.iterdir so the helper's read raises like a sandbox denial.
+    monkeypatch.setattr(Path, "iterdir", boom)
+
+    accessible, err = helper.check_session_dir_access()
+    assert accessible is False
+    assert err is not None
+    assert "Permission denied" in err
+    # Must explicitly NOT be conflated with "no sessions".
+    assert "not the same as 'no sessions'" in err.lower()
+
+
+def test_resume_prompt_warns_on_denied_dir(tmp_path, monkeypatch, capsys):
+    """check_and_display_resume_prompt surfaces a warning, returns None on deny.
+
+    This is the user-facing guarantee: a denied read does not masquerade as
+    "no paused sessions found".
+    """
+    helper = _make_helper(tmp_path)
+    helper.pause_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        helper,
+        "check_session_dir_access",
+        lambda: (False, "Permission denied reading session directory ..."),
+    )
+
+    # has_paused_sessions must NOT even be consulted on a denied dir — guard it.
+    monkeypatch.setattr(
+        helper,
+        "has_paused_sessions",
+        lambda: pytest.fail("should not check sessions when dir is unreadable"),
+    )
+
+    result = helper.check_and_display_resume_prompt()
+    out = capsys.readouterr().out
+    assert result is None
+    assert "Could not read the session directory" in out
+    assert "NOT the same as 'no sessions found'" in out
+
+
+def test_resume_prompt_proceeds_when_accessible_but_empty(tmp_path, monkeypatch):
+    """When accessible and empty, behaviour is unchanged: returns None quietly."""
+    helper = _make_helper(tmp_path)
+    helper.pause_dir.mkdir(parents=True)
+    # Accessible path -> falls through to the normal has_paused_sessions check.
+    assert helper.check_session_dir_access() == (True, None)
+    result = helper.check_and_display_resume_prompt()
+    assert result is None

--- a/tests/unit/utils/test_interpreter_resolver.py
+++ b/tests/unit/utils/test_interpreter_resolver.py
@@ -1,0 +1,161 @@
+"""Tests for ``claude_mpm.utils.interpreter_resolver`` (Bug #735).
+
+Proves the resolver finds an interpreter that can import ``claude_mpm`` across
+install layouts — in particular a *simulated pipx install* where the system
+``python3`` cannot import the package but the venv python beside the
+``claude-mpm`` console script can.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.utils import interpreter_resolver as ir
+
+
+@pytest.fixture(autouse=True)
+def _clear_override(monkeypatch):
+    """Ensure CLAUDE_MPM_PYTHON does not leak in from the real environment."""
+    monkeypatch.delenv(ir.ENV_OVERRIDE, raising=False)
+
+
+def test_env_override_wins_when_importable(monkeypatch):
+    """An explicit CLAUDE_MPM_PYTHON that can import wins immediately."""
+    monkeypatch.setenv(ir.ENV_OVERRIDE, "/opt/venv/bin/python")
+    monkeypatch.setattr(
+        ir, "_can_import_claude_mpm", lambda p: p == "/opt/venv/bin/python"
+    )
+    assert ir.resolve_claude_mpm_python() == "/opt/venv/bin/python"
+
+
+def test_env_override_ignored_when_not_importable(monkeypatch):
+    """A bad override is skipped and resolution falls through to sys.executable."""
+    monkeypatch.setenv(ir.ENV_OVERRIDE, "/bogus/python")
+    # Only sys.executable can import.
+    monkeypatch.setattr(ir.sys, "executable", "/real/venv/bin/python")
+    monkeypatch.setattr(
+        ir, "_can_import_claude_mpm", lambda p: p == "/real/venv/bin/python"
+    )
+    assert ir.resolve_claude_mpm_python() == "/real/venv/bin/python"
+
+
+def test_current_interpreter_used_when_importable(monkeypatch):
+    """sys.executable is returned when it can already import claude_mpm."""
+    monkeypatch.setattr(ir.sys, "executable", "/cur/python")
+    monkeypatch.setattr(ir, "_can_import_claude_mpm", lambda p: p == "/cur/python")
+    assert ir.resolve_claude_mpm_python() == "/cur/python"
+
+
+def test_simulated_pipx_resolves_venv_python(monkeypatch, tmp_path):
+    """Simulated pipx: system python3 fails, venv python beside script works.
+
+    Layout:
+        ~/.local/bin/claude-mpm        (symlink/shim)  -> <venv>/bin/claude-mpm
+        <venv>/bin/python              (the importable interpreter)
+
+    The current interpreter and bare python3 must NOT be able to import
+    claude_mpm; only the venv python next to the console script can.
+    """
+    # Build a fake pipx venv layout.
+    venv_bin = tmp_path / "pipx" / "venvs" / "claude-mpm" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python"
+    venv_python.write_text("#!/bin/sh\n")
+    venv_python.chmod(0o755)
+    real_script = venv_bin / "claude-mpm"
+    real_script.write_text("#!/bin/sh\n")
+    real_script.chmod(0o755)
+
+    # The shim on PATH is a symlink to the real venv script.
+    shim_dir = tmp_path / ".local" / "bin"
+    shim_dir.mkdir(parents=True)
+    shim = shim_dir / "claude-mpm"
+    shim.symlink_to(real_script)
+
+    # sys.executable is the SYSTEM python — cannot import claude_mpm.
+    monkeypatch.setattr(ir.sys, "executable", "/usr/bin/python3")
+
+    # which("claude-mpm") -> the shim; which("python3") -> system python.
+    def fake_which(name):
+        if name == ir.CONSOLE_SCRIPT:
+            return str(shim)
+        if name in ("python3", "python"):
+            return "/usr/bin/python3"
+        return None
+
+    monkeypatch.setattr(ir.shutil, "which", fake_which)
+
+    # Only the venv python can import claude_mpm.
+    def fake_can_import(p):
+        return str(Path(p)) == str(venv_python.resolve())
+
+    monkeypatch.setattr(ir, "_can_import_claude_mpm", fake_can_import)
+
+    resolved = ir.resolve_claude_mpm_python()
+    assert Path(resolved) == venv_python.resolve()
+    # Critically, it did NOT return the failing system python3.
+    assert resolved != "/usr/bin/python3"
+
+
+def test_fallback_to_python3_for_system_install(monkeypatch):
+    """When only system python3 can import, it is returned as the fallback."""
+    monkeypatch.setattr(ir.sys, "executable", "/usr/bin/python3-nope")
+    monkeypatch.setattr(
+        ir.shutil,
+        "which",
+        lambda name: "/usr/bin/python3" if name == "python3" else None,
+    )
+    monkeypatch.setattr(ir, "_can_import_claude_mpm", lambda p: p == "/usr/bin/python3")
+    assert ir.resolve_claude_mpm_python() == "/usr/bin/python3"
+
+
+def test_resolver_never_raises_when_nothing_works(monkeypatch):
+    """If nothing can import, return sys.executable (clear error downstream)."""
+    monkeypatch.setattr(ir.sys, "executable", "/some/python")
+    monkeypatch.setattr(ir.shutil, "which", lambda name: None)
+    monkeypatch.setattr(ir, "_can_import_claude_mpm", lambda p: False)
+    assert ir.resolve_claude_mpm_python() == "/some/python"
+
+
+def test_venv_python_for_executable_finds_sibling(tmp_path):
+    """The venv python sibling is found next to a (resolved) console script."""
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    py = bin_dir / "python3"
+    py.write_text("")
+    script = bin_dir / "claude-mpm"
+    script.write_text("")
+    found = ir._venv_python_for_executable(script)
+    assert found == py
+
+
+def test_can_import_uses_candidate_interpreter():
+    """A real probe: the current interpreter can import claude_mpm.
+
+    This is an end-to-end sanity check that the subprocess probe works against
+    a genuinely-importable interpreter (the one running the test suite).
+    """
+    import sys
+
+    assert ir._can_import_claude_mpm(sys.executable) is True
+
+
+def test_main_prints_resolution(monkeypatch, capsys):
+    """``main()`` prints the resolved interpreter and exits 0."""
+    monkeypatch.setattr(ir, "resolve_claude_mpm_python", lambda: "/x/python")
+    rc = ir.main()
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert out == "/x/python"
+
+
+def test_real_environment_resolves_importable_interpreter():
+    """Integration: in the real test environment the resolver returns an
+    interpreter that genuinely imports claude_mpm (no mocks)."""
+    # Make sure no override is active for this real run.
+    os.environ.pop(ir.ENV_OVERRIDE, None)
+    resolved = ir.resolve_claude_mpm_python()
+    assert ir._can_import_claude_mpm(resolved)


### PR DESCRIPTION
## Summary

Fixes three bugs reported in #735 affecting session pause/resume when claude-mpm is installed via pipx:

- **Bug 1 — Wrong interpreter in session skills**: `mpm-session-pause` and `mpm-session-resume` used a bare `python3` call, which resolves to the system Python outside the pipx venv. Added `src/claude_mpm/utils/interpreter_resolver.py` that walks `sys.executable` → `CLAUDE_MPM_PYTHON` env override → venv sibling → `python3` fallback, and both SKILL.md files now call this resolver instead.

- **Bug 2 — Permission-denied mistaken for empty**: `session_resume_helper.py` caught all `OSError` variants identically, so a permission-denied error on the session directory was silently treated as "no sessions". Now `PermissionError` is distinguished and surfaced as a distinct warning.

- **Bug 3 — Startup always re-deploys skills**: `pm_skills_deployer.py` unconditionally overwrote deployed skills on every startup, clobbering user customisations. The deployer now reads the `version:` field from SKILL.md frontmatter for both bundled and deployed copies, compares them as tuples, and skips deployment when the deployed version is equal to or newer than bundled.

## Tests

25 new unit tests across three new test files (all passing):

- `tests/unit/utils/test_interpreter_resolver.py` — 10 tests for interpreter resolution logic
- `tests/services/skills/test_pm_skills_deployer_version_aware.py` — 10 tests for version-aware deploy
- `tests/unit/services/cli/test_session_resume_permission.py` — 5 tests for permission-denied handling

## Verification

```
uv run pytest -p no:xdist tests/unit/utils/test_interpreter_resolver.py \
  tests/services/skills/test_pm_skills_deployer_version_aware.py \
  tests/unit/services/cli/test_session_resume_permission.py -v
# 25 passed in 0.17s
```

Closes #735