### PR TITLE
chore(framework): instruction-pipeline hardening follow-ups (#794)

### DIFF
--- a/src/claude_mpm/agents/BASE_PM.md
+++ b/src/claude_mpm/agents/BASE_PM.md
@@ -35,6 +35,6 @@ Two files in `.claude-mpm/` are written by claude-mpm and must **not** be hand-e
 | File | Role | Written by |
 |---|---|---|
 | `PM_INSTRUCTIONS_DEPLOYED.md` | Merged framework composition (PM_INSTRUCTIONS + AGENT_DELEGATION + WORKFLOW + MEMORY). Rebuilt on every startup in dev/filesystem mode. | `SystemInstructionsDeployer` |
-| `PM_INSTRUCTIONS.md` | Final assembled launcher cache (includes temporal/session context). Rebuilt when the assembled content hash changes. | `InstructionCacheService` |
+| `PM_INSTRUCTIONS_CACHE.md` | Final assembled launcher cache (includes temporal/session context). Rebuilt when the assembled content hash changes. | `InstructionCacheService` |
 
 See `docs/developer/instruction-files.md` for full details.

--- a/src/claude_mpm/constants.py
+++ b/src/claude_mpm/constants.py
@@ -16,10 +16,10 @@ from enum import Enum, StrEnum
 #   framework composition file).  That file is NOT passed to the model, so
 #   the banner is purely informational for human readers.
 #
-# BANNER_CACHE — written into the .meta sidecar of PM_INSTRUCTIONS.md (the
-#   launcher cache / system-prompt file).  The cache file itself must remain
-#   clean (no banner) because its content is passed verbatim to Claude via
-#   --system-prompt-file.
+# BANNER_CACHE — written into the .meta sidecar of PM_INSTRUCTIONS_CACHE.md
+#   (the launcher cache / system-prompt file).  The cache file itself must
+#   remain clean (no banner) because its content is passed verbatim to Claude
+#   via --system-prompt-file.
 # ---------------------------------------------------------------------------
 
 BANNER_DEPLOYED: str = (

--- a/src/claude_mpm/core/framework/loaders/packaged_loader.py
+++ b/src/claude_mpm/core/framework/loaders/packaged_loader.py
@@ -183,8 +183,8 @@ class PackagedLoader:
             # preserves memory-trigger awareness while deferring the full
             # ~1,776-token MEMORY.md body.
             # Check is not None (presence), not truthiness — an empty file is still valid.
-            _memory_content = self.load_packaged_file("MEMORY.md")
-            if _memory_content is not None:
+            memory_content = self.load_packaged_file("MEMORY.md")
+            if memory_content is not None:
                 content["memory_instructions"] = MEMORY_SYSTEM_REFERENCE
                 content["memory_instructions_level"] = "system"
                 self.logger.info(
@@ -266,10 +266,10 @@ class PackagedLoader:
             # Load MEMORY.md — system default is lazy-loaded (reference stub only).
             # Same rationale as load_framework_content: defers the full MEMORY body.
             # Check is not None (presence), not truthiness — an empty file is still valid.
-            _memory_content_fb = self.load_packaged_file_fallback(
+            memory_content_fallback = self.load_packaged_file_fallback(
                 "MEMORY.md", resources
             )
-            if _memory_content_fb is not None:
+            if memory_content_fallback is not None:
                 content["memory_instructions"] = MEMORY_SYSTEM_REFERENCE
                 content["memory_instructions_level"] = "system"
                 self.logger.info(

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -71,12 +71,14 @@ class SystemInstructionsDeployer:
         positive marker (from ``BLOCK_MARKERS``) — proving it really is content
         for *this* block and not, e.g., a malformed launcher-cache artefact.
 
-        The bug this prevents: ``.claude-mpm/PM_INSTRUCTIONS.md`` doubles as the
-        launcher cache AND a project-override source.  A malformed 19-byte cache
-        (``"System instructions"``) was accepted as a valid PM override because
-        ``_detect_stale_override`` only checks for *other* blocks' markers — and
-        a 19-byte file contains none.  The merged DEPLOYED file then LOST the
-        canonical ``## Identity`` / Prohibitions / Circuit-Breakers content.
+        The bug this prevented (now also addressed by renaming the cache to
+        ``PM_INSTRUCTIONS_CACHE.md``): ``.claude-mpm/PM_INSTRUCTIONS.md``
+        previously doubled as the launcher cache AND the project-override source.
+        A malformed 19-byte cache (``"System instructions"``) was accepted as a
+        valid PM override because ``_detect_stale_override`` only checks for
+        *other* blocks' markers — and a 19-byte file contains none.  The merged
+        DEPLOYED file then LOST the canonical ``## Identity`` / Prohibitions /
+        Circuit-Breakers content.
 
         The positive-marker requirement alone defeats that artefact: the 19-byte
         cache has no ``## Identity`` heading, so it is rejected.  A length floor
@@ -223,9 +225,13 @@ class SystemInstructionsDeployer:
 
         # NOTE: unlike _resolve_block for PM_INSTRUCTIONS.md, this intentionally
         # does NOT call _override_is_valid().  MEMORY.md is not a launcher-cache
-        # collision target (only PM_INSTRUCTIONS.md doubles as the launcher
-        # cache), so a malformed positive-marker artefact cannot arrive here.
-        # Stale-override detection (cross-block marker bleed) still applies.
+        # collision target.  The launcher cache was previously at
+        # .claude-mpm/PM_INSTRUCTIONS.md (same name as the PM block override
+        # input), but has been renamed to PM_INSTRUCTIONS_CACHE.md to eliminate
+        # the collision.  A stale old-path cache file lacks "## Identity" and is
+        # rejected by _override_is_valid() on the PM_INSTRUCTIONS.md block;
+        # MEMORY.md is unaffected.  Stale-override detection (cross-block marker
+        # bleed) still applies here.
         if user_path.exists():
             try:
                 user_content = user_path.read_text(encoding="utf-8")

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -141,7 +141,7 @@ class SystemInstructionsDeployer:
         if user_path.exists():
             try:
                 user_content = user_path.read_text(encoding="utf-8")
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 self.logger.warning(
                     "Could not read ~/.claude-mpm/WORKFLOW.md (%s); "
                     "falling back to system default.",
@@ -163,7 +163,7 @@ class SystemInstructionsDeployer:
         if project_path.exists():
             try:
                 project_content = project_path.read_text(encoding="utf-8")
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 self.logger.warning(
                     "Could not read .claude-mpm/WORKFLOW.md (%s); "
                     "falling back to system default.",
@@ -235,7 +235,7 @@ class SystemInstructionsDeployer:
         if user_path.exists():
             try:
                 user_content = user_path.read_text(encoding="utf-8")
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 self.logger.warning(
                     "Could not read ~/.claude-mpm/MEMORY.md (%s); "
                     "falling back to system default.",
@@ -257,7 +257,7 @@ class SystemInstructionsDeployer:
         if project_path.exists():
             try:
                 project_content = project_path.read_text(encoding="utf-8")
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 self.logger.warning(
                     "Could not read .claude-mpm/MEMORY.md (%s); "
                     "falling back to system default.",

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -92,7 +92,19 @@ class SystemInstructionsDeployer:
             True if the override is structurally valid for *block_name*.
         """
         own_markers = BLOCK_MARKERS.get(block_name, [])
-        if own_markers and not any(marker in content for marker in own_markers):
+        if not own_markers:
+            # No marker entry for this block in BLOCK_MARKERS: the positive-marker
+            # guard is a no-op and the override is accepted unconditionally.  Log
+            # at DEBUG so that a future block added without a marker entry is
+            # immediately discoverable in debug output without changing behaviour.
+            self.logger.debug(
+                "_override_is_valid: no BLOCK_MARKERS entry for %r — "
+                "positive-marker check skipped (override accepted unconditionally). "
+                "Add an entry to BLOCK_MARKERS to enable the integrity guard for this block.",
+                block_name,
+            )
+            return True
+        if not any(marker in content for marker in own_markers):
             return False
         return True
 

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -137,30 +137,48 @@ class SystemInstructionsDeployer:
         parts: list[str] = []
 
         if user_path.exists():
-            user_content = user_path.read_text(encoding="utf-8")
-            if self._detect_stale_override("WORKFLOW.md", user_content):
+            try:
+                user_content = user_path.read_text(encoding="utf-8")
+            except Exception as exc:
                 self.logger.warning(
-                    "Stale override detected: ~/.claude-mpm/WORKFLOW.md contains "
-                    "content from other blocks. Ignoring override and using "
-                    "system default. Remove ~/.claude-mpm/WORKFLOW.md to suppress "
-                    "this warning.",
+                    "Could not read ~/.claude-mpm/WORKFLOW.md (%s); "
+                    "falling back to system default.",
+                    exc,
                 )
-            else:
-                parts.append(user_content)
-                has_override = True
+                user_content = None
+            if user_content is not None:
+                if self._detect_stale_override("WORKFLOW.md", user_content):
+                    self.logger.warning(
+                        "Stale override detected: ~/.claude-mpm/WORKFLOW.md contains "
+                        "content from other blocks. Ignoring override and using "
+                        "system default. Remove ~/.claude-mpm/WORKFLOW.md to suppress "
+                        "this warning.",
+                    )
+                else:
+                    parts.append(user_content)
+                    has_override = True
 
         if project_path.exists():
-            project_content = project_path.read_text(encoding="utf-8")
-            if self._detect_stale_override("WORKFLOW.md", project_content):
+            try:
+                project_content = project_path.read_text(encoding="utf-8")
+            except Exception as exc:
                 self.logger.warning(
-                    "Stale override detected: .claude-mpm/WORKFLOW.md contains "
-                    "content from other blocks. Ignoring override and using "
-                    "system default. Remove .claude-mpm/WORKFLOW.md to suppress "
-                    "this warning.",
+                    "Could not read .claude-mpm/WORKFLOW.md (%s); "
+                    "falling back to system default.",
+                    exc,
                 )
-            else:
-                parts.append(project_content)
-                has_override = True
+                project_content = None
+            if project_content is not None:
+                if self._detect_stale_override("WORKFLOW.md", project_content):
+                    self.logger.warning(
+                        "Stale override detected: .claude-mpm/WORKFLOW.md contains "
+                        "content from other blocks. Ignoring override and using "
+                        "system default. Remove .claude-mpm/WORKFLOW.md to suppress "
+                        "this warning.",
+                    )
+                else:
+                    parts.append(project_content)
+                    has_override = True
 
         if has_override:
             # User/project override present — inline it verbatim (it is
@@ -209,30 +227,48 @@ class SystemInstructionsDeployer:
         # cache), so a malformed positive-marker artefact cannot arrive here.
         # Stale-override detection (cross-block marker bleed) still applies.
         if user_path.exists():
-            user_content = user_path.read_text(encoding="utf-8")
-            if self._detect_stale_override("MEMORY.md", user_content):
+            try:
+                user_content = user_path.read_text(encoding="utf-8")
+            except Exception as exc:
                 self.logger.warning(
-                    "Stale override detected: ~/.claude-mpm/MEMORY.md contains "
-                    "content from other blocks. Ignoring override and using "
-                    "system default. Remove ~/.claude-mpm/MEMORY.md to suppress "
-                    "this warning.",
+                    "Could not read ~/.claude-mpm/MEMORY.md (%s); "
+                    "falling back to system default.",
+                    exc,
                 )
-            else:
-                parts.append(user_content)
-                has_override = True
+                user_content = None
+            if user_content is not None:
+                if self._detect_stale_override("MEMORY.md", user_content):
+                    self.logger.warning(
+                        "Stale override detected: ~/.claude-mpm/MEMORY.md contains "
+                        "content from other blocks. Ignoring override and using "
+                        "system default. Remove ~/.claude-mpm/MEMORY.md to suppress "
+                        "this warning.",
+                    )
+                else:
+                    parts.append(user_content)
+                    has_override = True
 
         if project_path.exists():
-            project_content = project_path.read_text(encoding="utf-8")
-            if self._detect_stale_override("MEMORY.md", project_content):
+            try:
+                project_content = project_path.read_text(encoding="utf-8")
+            except Exception as exc:
                 self.logger.warning(
-                    "Stale override detected: .claude-mpm/MEMORY.md contains "
-                    "content from other blocks. Ignoring override and using "
-                    "system default. Remove .claude-mpm/MEMORY.md to suppress "
-                    "this warning.",
+                    "Could not read .claude-mpm/MEMORY.md (%s); "
+                    "falling back to system default.",
+                    exc,
                 )
-            else:
-                parts.append(project_content)
-                has_override = True
+                project_content = None
+            if project_content is not None:
+                if self._detect_stale_override("MEMORY.md", project_content):
+                    self.logger.warning(
+                        "Stale override detected: .claude-mpm/MEMORY.md contains "
+                        "content from other blocks. Ignoring override and using "
+                        "system default. Remove .claude-mpm/MEMORY.md to suppress "
+                        "this warning.",
+                    )
+                else:
+                    parts.append(project_content)
+                    has_override = True
 
         if has_override:
             self.logger.debug(

--- a/src/claude_mpm/services/instructions/instruction_cache_service.py
+++ b/src/claude_mpm/services/instructions/instruction_cache_service.py
@@ -43,8 +43,8 @@ logger = get_logger(__name__)
 class InstructionCacheService:
     """Manages cached assembled PM instruction content for file-based loading.
 
-    The cache is stored at `.claude-mpm/PM_INSTRUCTIONS.md` and includes
-    a metadata file `.claude-mpm/PM_INSTRUCTIONS.md.meta` containing:
+    The cache is stored at `.claude-mpm/PM_INSTRUCTIONS_CACHE.md` and includes
+    a metadata file `.claude-mpm/PM_INSTRUCTIONS_CACHE.md.meta` containing:
     - notice: Human-readable "do not edit" notice (auto-generated banner)
     - content_hash: SHA-256 of assembled instruction content
     - content_size_bytes: Size of cached content in bytes
@@ -54,9 +54,19 @@ class InstructionCacheService:
     - version: Cache format version
 
     Design note: the auto-generated "do not edit" notice is stored in the
-    .meta sidecar rather than prepended to the cache file.  PM_INSTRUCTIONS.md
-    is passed verbatim to Claude via --system-prompt-file, so any prefix added
-    to the file would pollute every session's system prompt.
+    .meta sidecar rather than prepended to the cache file.
+    PM_INSTRUCTIONS_CACHE.md is passed verbatim to Claude via
+    --system-prompt-file, so any prefix added to the file would pollute
+    every session's system prompt.
+
+    Rename rationale: the previous filename (PM_INSTRUCTIONS.md) collided
+    with the project-override input that the SystemInstructionsDeployer
+    reads from ``.claude-mpm/PM_INSTRUCTIONS.md``.  The rename resolves the
+    collision: the launcher cache is now PM_INSTRUCTIONS_CACHE.md while
+    the override input keeps its original name.  Existing installs that
+    have a stale cache at the old path are unaffected — the cache is
+    regenerated on startup and the deployer's override guard rejects any
+    leftover old-name file that lacks the ``## Identity`` marker.
 
     Cache Updates:
     - Triggered during agent deployment or interactive sessions
@@ -77,8 +87,8 @@ class InstructionCacheService:
     """
 
     CACHE_DIR = ".claude-mpm"
-    CACHE_FILENAME = "PM_INSTRUCTIONS.md"
-    META_FILENAME = "PM_INSTRUCTIONS.md.meta"
+    CACHE_FILENAME = "PM_INSTRUCTIONS_CACHE.md"
+    META_FILENAME = "PM_INSTRUCTIONS_CACHE.md.meta"
     CACHE_VERSION = "1.0"
 
     def __init__(self, project_root: Path | None = None) -> None:
@@ -146,11 +156,12 @@ class InstructionCacheService:
                 }
 
             # Write content to cache (atomic operation).
-            # The banner is intentionally NOT prepended here: PM_INSTRUCTIONS.md
-            # is passed verbatim to Claude via --system-prompt-file, so injecting
-            # an HTML comment would add ~200 bytes of noise into every session's
-            # system prompt.  The do-not-edit notice lives in the .meta sidecar
-            # (see _write_metadata) where it is visible to human readers without
+            # The banner is intentionally NOT prepended here:
+            # PM_INSTRUCTIONS_CACHE.md is passed verbatim to Claude via
+            # --system-prompt-file, so injecting an HTML comment would add
+            # ~200 bytes of noise into every session's system prompt.  The
+            # do-not-edit notice lives in the .meta sidecar (see
+            # _write_metadata) where it is visible to human readers without
             # polluting the model input.
             temp_file = self.cache_file.with_suffix(".tmp")
             temp_file.write_text(instruction_content, encoding="utf-8")
@@ -182,12 +193,12 @@ class InstructionCacheService:
         """Get path to cache file.
 
         Returns:
-            Path to PM_INSTRUCTIONS.md cache
+            Path to PM_INSTRUCTIONS_CACHE.md cache
 
         Example:
             >>> service = InstructionCacheService()
             >>> cache_path = service.get_cache_path()
-            >>> print(cache_path)  # .claude-mpm/PM_INSTRUCTIONS.md
+            >>> print(cache_path)  # .claude-mpm/PM_INSTRUCTIONS_CACHE.md
         """
         return self.cache_file
 

--- a/src/claude_mpm/services/skills/selective_skill_deployer.py
+++ b/src/claude_mpm/services/skills/selective_skill_deployer.py
@@ -458,9 +458,10 @@ def get_required_skills_from_agents(agents_dir: Path) -> set[str]:
     - Removes dependency on static YAML mapping
     - Fixes PM skills being removed as orphaned (they use inline markers)
 
-    Special handling for PM_INSTRUCTIONS.md:
-    - Also scans .claude-mpm/PM_INSTRUCTIONS.md for skill markers
-    - PM instructions are not in agents_dir but contain [SKILL: ...] references
+    Special handling for the launcher cache:
+    - Also scans .claude-mpm/PM_INSTRUCTIONS_CACHE.md for skill markers
+    - The assembled launcher cache is not in agents_dir but contains
+      [SKILL: ...] references from PM_INSTRUCTIONS.md and related sources
 
     Args:
         agents_dir: Path to deployed agents directory (e.g., .claude/agents/)
@@ -480,12 +481,16 @@ def get_required_skills_from_agents(agents_dir: Path) -> set[str]:
     # Scan all agent markdown files
     agent_files = list(agents_dir.glob("*.md"))
 
-    # Special case: Add PM_INSTRUCTIONS.md if it exists
-    # PM instructions live in .claude-mpm/ not .claude/agents/
-    pm_instructions = agents_dir.parent.parent / ".claude-mpm" / "PM_INSTRUCTIONS.md"
+    # Special case: Add the assembled launcher cache if it exists.
+    # PM_INSTRUCTIONS_CACHE.md lives in .claude-mpm/ (not .claude/agents/)
+    # and contains [SKILL: ...] markers assembled from PM_INSTRUCTIONS.md
+    # and related source files.
+    pm_instructions = (
+        agents_dir.parent.parent / ".claude-mpm" / "PM_INSTRUCTIONS_CACHE.md"
+    )
     if pm_instructions.exists():
         agent_files.append(pm_instructions)
-        logger.debug("Added PM_INSTRUCTIONS.md for skill scanning")
+        logger.debug("Added PM_INSTRUCTIONS_CACHE.md for skill scanning")
 
     logger.debug(f"Scanning {len(agent_files)} agent files (including PM instructions)")
 

--- a/tests/services/instructions/test_instruction_cache_service.py
+++ b/tests/services/instructions/test_instruction_cache_service.py
@@ -49,11 +49,11 @@ class TestInstructionCacheService:
         assert service.cache_dir == temp_project_root / ".claude-mpm"
         assert (
             service.cache_file
-            == temp_project_root / ".claude-mpm" / "PM_INSTRUCTIONS.md"
+            == temp_project_root / ".claude-mpm" / "PM_INSTRUCTIONS_CACHE.md"
         )
         assert (
             service.meta_file
-            == temp_project_root / ".claude-mpm" / "PM_INSTRUCTIONS.md.meta"
+            == temp_project_root / ".claude-mpm" / "PM_INSTRUCTIONS_CACHE.md.meta"
         )
 
     def test_init_uses_cwd_when_no_root_provided(self):
@@ -77,7 +77,7 @@ class TestInstructionCacheService:
         assert cache_service.meta_file.exists()
 
         # Verify cache file contains exactly the supplied content — no banner
-        # is prepended because PM_INSTRUCTIONS.md is passed verbatim to Claude
+        # is prepended because PM_INSTRUCTIONS_CACHE.md is passed verbatim to Claude
         # via --system-prompt-file.  The "do not edit" notice lives in the
         # .meta sidecar (see _write_metadata / BANNER_CACHE_NOTICE).
         cached_text = cache_service.cache_file.read_text()
@@ -264,7 +264,7 @@ class TestInstructionCacheService:
         """Test that get_cache_path returns the correct cache file path."""
         path = cache_service.get_cache_path()
         assert path == cache_service.cache_file
-        assert path.name == "PM_INSTRUCTIONS.md"
+        assert path.name == "PM_INSTRUCTIONS_CACHE.md"
 
     def test_get_cache_info_returns_metadata(
         self, cache_service, test_instruction_content

--- a/tests/test_lazy_load_memory.py
+++ b/tests/test_lazy_load_memory.py
@@ -337,3 +337,60 @@ def test_kuzu_augmentation_still_injects_when_detected() -> None:
     assert MEMORY_SYSTEM_REFERENCE in memory_stored, (
         "System-level MEMORY stub was lost when the kuzu prefix was prepended"
     )
+
+
+# ── Test 7: kuzu augmentation injects on the from_deployed=True path ──────────
+
+
+@pytest.mark.unit
+def test_kuzu_augmentation_injects_when_from_deployed_and_detected() -> None:
+    """Dynamic kuzu-memory prefix injects even when instructions came from DEPLOYED.
+
+    When ``_loaded_from_deployed=True`` the static MEMORY block is already
+    present in PM_INSTRUCTIONS_DEPLOYED.md and must NOT be re-loaded
+    (``load_memory_file`` must not be called).  However, the dynamic
+    kuzu-memory augmentation is environment-dependent and cannot be baked
+    into DEPLOYED; it must still run and produce its prefix notice.
+
+    This is the deployed-path counterpart of
+    ``test_kuzu_augmentation_still_injects_when_detected`` (which tests the
+    non-deployed path).
+    """
+    loader = InstructionLoader()
+    # Simulate that PM_INSTRUCTIONS_DEPLOYED.md was already loaded; the
+    # sentinel tells load_memory_instructions to skip the static re-load.
+    content: dict = {"_loaded_from_deployed": True}
+
+    with (
+        patch.object(loader, "_detect_kuzu_memory", return_value=True),
+        # load_memory_file must NOT be called on the deployed path.
+        patch.object(
+            loader.file_loader,
+            "load_memory_file",
+            side_effect=AssertionError(
+                "load_memory_file must not be called when _loaded_from_deployed is set"
+            ),
+        ),
+    ):
+        loader.load_memory_instructions(content)
+
+    memory_stored = content.get("memory_instructions", "")
+
+    # The kuzu prefix must have been injected despite the deployed path.
+    assert "kuzu-memory Active (legacy fallback)" in memory_stored, (
+        "kuzu-memory prefix was NOT injected on the from_deployed=True path — "
+        "the environment-dependent augmentation must run regardless of deployed status"
+    )
+    assert "mcp__kuzu-memory__kuzu_remember" in memory_stored, (
+        "kuzu MCP tool reference missing from augmented memory content (deployed path)"
+    )
+
+    # On the deployed path the static MEMORY body is already in DEPLOYED; only
+    # the dynamic kuzu prefix is written to memory_instructions.  The
+    # MEMORY_SYSTEM_REFERENCE stub is intentionally NOT present here because it
+    # would duplicate the content already in DEPLOYED (see instruction_loader.py
+    # lines ~391-403 for the exact branching logic).
+    level_stored = content.get("memory_instructions_level", "")
+    assert level_stored == "system", (
+        f"Expected memory_instructions_level='system' on deployed path, got {level_stored!r}"
+    )

--- a/tests/test_lazy_load_memory.py
+++ b/tests/test_lazy_load_memory.py
@@ -363,16 +363,14 @@ def test_kuzu_augmentation_injects_when_from_deployed_and_detected() -> None:
 
     with (
         patch.object(loader, "_detect_kuzu_memory", return_value=True),
-        # load_memory_file must NOT be called on the deployed path.
-        patch.object(
-            loader.file_loader,
-            "load_memory_file",
-            side_effect=AssertionError(
-                "load_memory_file must not be called when _loaded_from_deployed is set"
-            ),
-        ),
+        patch.object(loader.file_loader, "load_memory_file") as mock_load_memory,
     ):
         loader.load_memory_instructions(content)
+
+    # load_memory_file must NOT be called on the deployed path.
+    assert mock_load_memory.call_count == 0, (
+        "load_memory_file must not be called when _loaded_from_deployed is set"
+    )
 
     memory_stored = content.get("memory_instructions", "")
 


### PR DESCRIPTION
## Summary

Completes the remaining items from GitHub issue #794 (instruction-pipeline hardening). The branch contains 10 one-file-per-commit changes covering 5 items:

**Item 1** (`chore`): Add debug log when `_override_is_valid` skips marker check — easier diagnosis of silent override rejections.

**Item 2** (`fix`): Defensive `.read_text()` guards in `_resolve_workflow_block` and `_resolve_memory_block` — prevents unhandled exceptions on missing or unreadable files.

**Item 3** (`test`): Kuzu augmentation integration test for the `from_deployed` path — confirms kuzu content is injected when loading from a deployed agent file.

**Item 4** (`chore` × 4): Rename the launcher-cache output file from `PM_INSTRUCTIONS.md` → `PM_INSTRUCTIONS_CACHE.md` across `InstructionCacheService`, `SystemInstructionsDeployer`, `SelectiveSkillDeployer`, `constants.py`, and `skills scanner` — eliminates the name collision between the bundled source `PM_INSTRUCTIONS.md` and the assembled launcher cache.

**Item 5** (`refactor`): Rename locals `_memory_content` → `memory_content` and `_memory_content_fb` → `memory_content_fallback` in `packaged_loader.py` — the leading underscores falsely signalled "unused"; both variables are actively used in the `if` guard immediately following.

**Doc/test follow-ups** (`docs`, `test`):
- `BASE_PM.md` auto-generated-files table updated to show `PM_INSTRUCTIONS_CACHE.md` as the InstructionCacheService output.
- `test_instruction_cache_service.py` path and name assertions updated to `PM_INSTRUCTIONS_CACHE.md` / `PM_INSTRUCTIONS_CACHE.md.meta`.

## Test plan

- [x] `uv run pytest -p no:xdist tests/ -k "instruction_cache or system_instructions or deployer or lazy_load or kuzu or packaged_loader"` — 193 passed, 1 skipped (unrelated pyngrok), 0 failures
- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed, 0 changes
- [x] Sanity grep confirms every `PM_INSTRUCTIONS_CACHE` reference is in the correct location; source/input `PM_INSTRUCTIONS.md` references are untouched

Closes #794

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)