### PR TITLE
fix(agents): sync drifted bundled seed agents (ticketing, rust-engineer); clarify canonical source (#760)

### DIFF
--- a/src/claude_mpm/agents/bundled/rust-engineer.md
+++ b/src/claude_mpm/agents/bundled/rust-engineer.md
@@ -1,4 +1,11 @@
 ---
+# SEED-ONLY: minimal package-bundled agent definition.
+# Loaded at runtime by agent_discovery_service.py as a `source: bundled` fallback.
+# The authoritative, full-featured copy is the external `bobmatnyc/claude-mpm-agents`
+# version deployed to `.claude/agents/rust-engineer.md`. Keep frontmatter here in sync
+# with that authoritative copy (model/version/schema_version/toolchain pins); the body
+# is intentionally minimal and defers all patterns to the `toolchains-rust-core` skill.
+model: sonnet
 name: Rust Engineer
 description: Rust 2024 edition specialist for memory-safe systems, async patterns, and zero-cost abstractions
 version: 2.0.0
@@ -27,8 +34,8 @@ capabilities:
   network_access: true
 dependencies:
   system:
-  - rust>=1.75
-  - cargo>=1.75
+  - rust>=1.85
+  - cargo>=1.85
 skills:
 - toolchains-rust-core
 - universal-collaboration-git-workflow

--- a/src/claude_mpm/agents/bundled/ticketing.md
+++ b/src/claude_mpm/agents/bundled/ticketing.md
@@ -1,11 +1,21 @@
 ---
+# SEED-ONLY: minimal package-bundled agent definition.
+# Loaded at runtime by agent_discovery_service.py as a `source: bundled` fallback.
+# The authoritative, full-featured copy is the external `bobmatnyc/claude-mpm-agents`
+# version deployed to `.claude/agents/ticketing.md` (mcp-ticketer, currently v2.7.0).
+# This seed is intentionally a lightweight GitHub-issue / bug-reporting variant; keep its
+# frontmatter aligned to current schema standards but do NOT copy the external body here.
 model: haiku
 effort: fast
 name: Ticketing
-description: GitHub issue management and bug reporting for MPM repositories
+description: Lightweight GitHub issue management and bug reporting for MPM repositories (seed; see external claude-mpm-agents for the full mcp-ticketer agent)
+agent_id: ticketing
+agent_type: documentation
+source: bundled
 toolchain: universal
 category: mpm
-version: 1.1.0
+version: 1.3.0
+schema_version: 1.3.0
 ---
 
 # Ticketing Agent


### PR DESCRIPTION
## Summary

Resolves #760. Investigated whether `src/claude_mpm/agents/bundled/` is canonical/used-at-runtime or a redundant stale copy, then synced the two drifted seed agents to current standards.

## Canonical-source determination

**`src/claude_mpm/agents/bundled/` IS used at runtime — it is an active `source: bundled` fallback, not dead code.**

`src/claude_mpm/services/agents/deployment/agent_discovery_service.py` (step "1b", line ~174) actively globs `agents/bundled/*.md`, extracts their metadata, tags them `source: bundled`, and surfaces them as deployable/listable agents. In the dedup pass, these local bundled entries are preferred over git-cache entries. So any drift here directly affects discovery/listing output.

Git history confirms these are **deliberately minimal package-shipped seed agents** (commit `2d956dacb` "add **minimal** rust-engineer bundled agent"), NOT full mirrors of the external deployed copies. The authoritative, full-featured versions are sourced from the external `bobmatnyc/claude-mpm-agents` repo and deployed to `.claude/agents/` (`source: external`):
- deployed `ticketing.md` = v2.7.0, 1813 lines, mcp-ticketer agent
- deployed `rust-engineer.md` = v2.0.0, `model: sonnet`

## Decision & rationale

Because `bundled/` is loaded at runtime, I took the issue's **safe default: SYNC frontmatter to current standards** rather than delete. I did NOT copy the external bodies into the bundled files — the bundled definitions are intentionally lightweight (the bundled `ticketing` is a GitHub-issue/bug-reporting variant, not the 1813-line external mcp-ticketer agent). Copying the external body would be "inventing content" and create a false equivalence. Instead I reconciled the frontmatter and added a `SEED-ONLY` header to each file to prevent future drift confusion.

## What changed

**`bundled/rust-engineer.md`**
- Added missing `model: sonnet` (matches authoritative deployed copy) — the core gap called out in the issue
- Bumped toolchain pins `rust>=1.75`/`cargo>=1.75` → `1.85` (matches current standard)
- Added `SEED-ONLY` header comment

**`bundled/ticketing.md`**
- Added current schema fields: `schema_version: 1.3.0`, `agent_id: ticketing`, `agent_type: documentation`, `source: bundled`
- Bumped `version` 1.1.0 → 1.3.0; clarified description as the lightweight seed variant
- Added `SEED-ONLY` header comment pointing to the authoritative external full agent

Both files keep `source: bundled` (they ship with the package). Frontmatter validated via `FrontmatterValidator.validate_and_correct` → `valid=True, errors=[]` for both; YAML (including the new comment headers) parses cleanly.

## Out of scope (external repo follow-ups)

These live in `bobmatnyc/claude-mpm-agents` (external source of truth, overwritten in `.claude/agents/` on redeploy — not edited here):
- `code-analyzer.md` schema_version is one behind at 1.2.0 (should go to 1.3.0)
- Any further reconciliation of the deployed `source: external` agents must be coordinated in that repo, not in this package.

## Tests

`uv run pytest -p no:xdist tests/test_agent_discovery_logging.py tests/test_frontmatter_format.py tests/test_base_template_exclusion.py -v` → **57 passed**. `ruff format`/`ruff check` clean.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
