### PR TITLE
feat: add missing when_to_use triggers + normalize skill frontmatter (#762)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -426,7 +426,7 @@
         "filename": "src/claude_mpm/skills/bundled/express-local-dev.md",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 1203
+        "line_number": 1204
       }
     ],
     "src/claude_mpm/skills/bundled/fastapi-local-dev.md": [
@@ -435,7 +435,7 @@
         "filename": "src/claude_mpm/skills/bundled/fastapi-local-dev.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 177
+        "line_number": 178
       }
     ],
     "src/claude_mpm/skills/bundled/nextjs-local-dev.md": [
@@ -444,7 +444,7 @@
         "filename": "src/claude_mpm/skills/bundled/nextjs-local-dev.md",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 775
+        "line_number": 776
       }
     ],
     "src/claude_mpm/skills/bundled/rust/desktop-applications/references/testing-deployment.md": [
@@ -797,5 +797,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-09T23:01:20Z"
+  "generated_at": "2026-06-11T20:53:11Z"
 }

--- a/src/claude_mpm/skills/bundled/api-documentation.md
+++ b/src/claude_mpm/skills/bundled/api-documentation.md
@@ -1,6 +1,7 @@
 ---
 skill_id: api-documentation
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when writing, reviewing, or improving API documentation, generating OpenAPI/Swagger specs, or adding code interface docs
 description: Best practices for documenting APIs and code interfaces, eliminating redundant documentation guidance per agent.
 updated_at: 2025-10-30T17:00:00Z
 tags: [api, documentation, best-practices, interfaces]

--- a/src/claude_mpm/skills/bundled/async-testing.md
+++ b/src/claude_mpm/skills/bundled/async-testing.md
@@ -1,6 +1,7 @@
 ---
 skill_id: async-testing
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when writing or debugging tests for async/await code, promise chains, event emitters, or concurrent operations
 description: Patterns for testing asynchronous code across languages, eliminating redundant async testing guidance per agent.
 updated_at: 2025-10-30T17:00:00Z
 tags: [testing, async, asynchronous, concurrency]

--- a/src/claude_mpm/skills/bundled/code-review.md
+++ b/src/claude_mpm/skills/bundled/code-review.md
@@ -1,6 +1,7 @@
 ---
 skill_id: code-review
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when reviewing a pull request, auditing existing code for quality issues, or conducting a structured code review
 description: Systematic approach to reviewing code for quality, correctness, and maintainability.
 updated_at: 2025-10-30T17:00:00Z
 tags: [code-review, quality, collaboration, best-practices]

--- a/src/claude_mpm/skills/bundled/database-migration.md
+++ b/src/claude_mpm/skills/bundled/database-migration.md
@@ -1,6 +1,7 @@
 ---
 skill_id: database-migration
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when creating, running, or rolling back database schema migrations, including adding columns, renaming tables, or evolving schemas in production
 description: Safe patterns for evolving database schemas in production.
 updated_at: 2025-10-30T17:00:00Z
 tags: [database, migration, schema, production]

--- a/src/claude_mpm/skills/bundled/docker-containerization.md
+++ b/src/claude_mpm/skills/bundled/docker-containerization.md
@@ -1,6 +1,7 @@
 ---
 skill_id: docker-containerization
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when containerizing an application, writing Dockerfiles, configuring docker-compose, or debugging container build and runtime issues
 description: Essential Docker patterns for containerizing applications.
 updated_at: 2025-10-30T17:00:00Z
 tags: [docker, containers, deployment, devops]

--- a/src/claude_mpm/skills/bundled/express-local-dev.md
+++ b/src/claude_mpm/skills/bundled/express-local-dev.md
@@ -1,6 +1,7 @@
 ---
 skill_id: express-local-dev
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when setting up or running an Express.js development server, configuring Nodemon auto-reload, or managing PM2 production processes for Node.js backends
 description: Running Express development servers with auto-reload tools like Nodemon, managing production deployments with PM2 clustering, and implementing graceful shutdown patterns.
 updated_at: 2025-10-30T17:00:00Z
 tags: [express, nodejs, development, server, backend]

--- a/src/claude_mpm/skills/bundled/fastapi-local-dev.md
+++ b/src/claude_mpm/skills/bundled/fastapi-local-dev.md
@@ -1,6 +1,7 @@
 ---
 skill_id: fastapi-local-dev
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when starting or configuring a FastAPI development server with Uvicorn, setting up Gunicorn for production, or troubleshooting FastAPI server startup issues
 description: Running FastAPI development servers effectively using Uvicorn, managing production deployments with Gunicorn, and avoiding common pitfalls.
 updated_at: 2025-10-30T17:00:00Z
 tags: [fastapi, python, development, server, api]

