### PR TITLE
fix: replace deprecated kuzu-memory with trusty-memory in presets

### DIFF
--- a/src/claude_mpm/manifest/presets/default.json
+++ b/src/claude_mpm/manifest/presets/default.json
@@ -28,6 +28,6 @@
     }
   },
   "setup": {
-    "services": ["kuzu-memory", "mcp-ticketer"]
+    "services": ["trusty-memory", "mcp-ticketer"]
   }
 }

--- a/src/claude_mpm/manifest/presets/enterprise.json
+++ b/src/claude_mpm/manifest/presets/enterprise.json
@@ -28,6 +28,6 @@
     "model": "claude-haiku-4-5"
   },
   "setup": {
-    "services": ["kuzu-memory"]
+    "services": ["trusty-memory"]
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `kuzu-memory` with `trusty-memory` in `setup.services` for both `default.json` and `enterprise.json` preset files. kuzu-memory is deprecated in favour of trusty-memory (see README and CHANGELOG).
- No other config changes are made.

## Planner tier note (enterprise preset)

`enterprise.json` intentionally downgrades the `planner` agent from `claude-opus-4-7` (default preset) to `claude-sonnet-4-5` with `resource_tier: "tier2"`. This is a cost-control trade-off for enterprise deployments. JSON has no comment syntax and this repo uses no `_comment` convention, so the rationale is documented here only.

## Test plan

- [ ] Validate both JSON files parse correctly: `python -c "import json; json.load(open('src/claude_mpm/manifest/presets/default.json'))"`
- [ ] Validate enterprise.json: `python -c "import json; json.load(open('src/claude_mpm/manifest/presets/enterprise.json'))"`
- [ ] Confirm `uv run ruff format . && uv run ruff check .` passes (no Python changed, only JSON)
- [ ] Confirm `claude-mpm setup` no longer attempts to set up the deprecated kuzu-memory service when using default or enterprise preset

Closes #750

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)