### PR TITLE
fix: PM_INSTRUCTIONS_DEPLOYED.md version tag so deployed fast-path isn't discarded (#757)

### DIFF
--- a/src/claude_mpm/agents/BASE_PM.md
+++ b/src/claude_mpm/agents/BASE_PM.md
@@ -16,7 +16,7 @@ No cost-saving, "trivial change", or "documented command" exceptions.
 | Agent routing | `.claude-mpm/AGENT_DELEGATION.md` | Replaces routing table |
 | Workflow phases | `.claude-mpm/WORKFLOW.md` | Replaces default workflow |
 | Memory behavior | `.claude-mpm/MEMORY.md` | Replaces memory section |
-| Full PM replacement | `.claude-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | Replaces entire PM prompt — but note this file is AUTO-GENERATED (rebuilt on every startup in dev/filesystem mode); hand-edits will be overwritten |
+| Full PM replacement | `.claude-mpm/PM_INSTRUCTIONS.md` | Replaces the PM_INSTRUCTIONS block. (Do NOT edit `PM_INSTRUCTIONS_DEPLOYED.md` — it is AUTO-GENERATED and rebuilt every startup; hand-edits are overwritten.) |
 
 Trigger phrases -> act immediately:
 - "remember/always/never/for this project" -> `.claude-mpm/INSTRUCTIONS.md`

--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -2372,11 +2372,16 @@ def run_background_services(
 
     WHY: Centralizes all startup service initialization for cleaner main().
 
-    NOTE: System instructions (PM_INSTRUCTIONS.md, WORKFLOW.md, MEMORY.md) and
-    templates do NOT deploy automatically on startup. They only deploy when user
-    explicitly requests them via agent-manager commands. This prevents unwanted
-    file creation in project .claude/ directories.
-    See: SystemInstructionsDeployer and agent_deployment.py line 504-509
+    NOTE: The merged PM_INSTRUCTIONS_DEPLOYED.md (PM_INSTRUCTIONS + AGENT_DELEGATION
+    + WORKFLOW + MEMORY) IS rebuilt automatically on every startup. It happens in
+    sync_deployment_on_startup() -> _rebuild_pm_instructions_deployed(), so that
+    edits to the source/override blocks take effect on the next session without a
+    manual deploy step. The file is auto-generated (carries a DO-NOT-EDIT banner)
+    and carries the source PM_INSTRUCTIONS_VERSION tag so InstructionLoader treats
+    it as the current fast-path rather than discarding it as stale (issue #757).
+    PM-instruction *templates* (docs under .claude-mpm/templates/) are also
+    refreshed as part of that rebuild.
+    See: SystemInstructionsDeployer and sync_deployment_on_startup()
 
     NOTE: Startup migrations now run in cli/__init__.py BEFORE the banner
     This allows migration results to be displayed in the startup banner

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -9,6 +9,7 @@ SPEC-AGENTS-07~1 : docs/specs/agents.md#SPEC-AGENTS-07~1
 """
 
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -179,6 +180,41 @@ class SystemInstructionsDeployer:
             parts.append(system_path.read_text(encoding="utf-8"))
         return "\n\n".join(parts)
 
+    def _source_pm_version_tag(self, agents_path: Path) -> str:
+        """Return the ``PM_INSTRUCTIONS_VERSION`` comment from the source file.
+
+        The deployed ``PM_INSTRUCTIONS_DEPLOYED.md`` is the runtime fast-path
+        (PRIORITY 1 in ``InstructionLoader``). The loader decides whether to use
+        it by comparing the version tag in the deployed file against the version
+        tag in the *source* ``PM_INSTRUCTIONS.md``. If the deployed file lacks
+        the tag, ``_extract_version`` returns 0 and the loader discards it as
+        "stale" on every startup — even though it was freshly rebuilt.
+
+        A user/project override of ``PM_INSTRUCTIONS.md`` typically will NOT
+        carry the tag (users don't know to add it), so we cannot rely on the
+        merged block content to supply it. Instead we always propagate the tag
+        from the system source file, which correctly expresses "this file was
+        compiled from framework version NNNN".
+
+        Args:
+            agents_path: Path to the system agents directory.
+
+        Returns:
+            The full ``<!-- PM_INSTRUCTIONS_VERSION: NNNN -->`` comment line
+            (without trailing newline), or an empty string if the source file
+            has no version tag.
+        """
+        source_path = agents_path / "PM_INSTRUCTIONS.md"
+        if not source_path.exists():
+            return ""
+        match = re.search(
+            r"PM_INSTRUCTIONS_VERSION:\s*(\d+)",
+            source_path.read_text(encoding="utf-8"),
+        )
+        if not match:
+            return ""
+        return f"<!-- PM_INSTRUCTIONS_VERSION: {match.group(1)} -->"
+
     def deploy_system_instructions(
         self,
         target_dir: Path,
@@ -263,7 +299,19 @@ class SystemInstructionsDeployer:
             # does not carry a timestamp so it never causes spurious diffs on
             # repeated rebuilds.  Uses the shared constant from constants.py to
             # ensure a single definition across all writers.
-            target_file.write_text(BANNER_DEPLOYED + "\n\n".join(merged_content))
+            #
+            # Always propagate the source PM_INSTRUCTIONS_VERSION tag into the
+            # written file, right after the banner. InstructionLoader uses this
+            # tag (via _extract_version) to decide whether the deployed file is
+            # current relative to source. A user/project override of
+            # PM_INSTRUCTIONS.md usually omits the tag, which would make the
+            # deployed file read as v0 and be discarded as "stale" on every
+            # startup. Injecting the source tag keeps the fast-path usable.
+            version_tag = self._source_pm_version_tag(agents_path)
+            header = BANNER_DEPLOYED
+            if version_tag:
+                header = f"{header}{version_tag}\n\n"
+            target_file.write_text(header + "\n\n".join(merged_content))
 
             source_desc = ", ".join(str(p) for p in watched_paths if p.exists())
             deployment_info = {

--- a/tests/services/agents/deployment/test_deployed_version_propagation.py
+++ b/tests/services/agents/deployment/test_deployed_version_propagation.py
@@ -1,0 +1,228 @@
+"""Tests for PM_INSTRUCTIONS_VERSION propagation in SystemInstructionsDeployer.
+
+Regression coverage for GitHub issue #757:
+
+PM_INSTRUCTIONS_DEPLOYED.md is the runtime fast-path (PRIORITY 1 in
+InstructionLoader). The loader decides whether to use it by comparing the
+``PM_INSTRUCTIONS_VERSION`` tag in the deployed file against the same tag in the
+source PM_INSTRUCTIONS.md (via ``InstructionLoader._extract_version``). If the
+deployed file lacks the tag, ``_extract_version`` returns 0, the loader sees
+``0 < source`` and discards the freshly-rebuilt file as "stale" on every
+startup — writing it, warning about it, and never using it.
+
+The deployer must always propagate the *source* version tag into the written
+file, independent of whether a user/project override of PM_INSTRUCTIONS.md
+carries the tag (it usually does not).
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+from claude_mpm.config.paths import ClaudeMPMPaths
+from claude_mpm.core.framework.loaders.instruction_loader import InstructionLoader
+from claude_mpm.services.agents.deployment.system_instructions_deployer import (
+    SystemInstructionsDeployer,
+)
+
+SOURCE_VERSION = 16  # arbitrary "source" framework version used in fixtures
+
+
+def _make_system_files(agents_path: Path, *, version: int = SOURCE_VERSION) -> None:
+    """Create minimal system-level framework files in *agents_path*.
+
+    The system PM_INSTRUCTIONS.md carries a ``PM_INSTRUCTIONS_VERSION`` tag so
+    the deployer has a source version to propagate.
+    """
+    (agents_path / "PM_INSTRUCTIONS.md").write_text(
+        f"<!-- PM_INSTRUCTIONS_VERSION: {version:04d} -->\n"
+        "# PM Instructions\n\n## PM Core Identity\nSystem PM instructions.\n",
+        encoding="utf-8",
+    )
+    (agents_path / "AGENT_DELEGATION.md").write_text(
+        "# Agent Delegation\n\n## Available Agent Capabilities\nDelegation content.\n",
+        encoding="utf-8",
+    )
+    (agents_path / "WORKFLOW.md").write_text(
+        "# Workflow\n\n## Mandatory 5-Phase Sequence\nPhases.\n",
+        encoding="utf-8",
+    )
+    (agents_path / "MEMORY.md").write_text(
+        "# Memory\n\n## Static Memory Management\nMemory content.\n",
+        encoding="utf-8",
+    )
+
+
+def _deploy(
+    tmp_path: Path,
+    working_directory: Path,
+    agents_path: Path,
+) -> str:
+    """Run deploy_system_instructions and return the deployed file contents."""
+    fake_home = tmp_path / "fakehome"  # non-existent → no user override
+
+    logger = logging.getLogger("test_deployed_version_propagation")
+    deployer = SystemInstructionsDeployer(logger, working_directory)
+    results: dict = {"deployed": [], "updated": [], "errors": []}
+
+    with (
+        patch.object(
+            ClaudeMPMPaths,
+            "agents_dir",
+            new_callable=PropertyMock,
+            return_value=agents_path,
+        ),
+        patch(
+            "claude_mpm.services.agents.deployment.system_instructions_deployer.Path.home",
+            return_value=fake_home,
+        ),
+    ):
+        deployer.deploy_system_instructions(
+            target_dir=tmp_path,
+            force_rebuild=True,
+            results=results,
+        )
+
+    assert not results["errors"], f"Deployment errors: {results['errors']}"
+
+    deployed_file = working_directory / ".claude-mpm" / "PM_INSTRUCTIONS_DEPLOYED.md"
+    assert deployed_file.exists(), "PM_INSTRUCTIONS_DEPLOYED.md was not created"
+    return deployed_file.read_text(encoding="utf-8")
+
+
+class TestDeployedVersionPropagation:
+    """Deployed file carries the source version so the loader keeps it."""
+
+    def test_deployed_version_matches_source_no_override(self, tmp_path: Path) -> None:
+        """With only system files, the deployed file carries the source version."""
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "project"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        loader = InstructionLoader()
+        deployed_version = loader._extract_version(deployed)
+        assert deployed_version == SOURCE_VERSION, (
+            f"Deployed version {deployed_version} != source {SOURCE_VERSION}; "
+            "InstructionLoader would discard the deployed file as stale."
+        )
+
+    def test_deployed_version_present_when_override_lacks_tag(
+        self, tmp_path: Path
+    ) -> None:
+        """A project override without a version tag must NOT zero out the version.
+
+        This is the exact issue #757 failure: a user customises
+        .claude-mpm/PM_INSTRUCTIONS.md without copying the version comment, so
+        the merged block has no tag. The deployer must still inject the source
+        tag so the deployed file is not seen as v0.
+        """
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "project"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+
+        # Project override WITHOUT a version tag (the common customization case).
+        project_mpm_dir = working_dir / ".claude-mpm"
+        project_mpm_dir.mkdir()
+        (project_mpm_dir / "PM_INSTRUCTIONS.md").write_text(
+            "# Custom PM\n\n## Identity\nMy custom PM, no version tag.\n",
+            encoding="utf-8",
+        )
+
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        loader = InstructionLoader()
+        deployed_version = loader._extract_version(deployed)
+        assert deployed_version == SOURCE_VERSION, (
+            "Override without a version tag caused the deployed file to read as "
+            f"v{deployed_version:04d} instead of source v{SOURCE_VERSION:04d}; "
+            "the file would be discarded as stale on every startup (issue #757)."
+        )
+        # And the override content is still present (override semantics intact).
+        assert "My custom PM, no version tag." in deployed
+
+    def test_deployed_not_stale_against_source(self, tmp_path: Path) -> None:
+        """End-to-end: deployed version is never < source version.
+
+        Mirrors the comparison InstructionLoader._load_filesystem_framework_instructions
+        performs to decide between the deployed fast-path and the source file.
+        """
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "project"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        source_content = (agents_path / "PM_INSTRUCTIONS.md").read_text()
+        loader = InstructionLoader()
+        deployed_version = loader._extract_version(deployed)
+        source_version = loader._extract_version(source_content)
+
+        assert deployed_version >= source_version, (
+            f"Deployed v{deployed_version:04d} < source v{source_version:04d}: "
+            "the loader would log 'stale' and discard the fast-path."
+        )
+
+    def test_version_tag_appears_after_banner(self, tmp_path: Path) -> None:
+        """The banner stays first; the version tag follows it.
+
+        Banner-first is required (humans must see DO NOT EDIT immediately), and
+        the version tag must still be discoverable by the unanchored regex.
+        """
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "project"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        assert deployed.startswith("<!-- AUTO-GENERATED by claude-mpm"), (
+            "Banner must remain the first content in the deployed file."
+        )
+        assert "PM_INSTRUCTIONS_VERSION:" in deployed, (
+            "Deployed file must contain a PM_INSTRUCTIONS_VERSION tag."
+        )
+
+    def test_missing_source_version_tag_is_tolerated(self, tmp_path: Path) -> None:
+        """If the source itself has no version tag, deployment still succeeds.
+
+        Both deployed and source read as v0, so deployed is not < source and the
+        loader still accepts it — no crash, no spurious injection.
+        """
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "project"
+        working_dir.mkdir()
+
+        # System PM_INSTRUCTIONS.md WITHOUT a version tag.
+        (agents_path / "PM_INSTRUCTIONS.md").write_text(
+            "# PM Instructions\n\n## PM Core Identity\nNo version.\n",
+            encoding="utf-8",
+        )
+        (agents_path / "AGENT_DELEGATION.md").write_text(
+            "# Agent Delegation\n\n## Available Agent Capabilities\nx\n",
+            encoding="utf-8",
+        )
+        (agents_path / "WORKFLOW.md").write_text(
+            "# Workflow\n\n## Mandatory 5-Phase Sequence\nx\n",
+            encoding="utf-8",
+        )
+        (agents_path / "MEMORY.md").write_text(
+            "# Memory\n\n## Static Memory Management\nx\n",
+            encoding="utf-8",
+        )
+
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        loader = InstructionLoader()
+        # No tag anywhere → v0 == v0, deployed is not stale.
+        assert loader._extract_version(deployed) == 0


### PR DESCRIPTION
## Issue
Closes #757

`PM_INSTRUCTIONS_DEPLOYED.md` was written on every startup but always ignored. The deployer prepends a banner (no version tag) and merges the resolved blocks. When a user/project override of `PM_INSTRUCTIONS.md` omits the `PM_INSTRUCTIONS_VERSION` tag — the common case, since users don't know to copy it — the merged content has no tag, so `InstructionLoader._extract_version` returns 0. The loader then sees `deployed v0 < source v0016`, logs "stale", and discards the freshly-rebuilt file. So it was written, warned about, and never used.

## Decision: Option A (make the deployed file usable)

The deployed file **is** the intended runtime fast-path (PRIORITY 1 in `InstructionLoader._load_filesystem_framework_instructions`). The lazy-load WORKFLOW machinery and the version-comparison logic both exist precisely to serve and validate it. Removing it (Option B) would throw away a working optimization and the loader's whole PRIORITY-1 branch.

The fix propagates the **source** `PM_INSTRUCTIONS_VERSION` tag into the written file, right after the banner, regardless of whether an override carries it. The version now correctly expresses "this file was compiled from framework version NNNN", which is exactly the semantic the deployed-vs-source staleness check needs. `_extract_version` uses an unanchored `re.search`, so injecting the tag after the banner is found correctly; banner-first (DO NOT EDIT) is preserved.

## Changes
- `services/agents/deployment/system_instructions_deployer.py` — add `_source_pm_version_tag()`; inject the source version tag after the banner when writing `PM_INSTRUCTIONS_DEPLOYED.md`. Tolerates a source file with no tag (both read v0 → not stale).
- `agents/BASE_PM.md` — "Customizing PM Behavior" table: the "Full PM replacement" row pointed at the auto-generated `PM_INSTRUCTIONS_DEPLOYED.md`; corrected to `.claude-mpm/PM_INSTRUCTIONS.md` (the real override block) and clarified the deployed file must not be hand-edited.
- `cli/startup.py` — `run_background_services()` docstring claimed instructions do NOT deploy on startup; corrected to describe `sync_deployment_on_startup() → _rebuild_pm_instructions_deployed()` rebuilding the file every startup, plus the version-tag propagation.
- `tests/services/agents/deployment/test_deployed_version_propagation.py` — new regression test (5 cases): version matches source with no override, with an override lacking the tag (the #757 case), deployed never < source, banner-first + tag present, and source-without-tag tolerated.

## Tests
13 passed (new propagation suite + workflow-lazy-load deployer suite); 27 passed across the assembled-prompt snapshot, no-auto-deploy, and instructions-deployment suites. `tests/data/startup_context_baseline.json` intentionally untouched.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