--- a/src/claude_mpm/skills/bundled/git-workflow.md
+++ b/src/claude_mpm/skills/bundled/git-workflow.md
@@ -1,6 +1,7 @@
 ---
 skill_id: git-workflow
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when performing git operations such as branching, merging, rebasing, resolving conflicts, or establishing a commit and PR workflow
 description: Essential Git patterns for effective version control, eliminating redundant Git guidance per agent.
 updated_at: 2025-10-30T17:00:00Z
 tags: [git, version-control, workflow, best-practices]

--- a/src/claude_mpm/skills/bundled/imagemagick.md
+++ b/src/claude_mpm/skills/bundled/imagemagick.md
@@ -1,6 +1,7 @@
 ---
 skill_id: imagemagick
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when resizing, converting, compressing, or batch-processing images using ImageMagick CLI or as part of a media optimization pipeline
 description: Image manipulation and optimization techniques using ImageMagick.
 updated_at: 2025-10-30T17:00:00Z
 tags: [imagemagick, image-processing, optimization, media]

--- a/src/claude_mpm/skills/bundled/json-data-handling.md
+++ b/src/claude_mpm/skills/bundled/json-data-handling.md
@@ -1,6 +1,7 @@
 ---
 skill_id: json-data-handling
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when parsing, serializing, validating, transforming, or querying JSON data structures in any language
 description: Working effectively with JSON data structures.
 updated_at: 2025-10-30T17:00:00Z
 tags: [json, data, parsing, serialization]

--- a/src/claude_mpm/skills/bundled/mutation-testing.md
+++ b/src/claude_mpm/skills/bundled/mutation-testing.md
@@ -1,7 +1,8 @@
 ---
 skill_id: mutation-testing
-skill_version: 0.1.0
+skill_version: 0.2.0
 name: mutation-testing
+when_to_use: when auditing test suite effectiveness on a critical module, evaluating whether green tests actually protect behavior, or deciding whether to invest more in test coverage
 description: Audit whether a test suite actually detects regressions (not just whether it runs) by introducing small code mutations and measuring how many your tests catch. Apply when hardening a critical, logic-dense module's tests, evaluating coverage confidence after a near-miss bug, or deciding if "green tests" really mean "protected behavior". Advisory and on-demand — not a blocking CI gate.
 updated_at: 2026-06-09T00:00:00Z
 tags: [testing, quality-assurance, mutation-testing, test-effectiveness, advisory]

--- a/src/claude_mpm/skills/bundled/nextjs-local-dev.md
+++ b/src/claude_mpm/skills/bundled/nextjs-local-dev.md
@@ -1,6 +1,7 @@
 ---
 skill_id: nextjs-local-dev
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when starting, configuring, or troubleshooting a Next.js development server, or deploying a Next.js app with PM2
 description: Managing Next.js development servers effectively, including direct dev server usage, PM2 for production deployments, and troubleshooting.
 updated_at: 2025-10-30T17:00:00Z
 tags: [nextjs, react, development, server]

--- a/src/claude_mpm/skills/bundled/pdf.md
+++ b/src/claude_mpm/skills/bundled/pdf.md
@@ -1,6 +1,7 @@
 ---
 skill_id: pdf
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when generating, reading, converting, merging, or extracting content from PDF files programmatically
 description: Common PDF operations and libraries across languages.
 updated_at: 2025-10-30T17:00:00Z
 tags: [pdf, document-processing, manipulation, media]

--- a/src/claude_mpm/skills/bundled/performance-profiling.md
+++ b/src/claude_mpm/skills/bundled/performance-profiling.md
@@ -1,6 +1,7 @@
 ---
 skill_id: performance-profiling
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when diagnosing slow code, measuring execution time or memory usage, or running profiling tools to find performance bottlenecks
 description: Systematic approach to identifying and optimizing performance bottlenecks, eliminating redundant profiling guidance per agent.
 updated_at: 2025-10-30T17:00:00Z
 tags: [performance, profiling, optimization, benchmarking]

--- a/src/claude_mpm/skills/bundled/react/flexlayout-react.md
+++ b/src/claude_mpm/skills/bundled/react/flexlayout-react.md
@@ -1,9 +1,8 @@
 ---
-name: flexlayout-react
+skill_id: flexlayout-react
+skill_version: 1.1.0
+when_to_use: when building IDE-like interfaces, dashboard builders, multi-document editors, or React applications requiring draggable docking panels, tabs, and splitters
 description: FlexLayout for React - Advanced docking layout manager with drag-and-drop, tabs, splitters, and complex window management
-version: 1.0.0
-category: development
-author: Claude MPM Team
 license: MIT
 progressive_disclosure:
   entry_point:

--- a/src/claude_mpm/skills/bundled/refactoring-patterns.md
+++ b/src/claude_mpm/skills/bundled/refactoring-patterns.md
@@ -1,6 +1,7 @@
 ---
 skill_id: refactoring-patterns
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when restructuring or improving existing code — extract methods, rename symbols, reduce duplication, or improve readability — without altering behavior
 description: Common refactoring techniques to improve code quality without changing behavior.
 updated_at: 2025-10-30T17:00:00Z
 tags: [refactoring, code-quality, patterns, maintainability]

