### PR TITLE
fix: BLOCK_MARKERS reference non-existent headings (fragile stale-override detection)

### DIFF
--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -20,11 +20,14 @@ from claude_mpm.core.framework.loaders.workflow_constants import (
 
 # Markers that uniquely identify content belonging to specific blocks.
 # Used to detect stale override files that contain previously-deployed merged content.
+# IMPORTANT: these must stay in sync with the actual headings in the source .md files
+# under src/claude_mpm/agents/. The regression test
+# tests/services/agents/deployment/test_block_markers_exist.py enforces this.
 BLOCK_MARKERS: dict[str, list[str]] = {
-    "PM_INSTRUCTIONS.md": ["## PM Core Identity"],
-    "AGENT_DELEGATION.md": ["## Available Agent Capabilities"],
+    "PM_INSTRUCTIONS.md": ["## Identity"],
+    "AGENT_DELEGATION.md": ["## When to Delegate to Each Agent"],
     "WORKFLOW.md": ["## Mandatory 5-Phase Sequence"],
-    "MEMORY.md": ["## Static Memory Management"],
+    "MEMORY.md": ["## Memory System"],
 }
 
 

--- a/tests/services/agents/deployment/test_block_markers_exist.py
+++ b/tests/services/agents/deployment/test_block_markers_exist.py
@@ -1,0 +1,65 @@
+"""Regression test: every BLOCK_MARKERS entry must appear in its source .md file.
+
+This prevents BLOCK_MARKERS from silently drifting out of sync with the actual
+headings in the source agent .md files, which would cause stale-override detection
+to always miss (never fire), allowing stale deployed content to persist.
+
+WHAT: Asserts each marker string in BLOCK_MARKERS is present in its corresponding
+      source .md file under src/claude_mpm/agents/.
+WHY: Three of four markers were historically stale (pointed to headings that no
+     longer existed), making stale-override detection silently broken. Closes #749.
+"""
+
+from importlib.resources import files
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.services.agents.deployment.system_instructions_deployer import (
+    BLOCK_MARKERS,
+)
+
+
+def _agents_dir() -> Path:
+    """Return the path to src/claude_mpm/agents/ via importlib.resources."""
+    # importlib.resources returns a Traversable; cast to Path for .read_text()
+    agents_pkg = files("claude_mpm") / "agents"
+    # Resolve to a real filesystem path so we can open files
+    candidate = Path(str(agents_pkg))
+    if candidate.is_dir():
+        return candidate
+    # Fallback: walk up from this test file
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        guess = parent / "src" / "claude_mpm" / "agents"
+        if guess.is_dir():
+            return guess
+    raise FileNotFoundError("Cannot locate src/claude_mpm/agents/")
+
+
+@pytest.mark.parametrize(
+    "source_file,markers",
+    [(k, v) for k, v in BLOCK_MARKERS.items()],
+    ids=list(BLOCK_MARKERS.keys()),
+)
+def test_each_block_marker_present_in_source_file(
+    source_file: str, markers: list[str]
+) -> None:
+    """Every marker in BLOCK_MARKERS must appear verbatim in the source .md file.
+
+    If this test fails after a heading is renamed in a source .md file, update
+    BLOCK_MARKERS in system_instructions_deployer.py to match the new heading.
+    """
+    agents_dir = _agents_dir()
+    source_path = agents_dir / source_file
+    assert source_path.exists(), (
+        f"Source file {source_file!r} not found at {source_path}. "
+        "Remove or rename the entry in BLOCK_MARKERS."
+    )
+    content = source_path.read_text(encoding="utf-8")
+    for marker in markers:
+        assert marker in content, (
+            f"Marker {marker!r} not found in {source_file}. "
+            f"Update BLOCK_MARKERS in system_instructions_deployer.py to match "
+            f"the current headings in {source_file}."
+        )

--- a/tests/services/agents/deployment/test_stale_override_detection.py
+++ b/tests/services/agents/deployment/test_stale_override_detection.py
@@ -46,7 +46,7 @@ class TestDetectStaleOverride:
         """PM_INSTRUCTIONS override containing AGENT_DELEGATION markers is stale."""
         stale_content = (
             "# PM Instructions\n\n"
-            "## Available Agent Capabilities\n\n"
+            "## When to Delegate to Each Agent\n\n"
             "This belongs to AGENT_DELEGATION.md."
         )
         assert (
@@ -58,9 +58,7 @@ class TestDetectStaleOverride:
     ) -> None:
         """PM_INSTRUCTIONS override containing MEMORY markers is stale."""
         stale_content = (
-            "# PM Instructions\n\n"
-            "## Static Memory Management\n\n"
-            "This belongs to MEMORY.md."
+            "# PM Instructions\n\n## Memory System\n\nThis belongs to MEMORY.md."
         )
         assert (
             deployer._detect_stale_override("PM_INSTRUCTIONS.md", stale_content) is True
@@ -74,7 +72,7 @@ class TestDetectStaleOverride:
             "# Custom PM Instructions Override\n\n"
             "This is a legitimate project-specific override.\n"
             "It only contains PM-specific content.\n\n"
-            "## PM Core Identity\n\n"
+            "## Identity\n\n"
             "Custom identity definition."
         )
         assert (
@@ -180,7 +178,7 @@ class TestResolveBlockWithStaleDetection:
         project_override_dir.mkdir()
         stale_override = project_override_dir / "PM_INSTRUCTIONS.md"
         stale_override.write_text(
-            "# Stale\n\n## Available Agent Capabilities\n\nFrom AGENT_DELEGATION."
+            "# Stale\n\n## When to Delegate to Each Agent\n\nFrom AGENT_DELEGATION."
         )
 
         with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary

- Updates `BLOCK_MARKERS` in `system_instructions_deployer.py` to match the actual current headings in the source `.md` files (3 of 4 were stale)
- Adds regression test `test_block_markers_exist.py` that parametrizes over all entries and asserts each marker is present verbatim in its source file — so they can't silently go stale again
- Updates `test_stale_override_detection.py` to use the corrected marker strings

**Heading changes:**
| File | Old (stale) | New (correct) |
|------|-------------|---------------|
| `PM_INSTRUCTIONS.md` | `## PM Core Identity` | `## Identity` |
| `AGENT_DELEGATION.md` | `## Available Agent Capabilities` | `## When to Delegate to Each Agent` |
| `WORKFLOW.md` | `## Mandatory 5-Phase Sequence` | *(unchanged — was already correct)* |
| `MEMORY.md` | `## Static Memory Management` | `## Memory System` |

Closes #749

## Test plan

- [ ] `uv run pytest -p no:xdist tests/services/agents/deployment/test_block_markers_exist.py -v` — 4 parametrized tests pass (one per source file)
- [ ] `uv run pytest -p no:xdist tests/services/agents/deployment/test_stale_override_detection.py -v` — 10 existing tests pass
- [ ] If a source `.md` heading is renamed in future, `test_block_markers_exist.py` will fail immediately and force `BLOCK_MARKERS` to be updated

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)