### PR TITLE
fix: default trusty-memory to stdio MCP mode + migrate stale bridge entries

### DIFF
--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -429,7 +429,7 @@ def run_migration(project_dir: Path | None = None) -> bool:
                     servers[svc["name"]] = svc["mcp_entry"]
                     detect_mode_log = svc.get("detect", "http")
                     detect_via = (
-                        str(svc.get("addr_file", "addr-file"))
+                        str(svc.get("addr_file", "<missing-addr_file>"))
                         if detect_mode_log == "http"
                         else "jsonrpc-handshake"
                     )

--- a/src/claude_mpm/migrations/migrate_trusty_autodetect.py
+++ b/src/claude_mpm/migrations/migrate_trusty_autodetect.py
@@ -22,20 +22,25 @@ Detection modes (``"detect"`` key per service descriptor):
 
 * ``"http"`` (default) — existing behavior for persistent HTTP daemons:
   resolve ``addr_file`` / ``fallback_addr`` then probe ``/health``.
-  Used by ``trusty-search`` and ``trusty-memory``.
+  Used by ``trusty-search``.
 * ``"jsonrpc"`` — spawn the stdio server, send a JSON-RPC ``initialize``
   request, accept as detected if a valid response arrives within the timeout.
-  Used by ``trusty-review`` (review-on-demand, no persistent HTTP daemon).
+  Used by ``trusty-memory`` and ``trusty-review`` (stdio on-demand servers,
+  no persistent HTTP daemon).
 
 Address discovery (http-mode only):
 
-Both ``trusty-search`` and ``trusty-memory`` use OS-chosen dynamic ports
-written to ``~/.trusty-<svc>/http_addr`` (format: ``host:port`` on a single
-line). Hardcoded ports (7878 / 7070) would cause the autodetect to silently
-fail whenever the daemons picked different ports. We mirror the discovery
-logic used by the ``claude-mpm setup trusty-*`` handlers: read the addr file
-when present, fall back to the legacy port only when the file is missing or
-unreadable.
+``trusty-search`` uses OS-chosen dynamic ports written to
+``~/.trusty-search/http_addr`` (format: ``host:port`` on a single line).
+Hardcoded ports (7878) would cause the autodetect to silently fail whenever
+the daemon picked a different port. We mirror the discovery logic used by the
+``claude-mpm setup trusty-search`` handler: read the addr file when present,
+fall back to the legacy port only when the file is missing or unreadable.
+
+trusty-memory and trusty-review are stdio on-demand servers: they use
+``"jsonrpc"`` detection, have no ``addr_file``/``fallback_addr``, and require
+no HTTP palace-creation step (the stdio server derives the palace from cwd
+automatically on first use).
 
 References
 ----------
@@ -86,16 +91,21 @@ _SERVICES: tuple[dict[str, Any], ...] = (
             "args": ["serve"],
         },
     },
+    # trusty-memory is now a stdio on-demand server (like trusty-review): it is
+    # spawned per-session by Claude Code with the project cwd and derives the
+    # per-project palace from that cwd automatically on first use.  No persistent
+    # HTTP daemon is required, and no HTTP _ensure_palace step is needed in stdio
+    # mode — the server handles palace creation itself.  Detection therefore uses
+    # ``"jsonrpc"`` mode (probe ``trusty-memory serve --stdio`` directly) and the
+    # ``addr_file``/``fallback_addr`` fields are intentionally absent.
     {
         "name": "trusty-memory",
         "binary": "trusty-memory",
-        "detect": "http",
-        "addr_file": Path.home() / ".trusty-memory" / "http_addr",
-        "fallback_addr": "127.0.0.1:7070",
+        "detect": "jsonrpc",
         "mcp_entry": {
             "type": "stdio",
-            "command": "trusty-memory-mcp-bridge",
-            "args": [],
+            "command": "trusty-memory",
+            "args": ["serve", "--stdio"],
         },
     },
     # trusty-review is review-on-demand: it gets an .mcp.json entry so the
@@ -417,9 +427,10 @@ def run_migration(project_dir: Path | None = None) -> bool:
             with _mcp_config_transaction(project_dir):
                 for svc in to_write:
                     servers[svc["name"]] = svc["mcp_entry"]
+                    detect_mode_log = svc.get("detect", "http")
                     detect_via = (
-                        svc["addr_file"]
-                        if svc.get("detect", "http") == "http"
+                        str(svc.get("addr_file", "addr-file"))
+                        if detect_mode_log == "http"
                         else "jsonrpc-handshake"
                     )
                     logger.info(
@@ -434,13 +445,20 @@ def run_migration(project_dir: Path | None = None) -> bool:
             # hooks are still worth attempting on subsequent detected services).
             logger.warning("trusty autodetect failed to write .mcp.json: %s", exc)
 
-    # 2. Ensure the per-project palace exists for a healthy trusty-memory. This
-    #    runs every startup (idempotent GET/POST) regardless of whether the
-    #    .mcp.json entry already existed — registering the MCP server is not
-    #    enough; the palace must exist for memory calls to persist anything.
+    # 2. Ensure the per-project palace exists for a healthy trusty-memory.
+    #    In HTTP daemon mode: runs every startup (idempotent GET/POST) regardless
+    #    of whether the .mcp.json entry already existed — the palace must exist
+    #    for memory calls to persist anything.
+    #    In stdio/jsonrpc mode: ``trusty-memory serve --stdio`` is spawned by
+    #    Claude Code with the project cwd and auto-creates the palace on first
+    #    use, so no HTTP palace-creation step is required or possible (there is
+    #    no persistent daemon to call and no ``base_url``).
     for svc in detected:
         if svc["name"] == "trusty-memory":
-            _ensure_palace(svc["base_url"], project_dir.name, project_dir)
+            if svc.get("detect", "http") == "http" and "base_url" in svc:
+                _ensure_palace(svc["base_url"], project_dir.name, project_dir)
+            # else: stdio/jsonrpc mode — palace auto-created by the server on
+            # first use; no HTTP call needed or possible.
 
     # 3. Inject the capture/index hooks for whatever was detected. Idempotent
     #    via _mpm_service dedup keys; only touches ./.claude/settings.json when

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -229,6 +229,13 @@ def _run_rename_trusty_analyzer_migration() -> bool:
     return run_migration()
 
 
+def _run_trusty_memory_stdio_migration() -> bool:
+    """Rewrite stale trusty-memory-mcp-bridge entries to the canonical trusty-memory serve --stdio form."""
+    from .v6_5_36_trusty_memory_stdio import run_migration
+
+    return run_migration()
+
+
 def _run_remove_absolute_hook_paths_migration() -> bool:
     """Replace absolute MPM hook paths with the portable 'claude-hook' entry point (issue #563)."""
     from pathlib import Path
@@ -413,6 +420,12 @@ MIGRATIONS: list[Migration] = [
         version="6.5.34",
         description="Rename stale trusty-analyzer MCP server entry to trusty-analyze and remove old com.bobmatnyc.trusty-analyzer launchd plist (issue #782)",
         run=_run_rename_trusty_analyzer_migration,
+    ),
+    Migration(
+        id="v6_5_36_trusty_memory_stdio",
+        version="6.5.36",
+        description="Rewrite stale trusty-memory-mcp-bridge MCP entries to the canonical direct-stdio form (trusty-memory serve --stdio) — the bridge is broken in v0.15.2+",
+        run=_run_trusty_memory_stdio_migration,
     ),
 ]
 

