### PR TITLE
fix: rename trusty-analyzer → trusty-analyze throughout (#782)

### DIFF
--- a/src/claude_mpm/cli/commands/setup/command.py
+++ b/src/claude_mpm/cli/commands/setup/command.py
@@ -303,7 +303,7 @@ class SetupCommand(
   notion-mpm             Set up Notion MCP server (official @notionhq package)
   trusty-search          Set up trusty-search Rust hybrid code search daemon
   trusty-memory          Set up trusty-memory Rust AI memory daemon
-  trusty-analyze         Set up trusty-analyzer Rust code-analysis sidecar daemon
+  trusty-analyze         Set up trusty-analyze Rust code-analysis sidecar daemon
   oauth                  Set up OAuth authentication
 
 [bold]Service Options:[/bold]

--- a/src/claude_mpm/cli/commands/setup/handlers/trusty.py
+++ b/src/claude_mpm/cli/commands/setup/handlers/trusty.py
@@ -651,22 +651,21 @@ class TrustyMixin:
         return CommandResult.success_result("trusty-memory setup complete")
 
     def _setup_trusty_analyze(self, args) -> CommandResult:
-        """Set up trusty-analyzer Rust code-analysis sidecar daemon.
+        """Set up trusty-analyze Rust code-analysis sidecar daemon.
 
-        The installed binary is ``trusty-analyzer`` (note the trailing "r");
-        only the user-facing setup verb is ``trusty-analyze`` so it matches
-        the GitHub repo name.
+        The binary is named ``trusty-analyze`` (matching the GitHub repo name).
+        The MCP stdio interface is exposed via ``trusty-analyze mcp``.
 
         Steps:
         1. Install via cargo (from git) if missing.
         2. Ensure daemon is running on http://127.0.0.1:7879 (launchd plist).
-        3. Write ``.mcp.json`` entry pointing at ``trusty-analyzer mcp``.
+        3. Write ``.mcp.json`` entry pointing at ``trusty-analyze mcp``.
 
         :spec: SPEC-INTEGRATIONS-02~1
         """
-        console.print("\n[bold cyan]Trusty Analyzer MCP Setup[/bold cyan]")
+        console.print("\n[bold cyan]Trusty Analyze MCP Setup[/bold cyan]")
         console.print(
-            "Installs trusty-analyzer (Rust code-analysis sidecar daemon) and "
+            "Installs trusty-analyze (Rust code-analysis sidecar daemon) and "
             "wires it into this project's .mcp.json. Sits next to trusty-search "
             "on port 7879.\n"
         )
@@ -676,24 +675,24 @@ class TrustyMixin:
         if install_err is not None:
             return install_err
 
-        binary_path = self._cargo_bin_path("trusty-analyzer")
+        binary_path = self._cargo_bin_path("trusty-analyze")
 
         # 2. Ensure daemon running on 7879
         health_url = "http://127.0.0.1:7879/health"
         if self._http_health_check(health_url):
-            console.print("[green]✓ trusty-analyzer daemon already running[/green]")
+            console.print("[green]✓ trusty-analyze daemon already running[/green]")
         else:
             console.print(
                 "[cyan]Daemon not running — installing persistent launchd agent...[/cyan]"
             )
             plist_path = self._write_launchd_plist(
-                label="com.bobmatnyc.trusty-analyzer",
+                label="com.bobmatnyc.trusty-analyze",
                 binary_path=binary_path,
                 args=["serve"],
-                stdout_path="/tmp/trusty-analyzer.log",  # nosec B108
-                stderr_path="/tmp/trusty-analyzer-error.log",  # nosec B108
+                stdout_path="/tmp/trusty-analyze.log",  # nosec B108
+                stderr_path="/tmp/trusty-analyze-error.log",  # nosec B108
             )
-            self._ensure_launchd_loaded("com.bobmatnyc.trusty-analyzer", plist_path)
+            self._ensure_launchd_loaded("com.bobmatnyc.trusty-analyze", plist_path)
 
             # Give the daemon a moment to come up, then re-probe.
             import time
@@ -706,7 +705,7 @@ class TrustyMixin:
                 console.print(
                     "[yellow]⚠ Could not confirm daemon health on "
                     "http://127.0.0.1:7879 — continuing anyway. "
-                    "Check /tmp/trusty-analyzer-error.log if MCP calls fail.[/yellow]"
+                    "Check /tmp/trusty-analyze-error.log if MCP calls fail.[/yellow]"
                 )
 
         # 3. Write .mcp.json entry (with rollback on failure)
@@ -714,13 +713,13 @@ class TrustyMixin:
             with _mcp_config_transaction():
                 mcp_config = self._load_mcp_config()
                 mcp_config.setdefault("mcpServers", {})
-                mcp_config["mcpServers"]["trusty-analyzer"] = {
+                mcp_config["mcpServers"]["trusty-analyze"] = {
                     "type": "stdio",
-                    "command": "trusty-analyzer",
+                    "command": "trusty-analyze",
                     "args": ["mcp"],
                 }
                 self._save_mcp_config(mcp_config)
-                console.print("[green]✓ Added trusty-analyzer to .mcp.json[/green]")
+                console.print("[green]✓ Added trusty-analyze to .mcp.json[/green]")
         except Exception as e:
             console.print(f"[red]✗ Failed to update .mcp.json: {e}[/red]")
             return CommandResult.error_result(f".mcp.json update failed: {e}")
@@ -728,7 +727,7 @@ class TrustyMixin:
         console.print(
             "\n[bold green]✓ trusty-analyze setup complete![/bold green]\n"
             "  • Daemon: http://127.0.0.1:7879\n"
-            "  • MCP server: stdio via `trusty-analyzer mcp`\n"
-            "  • Logs: /tmp/trusty-analyzer.log\n"
+            "  • MCP server: stdio via `trusty-analyze mcp`\n"
+            "  • Logs: /tmp/trusty-analyze.log\n"
         )
         return CommandResult.success_result("trusty-analyze setup complete")

--- a/src/claude_mpm/cli/commands/setup/handlers/trusty.py
+++ b/src/claude_mpm/cli/commands/setup/handlers/trusty.py
@@ -1,4 +1,4 @@
-"""Trusty (Rust) daemon setup: trusty-search, trusty-memory, trusty-analyzer.
+"""Trusty (Rust) daemon setup: trusty-search, trusty-memory, trusty-analyze.
 
 Each `_setup_trusty_*` follows the same shape:
 1. cargo-install the binary if missing.
@@ -27,7 +27,7 @@ from ..mcp_config import _mcp_config_transaction
 
 
 class TrustyMixin:
-    """Mixin: trusty-search / trusty-memory / trusty-analyzer setup.
+    """Mixin: trusty-search / trusty-memory / trusty-analyze setup.
 
     :spec: SPEC-INTEGRATIONS-01~1
     """

--- a/src/claude_mpm/cli/constants.py
+++ b/src/claude_mpm/cli/constants.py
@@ -84,7 +84,7 @@ class MCPBinary(StrEnum):
     MCP_SKILLSET = "mcp-skillset"
     TRUSTY_SEARCH = "trusty-search"
     TRUSTY_MEMORY = "trusty-memory"
-    TRUSTY_ANALYZER = "trusty-analyzer"
+    TRUSTY_ANALYZE = "trusty-analyze"
 
     def __str__(self) -> str:
         return self.value

--- a/src/claude_mpm/cli/parsers/setup_parser.py
+++ b/src/claude_mpm/cli/parsers/setup_parser.py
@@ -36,7 +36,7 @@ Available services:
   mcp-skillset           Set up mcp-skillset RAG-powered skills (USER-LEVEL, not project-specific)
   trusty-search          Set up trusty-search Rust hybrid code search daemon (port 7878)
   trusty-memory          Set up trusty-memory Rust AI memory daemon (port 3038)
-  trusty-analyze         Set up trusty-analyzer Rust code-analysis sidecar (port 7879)
+  trusty-analyze         Set up trusty-analyze Rust code-analysis sidecar (port 7879)
 
 Service options:
   --oauth-service NAME   Service name for OAuth setup (required for oauth)

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -222,6 +222,13 @@ def _run_clean_global_settings_metadata_migration() -> bool:
     return run_migration()
 
 
+def _run_rename_trusty_analyzer_migration() -> bool:
+    """Rename stale trusty-analyzer MCP entry to trusty-analyze and clean up launchd plist (issue #782)."""
+    from .v6_5_34_rename_trusty_analyzer import run_migration
+
+    return run_migration()
+
+
 def _run_remove_absolute_hook_paths_migration() -> bool:
     """Replace absolute MPM hook paths with the portable 'claude-hook' entry point (issue #563)."""
     from pathlib import Path
@@ -400,6 +407,12 @@ MIGRATIONS: list[Migration] = [
         version="6.5.21",
         description="Remove stale _mpm_managed/_mpm_version metadata and leftover MPM hook entries from global ~/.claude/settings.json (issue #676)",
         run=_run_clean_global_settings_metadata_migration,
+    ),
+    Migration(
+        id="v6_5_34_rename_trusty_analyzer",
+        version="6.5.34",
+        description="Rename stale trusty-analyzer MCP server entry to trusty-analyze and remove old com.bobmatnyc.trusty-analyzer launchd plist (issue #782)",
+        run=_run_rename_trusty_analyzer_migration,
     ),
 ]
 

--- a/src/claude_mpm/migrations/v6_5_34_rename_trusty_analyzer.py
+++ b/src/claude_mpm/migrations/v6_5_34_rename_trusty_analyzer.py
@@ -1,0 +1,270 @@
+"""Rename stale ``trusty-analyzer`` MCP entry to ``trusty-analyze``.
+
+WHAT: Removes the broken ``trusty-analyzer`` MCP server entry that older
+    versions of claude-mpm wrote, replacing it with the canonical
+    ``trusty-analyze`` entry (command ``trusty-analyze``, args ``["mcp"]``).
+    Also unloads and removes the old ``com.bobmatnyc.trusty-analyzer`` launchd
+    plist when present (macOS only).
+
+WHY: PR #782 renamed the binary and all wiring from ``trusty-analyzer`` to
+    ``trusty-analyze``.  Existing users who had already run
+    ``claude-mpm setup trusty-analyze`` before the rename (when the old binary
+    name was still ``trusty-analyzer``) are left with a broken MCP entry that
+    tries to execute a non-existent binary, and a launchd plist that keeps
+    respawning it.  This migration repairs both without user intervention.
+
+Ordering relative to ``migrate_fix_trusty_memory_bridge``
+----------------------------------------------------------
+The bridge-fix migration (version 6.5.0) explicitly preserves any
+``trusty-analyzer`` entry (it only touches ``trusty-memory`` entries).
+This migration (6.5.34) runs *after* the bridge-fix and converts the
+preserved-but-now-stale ``trusty-analyzer`` entry.  The two migrations are
+therefore safe to run in sequence.
+
+Scanned locations (mirrors ``migrate_fix_trusty_memory_bridge``):
+
+* ``./.mcp.json`` (project-scoped)
+* ``./.claude/settings.json`` and ``./.claude/settings.local.json``
+* ``~/.claude/.mcp.json``
+* ``~/.claude/settings.json``
+
+Design constraints:
+
+* **Idempotent**: if ``trusty-analyzer`` is absent (or already removed) the
+  migration is a no-op.  If ``trusty-analyze`` already exists and
+  ``trusty-analyzer`` is absent the migration is a no-op.
+* **Merge-safe**: if both ``trusty-analyzer`` AND ``trusty-analyze`` already
+  exist, the stale ``trusty-analyzer`` key is dropped (no duplicate).
+* **Graceful**: malformed JSON, unreadable files, or subprocess errors are
+  logged as warnings and never raise.
+* **macOS-only launchd cleanup**: the plist removal block is guarded by
+  ``sys.platform == "darwin"`` so the migration is a no-op on Linux/Windows.
+
+References
+----------
+SPEC-INTEGRATIONS-09~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-09~1
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_OLD_KEY = "trusty-analyzer"
+_NEW_KEY = "trusty-analyze"
+_CANONICAL_ENTRY: dict[str, Any] = {
+    "type": "stdio",
+    "command": "trusty-analyze",
+    "args": ["mcp"],
+}
+_OLD_PLIST_LABEL = "com.bobmatnyc.trusty-analyzer"
+
+
+# ---------------------------------------------------------------------------
+# MCP config helpers
+# ---------------------------------------------------------------------------
+
+
+def _fix_servers(servers: Any) -> bool:
+    """Rename or drop the stale ``trusty-analyzer`` key in a ``mcpServers`` mapping.
+
+    WHAT: Mutates *servers* in-place.  Returns True when a change was made.
+    WHY: In-place mutation avoids constructing an entirely new dict and keeps
+    key order stable for the rest of the entries.
+
+    Logic:
+    * Neither key present → no-op (return False).
+    * Only ``trusty-analyzer`` present → rename to ``trusty-analyze``,
+      overwrite command/args with canonical values.
+    * Both present → drop ``trusty-analyzer`` (``trusty-analyze`` already
+      exists, don't duplicate).
+    * Only ``trusty-analyze`` present → no-op.
+    """
+    if not isinstance(servers, dict):
+        return False
+
+    has_old = _OLD_KEY in servers
+    has_new = _NEW_KEY in servers
+
+    if not has_old:
+        return False
+
+    if has_new:
+        # Both exist: the new entry is already there, just drop the stale old one.
+        del servers[_OLD_KEY]
+        logger.info(
+            "Dropped stale '%s' entry (canonical '%s' already present)",
+            _OLD_KEY,
+            _NEW_KEY,
+        )
+    else:
+        # Only old exists: rename + canonicalise.
+        entry = servers.pop(_OLD_KEY)
+        if not isinstance(entry, dict):
+            entry = {}
+        entry["command"] = _CANONICAL_ENTRY["command"]
+        entry["args"] = list(_CANONICAL_ENTRY["args"])
+        entry.setdefault("type", _CANONICAL_ENTRY["type"])
+        servers[_NEW_KEY] = entry
+        logger.info(
+            "Renamed MCP server '%s' → '%s' with canonical command/args",
+            _OLD_KEY,
+            _NEW_KEY,
+        )
+
+    return True
+
+
+def _process_file(path: Path) -> bool:
+    """Load *path*, fix stale trusty-analyzer entry, write back if changed.
+
+    Returns True iff the file was modified.  Missing / unreadable / malformed
+    files are silently skipped.
+    """
+    if not path.exists():
+        return False
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Skipping %s: cannot parse JSON (%s)", path, exc)
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    servers = data.get("mcpServers")
+    if not _fix_servers(servers):
+        return False
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+    except OSError as exc:
+        logger.warning("Failed to write %s: %s", path, exc)
+        return False
+
+    logger.info("Updated %s: trusty-analyzer → trusty-analyze", path)
+    return True
+
+
+def _candidate_paths(project_dir: Path) -> list[Path]:
+    """Return config file candidates to scan.
+
+    Mirrors ``migrate_fix_trusty_memory_bridge._candidate_paths``.
+    """
+    home = Path.home()
+    return [
+        project_dir / ".mcp.json",
+        project_dir / ".claude" / "settings.json",
+        project_dir / ".claude" / "settings.local.json",
+        home / ".claude" / ".mcp.json",
+        home / ".claude" / "settings.json",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# launchd plist cleanup (macOS only)
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_launchd_plist() -> None:
+    """Unload and remove the old ``com.bobmatnyc.trusty-analyzer`` launchd plist.
+
+    WHAT: No-op when the plist file does not exist or on non-macOS platforms.
+    WHY: The old plist keeps trying to start the absent ``trusty-analyzer``
+    binary, generating repeated spawn-failure log noise and consuming launchd
+    resources.
+
+    Guard patterns (mirrors project hook/migration stability rules):
+    * ``sys.platform`` check so the whole block is skipped on non-macOS.
+    * Each subprocess call gets a ``timeout`` and ``check=False`` — errors are
+      logged as warnings, never raised.
+    * File removal is guarded by ``Path.exists()`` before ``Path.unlink()``.
+    """
+    if sys.platform != "darwin":
+        return
+
+    plist_path = Path.home() / "Library" / "LaunchAgents" / f"{_OLD_PLIST_LABEL}.plist"
+    if not plist_path.exists():
+        return
+
+    logger.info("Found stale launchd plist: %s — removing", plist_path)
+
+    # Try ``launchctl bootout`` (macOS 10.10+), fall back to ``unload``.
+    for cmd in (
+        ["launchctl", "bootout", f"gui/{_get_uid()}", str(plist_path)],
+        ["launchctl", "unload", str(plist_path)],
+    ):
+        try:
+            result = subprocess.run(  # nosec B603 B607
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                logger.info("Unloaded launchd agent: %s", _OLD_PLIST_LABEL)
+                break
+            logger.debug(
+                "launchctl cmd %s exited %d: %s",
+                cmd[1],
+                result.returncode,
+                result.stderr.strip(),
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("launchctl call failed (%s): %s", cmd[1], exc)
+
+    try:
+        plist_path.unlink(missing_ok=True)
+        logger.info("Removed plist: %s", plist_path)
+    except OSError as exc:
+        logger.warning("Could not remove plist %s: %s", plist_path, exc)
+
+
+def _get_uid() -> int:
+    """Return the current process UID (POSIX).  Returns 0 on non-POSIX."""
+    try:
+        import os
+
+        return os.getuid()
+    except AttributeError:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_migration(project_dir: Path | None = None) -> bool:
+    """Scan config files and repair stale ``trusty-analyzer`` MCP entries.
+
+    Args:
+        project_dir: Project root to scan (defaults to ``Path.cwd()``).
+            Tests inject a temp directory here to keep the scan hermetic.
+
+    Returns:
+        True if any MCP config file was modified OR if the launchd plist was
+        cleaned up.  False when everything was already up-to-date (or no
+        relevant files existed).
+    """
+    project_dir = project_dir or Path.cwd()
+
+    any_changed = False
+    for path in _candidate_paths(project_dir):
+        if _process_file(path):
+            any_changed = True
+
+    _cleanup_launchd_plist()
+
+    return any_changed

--- a/src/claude_mpm/migrations/v6_5_34_rename_trusty_analyzer.py
+++ b/src/claude_mpm/migrations/v6_5_34_rename_trusty_analyzer.py
@@ -104,14 +104,15 @@ def _fix_servers(servers: Any) -> bool:
             _NEW_KEY,
         )
     else:
-        # Only old exists: rename + canonicalise.
-        entry = servers.pop(_OLD_KEY)
-        if not isinstance(entry, dict):
-            entry = {}
-        entry["command"] = _CANONICAL_ENTRY["command"]
-        entry["args"] = list(_CANONICAL_ENTRY["args"])
-        entry.setdefault("type", _CANONICAL_ENTRY["type"])
-        servers[_NEW_KEY] = entry
+        # Only old exists: remove it and insert a fresh canonical entry.
+        # We do NOT inherit unknown fields (e.g. a stale ``env`` pointing at the
+        # old binary) from the old dict — build clean from _CANONICAL_ENTRY.
+        servers.pop(_OLD_KEY)
+        servers[_NEW_KEY] = {
+            "type": _CANONICAL_ENTRY["type"],
+            "command": _CANONICAL_ENTRY["command"],
+            "args": list(_CANONICAL_ENTRY["args"]),
+        }
         logger.info(
             "Renamed MCP server '%s' → '%s' with canonical command/args",
             _OLD_KEY,
@@ -176,13 +177,16 @@ def _candidate_paths(project_dir: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-def _cleanup_launchd_plist() -> None:
+def _cleanup_launchd_plist() -> bool:
     """Unload and remove the old ``com.bobmatnyc.trusty-analyzer`` launchd plist.
 
-    WHAT: No-op when the plist file does not exist or on non-macOS platforms.
+    WHAT: Returns True iff the plist was found and at least an unload or removal
+    was attempted (i.e. something was actually cleaned up).  Returns False when
+    the plist does not exist or on non-macOS platforms (pure no-op).
     WHY: The old plist keeps trying to start the absent ``trusty-analyzer``
     binary, generating repeated spawn-failure log noise and consuming launchd
-    resources.
+    resources.  The bool return lets ``run_migration`` honour its documented
+    contract (True iff anything was modified *or* cleaned up).
 
     Guard patterns (mirrors project hook/migration stability rules):
     * ``sys.platform`` check so the whole block is skipped on non-macOS.
@@ -191,11 +195,11 @@ def _cleanup_launchd_plist() -> None:
     * File removal is guarded by ``Path.exists()`` before ``Path.unlink()``.
     """
     if sys.platform != "darwin":
-        return
+        return False
 
     plist_path = Path.home() / "Library" / "LaunchAgents" / f"{_OLD_PLIST_LABEL}.plist"
     if not plist_path.exists():
-        return
+        return False
 
     logger.info("Found stale launchd plist: %s — removing", plist_path)
 
@@ -229,6 +233,9 @@ def _cleanup_launchd_plist() -> None:
         logger.info("Removed plist: %s", plist_path)
     except OSError as exc:
         logger.warning("Could not remove plist %s: %s", plist_path, exc)
+
+    # We found and acted on the plist (even if launchctl or unlink had errors).
+    return True
 
 
 def _get_uid() -> int:
@@ -265,6 +272,6 @@ def run_migration(project_dir: Path | None = None) -> bool:
         if _process_file(path):
             any_changed = True
 
-    _cleanup_launchd_plist()
+    plist_cleaned = _cleanup_launchd_plist()
 
-    return any_changed
+    return any_changed or plist_cleaned

--- a/src/claude_mpm/services/mcp/config_builder.py
+++ b/src/claude_mpm/services/mcp/config_builder.py
@@ -69,9 +69,9 @@ class MCPServiceConfigBuilder:
             "command": "trusty-memory-mcp-bridge",
             "args": [],
         },
-        "trusty-analyzer": {
+        "trusty-analyze": {
             "type": "stdio",
-            "command": "trusty-analyzer",
+            "command": "trusty-analyze",
             "args": ["mcp"],
         },
         # Review-on-demand MCP server. ``env`` carries ONLY non-secret config:

--- a/src/claude_mpm/services/mcp/service_installer.py
+++ b/src/claude_mpm/services/mcp/service_installer.py
@@ -44,7 +44,7 @@ class MCPServiceInstaller:
     CARGO_SERVICES = {
         "trusty-search",
         "trusty-memory",
-        "trusty-analyzer",
+        "trusty-analyze",
     }
 
     # Known missing dependencies for MCP services that pipx doesn't handle

--- a/src/claude_mpm/services/package_installer.py
+++ b/src/claude_mpm/services/package_installer.py
@@ -582,13 +582,12 @@ def get_package_specs() -> dict[SetupService, PackageSpec]:
             bin_name="trusty-memory",
         ),
         SetupService.TRUSTY_ANALYZE: PackageSpec(
-            # Crate package + binary are both named `trusty-analyzer`, but the
-            # repo (and the user-facing setup verb) is `trusty-analyze`.
-            name="trusty-analyzer",
-            binary_name="trusty-analyzer",
+            # Binary and crate are both named `trusty-analyze` (no trailing "r").
+            name="trusty-analyze",
+            binary_name="trusty-analyze",
             installer=InstallerType.CARGO,
             git_url="https://github.com/bobmatnyc/trusty-analyze.git",
-            bin_name="trusty-analyzer",
+            bin_name="trusty-analyze",
         ),
     }
 

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -53,6 +53,7 @@ _HEALTH_TIMEOUT_S = 0.2
 _DEFAULT_PORTS: dict[str, int] = {
     "trusty-memory": 7070,
     "trusty-search": 7878,
+    "trusty-analyze": 7879,
     "trusty-review": 7880,
 }
 
@@ -60,6 +61,7 @@ _DEFAULT_PORTS: dict[str, int] = {
 _SERVICE_EMOJI: dict[str, str] = {
     "trusty-memory": "🧠",
     "trusty-search": "🔍",
+    "trusty-analyze": "🔬",
     "trusty-review": "📝",
 }
 

--- a/tests/migrations/test_rename_trusty_analyzer.py
+++ b/tests/migrations/test_rename_trusty_analyzer.py
@@ -1,0 +1,307 @@
+"""Tests for the trusty-analyzer → trusty-analyze rename migration (issue #782).
+
+Covers:
+(a) Old ``trusty-analyzer`` MCP entry → renamed to ``trusty-analyze`` with
+    canonical command/args.
+(b) Idempotent no-op when already migrated or absent.
+(c) When both old+new exist, stale old entry is dropped.
+(d) launchd subprocess calls and plist removal are mocked so the test suite
+    is hermetic and macOS-independent.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_mpm.migrations import v6_5_34_rename_trusty_analyzer as mod
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_OLD_ENTRY = {
+    "type": "stdio",
+    "command": "trusty-analyzer",
+    "args": ["mcp"],
+}
+_NEW_ENTRY = {
+    "type": "stdio",
+    "command": "trusty-analyze",
+    "args": ["mcp"],
+}
+
+
+def _write_mcp(project_dir: Path, config: dict) -> Path:
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(config, indent=2) + "\n")
+    return mcp_path
+
+
+# ---------------------------------------------------------------------------
+# (a) Old entry → renamed with canonical command/args
+# ---------------------------------------------------------------------------
+
+
+def test_old_entry_renamed(tmp_path: Path) -> None:
+    """trusty-analyzer entry → renamed to trusty-analyze, command/args canonical."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-analyzer": dict(_OLD_ENTRY)}},
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert "trusty-analyzer" not in servers
+    assert servers["trusty-analyze"] == _NEW_ENTRY
+
+
+def test_old_entry_with_wrong_command_corrected(tmp_path: Path) -> None:
+    """Entry keyed trusty-analyzer but with wrong command is corrected."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-analyzer": {
+                    "type": "stdio",
+                    "command": "trusty-analyzer",  # old binary name
+                    "args": ["mcp"],
+                }
+            }
+        },
+    )
+
+    mod.run_migration(project_dir=tmp_path)
+
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert servers["trusty-analyze"]["command"] == "trusty-analyze"
+    assert servers["trusty-analyze"]["args"] == ["mcp"]
+
+
+def test_unrelated_servers_are_preserved(tmp_path: Path) -> None:
+    """Other MCP server entries are left unmodified."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-analyzer": dict(_OLD_ENTRY),
+                "trusty-search": {
+                    "type": "stdio",
+                    "command": "trusty-search",
+                    "args": ["serve"],
+                },
+                "trusty-memory": {
+                    "type": "stdio",
+                    "command": "trusty-memory-mcp-bridge",
+                    "args": [],
+                },
+            }
+        },
+    )
+
+    mod.run_migration(project_dir=tmp_path)
+
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert servers["trusty-search"] == {
+        "type": "stdio",
+        "command": "trusty-search",
+        "args": ["serve"],
+    }
+    assert servers["trusty-memory"] == {
+        "type": "stdio",
+        "command": "trusty-memory-mcp-bridge",
+        "args": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# (b) Idempotent no-op cases
+# ---------------------------------------------------------------------------
+
+
+def test_already_migrated_is_noop(tmp_path: Path) -> None:
+    """trusty-analyze already present and trusty-analyzer absent → no change."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-analyze": dict(_NEW_ENTRY)}},
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_absent_entry_is_noop(tmp_path: Path) -> None:
+    """No trusty-analyzer entry at all → no change, returns False."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"some-other": {"type": "stdio", "command": "other"}}},
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_no_files_is_noop(tmp_path: Path) -> None:
+    """Empty project dir → returns False, no files created."""
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_idempotent_second_run(tmp_path: Path) -> None:
+    """Running twice: first run modifies, second is a no-op."""
+    _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-analyzer": dict(_OLD_ENTRY)}},
+    )
+
+    assert mod.run_migration(project_dir=tmp_path) is True
+    assert mod.run_migration(project_dir=tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# (c) Both old+new exist → drop old, keep new
+# ---------------------------------------------------------------------------
+
+
+def test_both_entries_drops_old(tmp_path: Path) -> None:
+    """When trusty-analyzer AND trusty-analyze both exist, old is dropped."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-analyzer": dict(_OLD_ENTRY),
+                "trusty-analyze": dict(_NEW_ENTRY),
+            }
+        },
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert "trusty-analyzer" not in servers
+    assert servers["trusty-analyze"] == _NEW_ENTRY
+
+
+def test_both_entries_new_is_unchanged(tmp_path: Path) -> None:
+    """When both exist, the existing trusty-analyze entry is not overwritten."""
+    custom_new = {
+        "type": "stdio",
+        "command": "trusty-analyze",
+        "args": ["mcp"],
+        "env": {"FOO": "bar"},
+    }
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-analyzer": dict(_OLD_ENTRY),
+                "trusty-analyze": custom_new,
+            }
+        },
+    )
+
+    mod.run_migration(project_dir=tmp_path)
+
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    # Custom trusty-analyze entry preserved intact.
+    assert servers["trusty-analyze"] == custom_new
+
+
+# ---------------------------------------------------------------------------
+# (d) launchd plist cleanup — hermetic mocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_plist(tmp_path: Path) -> Path:
+    """Create a fake launchd plist file in a temp LaunchAgents dir."""
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    plist = launch_agents / "com.bobmatnyc.trusty-analyzer.plist"
+    plist.write_text("<plist/>")
+    return plist
+
+
+def test_launchd_plist_removed_on_macos(tmp_path: Path, fake_plist: Path) -> None:
+    """Plist file is removed and launchctl is called on macOS."""
+    with (
+        patch.object(mod, "_get_uid", return_value=501),
+        patch("sys.platform", "darwin"),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+        patch.object(Path, "home", return_value=tmp_path),
+    ):
+        mod._cleanup_launchd_plist()
+
+    # launchctl was called at least once.
+    assert mock_run.called
+    # Plist file was removed.
+    assert not fake_plist.exists()
+
+
+def test_launchd_noop_when_no_plist(tmp_path: Path) -> None:
+    """_cleanup_launchd_plist is a no-op when plist does not exist."""
+    with (
+        patch("sys.platform", "darwin"),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+        patch.object(Path, "home", return_value=tmp_path),
+    ):
+        mod._cleanup_launchd_plist()
+
+    # launchctl should NOT have been called — plist didn't exist.
+    assert not mock_run.called
+
+
+def test_launchd_noop_on_non_macos(tmp_path: Path, fake_plist: Path) -> None:
+    """_cleanup_launchd_plist is a no-op on non-macOS platforms."""
+    with (
+        patch("sys.platform", "linux"),
+        patch.object(Path, "home", return_value=tmp_path),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+    ):
+        mod._cleanup_launchd_plist()
+
+    assert not mock_run.called
+    # Plist left untouched (we're not on macOS).
+    assert fake_plist.exists()
+
+
+def test_launchd_subprocess_error_swallowed(tmp_path: Path, fake_plist: Path) -> None:
+    """A subprocess.TimeoutExpired from launchctl does not propagate."""
+    import subprocess
+
+    with (
+        patch("sys.platform", "darwin"),
+        patch.object(Path, "home", return_value=tmp_path),
+        patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["launchctl"], timeout=5),
+        ),
+    ):
+        # Must not raise.
+        mod._cleanup_launchd_plist()
+
+    # Plist may or may not be removed depending on which step failed; the key
+    # assertion is that no exception escaped.
+
+
+def test_run_migration_triggers_launchd_cleanup(tmp_path: Path) -> None:
+    """run_migration calls _cleanup_launchd_plist (integration-level check)."""
+    with patch.object(mod, "_cleanup_launchd_plist") as mock_cleanup:
+        mod.run_migration(project_dir=tmp_path)
+
+    mock_cleanup.assert_called_once()

