### PR TITLE
fix: stop bundled skill from shadowing native /mcp command (#736)

### DIFF
--- a/src/claude_mpm/cli/startup_migrations.py
+++ b/src/claude_mpm/cli/startup_migrations.py
@@ -1692,6 +1692,7 @@ _MCP_SKILL_RENAME_MAP: dict[str, str] = {
     "mcp-vector-search-pr-mr-skill": "vector-search-pr-mr-skill",
     "toolchains-ai-protocols-mcp": "toolchains-ai-protocols-model-context",
     "universal-main-mcp-builder": "universal-main-protocol-builder",
+    "mcp-security-review": "security-review",  # issue #736: shadows native /mcp command
 }
 
 

--- a/src/claude_mpm/skills/bundled/main/security-review/SKILL.md
+++ b/src/claude_mpm/skills/bundled/main/security-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-security-review
+name: security-review
 description: Security review gate for MCP server installations. Checks provenance, classifies risk, enforces version pinning, and documents credentials exposure before any MCP is added to your environment.
 version: 1.0.0
 when_to_use: when installing, adding, configuring, or updating any MCP server

--- a/tests/cli/test_startup_migrations.py
+++ b/tests/cli/test_startup_migrations.py
@@ -711,3 +711,115 @@ class TestCleanStaleHookPathsProjectSettings:
         cleaned = json.loads(settings_file.read_text())
         cmd = cleaned["hooks"]["Stop"][0]["hooks"][0]["command"]
         assert cmd == "claude-hook"
+
+
+class TestMcpSecurityReviewRename:
+    """Regression tests for issue #736: mcp-security-review skill shadows /mcp command.
+
+    The bundled skill 'mcp-security-review' was renamed to 'security-review' in
+    commit 1be75bed9.  This class verifies:
+    1. The rename map entry is present so already-deployed ~/.claude/skills/
+       directories are migrated on startup.
+    2. The migration renames an installed mcp-security-review directory
+       idempotently, without touching an already-renamed target.
+    3. No bundled skill retains an 'mcp-*' name that could shadow the native
+       /mcp slash command in future.
+    """
+
+    @pytest.fixture
+    def fake_skills_home(self, tmp_path):
+        """Create a temporary ~/.claude/skills/ tree and patch Path.home/cwd."""
+        home = tmp_path / "home"
+        skills_dir = home / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(Path, "cwd", return_value=home),
+        ):
+            yield skills_dir
+
+    def test_rename_map_contains_mcp_security_review(self):
+        """_MCP_SKILL_RENAME_MAP must map 'mcp-security-review' → 'security-review'."""
+        from claude_mpm.cli.startup_migrations import _MCP_SKILL_RENAME_MAP
+
+        assert "mcp-security-review" in _MCP_SKILL_RENAME_MAP
+        assert _MCP_SKILL_RENAME_MAP["mcp-security-review"] == "security-review"
+
+    def test_get_target_skill_name_for_mcp_security_review(self):
+        """_get_target_skill_name uses the explicit map for mcp-security-review."""
+        from claude_mpm.cli.startup_migrations import _get_target_skill_name
+
+        assert _get_target_skill_name("mcp-security-review") == "security-review"
+
+    def test_rename_mcp_security_review_skill_dir(self, fake_skills_home):
+        """Installed mcp-security-review directory is renamed to security-review."""
+        from claude_mpm.cli.startup_migrations import _rename_mcp_skills
+
+        skill_dir = fake_skills_home / "mcp-security-review"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("name: mcp-security-review\n")
+
+        result = _rename_mcp_skills()
+
+        assert result is True
+        assert not (fake_skills_home / "mcp-security-review").exists()
+        renamed = fake_skills_home / "security-review"
+        assert renamed.exists()
+        assert (renamed / "SKILL.md").exists()
+
+    def test_rename_idempotent_when_target_already_exists(self, fake_skills_home):
+        """If security-review already exists, mcp-security-review is left untouched."""
+        from claude_mpm.cli.startup_migrations import _rename_mcp_skills
+
+        old = fake_skills_home / "mcp-security-review"
+        old.mkdir()
+        (old / "SKILL.md").write_text("name: mcp-security-review\n")
+
+        new = fake_skills_home / "security-review"
+        new.mkdir()
+        (new / "SKILL.md").write_text("name: security-review\n")
+
+        result = _rename_mcp_skills()
+
+        assert result is True
+        # Source left intact because target already exists
+        assert old.exists()
+        assert new.exists()
+
+    def test_check_detects_mcp_security_review_dir(self, fake_skills_home):
+        """_check_mcp_skills_need_rename returns True when mcp-security-review exists."""
+        from claude_mpm.cli.startup_migrations import _check_mcp_skills_need_rename
+
+        (fake_skills_home / "mcp-security-review").mkdir()
+
+        assert _check_mcp_skills_need_rename() is True
+
+    def test_no_bundled_skill_starts_with_mcp(self):
+        """No bundled skill directory name starts with 'mcp'.
+
+        A skill starting with 'mcp' will shadow Claude Code's native /mcp
+        slash command via prefix matching (issue #736).  This test acts as a
+        permanent guard against future regressions.
+        """
+        from pathlib import Path as _Path
+
+        bundled_main = (
+            _Path(__file__).parent.parent.parent
+            / "src"
+            / "claude_mpm"
+            / "skills"
+            / "bundled"
+            / "main"
+        )
+        if not bundled_main.is_dir():
+            pytest.skip("Bundled skills directory not found")
+
+        mcp_prefixed = [
+            entry.name
+            for entry in bundled_main.iterdir()
+            if entry.is_dir() and entry.name.startswith("mcp")
+        ]
+        assert mcp_prefixed == [], (
+            f"Bundled skill(s) with 'mcp' prefix found — these shadow the native "
+            f"/mcp command: {mcp_prefixed}. Rename them (see issue #736)."
+        )