--- a/src/claude_mpm/migrations/v6_5_36_trusty_memory_stdio.py
+++ b/src/claude_mpm/migrations/v6_5_36_trusty_memory_stdio.py
@@ -146,11 +146,14 @@ def _process_file(path: Path) -> bool:
     if not _fix_servers(servers):
         return False
 
+    tmp = path.with_suffix(".tmp")
     try:
-        with open(path, "w", encoding="utf-8") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
             f.write("\n")
+        tmp.replace(path)
     except OSError as exc:
+        tmp.unlink(missing_ok=True)
         logger.warning("Failed to write %s: %s", path, exc)
         return False
 

--- a/src/claude_mpm/migrations/v6_5_36_trusty_memory_stdio.py
+++ b/src/claude_mpm/migrations/v6_5_36_trusty_memory_stdio.py
@@ -1,0 +1,217 @@
+"""Rewrite stale trusty-memory bridge entries to the canonical stdio form.
+
+WHAT: Scans the user's MCP config file(s) for ``trusty-memory`` entries that
+    still use the old ``trusty-memory-mcp-bridge`` command (the bridge was
+    broken in v0.15.2 when the daemon stopped binding its UDS socket).  Rewrites
+    any such entry to the canonical direct-stdio form
+    ``{"type":"stdio","command":"trusty-memory","args":["serve","--stdio"]}``.
+
+WHY: Starting with claude-mpm 6.5.36, the framework default for trusty-memory
+    switches from the bridge architecture to ``trusty-memory serve --stdio``
+    (direct stdio mode, no daemon/socket required, spawned per-session by
+    Claude Code).  Existing projects that were configured before this release
+    will have a stale ``command: trusty-memory-mcp-bridge`` entry that no
+    longer works.  This migration repairs them automatically so users do not
+    have to re-run ``claude-mpm setup trusty-memory``.
+
+Idempotency:
+    * If the entry already uses the canonical stdio command — no change.
+    * If the entry is absent — no change.
+    * If both old and new keys coexist (impossible in practice but guarded) —
+      only the new key is preserved.
+
+Scanned locations (mirrors ``v6_5_34_rename_trusty_analyzer``):
+
+* ``./.mcp.json`` (project-scoped)
+* ``./.claude/settings.json`` and ``./.claude/settings.local.json``
+* ``~/.claude/.mcp.json``
+* ``~/.claude/settings.json``
+
+Design constraints:
+
+* **Safe writes**: uses :func:`_process_file` (load → mutate in-place →
+  write) with per-file error handling; a write failure for one file never
+  blocks the others.
+* **No rollback needed**: each mutation is a single key-value replacement that
+  cannot lose data (the old entry is always superseded by an equivalent one).
+* **Never raises**: all errors are logged at ``warning`` level and swallowed.
+* **Hermetic**: no subprocess calls, no network I/O, no binary detection.
+
+References
+----------
+SPEC-INTEGRATIONS-09~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-09~1
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The old bridge command that this migration replaces.
+_OLD_COMMAND = "trusty-memory-mcp-bridge"
+
+# Canonical stdio entry for trusty-memory (6.5.36+).
+_CANONICAL_ENTRY: dict[str, Any] = {
+    "type": "stdio",
+    "command": "trusty-memory",
+    "args": ["serve", "--stdio"],
+}
+
+_SERVICE_KEY = "trusty-memory"  # pragma: allowlist secret
+
+
+# ---------------------------------------------------------------------------
+# Per-file helpers
+# ---------------------------------------------------------------------------
+
+
+def _needs_rewrite(entry: Any) -> bool:
+    """Return True iff ``entry`` is an old bridge-form trusty-memory config.
+
+    WHAT: Detects the stale ``command: trusty-memory-mcp-bridge`` form
+    (typically ``args: []``).  Returns False for any other shape (already
+    canonical, unexpected type, etc.) so the migration never touches entries
+    it does not recognise.
+
+    WHY: Detecting by command name is robust against unknown args or extra
+    fields that earlier versions may have written.
+    """
+    if not isinstance(entry, dict):
+        return False
+    return entry.get("command") == _OLD_COMMAND
+
+
+def _fix_servers(servers: Any) -> bool:
+    """Rewrite the stale trusty-memory entry in ``servers`` if present.
+
+    WHAT: Mutates *servers* in-place.  Returns True when a change was made.
+    WHY: In-place mutation keeps key order stable for the rest of the entries
+    and avoids constructing an entirely new dict.
+
+    Logic:
+    * ``trusty-memory`` absent → no-op (return False).
+    * ``trusty-memory`` present with old bridge command → overwrite with
+      canonical entry (return True).
+    * ``trusty-memory`` present with canonical or unrecognised command →
+      no-op (return False).
+    """
+    if not isinstance(servers, dict):
+        return False
+
+    entry = servers.get(_SERVICE_KEY)
+    if not _needs_rewrite(entry):
+        return False
+
+    # Build a fresh canonical entry — do NOT inherit stale fields from the
+    # old bridge entry (e.g. a mismatched ``type`` or unexpected ``env``).
+    servers[_SERVICE_KEY] = {
+        "type": _CANONICAL_ENTRY["type"],
+        "command": _CANONICAL_ENTRY["command"],
+        "args": list(_CANONICAL_ENTRY["args"]),
+    }
+    logger.info(
+        "Rewrote trusty-memory MCP entry: %s → %s %s",
+        _OLD_COMMAND,
+        _CANONICAL_ENTRY["command"],
+        _CANONICAL_ENTRY["args"],
+    )
+    return True
+
+
+def _process_file(path: Path) -> bool:
+    """Load ``path``, fix stale trusty-memory entry, write back if changed.
+
+    WHAT: Returns True iff the file was modified.  Missing, unreadable, or
+    malformed files are silently skipped.
+    WHY: Per-file error isolation — one bad file never blocks the others.
+    """
+    if not path.exists():
+        return False
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Skipping %s: cannot parse JSON (%s)", path, exc)
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    servers = data.get("mcpServers")
+    if not _fix_servers(servers):
+        return False
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+    except OSError as exc:
+        logger.warning("Failed to write %s: %s", path, exc)
+        return False
+
+    logger.info(
+        "Updated %s: trusty-memory-mcp-bridge → trusty-memory serve --stdio", path
+    )
+    return True
+
+
+def _candidate_paths(project_dir: Path) -> list[Path]:
+    """Return config file candidates to scan.
+
+    WHAT: Mirrors ``v6_5_34_rename_trusty_analyzer._candidate_paths``.
+    WHY: Covers project-scoped, settings, and user-scope config locations
+    that could contain a stale trusty-memory entry.
+    """
+    home = Path.home()
+    return [
+        project_dir / ".mcp.json",
+        project_dir / ".claude" / "settings.json",
+        project_dir / ".claude" / "settings.local.json",
+        home / ".claude" / ".mcp.json",
+        home / ".claude" / "settings.json",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_migration(project_dir: Path | None = None) -> bool:
+    """Scan config files and rewrite stale trusty-memory bridge entries.
+
+    WHAT: Iterates over the candidate config paths for ``project_dir`` and
+    rewrites any ``trusty-memory`` entry whose command is
+    ``trusty-memory-mcp-bridge`` to the canonical stdio form
+    ``{"type":"stdio","command":"trusty-memory","args":["serve","--stdio"]}``.
+
+    WHY: trusty-memory's daemon+bridge architecture is broken in v0.15.2+;
+    the fix is to use direct stdio mode.  This migration auto-repairs existing
+    projects without requiring user intervention.
+
+    Args:
+        project_dir: Project root to scan (defaults to ``Path.cwd()``).
+            Tests inject a temp directory here to keep the scan hermetic.
+
+    Returns:
+        True if any MCP config file was modified.  False when everything was
+        already up-to-date (or no relevant files existed).  Never raises.
+    """
+    project_dir = project_dir or Path.cwd()
+
+    any_changed = False
+    for path in _candidate_paths(project_dir):
+        try:
+            if _process_file(path):
+                any_changed = True
+        except Exception as exc:
+            logger.warning(
+                "trusty-memory stdio migration: unexpected error for %s: %s", path, exc
+            )
+
+    return any_changed

--- a/src/claude_mpm/services/mcp/config_builder.py
+++ b/src/claude_mpm/services/mcp/config_builder.py
@@ -66,8 +66,8 @@ class MCPServiceConfigBuilder:
         },
         "trusty-memory": {
             "type": "stdio",
-            "command": "trusty-memory-mcp-bridge",
-            "args": [],
+            "command": "trusty-memory",
+            "args": ["serve", "--stdio"],
         },
         "trusty-analyze": {
             "type": "stdio",

--- a/tests/migrations/test_trusty_autodetect.py
+++ b/tests/migrations/test_trusty_autodetect.py
@@ -3,6 +3,11 @@
 These tests deliberately mock ``shutil.which``, the addr-file resolver, and
 the HTTP health probe so they never depend on a real daemon being installed
 on the test runner or on real ``~/.trusty-*/http_addr`` files existing.
+
+trusty-memory now uses ``"jsonrpc"`` detection (same as trusty-review):
+it is a stdio on-demand server with no persistent HTTP daemon.  Tests that
+previously mocked ``_http_health_check`` for trusty-memory now mock
+``_probe_mcp_stdio`` instead.
 """
 
 from __future__ import annotations
