### PR TITLE
fix(cli): wire --scope user through skills deploy command (#806)

### DIFF
--- a/src/claude_mpm/cli/commands/skills.py
+++ b/src/claude_mpm/cli/commands/skills.py
@@ -19,6 +19,7 @@ ARCHITECTURE:
 
 import os
 import subprocess  # nosec B404
+from pathlib import Path
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -199,19 +200,44 @@ class SkillsManagementCommand(BaseCommand):
             console.print(f"[red]Error listing skills: {e}[/red]")
             return CommandResult(success=False, message=str(e), exit_code=1)
 
+    @staticmethod
+    def _normalize_deploy_result(result: dict) -> dict:
+        """Normalize ``deploy_skills`` flat output to the project-deploy shape.
+
+        WHAT: Maps the ``deploy_skills_count``/``deployed_skills`` keys returned
+        by user-level ``deploy_skills`` onto the ``deployed``/``updated``/
+        ``skipped``/``failed``/``deployment_dir`` keys the result-rendering code
+        in ``_deploy_skills`` expects.
+        WHY: ``deploy_skills`` (flat, user-level) and ``deploy_skills_to_project``
+        return different result schemas; normalizing lets both scopes share one
+        rendering path (issue #806).
+        """
+        return {
+            "deployed": result.get("deployed_skills", []),
+            "updated": [],
+            "skipped": result.get("skipped_skills", []),
+            "failed": result.get("errors", []),
+            "deployment_dir": result.get(
+                "deployment_dir", str(Path.home() / ".claude" / "skills")
+            ),
+        }
+
     def _deploy_skills(self, args) -> CommandResult:
         """Deploy skills using two-phase sync: cache → deploy.
 
         Phase 3 Integration (1M-486): Uses Git skill source manager for deployment.
         - Phase 1: Sync skills to ~/.claude-mpm/cache/skills/ (if needed)
-        - Phase 2: Deploy from cache to project .claude-mpm/skills/
+        - Phase 2: Deploy from cache to the scope-selected destination
 
         This replaces bundled skill deployment with a multi-project
         architecture where one cache serves multiple project deployments.
+
+        WHAT: Honors --scope so 'user' deploys to ~/.claude/skills/ and
+        'project' deploys to the project-local skills directory (issue #806).
+        WHY: The handler previously ignored args.scope and always deployed
+        project-local, making --scope user a silent no-op.
         """
         try:
-            from pathlib import Path
-
             from ...config.skill_sources import SkillSourceConfiguration
             from ...services.skills.git_skill_source_manager import (
                 GitSkillSourceManager,
@@ -219,6 +245,7 @@ class SkillsManagementCommand(BaseCommand):
 
             force = getattr(args, "force", False)
             specific_skills = getattr(args, "skills", None)
+            scope = getattr(args, "scope", "project")
 
             console.print("\n[bold cyan]Deploying skills...[/bold cyan]\n")
 
@@ -238,13 +265,26 @@ class SkillsManagementCommand(BaseCommand):
             )
             console.print(f"[dim]Synced {synced_count} skill source(s)[/dim]\n")
 
-            # Phase 2: Deploy from cache to project
-            console.print("[dim]Phase 2: Deploying from cache to project...[/dim]\n")
-            deploy_result = git_skill_manager.deploy_skills_to_project(
-                project_dir=project_dir,
-                skill_list=specific_skills,
-                force=force,
-            )
+            # Phase 2: Deploy from cache to the scope-selected destination
+            if scope == "user":
+                console.print(
+                    "[cyan]Deploying to user level (~/.claude/skills/)...[/cyan]\n"
+                )
+                deploy_result = git_skill_manager.deploy_skills(
+                    target_dir=Path.home() / ".claude" / "skills",
+                    force=force,
+                    skill_filter=set(specific_skills) if specific_skills else None,
+                )
+                deploy_result = self._normalize_deploy_result(deploy_result)
+            else:
+                console.print(
+                    "[cyan]Deploying to project level (.claude/skills/)...[/cyan]\n"
+                )
+                deploy_result = git_skill_manager.deploy_skills_to_project(
+                    project_dir=project_dir,
+                    skill_list=specific_skills,
+                    force=force,
+                )
 
             # Display results
             if deploy_result["deployed"]:

--- a/tests/cli/test_skills_deploy_scope.py
+++ b/tests/cli/test_skills_deploy_scope.py
@@ -1,0 +1,134 @@
+"""Unit tests for ``claude-mpm skills deploy --scope`` routing.
+
+Verifies that ``SkillsManagementCommand._deploy_skills`` honors ``args.scope``
+(issue #806):
+
+- ``--scope user``    -> ``GitSkillSourceManager.deploy_skills`` (~/.claude/skills/)
+- ``--scope project`` -> ``GitSkillSourceManager.deploy_skills_to_project``
+- no flag (defaults to project) -> ``deploy_skills_to_project``
+
+The handler was previously hardcoded to project-local deployment, silently
+ignoring ``--scope user``.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from claude_mpm.cli.commands.skills import SkillsManagementCommand
+
+
+def _make_args(scope=None, force=False, skills=None):
+    """Build a deploy args namespace; omit ``scope`` entirely when None."""
+    kwargs = {"force": force, "skills": skills}
+    if scope is not None:
+        kwargs["scope"] = scope
+    return SimpleNamespace(**kwargs)
+
+
+def _patched_manager():
+    """Patch the manager + config classes and return the manager mock.
+
+    The patch targets the symbols at their definition modules because
+    ``_deploy_skills`` imports them lazily inside the function body.
+    """
+    sync_return = {"sources": {}}
+
+    manager = MagicMock()
+    manager.sync_all_sources.return_value = sync_return
+    manager.deploy_skills_to_project.return_value = {
+        "deployed": ["alpha"],
+        "updated": [],
+        "skipped": [],
+        "failed": [],
+        "deployment_dir": "/proj/.claude-mpm/skills",
+    }
+    manager.deploy_skills.return_value = {
+        "deployed_count": 1,
+        "deployed_skills": ["alpha"],
+        "skipped_count": 0,
+        "skipped_skills": [],
+        "errors": [],
+    }
+    return manager
+
+
+def test_scope_user_routes_to_user_level_deploy():
+    """``--scope user`` deploys via ``deploy_skills`` to ~/.claude/skills/."""
+    manager = _patched_manager()
+
+    with (
+        patch(
+            "claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager",
+            return_value=manager,
+        ),
+        patch("claude_mpm.config.skill_sources.SkillSourceConfiguration"),
+    ):
+        result = SkillsManagementCommand()._deploy_skills(_make_args(scope="user"))
+
+    assert result.success is True
+    assert result.exit_code == 0
+
+    manager.deploy_skills.assert_called_once()
+    manager.deploy_skills_to_project.assert_not_called()
+
+    # User-level deploy must target ~/.claude/skills/.
+    _, kwargs = manager.deploy_skills.call_args
+    assert kwargs["target_dir"] == Path.home() / ".claude" / "skills"
+
+
+def test_scope_project_routes_to_project_level_deploy():
+    """``--scope project`` deploys via ``deploy_skills_to_project``."""
+    manager = _patched_manager()
+
+    with (
+        patch(
+            "claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager",
+            return_value=manager,
+        ),
+        patch("claude_mpm.config.skill_sources.SkillSourceConfiguration"),
+    ):
+        result = SkillsManagementCommand()._deploy_skills(_make_args(scope="project"))
+
+    assert result.success is True
+    assert result.exit_code == 0
+
+    manager.deploy_skills_to_project.assert_called_once()
+    manager.deploy_skills.assert_not_called()
+
+
+def test_default_scope_is_project():
+    """Omitting ``--scope`` defaults to project-level deployment."""
+    manager = _patched_manager()
+
+    with (
+        patch(
+            "claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager",
+            return_value=manager,
+        ),
+        patch("claude_mpm.config.skill_sources.SkillSourceConfiguration"),
+    ):
+        result = SkillsManagementCommand()._deploy_skills(_make_args(scope=None))
+
+    assert result.success is True
+    manager.deploy_skills_to_project.assert_called_once()
+    manager.deploy_skills.assert_not_called()
+
+
+def test_scope_user_passes_skill_filter():
+    """``--skill`` selections are forwarded as a ``skill_filter`` set."""
+    manager = _patched_manager()
+
+    with (
+        patch(
+            "claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager",
+            return_value=manager,
+        ),
+        patch("claude_mpm.config.skill_sources.SkillSourceConfiguration"),
+    ):
+        SkillsManagementCommand()._deploy_skills(
+            _make_args(scope="user", skills=["alpha", "beta"])
+        )
+
+    _, kwargs = manager.deploy_skills.call_args
+    assert kwargs["skill_filter"] == {"alpha", "beta"}


### PR DESCRIPTION
## Summary
- `claude-mpm skills deploy --scope user` now correctly deploys to `~/.claude/skills/` instead of silently deploying project-local
- `_deploy_skills()` reads `scope = getattr(args, "scope", "project")` and branches: `user` → `git_skill_manager.deploy_skills(target_dir=~/.claude/skills/)`, `project` → existing `deploy_skills_to_project()` (unchanged)
- Added `_normalize_deploy_result()` helper to map the user-level result schema onto the existing rendering keys, keeping a single rendering path
- Each scope prints its destination clearly: `Deploying to user level (~/.claude/skills/)...` or `Deploying to project level (.claude/skills/)...`

## Test plan
- [x] `--scope user` → calls `deploy_skills` targeting `~/.claude/skills/`
- [x] `--scope project` → calls `deploy_skills_to_project`
- [x] No `--scope` flag → defaults to project (backward-compatible)
- [x] `--skill foo` forwarded correctly as `skill_filter`
- [x] Full `tests/cli/` regression: 1041 passed, 11 skipped
- [x] ruff format + ruff check clean

Closes #806

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)