### PR TITLE
fix(skills): replace iterdir with rglob in discover_bundled_skills for deep nesting (#808)

### DIFF
--- a/src/claude_mpm/skills/skills_service.py
+++ b/src/claude_mpm/skills/skills_service.py
@@ -169,20 +169,29 @@ class SkillsService(LoggerMixin):
     def discover_bundled_skills(self) -> list[dict[str, Any]]:
         """Discover all skills in bundled directory.
 
-        Scans bundled_skills_path for skills organized by category:
+        Recursively scans bundled_skills_path for any SKILL.md at any depth,
+        so both shallow and deeply-nested layouts are supported:
         bundled/
-          ├── development/
+          ├── development/                       # category = "development"
           │   ├── test-driven-development/
-          │   │   └── SKILL.md
+          │   │   └── SKILL.md                    # name = "test-driven-development"
           │   └── systematic-debugging/
           │       └── SKILL.md
-          └── testing/
-              └── ...
+          ├── toolchains/                         # category = "toolchains"
+          │   └── rust/
+          │       └── core/
+          │           └── SKILL.md                # name = "core"  (level 3)
+          └── universal/                          # category = "universal"
+              └── spec-linked-docs/
+                  └── SKILL.md                    # name = "spec-linked-docs"
+
+        The skill name is the immediate parent directory of SKILL.md; the
+        category is the first-level subdirectory under bundled_skills_path.
 
         Returns:
             List of skill dictionaries containing:
-            - name: Skill name (directory name)
-            - category: Category (parent directory name)
+            - name: Skill name (immediate parent directory of SKILL.md)
+            - category: Category (top-level subdirectory under bundled root)
             - path: Full path to skill directory
             - metadata: Parsed YAML frontmatter from SKILL.md
         """
@@ -194,25 +203,34 @@ class SkillsService(LoggerMixin):
             )
             return skills
 
-        for category_dir in self.bundled_skills_path.iterdir():
-            if not category_dir.is_dir() or category_dir.name.startswith("."):
+        for skill_md in self.bundled_skills_path.rglob("SKILL.md"):
+            skill_dir = skill_md.parent
+
+            try:
+                relative = skill_dir.relative_to(self.bundled_skills_path)
+            except ValueError:
                 continue
 
-            for skill_dir in category_dir.iterdir():
-                if not skill_dir.is_dir():
-                    continue
+            # Skip skills nested under any hidden directory.
+            if any(part.startswith(".") for part in relative.parts):
+                continue
 
-                skill_md = skill_dir / "SKILL.md"
-                if skill_md.exists():
-                    metadata = self._parse_skill_metadata(skill_md)
-                    skills.append(
-                        {
-                            "name": skill_dir.name,
-                            "category": category_dir.name,
-                            "path": skill_dir,
-                            "metadata": metadata,
-                        }
-                    )
+            # Category is the first-level subdirectory under the bundled root;
+            # fall back to the skill directory name for top-level SKILL.md files.
+            try:
+                category = relative.parts[0]
+            except IndexError:
+                category = skill_dir.name
+
+            metadata = self._parse_skill_metadata(skill_md)
+            skills.append(
+                {
+                    "name": skill_dir.name,
+                    "category": category,
+                    "path": skill_dir,
+                    "metadata": metadata,
+                }
+            )
 
         self.logger.info(f"Discovered {len(skills)} bundled skills")
 