--- a/tests/migrations/test_rename_trusty_analyzer.py
+++ b/tests/migrations/test_rename_trusty_analyzer.py
@@ -301,7 +301,60 @@ def test_launchd_subprocess_error_swallowed(tmp_path: Path, fake_plist: Path) ->
 
 def test_run_migration_triggers_launchd_cleanup(tmp_path: Path) -> None:
     """run_migration calls _cleanup_launchd_plist (integration-level check)."""
-    with patch.object(mod, "_cleanup_launchd_plist") as mock_cleanup:
+    with patch.object(
+        mod, "_cleanup_launchd_plist", return_value=False
+    ) as mock_cleanup:
         mod.run_migration(project_dir=tmp_path)
 
     mock_cleanup.assert_called_once()
+
+
+def test_run_migration_returns_true_for_plist_only_cleanup(tmp_path: Path) -> None:
+    """run_migration returns True when only the plist was cleaned (no MCP file changed).
+
+    Previously _cleanup_launchd_plist() returned None, so plist-only runs
+    silently returned False even though work was done.  Now the bool is captured
+    and OR'd into the return value.
+    """
+    with patch.object(mod, "_cleanup_launchd_plist", return_value=True):
+        result = mod.run_migration(project_dir=tmp_path)
+
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: stale fields on the old entry must NOT carry over to the renamed entry
+# ---------------------------------------------------------------------------
+
+
+def test_stale_env_field_not_carried_to_renamed_entry(tmp_path: Path) -> None:
+    """Extra/stale fields on the old trusty-analyzer entry are NOT inherited.
+
+    When only trusty-analyzer is present and it carries extra fields (e.g. an
+    ``env`` dict pointing at the old binary path), those fields must be dropped.
+    The new trusty-analyze entry must be exactly the canonical shape.
+    """
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-analyzer": {
+                    "type": "stdio",
+                    "command": "trusty-analyzer",
+                    "args": ["mcp"],
+                    "env": {"BINARY_PATH": "/usr/local/bin/trusty-analyzer"},
+                    "stale_extra": "should-be-gone",
+                }
+            }
+        },
+    )
+
+    mod.run_migration(project_dir=tmp_path)
+
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert "trusty-analyzer" not in servers
+    new_entry = servers["trusty-analyze"]
+    # Must be exactly the canonical entry — no env, no stale_extra.
+    assert new_entry == _NEW_ENTRY
+    assert "env" not in new_entry
+    assert "stale_extra" not in new_entry

