### PR TITLE
chore: drop write-only .yaml session-pause file (no reader)

### DIFF
--- a/src/claude_mpm/cli/commands/mpm_init_handler.py
+++ b/src/claude_mpm/cli/commands/mpm_init_handler.py
@@ -153,8 +153,9 @@ def manage_mpm_init(args):
             console.print()
             console.print("[blue]📝 Files Created:[/blue]")
             console.print(f"  • [dim]{session_id}.json[/dim] - Machine-readable data")
-            console.print(f"  • [dim]{session_id}.yaml[/dim] - Human-readable config")
-            console.print(f"  • [dim]{session_id}.md[/dim] - Full documentation")
+            console.print(
+                f"  • [dim]{session_id}.md[/dim] - Human-readable documentation"
+            )
             console.print("  • [dim]LATEST-SESSION.txt[/dim] - Quick reference pointer")
 
             # Git commit info

--- a/src/claude_mpm/services/cli/incremental_pause_manager.py
+++ b/src/claude_mpm/services/cli/incremental_pause_manager.py
@@ -261,7 +261,7 @@ class IncrementalPauseManager:
 
         This method:
         1. Appends a 'pause_finalized' action
-        2. Optionally delegates to SessionPauseManager to create JSON/YAML/MD files
+        2. Optionally delegates to SessionPauseManager to create JSON/MD files
         3. Removes the ACTIVE-PAUSE.jsonl file
         4. Returns path to the finalized session file
 
@@ -333,10 +333,7 @@ class IncrementalPauseManager:
                     enriched_state, session_path, atomic=True
                 )
 
-                # Also create YAML and Markdown
-                yaml_path = self.sessions_dir / f"{session_id}.yaml"
-                pause_manager._save_yaml(enriched_state, yaml_path)
-
+                # Also create Markdown
                 md_path = self.sessions_dir / f"{session_id}.md"
                 md_content = pause_manager._generate_markdown(enriched_state)
                 md_path.write_text(md_content)

--- a/src/claude_mpm/services/cli/session_pause_manager.py
+++ b/src/claude_mpm/services/cli/session_pause_manager.py
@@ -4,7 +4,9 @@ WHY: This service creates session pause documents that capture complete conversa
 context, git state, todos, and working directory for seamless resume.
 
 DESIGN DECISIONS:
-- Three format output (JSON, YAML, Markdown) for different use cases
+- Two format output (JSON, Markdown) for different use cases
+- .yaml was dropped: no reader exists in the codebase; .json is authoritative,
+  .md serves as the human-readable view and legacy-resume fallback
 - Atomic file operations using StateStorage
 - Git integration for automatic commits
 - Compatible with SessionResumeHelper for resume workflow
@@ -16,8 +18,6 @@ import subprocess  # nosec B404 - required for git operations
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from claude_mpm.core.logger import get_logger
 from claude_mpm.storage.state_storage import StateStorage
@@ -72,11 +72,6 @@ class SessionPauseManager:
         if not self.storage.write_json(state, json_path, atomic=True):
             raise RuntimeError(f"Failed to write JSON to {json_path}")
         logger.debug(f"Saved JSON: {json_path}")
-
-        # Save YAML format
-        yaml_path = self.pause_dir / f"{session_id}.yaml"
-        self._save_yaml(state, yaml_path)
-        logger.debug(f"Saved YAML: {yaml_path}")
 
         # Save Markdown format
         md_path = self.pause_dir / f"{session_id}.md"
@@ -320,26 +315,6 @@ class SessionPauseManager:
         """
         return (self.project_path / ".git").exists()
 
-    def _save_yaml(self, state: dict[str, Any], yaml_path: Path) -> None:
-        """Save state as YAML format.
-
-        Args:
-            state: State dictionary
-            yaml_path: Target YAML file path
-        """
-        try:
-            with yaml_path.open("w") as f:
-                yaml.dump(
-                    state,
-                    f,
-                    default_flow_style=False,
-                    allow_unicode=True,
-                    sort_keys=False,
-                )
-        except Exception as e:
-            logger.error(f"Failed to write YAML to {yaml_path}: {e}")
-            raise
-
     def _generate_markdown(self, state: dict[str, Any]) -> str:
         """Generate human-readable markdown format.
 
@@ -495,8 +470,7 @@ Project: {self.project_path}
 
 Files:
 - {session_id}.json (machine-readable)
-- {session_id}.yaml (human-readable config)
-- {session_id}.md (documentation)
+- {session_id}.md (human-readable documentation)
 
 Quick Resume:
   /mpm-init resume

--- a/src/claude_mpm/services/cli/session_resume_helper.py
+++ b/src/claude_mpm/services/cli/session_resume_helper.py
@@ -95,9 +95,9 @@ class SessionResumeHelper:
     def _find_md_only_sessions(self, directory: Path) -> list[Path]:
         """Find timestamped .md session files lacking a .json counterpart.
 
-        Normal session pauses write three sibling files atomically (.json, .yaml,
-        .md). If only the .md file exists, the session is from older code or an
-        interrupted write — we still want users to be able to see and resume it.
+        Normal session pauses write two sibling files (.json, .md). If only the
+        .md file exists, the session is from older code or an interrupted write
+        — we still want users to be able to see and resume it.
 
         Args:
             directory: Directory to scan for .md-only sessions.


### PR DESCRIPTION
## Summary

Closes #784

The session-pause feature wrote three sibling files per pause: `.json`, `.yaml`, `.md`. Investigation confirmed the `.yaml` file has no reader anywhere in the repo — `grep -rn` across `src/` found only print statements and docstrings that *advertise* the file; nothing ever loads it. This PR removes the write entirely.

- `.json` remains: authoritative format, loaded by `SessionResumeHelper`
- `.md` remains: human-readable view and legacy-resume fallback (when no `.json` sibling)
- `.yaml` dropped: pure write-only redundancy — no reader, no consumer

## Changes (one file per commit)

1. **`session_pause_manager.py`** — remove `_save_yaml()` method, yaml write block, `import yaml`, and update module docstring + `_update_latest_pointer()` output to list only `.json` and `.md`
2. **`incremental_pause_manager.py`** — remove `_save_yaml()` call from `finalize_pause()`; update docstring
3. **`mpm_init_handler.py`** — remove the `.yaml` line from the "Files Created" success output
4. **`session_resume_helper.py`** — update `_find_md_only_sessions` docstring ("three sibling files" → "two sibling files")

## Out of Scope

The `mpm-session-pause` skill markdown lives at user level (`~/.claude/skills/mpm-session-pause/`), outside this repo, and still lists `.yaml` in its 3-file description. This is a separate user-level follow-up; it cannot be addressed from within this repository.

## Test plan

- [x] `uv run pytest tests/unit/services/cli/test_session_resume_helper.py tests/unit/services/cli/test_session_resume_permission.py tests/test_session_resume_selection.py tests/hooks/test_auto_pause_handler.py -p no:xdist` — **137 passed**
- [x] `ruff format` + `ruff check --fix` — no violations on any changed file
- [x] No remaining `session*.yaml` writer or advertiser in `src/` Python files
- [x] No test assertions reference `.yaml` session files

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)