### PR TITLE
chore: refresh stale PM templates + deploy ticket-completeness-examples (#761)

### DIFF
--- a/src/claude_mpm/agents/templates/README.md
+++ b/src/claude_mpm/agents/templates/README.md
@@ -1,7 +1,7 @@
 # 🎯 PM Instruction Templates Ecosystem
 
 **Version**: 1.0.0
-**Last Updated**: 2025-10-21
+**Last Updated**: see git history
 **Parent Document**: [PM_INSTRUCTIONS.md](../PM_INSTRUCTIONS.md)
 
 Welcome to the PM Template Ecosystem - a modular system of specialized templates that enforce PM delegation discipline through validation, detection, examples, and standardization.
@@ -370,20 +370,24 @@ The PM Template Ecosystem modularizes PM instruction content into specialized, f
 ## 📊 Version Information
 
 **Current Ecosystem Version**: 1.0.0
-**Release Date**: 2025-10-21
-**Total Lines**: 2,831 lines
-**Total Templates**: 6 templates
+**Release Date**: see git history
+**Total Templates**: 11 templates (see deploy list in system_instructions_deployer.py)
 
 ### Template Version Matrix
 
-| Template | Version | Last Updated | Status |
-|----------|---------|--------------|--------|
-| validation_templates.md | 1.0.0 | 2025-10-20 | Stable |
-| circuit_breakers.md | 1.0.0 | 2025-10-20 | Stable |
-| pm_examples.md | 1.0.0 | 2025-10-20 | Stable |
-| git_file_tracking.md | 1.0.0 | 2025-10-21 | Stable |
-| pm_red_flags.md | 1.0.0 | 2025-10-21 | Stable |
-| response_format.md | 1.0.0 | 2025-10-21 | Stable |
+| Template | Status |
+|----------|--------|
+| validation_templates.md | Stable |
+| circuit_breakers.md | Stable |
+| pm_examples.md | Stable |
+| git_file_tracking.md | Stable |
+| pm_red_flags.md | Stable |
+| response_format.md | Stable |
+| context_management_examples.md | Stable |
+| research_gate_examples.md | Stable |
+| ticketing_examples.md | Stable |
+| ticket_completeness_examples.md | Stable |
+| structured_questions_examples.md | Stable |
 
 ### Changelog
 
@@ -460,6 +464,6 @@ For questions, issues, or suggestions:
 
 ---
 
-**Last Updated**: 2025-10-21
+**Last Updated**: see git history
 **Maintained By**: Claude MPM Development Team
 **Status**: Active, Stable (v1.0.0)

--- a/src/claude_mpm/agents/templates/context-management-examples.md
+++ b/src/claude_mpm/agents/templates/context-management-examples.md
@@ -540,5 +540,5 @@ Ready to continue. What would you like to work on?"
 
 ---
 
-**Last Updated**: 2025-12-01
+**Last Updated**: 2026-06-11
 **Phase**: Phase 3 Optimization - Example Extraction

--- a/src/claude_mpm/agents/templates/research-gate-examples.md
+++ b/src/claude_mpm/agents/templates/research-gate-examples.md
@@ -80,13 +80,6 @@ Step 4: Then delegate implementation with validated approach
 | "Optimize /api/users query: target <100ms from current 500ms" | ❌ NO | Clear: specific query, metric, baseline, target |
 | "Implement feature X" | ✅ YES | Needs requirements, acceptance criteria |
 | "Build dashboard" | ✅ YES | Needs design, metrics, data sources |
-# Research Gate Template Additions
-
-**Instructions**: Add this content to `/Users/masa/Projects/claude-mpm/src/claude_mpm/agents/templates/research-gate-examples.md`
-
-**Current template size**: 83 lines
-**After additions**: ~300 lines
-**New sections**: 5 major additions
 
 ---
 

--- a/src/claude_mpm/agents/templates/ticketing-examples.md
+++ b/src/claude_mpm/agents/templates/ticketing-examples.md
@@ -273,5 +273,5 @@ Ticketing: Returns 1 ticket in 185 tokens
 
 ---
 
-**Last Updated**: 2025-12-01
+**Last Updated**: 2026-06-11
 **Phase**: Phase 3 Optimization - Example Extraction

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -333,6 +333,7 @@ class SystemInstructionsDeployer:
                 "research-gate-examples.md",
                 "response-format.md",
                 "structured-questions-examples.md",
+                "ticket-completeness-examples.md",
                 "ticketing-examples.md",
                 "validation-templates.md",
             ]


### PR DESCRIPTION
## Summary

- **README.md**: Removed hardcoded `2025-10-21` dates and incorrect "6 templates / 2831 lines" stats; replaced with `see git history` and the actual count of 11 deployed templates; extended the version matrix to include all 11 templates.
- **research-gate-examples.md**: Removed a stale dev-artifact block ("# Research Gate Template Additions / Instructions: Add this content to...") that was left over from authoring; not real content.
- **context-management-examples.md** / **ticketing-examples.md**: Bumped `Last Updated` footer from `2025-12-01` to `2026-06-11`.
- **system_instructions_deployer.py**: Added `ticket-completeness-examples.md` to the `pm_templates` deploy list. The file already existed in `agents/templates/` but was orphaned (present on disk, never deployed to active agents). File is present ↔ now in list.

Dev artifacts (`.claude-mpm/memories/README.md`) remain gitignored and are not shipped.

## Ticket-completeness decision

File `ticket-completeness-examples.md` **exists** in `agents/templates/`, so it is **added** to the deployer list. This is a wire-up, not a new file.

## Test plan

- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed, 2167 files unchanged
- [x] `uv run pytest -p no:xdist -k "deploy or template or instructions" -v` — **1348 passed, 54 skipped, 0 failed** in 102s
- [x] One file per commit, conventional prefixes, `Closes #761` on deployer commit

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)