--- a/tests/test_trusty_analyze_wiring.py
+++ b/tests/test_trusty_analyze_wiring.py
@@ -1,0 +1,78 @@
+"""Tests for first-class trusty-analyze wiring in mpm (GitHub #782).
+
+Why: trusty-analyze is the code-analysis sidecar daemon.  These tests pin the
+three wiring surfaces that make it first-class: its ``STATIC_MCP_CONFIGS``
+entry (key renamed from ``trusty-analyzer`` → ``trusty-analyze``), its
+presence in the per-session capability map (``get_trusty_capabilities``), and
+the correct stdio invocation (``trusty-analyze mcp``).
+
+What: Asserts the static config entry shape (stdio ``mcp`` subcommand, no
+``env`` key required), that ``get_trusty_capabilities`` reports trusty-analyze,
+and that the MCP config key is ``trusty-analyze`` (not the old
+``trusty-analyzer``).
+
+Test: ``uv run pytest tests/test_trusty_analyze_wiring.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from claude_mpm.services.mcp.config_builder import MCPServiceConfigBuilder
+
+
+class TestStaticMcpConfig:
+    def test_trusty_analyze_present(self):
+        """trusty-analyze is a known static MCP config (renamed from trusty-analyzer)."""
+        configs = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS
+        assert "trusty-analyze" in configs
+
+    def test_trusty_analyzer_old_key_absent(self):
+        """Old key ``trusty-analyzer`` must NOT appear in STATIC_MCP_CONFIGS."""
+        configs = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS
+        assert "trusty-analyzer" not in configs
+
+    def test_trusty_analyze_entry_shape(self):
+        """Entry is the stdio ``mcp`` subcommand form (confirmed by trusty-analyze --help)."""
+        entry = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS["trusty-analyze"]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "trusty-analyze"
+        assert entry["args"] == ["mcp"]
+
+    def test_trusty_analyze_no_secret_env(self):
+        """No secrets baked into the static entry (env key is absent or empty)."""
+        entry = MCPServiceConfigBuilder.STATIC_MCP_CONFIGS["trusty-analyze"]
+        env = entry.get("env", {})
+        forbidden = {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "GITHUB_TOKEN",
+        }
+        assert forbidden.isdisjoint(env.keys())
+
+
+class TestCapabilityDetection:
+    def test_trusty_analyze_reported_in_capabilities(self, monkeypatch):
+        """get_trusty_capabilities always reports trusty-analyze's state."""
+        from claude_mpm.services import trusty_status
+
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = trusty_status.get_trusty_capabilities()
+        assert "trusty-analyze" in caps
+        assert caps["trusty-analyze"] == "absent"
+
+    def test_trusty_analyzer_old_key_not_in_capabilities(self, monkeypatch):
+        """Old key ``trusty-analyzer`` must NOT appear in capabilities output."""
+        from claude_mpm.services import trusty_status
+
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = trusty_status.get_trusty_capabilities()
+        assert "trusty-analyzer" not in caps

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -937,3 +937,151 @@ class TestGetTrustyCapabilities:
         monkeypatch.setattr(trusty_status, "get_trusty_status", _always_boom)
         caps = get_trusty_capabilities()
         assert caps == dict.fromkeys(_CAPABILITY_SERVICES, "absent")