--- a/tests/unit/core/test_sdk_command_router.py
+++ b/tests/unit/core/test_sdk_command_router.py
@@ -374,3 +374,79 @@ class TestClearCommand:
         result = router.route("/clear")
         assert result.handled is True
         assert result.should_exit is False
+
+
+# ---------------------------------------------------------------------------
+# 12. Regression: /mcp not shadowed by bundled skill (issue #736)
+# ---------------------------------------------------------------------------
+
+
+class TestMcpNotShadowedBySkill:
+    """Regression tests for issue #736.
+
+    A bundled skill named 'mcp-security-review' caused Claude Code's prefix
+    matcher to intercept the native /mcp slash command (used for MCP server
+    re-authentication) and route it to the skill instead of the built-in
+    handler.  The fix renamed the skill to 'security-review' and added a
+    startup migration to rename already-deployed copies.
+
+    These tests verify that the SDKCommandRouter itself routes /mcp to its
+    own _handle_mcp implementation (or passes through to the LLM when no
+    client is attached), and that no bundled skill directory uses the
+    'mcp-*' naming that triggers the interference.
+    """
+
+    def test_mcp_handled_by_router_when_client_present(
+        self, router: SDKCommandRouter, mock_client: MagicMock
+    ) -> None:
+        """With a client, /mcp is routed to _handle_mcp, NOT to a skill."""
+        status_obj = MagicMock()
+        status_obj.servers = []
+        mock_client.get_mcp_status.return_value = status_obj
+
+        result = router.route("/mcp")
+
+        assert result.handled is True
+        mock_client.get_mcp_status.assert_called_once()
+
+    def test_mcp_passes_through_to_llm_when_no_client(
+        self, router_no_client: SDKCommandRouter
+    ) -> None:
+        """Without a client, /mcp is NOT intercepted — it falls through."""
+        result = router_no_client.route("/mcp")
+        # handled=False means it reaches the LLM / native REPL handler
+        assert result.handled is False
+
+    def test_mcp_is_not_in_unsupported_commands(self, router: SDKCommandRouter) -> None:
+        """/mcp must never be in UNSUPPORTED_COMMANDS."""
+        assert "/mcp" not in router.UNSUPPORTED_COMMANDS
+
+    def test_no_bundled_skill_name_starts_with_mcp(self) -> None:
+        """No bundled skill dir name starts with 'mcp'.
+
+        Such a name triggers Claude Code's prefix matching and causes /mcp to
+        be routed to the skill instead of the native built-in.
+        """
+        from pathlib import Path
+
+        bundled_main = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "claude_mpm"
+            / "skills"
+            / "bundled"
+            / "main"
+        )
+        if not bundled_main.is_dir():
+            import pytest
+
+            pytest.skip("Bundled skills directory not found")
+
+        mcp_dirs = [
+            d.name
+            for d in bundled_main.iterdir()
+            if d.is_dir() and d.name.startswith("mcp")
+        ]
+        assert mcp_dirs == [], (
+            f"Skill(s) with 'mcp' prefix would shadow /mcp command: {mcp_dirs}"
+        )


### PR DESCRIPTION
## Root cause

The bundled skill `mcp-security-review` used a name starting with `mcp`, which triggered Claude Code's prefix-matching command router to intercept the native `/mcp` slash command (used for MCP server re-authentication) and route it to the skill instead of the built-in handler.

The same problem affected `/remote-control` (shadowed by a skill or the `/rc` alias) and was fixed by surfacing those names as unsupported via precedent commit `361415670`.

## Fix

Three commits on this branch (plus the prior commit `1be75bed9` already present on branch):

1. **`1be75bed9`** (existing) — Rename bundled skill directory `mcp-security-review` → `security-review` in `src/claude_mpm/skills/bundled/main/`. Fixes new installs immediately.

2. **`fe51ec4a8`** — Add `"mcp-security-review": "security-review"` to `_MCP_SKILL_RENAME_MAP` in `startup_migrations.py`. Ensures already-deployed `~/.claude/skills/mcp-security-review` directories are transparently renamed to `security-review` on the next startup (idempotent, non-fatal).

3. **`edf7fb4c5`** — Regression tests in `test_startup_migrations.py` (`TestMcpSecurityReviewRename`, 6 tests): map entry present, explicit target name, directory rename, idempotency, check detection, and a **permanent guard** that fails if any future bundled skill dir starts with `mcp`.

4. **`e83ac0ba0`** — Regression tests in `test_sdk_command_router.py` (`TestMcpNotShadowedBySkill`, 4 tests): `/mcp` routes to `_handle_mcp` with client, falls through without client, never in `UNSUPPORTED_COMMANDS`, and the same permanent bundled-skill guard.

## Test results

```
79 passed, 1 warning in 0.51s
```

Closes #736