--- a/src/claude_mpm/skills/bundled/security-scanning.md
+++ b/src/claude_mpm/skills/bundled/security-scanning.md
@@ -1,6 +1,7 @@
 ---
 skill_id: security-scanning
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when scanning code for security vulnerabilities (OWASP Top 10, injection, XSS, secrets exposure), running static analysis tools, or hardening an application before release
 description: Identify and fix common security vulnerabilities in code, eliminating redundant security guidance per agent.
 updated_at: 2025-10-30T17:00:00Z
 tags: [security, vulnerability, scanning, code-analysis]

--- a/src/claude_mpm/skills/bundled/session-analyzer.md
+++ b/src/claude_mpm/skills/bundled/session-analyzer.md
@@ -1,6 +1,7 @@
 ---
 skill_id: session-analyzer
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when analyzing a completed Claude session to understand cost breakdown, agent behavior, tool usage timeline, or to generate a visual session report
 description: "Debug and teach agentic coding: a deterministic-first session timeline + cost report, with optional narrative polish and a standalone JSX visualiser."
 updated_at: 2026-06-10T00:00:00Z
 tags: [session, reporting, cost, teaching, debugging]

--- a/src/claude_mpm/skills/bundled/vite-local-dev.md
+++ b/src/claude_mpm/skills/bundled/vite-local-dev.md
@@ -1,6 +1,7 @@
 ---
 skill_id: vite-local-dev
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when setting up, running, or tuning a Vite development server, configuring HMR, or resolving Vite process management issues
 description: Maximizing Vite's development server performance, managing HMR effectively, and avoiding process management pitfalls.
 updated_at: 2025-10-30T17:00:00Z
 tags: [vite, development, hmr, frontend, build-tool]

--- a/src/claude_mpm/skills/bundled/web-performance-optimization.md
+++ b/src/claude_mpm/skills/bundled/web-performance-optimization.md
@@ -1,6 +1,7 @@
 ---
 skill_id: web-performance-optimization
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when improving Lighthouse scores, Core Web Vitals (LCP, CLS, FID/INP), page load times, bundle sizes, or implementing web performance best practices
 description: Comprehensive guide to optimizing web performance using Lighthouse metrics and Core Web Vitals, covering modern optimization techniques and measurement strategies.
 updated_at: 2025-10-30T17:00:00Z
 tags: [performance, optimization, lighthouse, core-web-vitals, frontend]

--- a/src/claude_mpm/skills/bundled/xlsx.md
+++ b/src/claude_mpm/skills/bundled/xlsx.md
@@ -1,6 +1,7 @@
 ---
 skill_id: xlsx
-skill_version: 0.1.0
+skill_version: 0.2.0
+when_to_use: when reading, writing, generating, or transforming Excel (.xlsx) files programmatically in any language
 description: Working with Excel files programmatically.
 updated_at: 2025-10-30T17:00:00Z
 tags: [excel, xlsx, spreadsheet, data]


### PR DESCRIPTION
## Summary

- Adds specific `when_to_use:` frontmatter field to 20 flat-root bundled skills (`src/claude_mpm/skills/bundled/*.md`) that were missing it. Each trigger is skill-specific (not a generic placeholder). Bumps `skill_version` from 0.1.0 → 0.2.0 for each edited file.
- Tauri skills (11 files) already carried `when_to_use` — no changes needed.
- Normalizes `src/claude_mpm/skills/bundled/react/flexlayout-react.md` from non-standard frontmatter (`name/version/category/author`) to standard schema (`skill_id/skill_version`) matching `registry.py` parsing, adds top-level `when_to_use`, and bumps version 1.0.0 → 1.1.0.

## Commit grouping (issue instruction)

| Commit | Scope | Files |
|---|---|---|
| Group 1 | Flat-root `when_to_use` triggers | 20 bundled skills + .secrets.baseline |
| Group 2 | flexlayout-react normalization + `when_to_use` | 1 file |

## Files changed per group

**Group 1 — flat bundled skills (20):**
api-documentation, async-testing, code-review, database-migration, docker-containerization, express-local-dev, fastapi-local-dev, git-workflow, imagemagick, json-data-handling, mutation-testing, nextjs-local-dev, pdf, performance-profiling, refactoring-patterns, security-scanning, session-analyzer, vite-local-dev, web-performance-optimization, xlsx

**Group 2 — react subdirectory (1):**
react/flexlayout-react.md — normalized from `name/version/category/author` to `skill_id/skill_version`, added `when_to_use`, kept `license` and `progressive_disclosure`

## Out of scope (per issue notes)

- pdf.md / xlsx.md / json-data-handling.md body content untouched (issue #763)
- SKILL.md files in subdirectories (separate issue scope)

## Test plan

- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed
- [x] `uv run pytest -p no:xdist tests/ -k "skill or registry" -v` — 748 passed, 20 skipped (pre-existing), 0 failures
- [x] Pre-commit hooks passed (structure lint, secrets scan, commitizen)

Closes #762

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)