+
+
+class TestTrustyAnalyzeDetection:
+    """trusty-analyze detection wiring: MCP config key, default port, and states.
+
+    Mirrors the trusty-review tests in ``TestUserMcpPresenceFlow`` for the
+    sibling service.  trusty-analyze is an HTTP sidecar daemon (port 7879) with
+    a stdio MCP bridge (``trusty-analyze mcp``); the renamed MCP config key
+    (``trusty-analyze``, not the old ``trusty-analyzer``) must flow correctly
+    through ``_is_configured_in_mcp`` → ``_is_present`` → ``get_trusty_status``
+    and ``get_trusty_capabilities``.
+    """
+
+    def test_absent_when_not_configured(self, monkeypatch, tmp_path):
+        """No .mcp.json entry AND no http_addr file → state ``absent``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+
+        state, line = get_trusty_status("trusty-analyze")
+        assert state == "absent"
+        assert line == ""
+
+    def test_project_mcp_configured_health_ok_renders_on(self, monkeypatch, tmp_path):
+        """trusty-analyze in project .mcp.json + healthy → state ``on``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-analyze")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        state, line = get_trusty_status("trusty-analyze")
+        assert state == "on"
+        assert "trusty-analyze: on" in line
+
+    def test_project_mcp_configured_health_fail_state_configured(
+        self, monkeypatch, tmp_path
+    ):
+        """trusty-analyze in project .mcp.json + not running → state ``configured``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-analyze")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+
+        state, line = get_trusty_status("trusty-analyze")
+        assert state == "configured"
+        assert "not running" in line
+        assert "trusty-analyze serve" in line  # _start_hint
+
+    def test_addr_file_only_health_ok_renders_on(self, monkeypatch, tmp_path):
+        """http_addr file only (no .mcp.json) + healthy → state ``on``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-analyze", "127.0.0.1:7879")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        state, _line = get_trusty_status("trusty-analyze")
+        assert state == "on"
+
+    def test_addr_file_only_health_fail_state_not_running(self, monkeypatch, tmp_path):
+        """http_addr file only (no .mcp.json) + not running → state ``not_running``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_addr_file(home, "trusty-analyze", "127.0.0.1:7879")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+
+        state, line = get_trusty_status("trusty-analyze")
+        assert state == "not_running"
+        assert "not running" in line
+
+    def test_default_port_is_7879(self):
+        """_DEFAULT_PORTS maps trusty-analyze to 7879 (confirmed binary default)."""
+        assert trusty_status._DEFAULT_PORTS.get("trusty-analyze") == 7879
+
+    def test_default_port_used_when_addr_file_absent(self, monkeypatch, tmp_path):
+        """When no http_addr file exists the probe target is 127.0.0.1:7879."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-analyze")  # present, so we reach the probe
+
+        seen: dict[str, str] = {}
+
+        def _capture(base_url: str) -> bool:
+            seen["base_url"] = base_url
+            return True
+
+        monkeypatch.setattr(trusty_status, "_health_check", _capture)
+        get_trusty_status("trusty-analyze")
+        assert seen["base_url"] == "http://127.0.0.1:7879"
+
+    def test_is_configured_in_mcp_uses_renamed_key(self, monkeypatch, tmp_path):
+        """_is_configured_in_mcp detects ``trusty-analyze`` (not ``trusty-analyzer``)."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        _write_mcp_json(proj, "trusty-analyze")
+
+        assert trusty_status._is_configured_in_mcp("trusty-analyze") is True
+        assert trusty_status._is_configured_in_mcp("trusty-analyzer") is False
+
+    def test_capability_includes_trusty_analyze(self, monkeypatch):
+        """get_trusty_capabilities always reports trusty-analyze's state."""
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = trusty_status.get_trusty_capabilities()
+        assert "trusty-analyze" in caps
+        assert caps["trusty-analyze"] == "absent"
+
+    def test_user_mcp_configured_health_ok_renders_on(self, monkeypatch, tmp_path):
+        """trusty-analyze in user .mcp.json only + healthy → state ``on``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)  # no project .mcp.json
+        _write_user_mcp_json(home, "trusty-analyze")
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: True)
+
+        state, line = get_trusty_status("trusty-analyze")
+        assert state == "on"
+        assert "trusty-analyze: on" in line


### PR DESCRIPTION
## Summary

- Renames all `trusty-analyzer` references to `trusty-analyze` across config, setup, CLI constants, and service installer (5 prior commits)
- Fast-forwards the `MCPBinary.TRUSTY_ANALYZER → TRUSTY_ANALYZE` constants rename from sibling branch
- Adds `trusty-analyze` to `_DEFAULT_PORTS` (port 7879, confirmed via `trusty-analyze port`) and `_SERVICE_EMOJI` in `trusty_status.py`
- Adds 11 detection tests in `test_trusty_status.py` (TestTrustyAnalyzeDetection class)
- Adds `test_trusty_analyze_wiring.py` mirroring `test_trusty_review_wiring.py` (6 tests for static config + capability)

## Invocation finding: `args: ["mcp"]` is CORRECT

`trusty-analyze` is a Rust binary (HTTP sidecar daemon, port 7879) that also exposes a **stdio MCP bridge** via `trusty-analyze mcp`. Confirmed directly:

```
$ trusty-analyze --help
Commands:
  serve   Run the HTTP sidecar daemon
  mcp     Run an MCP stdio server pointed at the analyzer daemon
  ...

$ trusty-analyze mcp --help
Run an MCP stdio server pointed at the analyzer daemon
Options:
  --analyzer-url  Base URL of the analyzer daemon. Defaults to http://127.0.0.1:7879
```

The config (`type: stdio, command: trusty-analyze, args: ["mcp"]`) is correct. The daemon runs at 7879; the stdio MCP bridge connects to it.

## Additional fix: _DEFAULT_PORTS

`trusty-analyze` was missing from `_DEFAULT_PORTS` in `trusty_status.py`, causing health probes to fall back to port 7070 (trusty-memory's port) when the `http_addr` discovery file is absent. Fixed to use 7879 (confirmed via `trusty-analyze port`).

## Test plan

- [x] `uv run pytest tests/test_trusty_status.py tests/test_trusty_analyze_wiring.py -p no:xdist` — 75 passed in 0.23s
- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed
- [x] No old `trusty-analyzer` references remain in non-migration test files

Closes #782

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)