@@ -67,8 +72,11 @@ def project_dir(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
-    """Both binaries on PATH + both daemons healthy → both entries written."""
+def test_writes_entries_when_both_detectable(project_dir: Path) -> None:
+    """trusty-search (HTTP) + trusty-memory (jsonrpc) both detectable → both entries written.
+
+    trusty-search uses HTTP health check; trusty-memory uses jsonrpc probe.
+    """
     with (
         patch.object(
             mod.shutil,
@@ -77,6 +85,7 @@ def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -93,23 +102,40 @@ def test_writes_entries_when_both_daemons_healthy(project_dir: Path) -> None:
         "command": "trusty-search",
         "args": ["serve"],
     }
+    # trusty-memory now uses the canonical stdio form (no bridge).
     assert servers["trusty-memory"] == {
         "type": "stdio",
-        "command": "trusty-memory-mcp-bridge",
-        "args": [],
+        "command": "trusty-memory",
+        "args": ["serve", "--stdio"],
     }
 
 
-def test_no_op_when_daemons_not_running(project_dir: Path) -> None:
-    """Binary present but health probe fails → no file written, no exception."""
+def test_no_op_when_search_http_probe_fails(project_dir: Path) -> None:
+    """trusty-search binary present but HTTP probe fails → search NOT written."""
     with (
         patch.object(
             mod.shutil,
             "which",
-            side_effect=_make_which({"trusty-search", "trusty-memory"}),
+            side_effect=_make_which({"trusty-search"}),
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=False),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_no_op_when_memory_jsonrpc_probe_fails(project_dir: Path) -> None:
+    """trusty-memory binary present but jsonrpc probe fails → memory NOT written."""
+    with (
+        patch.object(
+            mod.shutil,
+            "which",
+            side_effect=_make_which({"trusty-memory"}),
+        ),
+        patch.object(mod, "_probe_mcp_stdio", return_value=False),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -121,6 +147,7 @@ def test_no_op_when_binaries_missing(project_dir: Path) -> None:
     """No binary on PATH → skip without probing HTTP or reading addr files."""
     probe_called: list[str] = []
     resolve_called: list[Path] = []
+    jsonrpc_called: list[list[str]] = []
 
     def tracking_probe(url: str) -> bool:
         probe_called.append(url)
@@ -130,16 +157,22 @@ def test_no_op_when_binaries_missing(project_dir: Path) -> None:
         resolve_called.append(addr_file)
         return f"http://{fallback_addr}"
 
+    def tracking_jsonrpc(cmd: list[str], **kwargs: object) -> bool:
+        jsonrpc_called.append(cmd)
+        return True
+
     with (
         patch.object(mod.shutil, "which", side_effect=_make_which(set())),
         patch.object(mod, "_resolve_base_url", side_effect=tracking_resolve),
         patch.object(mod, "_http_health_check", side_effect=tracking_probe),
+        patch.object(mod, "_probe_mcp_stdio", side_effect=tracking_jsonrpc),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
     assert changed is False
     assert probe_called == [], "Health probe should be skipped when binary missing"
     assert resolve_called == [], "addr resolution should be skipped when binary missing"
+    assert jsonrpc_called == [], "jsonrpc probe should be skipped when binary missing"
     assert not (project_dir / ".mcp.json").exists()
 
 
@@ -154,14 +187,20 @@ def test_idempotent_when_entries_already_present(project_dir: Path) -> None:
             },
             "trusty-memory": {
                 "type": "stdio",
-                "command": "trusty-memory-mcp-bridge",
-                "args": [],
+                "command": "trusty-memory",
+                "args": ["serve", "--stdio"],
             },
         }
     }
     mcp_path = project_dir / ".mcp.json"
     mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
     original_contents = mcp_path.read_text()
+
+    probe_called: list[list[str]] = []
+
+    def tracking_jsonrpc(cmd: list[str], **kwargs: object) -> bool:
+        probe_called.append(cmd)
+        return True
 
     with (
         patch.object(
@@ -171,12 +210,17 @@ def test_idempotent_when_entries_already_present(project_dir: Path) -> None:
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", side_effect=tracking_jsonrpc),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
     assert changed is False
     # File untouched.
     assert mcp_path.read_text() == original_contents
+    # No subprocess spawned for already-present entry.
+    assert probe_called == [], (
+        "jsonrpc probe must NOT be called when entry already present"
+    )
 
 
 def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> None:
@@ -202,6 +246,7 @@ def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> Non
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -215,7 +260,7 @@ def test_partial_injection_preserves_unrelated_entries(project_dir: Path) -> Non
 
 
 # ---------------------------------------------------------------------------
-# Palace auto-create
+# Palace auto-create — stdio mode: NO HTTP palace call
 # ---------------------------------------------------------------------------
 
 
@@ -224,141 +269,45 @@ def _detect_only_memory() -> Callable[[str], str | None]:
     return _make_which({"trusty-memory"})
 
 
-def test_palace_created_when_absent(project_dir: Path) -> None:
-    """Healthy trusty-memory + no matching palace → POST issued once."""
-    calls: list[tuple[str, str]] = []
+def test_palace_not_called_in_stdio_mode(project_dir: Path) -> None:
+    """In stdio/jsonrpc mode, _ensure_palace must NOT be called for trusty-memory.
 
-    class _Resp:
-        status = 200
-
-        def read(self) -> bytes:
-            return b"[]"  # GET /palaces → empty list
-
-        def __enter__(self) -> _Resp:
-            return self
-
-        def __exit__(self, *a: object) -> None:
-            return None
-
-    def fake_urlopen(req, timeout=5):  # noqa: ANN001, ARG001
-        calls.append((req.get_method(), req.full_url))
-        return _Resp()
-
-    with (
-        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
-        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
-        patch.object(mod, "_http_health_check", return_value=True),
-        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
-        patch.object(mod.urllib.request, "urlopen", side_effect=fake_urlopen),
-    ):
-        mod.run_migration(project_dir=project_dir)
-
-    methods = [m for m, _ in calls]
-    assert "GET" in methods, "must list palaces first"
-    assert "POST" in methods, "must create palace when absent"
-
-
-def test_palace_post_includes_cwd(project_dir: Path) -> None:
-    """Palace POST body must include ``cwd`` so the daemon validates against the
-    project directory, not its own process cwd (which is typically ``~`` or
-    ``/`` and fails the daemon's project-root enforcement).
+    The stdio server auto-creates the palace from the project cwd on first use;
+    there is no HTTP daemon to call.
     """
-    post_bodies: list[dict] = []
-
-    class _Resp:
-        status = 200
-
-        def read(self) -> bytes:
-            return b"[]"  # GET /palaces → empty list (not present)
-
-        def __enter__(self) -> _Resp:
-            return self
-
-        def __exit__(self, *a: object) -> None:
-            return None
-
-    def fake_urlopen(req, timeout=5):  # noqa: ANN001, ARG001
-        if req.get_method() == "POST":
-            post_bodies.append(json.loads(req.data))
-        return _Resp()
+    palace_calls: list[tuple] = []
 
     with (
         patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
-        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
-        patch.object(mod, "_http_health_check", return_value=True),
-        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
-        patch.object(mod.urllib.request, "urlopen", side_effect=fake_urlopen),
-    ):
-        mod.run_migration(project_dir=project_dir)
-
-    assert len(post_bodies) == 1, f"expected one POST, got: {post_bodies}"
-    body = post_bodies[0]
-    assert "cwd" in body, (
-        "POST body must include 'cwd' for daemon palace-name enforcement; "
-        f"got keys: {list(body.keys())}"
-    )
-    assert body["cwd"] == str(project_dir), (
-        f"cwd must be the project_dir path, got: {body['cwd']!r}"
-    )
-
-
-def test_palace_not_created_when_present(project_dir: Path) -> None:
-    """Healthy trusty-memory + matching palace exists → no POST (idempotent)."""
-    palace_name = project_dir.name
-    payload = json.dumps([{"name": palace_name}]).encode("utf-8")
-    calls: list[str] = []
-
-    class _Resp:
-        status = 200
-
-        def __init__(self, body: bytes) -> None:
-            self._body = body
-
-        def read(self) -> bytes:
-            return self._body
-
-        def __enter__(self) -> _Resp:
-            return self
-
-        def __exit__(self, *a: object) -> None:
-            return None
-
-    def fake_urlopen(req, timeout=5):  # noqa: ANN001, ARG001
-        calls.append(req.get_method())
-        return _Resp(payload)
-
-    with (
-        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
-        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
-        patch.object(mod, "_http_health_check", return_value=True),
-        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
-        patch.object(mod.urllib.request, "urlopen", side_effect=fake_urlopen),
-    ):
-        mod.run_migration(project_dir=project_dir)
-
-    assert "GET" in calls
-    assert "POST" not in calls, "palace already present — must not re-create"
-
-
-def test_palace_failure_is_non_fatal(project_dir: Path) -> None:
-    """Palace HTTP errors never raise and never block the .mcp.json write."""
-
-    def boom(req, timeout=5):  # noqa: ANN001, ARG001
-        raise OSError("connection refused")
-
-    with (
-        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
-        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
-        patch.object(mod, "_http_health_check", return_value=True),
-        patch.object(mod, "_ensure_palace", wraps=_REAL_ENSURE_PALACE),
-        patch.object(mod.urllib.request, "urlopen", side_effect=boom),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
+        patch.object(
+            mod, "_ensure_palace", wraps=lambda *a, **k: palace_calls.append(a)
+        ),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
-    # .mcp.json still written despite palace failure.
     assert changed is True
-    config = json.loads((project_dir / ".mcp.json").read_text())
-    assert "trusty-memory" in config["mcpServers"]
+    assert (
+        "trusty-memory"
+        in json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]
+    )
+    # Crucially: _ensure_palace must NOT be called for stdio-mode trusty-memory.
+    assert palace_calls == [], (
+        "stdio-mode trusty-memory must not call _ensure_palace; "
+        f"got calls: {palace_calls}"
+    )
+
+
+def test_no_keyerror_on_missing_base_url(project_dir: Path) -> None:
+    """jsonrpc-mode trusty-memory has no base_url — accessing svc['base_url'] must not raise."""
+    with (
+        patch.object(mod.shutil, "which", side_effect=_detect_only_memory()),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
+    ):
+        # Must not raise KeyError or any other exception.
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +349,7 @@ def test_opt_out_via_config(project_dir: Path, monkeypatch: pytest.MonkeyPatch) 
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -418,8 +368,7 @@ def test_config_auto_link_true_does_not_block(
 
     with (
         patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-memory"})),
-        patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
-        patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -455,6 +404,7 @@ def test_hooks_injected_for_detected_services(
         ),
         patch.object(mod, "_resolve_base_url", side_effect=_fake_resolve_base_url),
         patch.object(mod, "_http_health_check", return_value=True),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
     ):
         changed = mod.run_migration(project_dir=project_dir)
 
@@ -489,7 +439,7 @@ def test_no_hooks_or_palace_when_binaries_missing(
 
 
 # --------------------------------------------------------------------------
-# trusty-review (review-on-demand): MCP entry only, no palace, no hooks.
+# trusty-memory: jsonrpc detection mode (like trusty-review)
 # --------------------------------------------------------------------------
 
 
@@ -499,6 +449,101 @@ def _service_descriptor(name: str) -> dict[str, object]:
         if svc["name"] == name:
             return svc
     raise AssertionError(f"{name} not found in _SERVICES")
+
+
+def test_trusty_memory_registered_in_services() -> None:
+    """trusty-memory is a known autodetect service with jsonrpc detection mode."""
+    svc = _service_descriptor("trusty-memory")
+    assert svc["binary"] == "trusty-memory"
+    # trusty-memory is now stdio on-demand — no HTTP daemon, so no fallback_addr.
+    assert "fallback_addr" not in svc
+    assert "addr_file" not in svc
+    assert svc.get("detect") == "jsonrpc"
+    assert svc["mcp_entry"] == {
+        "type": "stdio",
+        "command": "trusty-memory",
+        "args": ["serve", "--stdio"],
+    }
+
+
+def test_trusty_memory_wired_via_jsonrpc_probe(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Healthy trusty-memory → .mcp.json entry written via jsonrpc probe."""
+    from claude_mpm.services import trusty_hooks
+
+    palace_calls: list[object] = []
+
+    monkeypatch.setattr(mod, "_ensure_palace", lambda *a, **k: palace_calls.append(a))
+    monkeypatch.setattr(trusty_hooks, "inject_trusty_hooks", lambda *a, **k: False)
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-memory"})),
+        patch.object(mod, "_probe_mcp_stdio", return_value=True),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    servers = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]
+    assert servers["trusty-memory"] == {
+        "type": "stdio",
+        "command": "trusty-memory",
+        "args": ["serve", "--stdio"],
+    }
+    # No palace created — stdio mode auto-creates it on first use.
+    assert palace_calls == []
+
+
+def test_trusty_memory_not_wired_when_probe_fails(project_dir: Path) -> None:
+    """Binary present but JSON-RPC probe returns False → entry NOT written."""
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-memory"})),
+        patch.object(mod, "_probe_mcp_stdio", return_value=False),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is False
+    assert not (project_dir / ".mcp.json").exists()
+
+
+def test_trusty_memory_idempotent_when_already_present(project_dir: Path) -> None:
+    """trusty-memory entry already in .mcp.json → probe not called, no-op."""
+    existing = {
+        "mcpServers": {
+            "trusty-memory": {
+                "type": "stdio",
+                "command": "trusty-memory",
+                "args": ["serve", "--stdio"],
+            }
+        }
+    }
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
+    original_contents = mcp_path.read_text()
+
+    probe_called: list[list[str]] = []
+
+    def tracking_probe(cmd: list[str], **kwargs: object) -> bool:
+        probe_called.append(cmd)
+        return True
+
+    with (
+        patch.object(mod.shutil, "which", side_effect=_make_which({"trusty-memory"})),
+        patch.object(mod, "_probe_mcp_stdio", side_effect=tracking_probe),
+    ):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert probe_called == [], (
+        f"_probe_mcp_stdio must NOT be called when entry already present; "
+        f"got calls: {probe_called}"
+    )
+    assert changed is False
+    assert mcp_path.read_text() == original_contents
+
+
+# --------------------------------------------------------------------------
+# trusty-review (review-on-demand): MCP entry only, no palace, no hooks.
+# --------------------------------------------------------------------------
 
 
 def test_trusty_review_registered_in_services() -> None:
@@ -622,9 +667,12 @@ def test_trusty_review_idempotent_when_already_present(project_dir: Path) -> Non
     assert mcp_path.read_text() == original_contents
 
 
-def test_http_services_unaffected_by_jsonrpc_mode(project_dir: Path) -> None:
-    """http-mode services (trusty-search, trusty-memory) still work via the
-    existing HTTP health-check path when trusty-review's jsonrpc probe fires."""
+def test_all_jsonrpc_services_use_probe_not_http(project_dir: Path) -> None:
+    """trusty-memory + trusty-review use jsonrpc probe; trusty-search uses HTTP.
+
+    With all three installed: HTTP probe fires once (search), jsonrpc fires
+    twice (memory + review).
+    """
     http_probe_called: list[str] = []
     jsonrpc_probe_called: list[list[str]] = []
 
@@ -651,12 +699,14 @@ def test_http_services_unaffected_by_jsonrpc_mode(project_dir: Path) -> None:
         changed = mod.run_migration(project_dir=project_dir)
 
     assert changed is True
-    # HTTP probe called for search + memory, not review.
-    assert len(http_probe_called) == 2
+    # HTTP probe called only for trusty-search.
+    assert len(http_probe_called) == 1
     assert all("/health" in url for url in http_probe_called)
-    # JSON-RPC probe called only for trusty-review.
-    assert len(jsonrpc_probe_called) == 1
-    assert jsonrpc_probe_called[0] == ["trusty-review", "serve", "--stdio"]
+    # JSON-RPC probe called for trusty-memory AND trusty-review.
+    assert len(jsonrpc_probe_called) == 2
+    probe_commands = {tuple(cmd) for cmd in jsonrpc_probe_called}
+    assert ("trusty-memory", "serve", "--stdio") in probe_commands
+    assert ("trusty-review", "serve", "--stdio") in probe_commands
     # All three entries wired.
     servers = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]
     assert set(servers.keys()) == {"trusty-search", "trusty-memory", "trusty-review"}

--- a/tests/migrations/test_trusty_memory_stdio.py
+++ b/tests/migrations/test_trusty_memory_stdio.py
@@ -1,0 +1,279 @@
+"""Tests for the trusty-memory stdio migration (v6_5_36).
+
+The migration rewrites stale ``trusty-memory-mcp-bridge`` MCP entries to the
+canonical ``trusty-memory serve --stdio`` form.  All tests are hermetic: no
+real binaries, no network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.migrations import v6_5_36_trusty_memory_stdio as mod
+
+# Canonical stdio entry for trusty-memory after the migration.
+_STDIO_ENTRY = {
+    "type": "stdio",
+    "command": "trusty-memory",
+    "args": ["serve", "--stdio"],
+}
+
+# Old bridge entry that this migration replaces.
+_BRIDGE_ENTRY = {
+    "type": "stdio",
+    "command": "trusty-memory-mcp-bridge",
+    "args": [],
+}
+
+
+def _write_mcp(project_dir: Path, config: dict) -> Path:
+    mcp_path = project_dir / ".mcp.json"
+    mcp_path.write_text(json.dumps(config, indent=2) + "\n")
+    return mcp_path
+
+
+# ---------------------------------------------------------------------------
+# Core rewrite behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_entry_rewritten_to_stdio(tmp_path: Path) -> None:
+    """Bridge command → rewritten to the canonical stdio form."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}},
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    assert servers["trusty-memory"] == _STDIO_ENTRY
+
+
+def test_already_stdio_is_noop(tmp_path: Path) -> None:
+    """Already-stdio entry → no change, returns False, file untouched."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_STDIO_ENTRY)}},
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_absent_entry_is_noop(tmp_path: Path) -> None:
+    """No trusty-memory entry at all → no change, returns False."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {"mcpServers": {"some-other-server": {"type": "stdio", "command": "whatever"}}},
+    )
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+def test_no_files_is_noop(tmp_path: Path) -> None:
+    """Empty project dir (no config files) → no change, returns False."""
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_after_rewrite(tmp_path: Path) -> None:
+    """Running twice: first run rewrites, second run is a no-op."""
+    _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}},
+    )
+
+    assert mod.run_migration(project_dir=tmp_path) is True
+    assert mod.run_migration(project_dir=tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Unrelated entries are preserved
+# ---------------------------------------------------------------------------
+
+
+def test_search_and_other_entries_untouched(tmp_path: Path) -> None:
+    """trusty-search and other entries must never be modified."""
+    mcp_path = _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "trusty-memory": dict(_BRIDGE_ENTRY),
+                "trusty-search": {
+                    "type": "stdio",
+                    "command": "trusty-search",
+                    "args": ["serve"],
+                },
+                "unrelated": {"type": "stdio", "command": "other"},
+            }
+        },
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    servers = json.loads(mcp_path.read_text())["mcpServers"]
+    # Memory repaired to stdio...
+    assert servers["trusty-memory"] == _STDIO_ENTRY
+    # ...search and unrelated entries left exactly as they were.
+    assert servers["trusty-search"] == {
+        "type": "stdio",
+        "command": "trusty-search",
+        "args": ["serve"],
+    }
+    assert servers["unrelated"] == {"type": "stdio", "command": "other"}
+
+
+# ---------------------------------------------------------------------------
+# User-level MCP config
+# ---------------------------------------------------------------------------
+
+
+def test_user_level_mcp_json_rewritten(tmp_path: Path) -> None:
+    """Bridge entry in ~/.claude/.mcp.json → also rewritten."""
+    home = tmp_path / "home"
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True)
+    user_mcp = claude_dir / ".mcp.json"
+    user_mcp.write_text(
+        json.dumps({"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}}, indent=2)
+        + "\n"
+    )
+
+    # Project dir has no .mcp.json.
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    # Patch Path.home() to point at our isolated home.
+    from unittest.mock import patch
+
+    with patch.object(Path, "home", lambda: home):
+        changed = mod.run_migration(project_dir=project_dir)
+
+    assert changed is True
+    servers = json.loads(user_mcp.read_text())["mcpServers"]
+    assert servers["trusty-memory"] == _STDIO_ENTRY
+
+
+# ---------------------------------------------------------------------------
+# Error resilience
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_is_skipped_gracefully(tmp_path: Path) -> None:
+    """Malformed JSON in .mcp.json → skip, no exception, return False."""
+    mcp_path = tmp_path / ".mcp.json"
+    mcp_path.write_text("{ not valid json")
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    # File is untouched (no partial write).
+    assert mcp_path.read_text() == "{ not valid json"
+
+
+def test_missing_mcp_servers_key_is_noop(tmp_path: Path) -> None:
+    """JSON file without 'mcpServers' key → no-op, no exception."""
+    mcp_path = _write_mcp(tmp_path, {"someOtherKey": "value"})
+    original = mcp_path.read_text()
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is False
+    assert mcp_path.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# _needs_rewrite helper
+# ---------------------------------------------------------------------------
+
+
+def test_needs_rewrite_true_for_bridge() -> None:
+    """_needs_rewrite returns True for the old bridge command."""
+    assert (
+        mod._needs_rewrite({"command": "trusty-memory-mcp-bridge", "args": []}) is True
+    )
+
+
+def test_needs_rewrite_false_for_canonical() -> None:
+    """_needs_rewrite returns False when already canonical."""
+    assert mod._needs_rewrite(_STDIO_ENTRY) is False
+
+
+def test_needs_rewrite_false_for_non_dict() -> None:
+    """_needs_rewrite returns False for non-dict entries (no AttributeError)."""
+    assert mod._needs_rewrite(None) is False
+    assert mod._needs_rewrite("string") is False
+    assert mod._needs_rewrite(42) is False
+
+
+# ---------------------------------------------------------------------------
+# _fix_servers helper
+# ---------------------------------------------------------------------------
+
+
+def test_fix_servers_rewrites_bridge() -> None:
+    """_fix_servers mutates dict in-place and returns True."""
+    servers = {"trusty-memory": dict(_BRIDGE_ENTRY)}
+    result = mod._fix_servers(servers)
+    assert result is True
+    assert servers["trusty-memory"] == _STDIO_ENTRY
+
+
+def test_fix_servers_noop_on_canonical() -> None:
+    """_fix_servers returns False when entry already canonical."""
+    servers = {"trusty-memory": dict(_STDIO_ENTRY)}
+    result = mod._fix_servers(servers)
+    assert result is False
+    assert servers["trusty-memory"] == _STDIO_ENTRY
+
+
+def test_fix_servers_noop_on_absent() -> None:
+    """_fix_servers returns False when trusty-memory key is absent."""
+    servers: dict = {}
+    result = mod._fix_servers(servers)
+    assert result is False
+
+
+def test_fix_servers_noop_on_non_dict() -> None:
+    """_fix_servers returns False for non-dict servers (no TypeError)."""
+    assert mod._fix_servers(None) is False
+    assert mod._fix_servers([]) is False
+
+
+# ---------------------------------------------------------------------------
+# Registry: migration is registered with the correct id/version
+# ---------------------------------------------------------------------------
+
+
+def test_migration_registered_in_registry() -> None:
+    """The migration is registered in the MIGRATIONS list with correct id/version."""
+    from claude_mpm.migrations.registry import MIGRATIONS
+
+    matching = [m for m in MIGRATIONS if m.id == "v6_5_36_trusty_memory_stdio"]
+    assert len(matching) == 1, (
+        f"Expected exactly one migration with id 'v6_5_36_trusty_memory_stdio', "
+        f"found: {[m.id for m in MIGRATIONS]}"
+    )
+    migration = matching[0]
+    assert migration.version == "6.5.36"
+    assert "trusty-memory" in migration.description.lower()

--- a/tests/migrations/test_trusty_memory_stdio.py
+++ b/tests/migrations/test_trusty_memory_stdio.py
@@ -202,6 +202,35 @@ def test_missing_mcp_servers_key_is_noop(tmp_path: Path) -> None:
     assert mcp_path.read_text() == original
 
 
+def test_atomic_write_no_tmp_left_on_success(tmp_path: Path) -> None:
+    """Successful rewrite must not leave a .tmp sibling behind."""
+    _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}},
+    )
+
+    changed = mod.run_migration(project_dir=tmp_path)
+
+    assert changed is True
+    # The atomic write uses a sibling .tmp file; it must be cleaned up.
+    assert not (tmp_path / ".mcp.json.tmp").exists()
+
+
+def test_atomic_write_result_is_valid_json(tmp_path: Path) -> None:
+    """After rewrite, .mcp.json must be parseable and contain the canonical entry."""
+    _write_mcp(
+        tmp_path,
+        {"mcpServers": {"trusty-memory": dict(_BRIDGE_ENTRY)}},
+    )
+
+    mod.run_migration(project_dir=tmp_path)
+
+    mcp_path = tmp_path / ".mcp.json"
+    # File must be valid JSON (not truncated).
+    data = json.loads(mcp_path.read_text())
+    assert data["mcpServers"]["trusty-memory"] == _STDIO_ENTRY
+
+
 # ---------------------------------------------------------------------------
 # _needs_rewrite helper
 # ---------------------------------------------------------------------------

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -1178,7 +1178,10 @@ class TestTrustyMemoryStdioDetection:
         )
         # The service key "trusty-memory" is present → _is_present returns True.
         assert trusty_status._is_present("trusty-memory") is True
