### PR TITLE
chore: reduce instruction duplication + fix metadata components list (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,55 +20,19 @@ Claude Multi-Agent Project Manager — orchestrates Claude subagents with agent 
 
 ## 🔴 Git Commit Rules
 
-**ONE FILE PER COMMIT.** Never bundle multiple file changes into a single commit.
+**ONE FILE PER COMMIT.** Never bundle multiple file changes into a single commit. Use conventional commit prefixes: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`.
 
-```bash
-# Correct
-git add src/claude_mpm/migrations/runner.py
-git commit -m "feat: add migration runner with rich output"
-
-git add CLAUDE.md
-git commit -m "docs: update CLAUDE.md with priority rankings"
-```
-
-Use conventional commit prefixes: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`
-
-### Referencing Issues
-
-Use `Closes #N` in the commit body to auto-close a GitHub issue when the commit lands on `main`. `Fixes #N` and `Resolves #N` are equivalent.
-
-```bash
-git commit -m "fix: resolve agent discovery path bug
-
-Closes #447"
-```
+Use `Closes #N` in the commit body to auto-close a GitHub issue when the commit lands on `main`.
 
 ---
 
 ## 🟡 Worktree Development Workflow
 
-Keep the primary checkout on `main`/HEAD at all times — never check out a feature branch in it.
+Canonical worktree workflow: see `src/claude_mpm/agents/WORKFLOW.md` → "Worktree Workflow" and "Worktree-Based Branch Workflow (CRITICAL)".
 
-**Per-issue worktree:**
+Key rule: keep the primary checkout on `main`/HEAD at all times — never check out a feature branch in it. `.claude/worktrees/` is gitignored.
 
-```bash
-git worktree add .claude/worktrees/issue-<N>-<slug> -b feat/<N>-<slug>
-# All build, test, and commit operations happen inside the worktree
-```
-
-`.claude/worktrees/` is gitignored; each issue gets its own tree. Parallel agents or parallel issues use separate worktrees — never run concurrent branch mutations in one tree.
-
-**Cleanup after squash-merge:**
-
-```bash
-git worktree remove .claude/worktrees/issue-<N>-<slug>
-git branch -d feat/<N>-<slug>
-git pull
-```
-
-Only run after confirming the squash-merge has landed on `main`.
-
-> **Note:** The MPM PM enforces this automatically via the Agent tool's `isolation: "worktree"` parameter. Canonical rules live in `src/claude_mpm/agents/WORKFLOW.md`.
+> **Note:** The MPM PM enforces this automatically via the Agent tool's `isolation: "worktree"` parameter.
 
 ---
 
@@ -129,10 +93,7 @@ Agent frontmatter (`agents/*.md`) supports **both** MPM-proprietary and Claude C
 
 **Claude Code native**: `name`, `description`, `model`, `tools`, `disallowedTools`, `permissionMode`, `maxTurns`, `memory`, `skills`, `hooks`, `background`, `effort`, `isolation`, `color`
 
-Invoke subagents via the `Agent` tool (not bash):
-```
-Agent(subagent_type="agent-name", description="...", prompt="...", model="haiku")
-```
+Invoke subagents via the `Agent` tool (not bash). See `src/claude_mpm/agents/WORKFLOW.md` for delegation patterns.
 
 ---
 

--- a/src/claude_mpm/services/instructions/instruction_cache_service.py
+++ b/src/claude_mpm/services/instructions/instruction_cache_service.py
@@ -378,7 +378,9 @@ class InstructionCacheService:
             "components": [
                 "BASE_PM.md",
                 "PM_INSTRUCTIONS.md",
+                "AGENT_DELEGATION.md",
                 "WORKFLOW.md",
+                "MEMORY.md",
                 "agent_capabilities",
                 "temporal_context",
             ],

--- a/tests/data/startup_context_baseline.json
+++ b/tests/data/startup_context_baseline.json
@@ -26,11 +26,11 @@
   },
   "CLAUDE_MD": {
     "path": "CLAUDE.md",
-    "bytes": 7478,
-    "approx_tokens": 1869
+    "bytes": 6661,
+    "approx_tokens": 1665
   },
   "_total": {
-    "bytes": 55061,
-    "approx_tokens": 13765
+    "bytes": 54244,
+    "approx_tokens": 13561
   }
 }


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Compressed Git Commit Rules (2-line rule, drop code examples), replaced step-by-step worktree instructions with pointer to `WORKFLOW.md`, dropped redundant `Agent(...)` invocation code block (frontmatter field list preserved). No rules removed.
- **`InstructionCacheService._write_metadata()`**: Added `AGENT_DELEGATION.md` and `MEMORY.md` to the hardcoded `components` list so debug metadata accurately reflects all assembled startup-context components.
- **`tests/data/startup_context_baseline.json`**: Regenerated after CLAUDE.md size reduction (7478B → 6661B, −817B; total 55061B → 54244B).

## What was preserved (no rules dropped)

| CLAUDE.md section | Before | After |
|---|---|---|
| Git commit one-file rule | Full section with bash examples | 2-line rule + `Closes #N` note |
| Worktree workflow | Full step-by-step (duplicated from WORKFLOW.md) | Pointer to WORKFLOW.md + single key rule |
| Subagent patterns | Frontmatter list + `Agent(...)` code block | Frontmatter list + link to WORKFLOW.md |
| All 🔴 CRITICAL sections | Intact | Intact |
| Priority Guide, Release, Security, Test Workflow, Architecture, Hooks, Config, Migrations, Debugging, Code Standards | Intact | Intact |

PM_INSTRUCTIONS.md already had a pointer-style worktree section (lines 338–350 reference `WORKFLOW.md`) — no change needed there.

## Test plan

- [x] `uv run pytest -p no:xdist tests/test_startup_context_budget.py -v` — PASSED
- [x] `uv run pytest -p no:xdist tests/ -k "instruction_cache" -v` — 35 passed
- [x] `ruff format` + `ruff check --fix` — clean

Closes #759

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)