--- a/tests/skills/test_discover_bundled_skills_depth.py
+++ b/tests/skills/test_discover_bundled_skills_depth.py
@@ -1,0 +1,81 @@
+"""Regression tests for deeply-nested bundled skill discovery (issue #808).
+
+WHAT: Verify ``SkillsService.discover_bundled_skills()`` finds SKILL.md files at
+any depth under the bundled root, not just two levels deep.
+WHY: The previous nested ``iterdir()`` implementation only reached level-2
+``SKILL.md`` files, silently dropping skills laid out as
+``toolchains/<lang>/<tier>/SKILL.md`` and ``universal/<skill>/SKILL.md``.
+
+References
+----------
+SPEC-SKILLS-02~1 : docs/specs/skills.md#SPEC-SKILLS-02~1
+"""
+
+from pathlib import Path
+
+from claude_mpm.skills.skills_service import SkillsService
+
+_SKILL_MD = """---
+name: {name}
+description: Test skill {name}
+---
+
+# {name}
+"""
+
+
+def _write_skill(skill_dir: Path, name: str) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(_SKILL_MD.format(name=name), encoding="utf-8")
+
+
+def _build_bundled_tree(root: Path) -> None:
+    """Create a fake bundled/ tree spanning levels 2 and 3 plus a hidden dir."""
+    # Level 2 — already worked before the fix.
+    _write_skill(root / "category-a" / "skill-flat", "skill-flat")
+    # Level 3 — was broken before the fix.
+    _write_skill(root / "toolchains" / "rust" / "core", "core")
+    _write_skill(root / "universal" / "collab" / "brainstorm", "brainstorm")
+    # Hidden dir — must be ignored.
+    _write_skill(root / ".hidden" / "skill", "hidden-skill")
+
+
+def _discover(tmp_path: Path) -> dict[str, dict]:
+    bundled = tmp_path / "bundled"
+    _build_bundled_tree(bundled)
+
+    service = SkillsService()
+    service.bundled_skills_path = bundled
+    skills = service.discover_bundled_skills()
+
+    # Restrict to skills under our temp tree; the Superpowers cache scan may add
+    # unrelated real skills from the developer's home directory.
+    return {s["name"]: s for s in skills if Path(s["path"]).is_relative_to(bundled)}
+
+
+def test_discovers_skills_at_all_depths(tmp_path: Path) -> None:
+    found = _discover(tmp_path)
+    assert set(found) == {"skill-flat", "core", "brainstorm"}
+
+
+def test_flat_skill_category_and_name(tmp_path: Path) -> None:
+    found = _discover(tmp_path)
+    assert found["skill-flat"]["category"] == "category-a"
+    assert found["skill-flat"]["name"] == "skill-flat"
+
+
+def test_level3_toolchain_skill_category_and_name(tmp_path: Path) -> None:
+    found = _discover(tmp_path)
+    assert found["core"]["category"] == "toolchains"
+    assert found["core"]["name"] == "core"
+
+
+def test_level3_universal_skill_category_and_name(tmp_path: Path) -> None:
+    found = _discover(tmp_path)
+    assert found["brainstorm"]["category"] == "universal"
+    assert found["brainstorm"]["name"] == "brainstorm"
+
+
+def test_hidden_dirs_are_not_discovered(tmp_path: Path) -> None:
+    found = _discover(tmp_path)
+    assert "hidden-skill" not in found


### PR DESCRIPTION
## Summary
- `discover_bundled_skills()` was using two nested `iterdir()` calls (max 2 levels), missing skills 3+ levels deep like `toolchains/<lang>/core/SKILL.md` and `universal/<category>/<skill>/SKILL.md`
- Replaced with `self.bundled_skills_path.rglob("SKILL.md")` (matching the approach already used in `skills/registry.py`)
- Category is now derived from the first-level subdirectory under `bundled/` via `relative.parts[0]`
- Hidden directory guard preserved; Superpowers cache scan untouched
- Since `_get_bundled_skill_names()` in the v6_5_40 migration wraps `discover_bundled_skills()`, the migration now picks up deeply-nested skills too — enabling future duplicate sweeps across projects

## Previously-missed skills now discovered
All 7 deeply-nested skills now found: `toolchains/{rust,python,golang,typescript,java,javascript}/core` and `universal/spec-linked-docs`. Total bundled skills: 53 → 60.

## Test plan
- [x] Flat skills (level 2) still discovered correctly
- [x] Level-3 `toolchains/rust/core` discovered with correct name + category
- [x] Level-3 `universal/collab/brainstorm` discovered
- [x] Hidden dirs (`.hidden/`) excluded
- [x] Category correctly derived as first-level subdir
- [x] Full `tests/skills/` suite: 75 passed
- [x] ruff format + ruff check clean

Note: The 31-project re-sweep to remove newly-detectable per-project duplicates is a follow-up operational step, tracked in #808.

Closes #808

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)