-        # The bridge entry type is "stdio" → _is_stdio_configured returns True.
+        # The bridge entry uses stdio TRANSPORT (type: "stdio"), so
+        # _is_stdio_configured correctly returns True here.  _is_stdio_configured
+        # checks the "type" field, NOT the command name — a future tightening of
+        # this check should be deliberate, not accidental.
         assert trusty_status._is_stdio_configured("trusty-memory") is True
 
     def test_absent_when_not_configured(self, monkeypatch, tmp_path):

--- a/tests/test_trusty_status.py
+++ b/tests/test_trusty_status.py
@@ -1085,3 +1085,119 @@ class TestTrustyAnalyzeDetection:
         state, line = get_trusty_status("trusty-analyze")
         assert state == "on"
         assert "trusty-analyze: on" in line
+
+
+class TestTrustyMemoryStdioDetection:
+    """trusty-memory stdio detection path (6.5.36+).
+
+    trusty-memory now uses ``command: trusty-memory, args: [serve, --stdio]``
+    (direct stdio, no bridge, no HTTP daemon).  When it is registered in
+    .mcp.json as a stdio entry and the HTTP health probe fails (no daemon),
+    ``_is_stdio_configured`` returns True and ``get_trusty_status`` must report
+    ``on (stdio)`` — NOT ``not running``.
+    """
+
+    def _write_stdio_mcp_json(self, proj: Path) -> None:
+        """Write a .mcp.json with the canonical 6.5.36+ stdio entry."""
+        import json
+
+        entry = {
+            "type": "stdio",
+            "command": "trusty-memory",
+            "args": ["serve", "--stdio"],
+        }
+        (proj / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"trusty-memory": entry}}, indent=2),
+            encoding="utf-8",
+        )
+
+    def test_stdio_configured_no_daemon_reports_on_stdio(self, monkeypatch, tmp_path):
+        """stdio-configured trusty-memory + no HTTP daemon → state ``on``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        self._write_stdio_mcp_json(proj)
+        # HTTP health check fails (no daemon).
+        monkeypatch.setattr(trusty_status, "_health_check", lambda _url: False)
+        monkeypatch.setattr(trusty_status, "_palace_name", lambda: "myproject")
+
+        state, line = get_trusty_status("trusty-memory")
+
+        assert state == "on", (
+            f"Expected 'on' for stdio-configured trusty-memory (no daemon), got {state!r}"
+        )
+        assert "on (stdio)" in line
+        assert "palace: myproject" in line
+
+    def test_stdio_configured_is_present(self, monkeypatch, tmp_path):
+        """stdio-configured trusty-memory is detected by _is_present."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        self._write_stdio_mcp_json(proj)
+
+        assert trusty_status._is_present("trusty-memory") is True
+
+    def test_stdio_configured_is_stdio_configured(self, monkeypatch, tmp_path):
+        """_is_stdio_configured returns True for the canonical 6.5.36+ entry."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        self._write_stdio_mcp_json(proj)
+
+        assert trusty_status._is_stdio_configured("trusty-memory") is True
+
+    def test_bridge_configured_still_works(self, monkeypatch, tmp_path):
+        """Old bridge form (pre-6.5.36) in .mcp.json → still detected as present."""
+        import json
+
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+        # Old bridge form — command does NOT match "trusty-memory".
+        old_entry = {
+            "type": "stdio",
+            "command": "trusty-memory-mcp-bridge",
+            "args": [],
+        }
+        (proj / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"trusty-memory": old_entry}}, indent=2),
+            encoding="utf-8",
+        )
+        # The service key "trusty-memory" is present → _is_present returns True.
+        assert trusty_status._is_present("trusty-memory") is True
+        # The bridge entry type is "stdio" → _is_stdio_configured returns True.
+        assert trusty_status._is_stdio_configured("trusty-memory") is True
+
+    def test_absent_when_not_configured(self, monkeypatch, tmp_path):
+        """No .mcp.json entry AND no http_addr file → state ``absent``."""
+        home = tmp_path / "home"
+        proj = tmp_path / "proj"
+        home.mkdir()
+        proj.mkdir()
+        _point_home(monkeypatch, home)
+        _point_cwd(monkeypatch, proj)
+
+        state, line = get_trusty_status("trusty-memory")
+        assert state == "absent"
+        assert line == ""
+
+    def test_capability_includes_trusty_memory(self, monkeypatch):
+        """get_trusty_capabilities always reports trusty-memory's state."""
+        monkeypatch.setattr(
+            trusty_status, "get_trusty_status", lambda _s: ("absent", "")
+        )
+        caps = trusty_status.get_trusty_capabilities()
+        assert "trusty-memory" in caps


### PR DESCRIPTION
## Summary

- Switch `STATIC_MCP_CONFIGS["trusty-memory"]` to canonical stdio form (`serve --stdio`)
- Update `migrate_trusty_autodetect`: trusty-memory detection mode `http` → `jsonrpc` (no HTTP daemon, palace auto-created by server on first use)
- Add `v6_5_36_trusty_memory_stdio` migration: rewrites stale `trusty-memory-mcp-bridge` entries in all MCP config files to the canonical direct-stdio form
- Register migration in `registry.py` at `version=6.5.36`
- Confirm `trusty_status.py` already handles stdio-configured trusty-memory correctly — no source change needed

Closes #788

## trusty_status.py finding

No source change was required. The existing `_is_stdio_configured()` function (introduced in a prior PR) already reads `.mcp.json` and returns `True` when the entry has `"type": "stdio"`. The `get_trusty_status()` function already has the branch `if is_healthy or is_stdio:` which short-circuits the HTTP health-fail path. When trusty-memory is configured with `type=stdio` and no HTTP daemon is running: `_is_present` → True (key in mcpServers), health check → False, `_is_stdio_configured` → True, result → `("on", "🧠 trusty-memory: on (stdio)   palace: <name>")`. The 6 new tests in `TestTrustyMemoryStdioDetection` prove this end-to-end.

## Test plan

- [ ] `uv run pytest tests/test_trusty_status.py tests/migrations/ -p no:xdist` — 304 passed
- [ ] `uv run ruff format . && uv run ruff check --fix .` — all checks passed
- [ ] One file per commit (7 commits)
- [ ] Existing trusty-memory users with `trusty-memory-mcp-bridge` entries will have them auto-repaired on next startup

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)