### PR TITLE
feat: live tools/list proxy probe for Available Tool Services detection (closes #814)

### DIFF
--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -384,15 +384,32 @@ class FrameworkLoader:
         degraded-mode note when all absent, and an empty string on probe error.
         """
         try:
-            from claude_mpm.services.trusty_status import get_trusty_capabilities
+            from claude_mpm.services.trusty_status import (
+                get_probe_hint,
+                get_trusty_capabilities_live,
+            )
 
-            capabilities = get_trusty_capabilities()
-        except Exception as e:  # pragma: no cover - defensive
-            self.logger.debug(f"Skipping tool status section: {e}")
-            return ""
+            capabilities = get_trusty_capabilities_live()
+        except Exception:
+            try:
+                from claude_mpm.services.trusty_status import get_trusty_capabilities
+
+                capabilities = get_trusty_capabilities()
+            except Exception as e:  # pragma: no cover - defensive
+                self.logger.debug(f"Skipping tool status section: {e}")
+                return ""
 
         if not capabilities:
             return ""
+
+        # get_probe_hint is defined alongside get_trusty_capabilities_live; if
+        # the import above used the fallback path, provide a no-op stand-in.
+        try:
+            from claude_mpm.services.trusty_status import get_probe_hint
+        except Exception:
+
+            def get_probe_hint(_svc: str) -> str:  # type: ignore[misc]
+                return ""
 
         # Human-facing labels for each detected state.
         status_labels = {
@@ -400,6 +417,7 @@ class FrameworkLoader:
             "configured": "NOT RUNNING",
             "not_running": "NOT RUNNING",
             "absent": "ABSENT",
+            "degraded": "⚠ DEGRADED",
         }
 
         # Per-service Impact text keyed by availability (ON vs everything else).
@@ -465,7 +483,13 @@ class FrameworkLoader:
                     impact = f"{impact} {note}"
             lines.append(f"| {service} | {label} | {impact} |")
             if not is_on:
-                negations.append(f"- {impact}")
+                # For DEGRADED services, append the actionable hint from the probe
+                # in parentheses so the PM knows why the service is unavailable.
+                hint = get_probe_hint(service)
+                negation = f"- {impact}"
+                if hint and state == "degraded":
+                    negation = f"{negation} ({hint})"
+                negations.append(negation)
 
         if negations:
             lines.append("\n**Skip the following this session:**\n")

--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -398,18 +398,15 @@ class FrameworkLoader:
             except Exception as e:  # pragma: no cover - defensive
                 self.logger.debug(f"Skipping tool status section: {e}")
                 return ""
-
-        if not capabilities:
-            return ""
-
-        # get_probe_hint is defined alongside get_trusty_capabilities_live; if
-        # the import above used the fallback path, provide a no-op stand-in.
-        try:
-            from claude_mpm.services.trusty_status import get_probe_hint
-        except Exception:
+            # get_probe_hint is defined unconditionally in trusty_status.py, but
+            # we're here because the live-probe import failed; provide a no-op so
+            # downstream code works without a second import attempt.
 
             def get_probe_hint(_svc: str) -> str:  # type: ignore[misc]
                 return ""
+
+        if not capabilities:
+            return ""
 
         # Human-facing labels for each detected state.
         status_labels = {

--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -136,6 +136,8 @@ async def _probe_single_service(
                 timeout=timeout,
             )
         except TimeoutError:
+            # asyncio.TimeoutError (aliased to builtins.TimeoutError on Python 3.11+)
+            # is what asyncio.wait_for raises; catching TimeoutError covers both.
             return ProbeResult(
                 state="degraded",
                 hint=f"{service} initialize handshake timed out after {timeout}s — check daemon / binary",
@@ -170,6 +172,17 @@ async def _probe_single_service(
         tools_line = (json.dumps(_TOOLS_LIST_REQUEST) + "\n").encode()
         process.stdin.write(tools_line)
         await process.stdin.drain()
+        # Close stdin to signal EOF — some stdio MCP servers buffer stdout until
+        # stdin is closed; without this the probe would time out against such a
+        # server and falsely report DEGRADED for a healthy service.
+        process.stdin.close()
+        # wait_closed() is available in Python 3.7+ to wait for the underlying
+        # transport to flush. On Python 3.13 (our minimum) this is always present.
+        # Ignore OSError in case the transport is already gone (e.g. child exited).
+        try:
+            await process.stdin.wait_closed()
+        except OSError:
+            pass
 
         # Read tools/list response with timeout.
         try:
@@ -178,6 +191,8 @@ async def _probe_single_service(
                 timeout=timeout,
             )
         except TimeoutError:
+            # asyncio.TimeoutError (aliased to builtins.TimeoutError on Python 3.11+)
+            # is what asyncio.wait_for raises; catching TimeoutError covers both.
             return ProbeResult(
                 state="degraded",
                 hint=f"{service} tools/list timed out — service may be reachable but not fully wired",
@@ -220,9 +235,14 @@ async def _probe_single_service(
                 ),
             )
 
-        # Sentinel present → definitively ON.
-        # Fallback: any tools returned → ON (sentinel may not be in all builds;
-        # documented in module docstring — this is intentional loose-check).
+        # Two-tier sentinel check (issue #814):
+        # Tier 1 — sentinel (console_metrics) present → definitively ON.
+        # Tier 2 — any tools returned without sentinel → ON (sentinel may not be
+        # in every deployment build; loose-check intentional, see module docstring).
+        if SENTINEL_TOOL in tool_names:
+            # Sentinel present: fully wired.
+            return ProbeResult(state="on", hint="")
+        # Fallback tier: some tools but no sentinel → still ON.
         return ProbeResult(state="on", hint="")
 
     except Exception as exc:  # pragma: no cover - unexpected catch-all

--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -36,7 +36,14 @@ logger = logging.getLogger(__name__)
 SENTINEL_TOOL = "console_metrics"
 
 # Service name -> stdio spawn command. These are the EXACT argv lists the
-# trusty-* binaries expect when started in stdio MCP server mode.
+# trusty-* binaries expect when started in stdio MCP server mode:
+#   memory  → `serve --stdio`
+#   search  → `serve`
+#   analyze → `mcp`
+#   review  → `serve --stdio`
+# These must track the trusty binaries' stdio-MCP CLI. A CLI drift (e.g. a
+# renamed subcommand after a trusty release) will surface as DEGRADED probes
+# rather than a crash, making the mismatch easy to diagnose and fix here.
 SERVICE_PROBE_COMMANDS: dict[str, list[str]] = {
     "trusty-memory": ["trusty-memory", "serve", "--stdio"],
     "trusty-search": ["trusty-search", "serve"],
@@ -235,14 +242,11 @@ async def _probe_single_service(
                 ),
             )
 
-        # Two-tier sentinel check (issue #814):
-        # Tier 1 — sentinel (console_metrics) present → definitively ON.
-        # Tier 2 — any tools returned without sentinel → ON (sentinel may not be
-        # in every deployment build; loose-check intentional, see module docstring).
-        if SENTINEL_TOOL in tool_names:
-            # Sentinel present: fully wired.
-            return ProbeResult(state="on", hint="")
-        # Fallback tier: some tools but no sentinel → still ON.
+        # Both presence of SENTINEL_TOOL ("console_metrics") and "any tools
+        # returned" are treated as ON today.  The sentinel check is intentionally
+        # loose: if the sentinel is absent but other tools are present the binary
+        # is still considered healthy (not every deployment build exposes it).
+        # See SENTINEL_TOOL and module docstring for rationale.
         return ProbeResult(state="on", hint="")
 
     except Exception as exc:  # pragma: no cover - unexpected catch-all
@@ -321,21 +325,24 @@ def probe_all_services_sync(
 
     What: Calls asyncio.run(probe_all_services(timeout_per_probe)). If an event
     loop is already running (e.g. inside pytest-asyncio), falls back to returning
-    all ABSENT with a hint explaining the conflict. Any other exception → all
-    DEGRADED. Never raises.
+    all DEGRADED with a hint explaining the conflict — tool availability is
+    unknown, not absent. Any other exception → all DEGRADED. Never raises.
 
     Test: tests/services/test_tool_service_probe.py::TestFailSafe — verifies no
-    exception propagates even when asyncio.run raises.
+    exception propagates even when asyncio.run raises, and that an event-loop
+    conflict yields DEGRADED (not ABSENT) for all services.
     """
     try:
         return asyncio.run(probe_all_services(timeout_per_probe))
     except RuntimeError as exc:
         # "This event loop is already running." — common in test environments
         # or when called from inside an async context.
-        hint = f"event loop conflict: {exc}"
+        # DEGRADED (not ABSENT): the probe couldn't run; we don't know whether
+        # the binaries are installed or not.
+        hint = f"probe skipped (event loop conflict) — tool availability unknown: {exc}"
         logger.debug("probe_all_services_sync: %s", hint)
         return {
-            svc: ProbeResult(state="absent", hint=hint)
+            svc: ProbeResult(state="degraded", hint=hint)
             for svc in SERVICE_PROBE_COMMANDS
         }
     except Exception as exc:  # pragma: no cover - defensive catch-all

--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -45,7 +45,7 @@ SERVICE_PROBE_COMMANDS: dict[str, list[str]] = {
 }
 
 # JSON-RPC initialize request (MCP protocol 2024-11-05).
-_INIT_REQUEST: dict = {
+_INIT_REQUEST: dict[str, object] = {
     "jsonrpc": "2.0",
     "method": "initialize",
     "params": {
@@ -57,14 +57,14 @@ _INIT_REQUEST: dict = {
 }
 
 # JSON-RPC notifications/initialized notification (no response expected).
-_INITIALIZED_NOTIFICATION: dict = {
+_INITIALIZED_NOTIFICATION: dict[str, object] = {
     "jsonrpc": "2.0",
     "method": "notifications/initialized",
     "params": {},
 }
 
 # JSON-RPC tools/list request.
-_TOOLS_LIST_REQUEST: dict = {
+_TOOLS_LIST_REQUEST: dict[str, object] = {
     "jsonrpc": "2.0",
     "method": "tools/list",
     "params": {},
@@ -203,8 +203,13 @@ async def _probe_single_service(
                 hint=f"{service} tools/list response missing 'result' key",
             )
 
-        tools: list[dict] = tools_resp["result"].get("tools", [])
-        tool_names: set[str] = {t.get("name", "") for t in tools if isinstance(t, dict)}
+        result_block = tools_resp.get("result") or {}
+        tools_list: list[object] = (
+            result_block.get("tools", []) if isinstance(result_block, dict) else []
+        )
+        tool_names: set[str] = {
+            str(t["name"]) for t in tools_list if isinstance(t, dict) and "name" in t
+        }
 
         if not tool_names:
             return ProbeResult(

--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -1,0 +1,322 @@
+"""Live stdio MCP probe for Available Tool Services detection (GitHub #814).
+
+Why: The existing trusty_status.py detects services via filesystem signals
+(.mcp.json presence, http_addr file) — this is latency-free but cannot confirm
+whether a service is actually wired correctly and exposing tools. This module
+adds a live probe that spawns each service as a stdio MCP server, performs an
+initialize + tools/list handshake, and classifies the service as ON / DEGRADED
+/ ABSENT based on the actual tool-list response.
+
+What: Exposes ProbeResult, SERVICE_PROBE_COMMANDS, and three functions —
+_probe_single_service (async, internal), probe_all_services (async, public),
+and probe_all_services_sync (sync wrapper). All four probes run concurrently
+via asyncio.gather so total added latency is bounded by one probe timeout
+(~1.5s) rather than 4x timeout. Always reaps child processes in finally blocks.
+
+Test: tests/services/test_tool_service_probe.py — covers ABSENT, ON (with and
+without the sentinel tool), DEGRADED (no tools / timeout / crash), concurrency,
+process reaping, and fail-safe behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from dataclasses import dataclass, field
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# The tool we look for first in the tools/list response to confirm a service
+# is fully wired. If absent but other tools are returned we still report ON
+# (the sentinel may not be present in every deployment build), documented here
+# so future readers understand the intentional fallback.
+SENTINEL_TOOL = "console_metrics"
+
+# Service name -> stdio spawn command. These are the EXACT argv lists the
+# trusty-* binaries expect when started in stdio MCP server mode.
+SERVICE_PROBE_COMMANDS: dict[str, list[str]] = {
+    "trusty-memory": ["trusty-memory", "serve", "--stdio"],
+    "trusty-search": ["trusty-search", "serve"],
+    "trusty-analyze": ["trusty-analyze", "mcp"],
+    "trusty-review": ["trusty-review", "serve", "--stdio"],
+}
+
+# JSON-RPC initialize request (MCP protocol 2024-11-05).
+_INIT_REQUEST: dict = {
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "claude-mpm-probe", "version": "1.0.0"},
+    },
+    "id": 1,
+}
+
+# JSON-RPC notifications/initialized notification (no response expected).
+_INITIALIZED_NOTIFICATION: dict = {
+    "jsonrpc": "2.0",
+    "method": "notifications/initialized",
+    "params": {},
+}
+
+# JSON-RPC tools/list request.
+_TOOLS_LIST_REQUEST: dict = {
+    "jsonrpc": "2.0",
+    "method": "tools/list",
+    "params": {},
+    "id": 2,
+}
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Result of a single service probe.
+
+    Why: Encapsulates the three-state outcome (ON / DEGRADED / ABSENT) together
+    with an optional actionable hint so callers can render the state and the
+    remediation advice from one object.
+
+    What: state is one of "on" | "degraded" | "absent". hint is a non-empty
+    actionable string when state != "on", empty string otherwise.
+
+    Test: Constructed directly in test assertions; frozen so tests cannot mutate.
+    """
+
+    state: Literal["on", "degraded", "absent"]
+    hint: str = field(default="")
+
+
+async def _probe_single_service(
+    service: str,
+    command: list[str],
+    timeout: float,
+) -> ProbeResult:
+    """Probe one service via its stdio MCP server interface.
+
+    Why: Provides ground-truth service availability by actually performing the
+    MCP initialize + tools/list handshake rather than relying on config files.
+
+    What: Checks binary presence via shutil.which, spawns the subprocess with
+    asyncio, performs the MCP handshake, reads the tools list, classifies the
+    result, and ALWAYS kills + waits the subprocess in a finally block. Never
+    raises out of this function — all exceptions become DEGRADED results.
+
+    Test: tests/services/test_tool_service_probe.py — covers each outcome branch
+    and verifies the process is always reaped.
+    """
+    process: asyncio.subprocess.Process | None = None
+    try:
+        # Fast path: binary not on PATH → ABSENT immediately (no subprocess).
+        if not shutil.which(command[0]):
+            return ProbeResult(state="absent", hint="")
+
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+        assert process.stdin is not None
+        assert process.stdout is not None
+
+        # --- Step 1: send initialize request ---
+        init_line = (json.dumps(_INIT_REQUEST) + "\n").encode()
+        process.stdin.write(init_line)
+        await process.stdin.drain()
+
+        # Read initialize response with timeout.
+        try:
+            raw_init = await asyncio.wait_for(
+                process.stdout.readline(),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} initialize handshake timed out after {timeout}s — check daemon / binary",
+            )
+
+        if not raw_init:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} closed stdout without responding to initialize",
+            )
+
+        try:
+            init_resp = json.loads(raw_init.decode("utf-8", errors="replace").strip())
+        except json.JSONDecodeError as exc:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} returned non-JSON initialize response: {exc}",
+            )
+
+        if not isinstance(init_resp, dict) or "result" not in init_resp:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} initialize response missing 'result' key",
+            )
+
+        # --- Step 2: send notifications/initialized (no response expected) ---
+        notif_line = (json.dumps(_INITIALIZED_NOTIFICATION) + "\n").encode()
+        process.stdin.write(notif_line)
+        await process.stdin.drain()
+
+        # --- Step 3: send tools/list request ---
+        tools_line = (json.dumps(_TOOLS_LIST_REQUEST) + "\n").encode()
+        process.stdin.write(tools_line)
+        await process.stdin.drain()
+
+        # Read tools/list response with timeout.
+        try:
+            raw_tools = await asyncio.wait_for(
+                process.stdout.readline(),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} tools/list timed out — service may be reachable but not fully wired",
+            )
+
+        if not raw_tools:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} closed stdout during tools/list — check `serve --stdio` wiring",
+            )
+
+        try:
+            tools_resp = json.loads(raw_tools.decode("utf-8", errors="replace").strip())
+        except json.JSONDecodeError as exc:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} returned non-JSON tools/list response: {exc}",
+            )
+
+        if not isinstance(tools_resp, dict) or "result" not in tools_resp:
+            return ProbeResult(
+                state="degraded",
+                hint=f"{service} tools/list response missing 'result' key",
+            )
+
+        tools: list[dict] = tools_resp["result"].get("tools", [])
+        tool_names: set[str] = {t.get("name", "") for t in tools if isinstance(t, dict)}
+
+        if not tool_names:
+            return ProbeResult(
+                state="degraded",
+                hint=(
+                    f"{service} reachable but no tools exposed — "
+                    f"check `serve --stdio` wiring / restart daemon"
+                ),
+            )
+
+        # Sentinel present → definitively ON.
+        # Fallback: any tools returned → ON (sentinel may not be in all builds;
+        # documented in module docstring — this is intentional loose-check).
+        return ProbeResult(state="on", hint="")
+
+    except Exception as exc:  # pragma: no cover - unexpected catch-all
+        logger.debug("_probe_single_service(%s): unexpected error: %s", service, exc)
+        return ProbeResult(
+            state="degraded",
+            hint=f"{service} probe failed unexpectedly: {exc}",
+        )
+    finally:
+        # Always reap the subprocess — no orphans, even on timeout or crash.
+        if process is not None:
+            try:
+                process.kill()
+            except (OSError, ProcessLookupError):
+                pass
+            try:
+                await asyncio.wait_for(process.wait(), timeout=2.0)
+            except (TimeoutError, OSError, ProcessLookupError):
+                pass
+
+
+async def probe_all_services(
+    timeout_per_probe: float = 1.5,
+) -> dict[str, ProbeResult]:
+    """Probe all four trusty services concurrently.
+
+    Why: Running probes concurrently via asyncio.gather bounds total latency to
+    one probe timeout rather than 4x timeout, keeping startup overhead minimal.
+
+    What: Spawns one _probe_single_service coroutine per entry in
+    SERVICE_PROBE_COMMANDS, collects results with gather(return_exceptions=True)
+    so a single probe failure cannot abort the others, and maps exceptions to
+    DEGRADED results before returning the complete dict.
+
+    Test: tests/services/test_tool_service_probe.py::TestConcurrency — verifies
+    all four probes complete in ~timeout time, not 4x timeout.
+    """
+    services = list(SERVICE_PROBE_COMMANDS.items())
+    coros = [
+        _probe_single_service(svc, cmd, timeout_per_probe) for svc, cmd in services
+    ]
+    try:
+        raw_results = await asyncio.gather(*coros, return_exceptions=True)
+    except Exception as exc:  # pragma: no cover - gather itself cannot normally raise
+        logger.debug("probe_all_services: gather failed: %s", exc)
+        return {
+            svc: ProbeResult(state="degraded", hint=f"probe gather failed: {exc}")
+            for svc in SERVICE_PROBE_COMMANDS
+        }
+
+    results: dict[str, ProbeResult] = {}
+    for (svc, _cmd), result in zip(services, raw_results):
+        if isinstance(result, BaseException):
+            results[svc] = ProbeResult(
+                state="degraded",
+                hint=f"{svc} probe raised: {result}",
+            )
+        elif isinstance(result, ProbeResult):
+            results[svc] = result
+        else:
+            # Should never happen — _probe_single_service always returns ProbeResult
+            results[svc] = ProbeResult(
+                state="degraded",
+                hint=f"{svc} probe returned unexpected type: {type(result)}",
+            )
+    return results
+
+
+def probe_all_services_sync(
+    timeout_per_probe: float = 1.5,
+) -> dict[str, ProbeResult]:
+    """Synchronous wrapper around probe_all_services for use in non-async callers.
+
+    Why: trusty_status.py and framework_loader.py are synchronous; this wrapper
+    bridges to the async probe without requiring callers to manage event loops.
+
+    What: Calls asyncio.run(probe_all_services(timeout_per_probe)). If an event
+    loop is already running (e.g. inside pytest-asyncio), falls back to returning
+    all ABSENT with a hint explaining the conflict. Any other exception → all
+    DEGRADED. Never raises.
+
+    Test: tests/services/test_tool_service_probe.py::TestFailSafe — verifies no
+    exception propagates even when asyncio.run raises.
+    """
+    try:
+        return asyncio.run(probe_all_services(timeout_per_probe))
+    except RuntimeError as exc:
+        # "This event loop is already running." — common in test environments
+        # or when called from inside an async context.
+        hint = f"event loop conflict: {exc}"
+        logger.debug("probe_all_services_sync: %s", hint)
+        return {
+            svc: ProbeResult(state="absent", hint=hint)
+            for svc in SERVICE_PROBE_COMMANDS
+        }
+    except Exception as exc:  # pragma: no cover - defensive catch-all
+        hint = f"sync probe wrapper failed: {exc}"
+        logger.debug("probe_all_services_sync: %s", hint)
+        return {
+            svc: ProbeResult(state="degraded", hint=hint)
+            for svc in SERVICE_PROBE_COMMANDS
+        }

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -724,7 +724,6 @@ def get_trusty_capabilities_live(timeout: float = 1.5) -> dict[str, str]:
     Test: tests/services/test_tool_service_probe.py::TestGetTrustyCapabilitiesLive
     — verifies state mapping, hint storage, and fallback behaviour.
     """
-    global _PROBE_HINTS
     try:
         from claude_mpm.services.tool_service_probe import probe_all_services_sync
 
@@ -733,13 +732,14 @@ def get_trusty_capabilities_live(timeout: float = 1.5) -> dict[str, str]:
             svc: result.hint for svc, result in probe_results.items() if result.hint
         }
         with _PROBE_HINTS_LOCK:
-            _PROBE_HINTS = new_hints
+            _PROBE_HINTS.clear()
+            _PROBE_HINTS.update(new_hints)
         return {svc: result.state for svc, result in probe_results.items()}
     except Exception:
         # Fall back to the original filesystem-based detection so startup
         # never breaks over a probe failure.
         with _PROBE_HINTS_LOCK:
-            _PROBE_HINTS = {}
+            _PROBE_HINTS.clear()
         return get_trusty_capabilities()
 
 

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -657,6 +657,11 @@ def get_trusty_status(service: str) -> tuple[str, str]:
         return ("absent", "")
 
 
+# Module-level store for probe hints populated by get_trusty_capabilities_live().
+# Keys are service names; values are the actionable hint strings for DEGRADED
+# services. get_probe_hint() reads this dict.
+_PROBE_HINTS: dict[str, str] = {}
+
 # Services whose per-session capability is reported to the PM prompt. Order is
 # stable so the injected table renders deterministically.
 _CAPABILITY_SERVICES: tuple[str, ...] = (
@@ -695,3 +700,50 @@ def get_trusty_capabilities() -> dict[str, str]:
             state = "absent"
         capabilities[service] = state
     return capabilities
+
+
+def get_trusty_capabilities_live(timeout: float = 1.5) -> dict[str, str]:
+    """Why: get_trusty_capabilities() infers service state from config files and
+    HTTP health checks, but cannot confirm the stdio MCP transport is correctly
+    wired. This function adds a live initialize + tools/list probe that gives
+    ground-truth availability — including a DEGRADED state with an actionable
+    hint when the binary is present but the probe fails.
+
+    What: Calls probe_all_services_sync(timeout) from tool_service_probe, maps
+    ProbeResult.state → state string ("on" / "degraded" / "absent"), stores
+    hints in the module-level _PROBE_HINTS dict for get_probe_hint() to serve,
+    and returns the same {service: state} dict shape as get_trusty_capabilities().
+    Falls back to get_trusty_capabilities() on any import error or exception so
+    startup is never broken by a probe failure.
+
+    Test: tests/services/test_tool_service_probe.py::TestGetTrustyCapabilitiesLive
+    — verifies state mapping, hint storage, and fallback behaviour.
+    """
+    global _PROBE_HINTS
+    try:
+        from claude_mpm.services.tool_service_probe import probe_all_services_sync
+
+        probe_results = probe_all_services_sync(timeout)
+        _PROBE_HINTS = {
+            svc: result.hint for svc, result in probe_results.items() if result.hint
+        }
+        return {svc: result.state for svc, result in probe_results.items()}
+    except Exception:
+        # Fall back to the original filesystem-based detection so startup
+        # never breaks over a probe failure.
+        _PROBE_HINTS = {}
+        return get_trusty_capabilities()
+
+
+def get_probe_hint(service: str) -> str:
+    """Why: Callers (framework_loader) need the actionable hint for DEGRADED
+    services to include in the "Skip the following this session" block.
+
+    What: Returns the hint string stored by the most recent
+    get_trusty_capabilities_live() call for ``service``, or an empty string if
+    the service is ON / ABSENT or no live probe has been run yet.
+
+    Test: tests/services/test_tool_service_probe.py::TestGetProbeHint — verifies
+    hint returned for DEGRADED, empty string for ON/ABSENT and unknown services.
+    """
+    return _PROBE_HINTS.get(service, "")

--- a/src/claude_mpm/services/trusty_status.py
+++ b/src/claude_mpm/services/trusty_status.py
@@ -41,6 +41,7 @@ Design (scoped per #598)
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -660,7 +661,11 @@ def get_trusty_status(service: str) -> tuple[str, str]:
 # Module-level store for probe hints populated by get_trusty_capabilities_live().
 # Keys are service names; values are the actionable hint strings for DEGRADED
 # services. get_probe_hint() reads this dict.
+# Guarded by _PROBE_HINTS_LOCK for thread-safety and test isolation — tests that
+# call get_trusty_capabilities_live() concurrently cannot corrupt each other's
+# hint state.
 _PROBE_HINTS: dict[str, str] = {}
+_PROBE_HINTS_LOCK: threading.Lock = threading.Lock()
 
 # Services whose per-session capability is reported to the PM prompt. Order is
 # stable so the injected table renders deterministically.
@@ -724,14 +729,17 @@ def get_trusty_capabilities_live(timeout: float = 1.5) -> dict[str, str]:
         from claude_mpm.services.tool_service_probe import probe_all_services_sync
 
         probe_results = probe_all_services_sync(timeout)
-        _PROBE_HINTS = {
+        new_hints = {
             svc: result.hint for svc, result in probe_results.items() if result.hint
         }
+        with _PROBE_HINTS_LOCK:
+            _PROBE_HINTS = new_hints
         return {svc: result.state for svc, result in probe_results.items()}
     except Exception:
         # Fall back to the original filesystem-based detection so startup
         # never breaks over a probe failure.
-        _PROBE_HINTS = {}
+        with _PROBE_HINTS_LOCK:
+            _PROBE_HINTS = {}
         return get_trusty_capabilities()
 
 
@@ -746,4 +754,5 @@ def get_probe_hint(service: str) -> str:
     Test: tests/services/test_tool_service_probe.py::TestGetProbeHint — verifies
     hint returned for DEGRADED, empty string for ON/ABSENT and unknown services.
     """
-    return _PROBE_HINTS.get(service, "")
+    with _PROBE_HINTS_LOCK:
+        return _PROBE_HINTS.get(service, "")

--- a/tests/services/test_tool_service_probe.py
+++ b/tests/services/test_tool_service_probe.py
@@ -53,6 +53,8 @@ def _make_process(
     process.stdin = MagicMock()
     process.stdin.write = MagicMock()
     process.stdin.drain = AsyncMock()
+    process.stdin.close = MagicMock()
+    process.stdin.wait_closed = AsyncMock()
 
     remaining = list(stdout_lines)
 
@@ -348,6 +350,8 @@ class TestProbeTimeout:
         process.stdin = MagicMock()
         process.stdin.write = MagicMock()
         process.stdin.drain = AsyncMock()
+        process.stdin.close = MagicMock()
+        process.stdin.wait_closed = AsyncMock()
         process.stdout = MagicMock()
         process.stdout.readline = _hang
         process.kill = MagicMock()
@@ -381,6 +385,8 @@ class TestProbeTimeout:
         process.stdin = MagicMock()
         process.stdin.write = MagicMock()
         process.stdin.drain = AsyncMock()
+        process.stdin.close = MagicMock()
+        process.stdin.wait_closed = AsyncMock()
         process.stdout = MagicMock()
         process.stdout.readline = _hang
         process.kill = MagicMock()
@@ -600,6 +606,9 @@ class TestGetTrustyCapabilitiesLive:
             "trusty-review": ProbeResult(state="on"),
         }
         with patch(
+            # Patch at source module: get_trusty_capabilities_live does a
+            # local import, so patching trusty_status.probe_all_services_sync
+            # would have no effect.
             "claude_mpm.services.tool_service_probe.probe_all_services_sync",
             return_value=fake_results,
         ):
@@ -620,6 +629,9 @@ class TestGetTrustyCapabilitiesLive:
             "trusty-review": ProbeResult(state="on"),
         }
         with patch(
+            # Patch at source module: get_trusty_capabilities_live does a
+            # local import, so patching trusty_status.probe_all_services_sync
+            # would have no effect.
             "claude_mpm.services.tool_service_probe.probe_all_services_sync",
             return_value=fake_results,
         ):
@@ -677,6 +689,9 @@ class TestGetTrustyCapabilitiesLive:
             },
         )
         with patch(
+            # Patch at source module: get_trusty_capabilities_live does a
+            # local import, so patching trusty_status.probe_all_services_sync
+            # would have no effect.
             "claude_mpm.services.tool_service_probe.probe_all_services_sync",
             side_effect=RuntimeError("boom"),
         ):
@@ -691,7 +706,9 @@ class TestGetProbeHint:
     def test_returns_empty_for_unknown_service(self) -> None:
         from claude_mpm.services import trusty_status
 
-        trusty_status._PROBE_HINTS.clear()
+        # Clear hints under lock to avoid cross-test interference.
+        with trusty_status._PROBE_HINTS_LOCK:
+            trusty_status._PROBE_HINTS.clear()
         assert trusty_status.get_probe_hint("no-such-service") == ""
 
     def test_returns_hint_after_live_probe(self) -> None:
@@ -704,6 +721,9 @@ class TestGetProbeHint:
             "trusty-review": ProbeResult(state="on"),
         }
         with patch(
+            # Patch at source module: get_trusty_capabilities_live does a
+            # local import, so patching trusty_status.probe_all_services_sync
+            # would have no effect.
             "claude_mpm.services.tool_service_probe.probe_all_services_sync",
             return_value=fake_results,
         ):
@@ -711,3 +731,79 @@ class TestGetProbeHint:
 
         assert trusty_status.get_probe_hint("trusty-memory") == "check wiring"
         assert trusty_status.get_probe_hint("trusty-search") == ""
+
+
+# ---------------------------------------------------------------------------
+# stdin EOF buffering: servers that only respond after stdin is closed
+# ---------------------------------------------------------------------------
+
+
+class TestStdinEOFBuffering:
+    """Servers that flush tools/list only after stdin EOF must classify as ON."""
+
+    async def test_buffering_server_returns_on(self) -> None:
+        """Simulate a server that only writes its tools/list response after stdin
+        is closed. Without stdin.close() the probe would time out → DEGRADED.
+        With the fix, closing stdin triggers the flush → ON.
+        """
+        init_resp_bytes = _make_init_response()
+        tools_resp_bytes = _make_tools_response([SENTINEL_TOOL, "other_tool"])
+
+        process = MagicMock()
+        process.stdin = MagicMock()
+        process.stdin.write = MagicMock()
+        process.stdin.drain = AsyncMock()
+        process.stdin.close = MagicMock()
+        # wait_closed() must be awaitable; returns once stdin is closed.
+        process.stdin.wait_closed = AsyncMock()
+        process.kill = MagicMock()
+        process.wait = AsyncMock(return_value=0)
+
+        # Track whether stdin was closed; only return tools response after close.
+        stdin_closed = False
+
+        def _record_stdin_close() -> None:
+            nonlocal stdin_closed
+            stdin_closed = True
+
+        process.stdin.close = MagicMock(side_effect=_record_stdin_close)
+
+        read_call = 0
+
+        async def _readline() -> bytes:
+            nonlocal read_call
+            read_call += 1
+            if read_call == 1:
+                # initialize response — always returned immediately.
+                return init_resp_bytes
+            # tools/list response — only available after stdin closed.
+            # Spin briefly to let the stdin.close() side-effect register.
+            for _ in range(50):
+                if stdin_closed:
+                    return tools_resp_bytes
+                await asyncio.sleep(0.01)
+            # Stdin was never closed → return empty (simulating buffer-hold).
+            return b""
+
+        process.stdout = MagicMock()
+        process.stdout.readline = _readline
+
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/usr/local/bin/trusty-memory",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory", "serve", "--stdio"], timeout=2.0
+            )
+
+        assert result.state == "on", (
+            f"Expected ON but got {result.state!r}: {result.hint}"
+        )
+        # Verify stdin was closed during the probe.
+        process.stdin.close.assert_called_once()

--- a/tests/services/test_tool_service_probe.py
+++ b/tests/services/test_tool_service_probe.py
@@ -552,15 +552,25 @@ class TestFailSafe:
         assert isinstance(result, dict)
         assert set(result) == set(SERVICE_PROBE_COMMANDS)
 
-    def test_event_loop_conflict_returns_absent(self) -> None:
+    def test_event_loop_conflict_returns_degraded(self) -> None:
+        """RuntimeError from asyncio.run → DEGRADED (not ABSENT) for all services.
+
+        ABSENT means the binary is not on PATH.  An event-loop conflict means
+        the probe couldn't run at all — tool availability is unknown, which maps
+        to DEGRADED so agents are told to treat the service as unreliable rather
+        than uninstalled.
+        """
         with patch(
             "claude_mpm.services.tool_service_probe.asyncio.run",
             side_effect=RuntimeError("This event loop is already running."),
         ):
             result = probe_all_services_sync()
-        # RuntimeError → ABSENT (event loop conflict path).
+        # RuntimeError (event loop conflict) → DEGRADED, never ABSENT.
         for svc, r in result.items():
-            assert r.state == "absent", f"{svc}: expected absent, got {r.state}"
+            assert r.state == "degraded", f"{svc}: expected degraded, got {r.state}"
+        # Hint must explain the conflict clearly.
+        for r in result.values():
+            assert "event loop conflict" in r.hint
 
     def test_unexpected_exception_returns_degraded(self) -> None:
         with patch(
@@ -657,18 +667,15 @@ class TestGetTrustyCapabilitiesLive:
                 "trusty-review": "absent",
             },
         )
-        # Remove the module from sys.modules to simulate ImportError on next import.
-        saved = sys.modules.pop("claude_mpm.services.tool_service_probe", None)
-        # Stash the module in a fake entry that raises.
-        sys.modules["claude_mpm.services.tool_service_probe"] = None  # type: ignore[assignment]
-        try:
+        # Simulate ImportError on the next `from claude_mpm.services.tool_service_probe
+        # import ...` by patching the module with a sentinel that raises ImportError.
+        # patch.dict auto-restores sys.modules after the with-block, making this
+        # portable and safe across test-runner isolation strategies.
+        with patch.dict(
+            sys.modules,
+            {"claude_mpm.services.tool_service_probe": None},  # type: ignore[dict-item]
+        ):
             caps = trusty_status.get_trusty_capabilities_live()
-        finally:
-            # Restore the module.
-            if saved is not None:
-                sys.modules["claude_mpm.services.tool_service_probe"] = saved
-            else:
-                sys.modules.pop("claude_mpm.services.tool_service_probe", None)
 
         # Should have fallen back without raising.
         assert isinstance(caps, dict)

--- a/tests/services/test_tool_service_probe.py
+++ b/tests/services/test_tool_service_probe.py
@@ -1,0 +1,713 @@
+"""Tests for the live stdio MCP probe (GitHub #814).
+
+Why: tool_service_probe.py performs subprocess-based MCP handshakes. Tests must
+cover all outcome branches (ABSENT/ON/DEGRADED), timeout safety, process
+reaping, concurrency, and fail-safe behaviour — all without requiring real
+trusty daemons.
+
+What: Uses unittest.mock and AsyncMock to simulate subprocess behaviour. Async
+tests run via pytest-asyncio (mode=auto).
+
+Test: Run with `pytest tests/services/test_tool_service_probe.py -v --timeout=30`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_mpm.services.tool_service_probe import (
+    SENTINEL_TOOL,
+    SERVICE_PROBE_COMMANDS,
+    ProbeResult,
+    _probe_single_service,
+    probe_all_services,
+    probe_all_services_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_process(
+    stdout_lines: list[bytes],
+    *,
+    kill_side_effect: Exception | None = None,
+) -> MagicMock:
+    """Build a mock asyncio.subprocess.Process.
+
+    Why: Allows tests to control exactly what the subprocess writes to stdout
+    without spawning real processes.
+
+    What: Returns a MagicMock whose stdout.readline is an AsyncMock that pops
+    from stdout_lines in order (returns b"" when exhausted), stdin.write is a
+    MagicMock, stdin.drain is an AsyncMock, kill() raises kill_side_effect if
+    set, and wait() is an AsyncMock returning 0.
+    """
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.stdin.write = MagicMock()
+    process.stdin.drain = AsyncMock()
+
+    remaining = list(stdout_lines)
+
+    async def _readline() -> bytes:
+        if remaining:
+            return remaining.pop(0)
+        return b""
+
+    process.stdout = MagicMock()
+    process.stdout.readline = _readline
+
+    if kill_side_effect:
+        process.kill = MagicMock(side_effect=kill_side_effect)
+    else:
+        process.kill = MagicMock()
+
+    process.wait = AsyncMock(return_value=0)
+    return process
+
+
+def _make_init_response(with_error: bool = False) -> bytes:
+    """JSON-RPC initialize response line."""
+    import json
+
+    if with_error:
+        resp = {"jsonrpc": "2.0", "error": {"code": -1, "message": "err"}, "id": 1}
+    else:
+        resp = {
+            "jsonrpc": "2.0",
+            "result": {"protocolVersion": "2024-11-05", "capabilities": {}},
+            "id": 1,
+        }
+    return (json.dumps(resp) + "\n").encode()
+
+
+def _make_tools_response(tool_names: list[str]) -> bytes:
+    """JSON-RPC tools/list response line."""
+    import json
+
+    tools = [
+        {"name": n, "description": f"desc {n}", "inputSchema": {}} for n in tool_names
+    ]
+    resp = {"jsonrpc": "2.0", "result": {"tools": tools}, "id": 2}
+    return (json.dumps(resp) + "\n").encode()
+
+
+# ---------------------------------------------------------------------------
+# ProbeResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestProbeResult:
+    """Basic structural tests for the ProbeResult dataclass."""
+
+    def test_on_state(self) -> None:
+        r = ProbeResult(state="on")
+        assert r.state == "on"
+        assert r.hint == ""
+
+    def test_degraded_with_hint(self) -> None:
+        r = ProbeResult(state="degraded", hint="restart daemon")
+        assert r.state == "degraded"
+        assert r.hint == "restart daemon"
+
+    def test_absent_no_hint(self) -> None:
+        r = ProbeResult(state="absent")
+        assert r.hint == ""
+
+    def test_frozen(self) -> None:
+        r = ProbeResult(state="on")
+        with pytest.raises((AttributeError, TypeError)):
+            r.state = "absent"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _probe_single_service: ABSENT
+# ---------------------------------------------------------------------------
+
+
+class TestProbeAbsent:
+    """Binary not on PATH → ABSENT, no subprocess spawned."""
+
+    async def test_absent_when_binary_not_found(self) -> None:
+        with patch(
+            "claude_mpm.services.tool_service_probe.shutil.which", return_value=None
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory", "serve", "--stdio"], timeout=1.0
+            )
+        assert result.state == "absent"
+        assert result.hint == ""
+
+    async def test_absent_does_not_spawn_process(self) -> None:
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which", return_value=None
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec"
+            ) as mock_spawn,
+        ):
+            await _probe_single_service("trusty-memory", ["trusty-memory"], timeout=1.0)
+        mock_spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _probe_single_service: ON
+# ---------------------------------------------------------------------------
+
+
+class TestProbeOn:
+    """Binary present and handshake succeeds."""
+
+    async def test_on_with_sentinel_tool(self) -> None:
+        process = _make_process(
+            [_make_init_response(), _make_tools_response([SENTINEL_TOOL, "other_tool"])]
+        )
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/usr/local/bin/trusty-memory",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory", "serve", "--stdio"], timeout=2.0
+            )
+        assert result.state == "on"
+        assert result.hint == ""
+
+    async def test_on_without_sentinel_but_tools_present(self) -> None:
+        """Looser check: any tools returned → ON (sentinel may not always be present)."""
+        process = _make_process(
+            [
+                _make_init_response(),
+                _make_tools_response(["memory_recall", "memory_note"]),
+            ]
+        )
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/usr/bin/trusty-memory",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory", "serve", "--stdio"], timeout=2.0
+            )
+        assert result.state == "on"
+
+    async def test_on_hints_empty(self) -> None:
+        process = _make_process(
+            [_make_init_response(), _make_tools_response([SENTINEL_TOOL])]
+        )
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/trusty-search",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-search", ["trusty-search", "serve"], timeout=2.0
+            )
+        assert result.hint == ""
+
+
+# ---------------------------------------------------------------------------
+# _probe_single_service: DEGRADED
+# ---------------------------------------------------------------------------
+
+
+class TestProbeDegraded:
+    """Various failure modes all yield DEGRADED with a non-empty hint."""
+
+    async def test_degraded_empty_tools_list(self) -> None:
+        process = _make_process([_make_init_response(), _make_tools_response([])])
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state == "degraded"
+        assert result.hint != ""
+
+    async def test_degraded_garbage_response(self) -> None:
+        process = _make_process([b"not json at all\n"])
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state == "degraded"
+        assert result.hint != ""
+
+    async def test_degraded_missing_result_key(self) -> None:
+        import json
+
+        bad_init = (json.dumps({"jsonrpc": "2.0", "id": 1}) + "\n").encode()
+        process = _make_process([bad_init])
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state == "degraded"
+
+    async def test_degraded_stdout_closed(self) -> None:
+        """Subprocess writes nothing (empty bytes) → DEGRADED."""
+        process = _make_process([b""])
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state == "degraded"
+
+    async def test_degraded_never_raises(self) -> None:
+        """Even when the subprocess explodes, no exception should escape."""
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                side_effect=OSError("spawn failed"),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state in ("degraded", "absent")
+
+
+# ---------------------------------------------------------------------------
+# Timeout safety
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTimeout:
+    """Probes that hang must resolve as DEGRADED within the timeout."""
+
+    async def test_timeout_yields_degraded(self) -> None:
+        """A subprocess that never writes → DEGRADED after timeout."""
+
+        async def _hang() -> bytes:
+            await asyncio.sleep(60)
+            return b""  # unreachable in test
+
+        process = MagicMock()
+        process.stdin = MagicMock()
+        process.stdin.write = MagicMock()
+        process.stdin.drain = AsyncMock()
+        process.stdout = MagicMock()
+        process.stdout.readline = _hang
+        process.kill = MagicMock()
+        process.wait = AsyncMock(return_value=0)
+
+        start = time.monotonic()
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=0.2
+            )
+        elapsed = time.monotonic() - start
+
+        assert result.state == "degraded"
+        assert elapsed < 3.0, f"Timeout probe took too long: {elapsed:.1f}s"
+
+    async def test_timeout_hint_mentions_service(self) -> None:
+        async def _hang() -> bytes:
+            await asyncio.sleep(60)
+            return b""
+
+        process = MagicMock()
+        process.stdin = MagicMock()
+        process.stdin.write = MagicMock()
+        process.stdin.drain = AsyncMock()
+        process.stdout = MagicMock()
+        process.stdout.readline = _hang
+        process.kill = MagicMock()
+        process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            result = await _probe_single_service(
+                "trusty-search", ["trusty-search", "serve"], timeout=0.2
+            )
+        assert "trusty-search" in result.hint
+
+
+# ---------------------------------------------------------------------------
+# Process reaping
+# ---------------------------------------------------------------------------
+
+
+class TestProcessReaping:
+    """After probe completes (success or failure), the subprocess must be reaped."""
+
+    async def test_process_killed_on_success(self) -> None:
+        process = _make_process(
+            [_make_init_response(), _make_tools_response([SENTINEL_TOOL])]
+        )
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            await _probe_single_service("trusty-memory", ["trusty-memory"], timeout=2.0)
+        process.kill.assert_called()
+
+    async def test_process_killed_on_degraded(self) -> None:
+        process = _make_process([b"garbage\n"])
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            await _probe_single_service("trusty-memory", ["trusty-memory"], timeout=2.0)
+        process.kill.assert_called()
+
+    async def test_process_killed_even_if_kill_raises(self) -> None:
+        """Even if kill() raises OSError, the probe must not propagate it."""
+        process = _make_process(
+            [b"garbage\n"],
+            kill_side_effect=OSError("already dead"),
+        )
+        with (
+            patch(
+                "claude_mpm.services.tool_service_probe.shutil.which",
+                return_value="/bin/x",
+            ),
+            patch(
+                "claude_mpm.services.tool_service_probe.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+        ):
+            # Must not raise even though kill raises.
+            result = await _probe_single_service(
+                "trusty-memory", ["trusty-memory"], timeout=2.0
+            )
+        assert result.state == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: probe_all_services
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    """All four probes run concurrently — total time ~ 1x timeout, not 4x."""
+
+    async def test_all_services_returned(self) -> None:
+        async def _fast_absent(svc: str, cmd: list[str], t: float) -> ProbeResult:
+            return ProbeResult(state="absent")
+
+        with patch(
+            "claude_mpm.services.tool_service_probe._probe_single_service",
+            side_effect=_fast_absent,
+        ):
+            results = await probe_all_services(timeout_per_probe=1.0)
+
+        assert set(results) == set(SERVICE_PROBE_COMMANDS)
+
+    async def test_concurrent_execution_bounded_time(self) -> None:
+        """Four probes with 0.2s sleep each should finish in < 0.8s total."""
+        delay = 0.15
+
+        async def _slow_absent(svc: str, cmd: list[str], t: float) -> ProbeResult:
+            await asyncio.sleep(delay)
+            return ProbeResult(state="absent")
+
+        start = time.monotonic()
+        with patch(
+            "claude_mpm.services.tool_service_probe._probe_single_service",
+            side_effect=_slow_absent,
+        ):
+            await probe_all_services(timeout_per_probe=1.0)
+        elapsed = time.monotonic() - start
+
+        # Concurrent: should finish in ~delay, not 4x delay.
+        assert elapsed < delay * 3, (
+            f"Expected concurrent execution but took {elapsed:.2f}s (4x delay = {4 * delay:.2f}s)"
+        )
+
+    async def test_one_raise_does_not_abort_others(self) -> None:
+        """An exception from one probe should yield DEGRADED, not cancel siblings."""
+        call_count = 0
+
+        async def _mixed(svc: str, cmd: list[str], t: float) -> ProbeResult:
+            nonlocal call_count
+            call_count += 1
+            if svc == "trusty-search":
+                raise RuntimeError("boom")
+            return ProbeResult(state="absent")
+
+        with patch(
+            "claude_mpm.services.tool_service_probe._probe_single_service",
+            side_effect=_mixed,
+        ):
+            results = await probe_all_services(timeout_per_probe=1.0)
+
+        assert call_count == 4
+        assert results["trusty-search"].state == "degraded"
+        assert results["trusty-memory"].state == "absent"
+
+
+# ---------------------------------------------------------------------------
+# probe_all_services_sync: fail-safe
+# ---------------------------------------------------------------------------
+
+
+class TestFailSafe:
+    """probe_all_services_sync must never raise, even on event-loop conflicts."""
+
+    def test_sync_wrapper_never_raises(self) -> None:
+        with patch(
+            "claude_mpm.services.tool_service_probe.asyncio.run",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = probe_all_services_sync()
+        # Should return a dict — any state is fine, but no exception.
+        assert isinstance(result, dict)
+        assert set(result) == set(SERVICE_PROBE_COMMANDS)
+
+    def test_event_loop_conflict_returns_absent(self) -> None:
+        with patch(
+            "claude_mpm.services.tool_service_probe.asyncio.run",
+            side_effect=RuntimeError("This event loop is already running."),
+        ):
+            result = probe_all_services_sync()
+        # RuntimeError → ABSENT (event loop conflict path).
+        for svc, r in result.items():
+            assert r.state == "absent", f"{svc}: expected absent, got {r.state}"
+
+    def test_unexpected_exception_returns_degraded(self) -> None:
+        with patch(
+            "claude_mpm.services.tool_service_probe.asyncio.run",
+            side_effect=OSError("disk full"),
+        ):
+            result = probe_all_services_sync()
+        # OSError is not RuntimeError → DEGRADED.
+        for svc, r in result.items():
+            assert r.state == "degraded", f"{svc}: expected degraded, got {r.state}"
+
+    def test_sync_wrapper_returns_all_services(self) -> None:
+        with patch(
+            "claude_mpm.services.tool_service_probe.asyncio.run",
+            return_value={
+                svc: ProbeResult(state="absent") for svc in SERVICE_PROBE_COMMANDS
+            },
+        ):
+            result = probe_all_services_sync()
+        assert set(result) == set(SERVICE_PROBE_COMMANDS)
+
+
+# ---------------------------------------------------------------------------
+# trusty_status integration: get_trusty_capabilities_live and get_probe_hint
+# ---------------------------------------------------------------------------
+
+
+class TestGetTrustyCapabilitiesLive:
+    """Tests for the new trusty_status functions.
+
+    Why: get_trusty_capabilities_live does a local import of probe_all_services_sync
+    inside the function body, so we patch at the source module level
+    (claude_mpm.services.tool_service_probe) rather than on trusty_status.
+    """
+
+    def test_states_mapped_correctly(self) -> None:
+        from claude_mpm.services import trusty_status
+
+        fake_results = {
+            "trusty-memory": ProbeResult(state="on"),
+            "trusty-search": ProbeResult(state="absent"),
+            "trusty-analyze": ProbeResult(state="degraded", hint="no tools"),
+            "trusty-review": ProbeResult(state="on"),
+        }
+        with patch(
+            "claude_mpm.services.tool_service_probe.probe_all_services_sync",
+            return_value=fake_results,
+        ):
+            caps = trusty_status.get_trusty_capabilities_live()
+
+        assert caps["trusty-memory"] == "on"
+        assert caps["trusty-search"] == "absent"
+        assert caps["trusty-analyze"] == "degraded"
+        assert caps["trusty-review"] == "on"
+
+    def test_hints_stored(self) -> None:
+        from claude_mpm.services import trusty_status
+
+        fake_results = {
+            "trusty-memory": ProbeResult(state="degraded", hint="restart daemon"),
+            "trusty-search": ProbeResult(state="absent"),
+            "trusty-analyze": ProbeResult(state="on"),
+            "trusty-review": ProbeResult(state="on"),
+        }
+        with patch(
+            "claude_mpm.services.tool_service_probe.probe_all_services_sync",
+            return_value=fake_results,
+        ):
+            trusty_status.get_trusty_capabilities_live()
+
+        assert trusty_status.get_probe_hint("trusty-memory") == "restart daemon"
+        assert trusty_status.get_probe_hint("trusty-search") == ""
+        assert trusty_status.get_probe_hint("trusty-analyze") == ""
+
+    def test_fallback_on_import_error(self, monkeypatch: Any) -> None:
+        """When the probe module raises on import, falls back to config-based detection."""
+        import sys
+
+        from claude_mpm.services import trusty_status
+
+        monkeypatch.setattr(
+            trusty_status,
+            "get_trusty_capabilities",
+            lambda: {
+                "trusty-memory": "on",
+                "trusty-search": "absent",
+                "trusty-analyze": "absent",
+                "trusty-review": "absent",
+            },
+        )
+        # Remove the module from sys.modules to simulate ImportError on next import.
+        saved = sys.modules.pop("claude_mpm.services.tool_service_probe", None)
+        # Stash the module in a fake entry that raises.
+        sys.modules["claude_mpm.services.tool_service_probe"] = None  # type: ignore[assignment]
+        try:
+            caps = trusty_status.get_trusty_capabilities_live()
+        finally:
+            # Restore the module.
+            if saved is not None:
+                sys.modules["claude_mpm.services.tool_service_probe"] = saved
+            else:
+                sys.modules.pop("claude_mpm.services.tool_service_probe", None)
+
+        # Should have fallen back without raising.
+        assert isinstance(caps, dict)
+        assert set(caps) >= {"trusty-memory", "trusty-search"}
+
+    def test_fallback_on_probe_exception(self, monkeypatch: Any) -> None:
+        """Any exception from probe_all_services_sync → falls back, does not raise."""
+        from claude_mpm.services import trusty_status
+
+        monkeypatch.setattr(
+            trusty_status,
+            "get_trusty_capabilities",
+            lambda: {
+                "trusty-memory": "absent",
+                "trusty-search": "absent",
+                "trusty-analyze": "absent",
+                "trusty-review": "absent",
+            },
+        )
+        with patch(
+            "claude_mpm.services.tool_service_probe.probe_all_services_sync",
+            side_effect=RuntimeError("boom"),
+        ):
+            caps = trusty_status.get_trusty_capabilities_live()
+
+        assert isinstance(caps, dict)
+
+
+class TestGetProbeHint:
+    """get_probe_hint returns stored hints or empty string."""
+
+    def test_returns_empty_for_unknown_service(self) -> None:
+        from claude_mpm.services import trusty_status
+
+        trusty_status._PROBE_HINTS.clear()
+        assert trusty_status.get_probe_hint("no-such-service") == ""
+
+    def test_returns_hint_after_live_probe(self) -> None:
+        from claude_mpm.services import trusty_status
+
+        fake_results = {
+            "trusty-memory": ProbeResult(state="degraded", hint="check wiring"),
+            "trusty-search": ProbeResult(state="absent"),
+            "trusty-analyze": ProbeResult(state="on"),
+            "trusty-review": ProbeResult(state="on"),
+        }
+        with patch(
+            "claude_mpm.services.tool_service_probe.probe_all_services_sync",
+            return_value=fake_results,
+        ):
+            trusty_status.get_trusty_capabilities_live()
+
+        assert trusty_status.get_probe_hint("trusty-memory") == "check wiring"
+        assert trusty_status.get_probe_hint("trusty-search") == ""

--- a/tests/test_framework_loader_tool_status.py
+++ b/tests/test_framework_loader_tool_status.py
@@ -34,8 +34,10 @@ def _render(monkeypatch, capabilities) -> str:
     """Invoke the section generator with a stubbed capabilities probe.
 
     ``capabilities`` may be a dict (returned verbatim) or an Exception instance
-    (raised) to exercise the fail-safe path. The method only touches
-    ``self.logger``, so we bind it to a minimal stub to avoid heavy init.
+    (raised) to exercise the fail-safe path. The method touches ``self.logger``
+    and ``self._trusty_search_index_note()``, so the stub provides both.
+    We patch both get_trusty_capabilities_live (new live probe) and the fallback
+    get_trusty_capabilities so either code path exercises the right mock.
     """
 
     def _fake_caps():
@@ -44,7 +46,13 @@ def _render(monkeypatch, capabilities) -> str:
         return capabilities
 
     monkeypatch.setattr(trusty_status, "get_trusty_capabilities", _fake_caps)
-    stub = SimpleNamespace(logger=logging.getLogger("test_tool_status"))
+    monkeypatch.setattr(trusty_status, "get_trusty_capabilities_live", _fake_caps)
+    # get_probe_hint should return "" for all services in these tests (no live probe).
+    monkeypatch.setattr(trusty_status, "get_probe_hint", lambda _svc: "")
+    stub = SimpleNamespace(
+        logger=logging.getLogger("test_tool_status"),
+        _trusty_search_index_note=lambda: "",
+    )
     return FrameworkLoader._generate_tool_status_section(stub)
 
 


### PR DESCRIPTION
## Summary

- **Closes:** #814
- **Cross-ref:** trusty-tools#1160

Replaces config-presence detection (`.mcp.json` / `http_addr` file heuristics) with a live stdio MCP proxy probe for the "Available Tool Services (auto-detected at session start)" block.

### What changed

**New file: `src/claude_mpm/services/tool_service_probe.py`**
- `ProbeResult` dataclass: `state: Literal["on", "degraded", "absent"]` + `hint: str`
- `SERVICE_PROBE_COMMANDS` mapping all four trusty services to their exact stdio spawn commands
- `_probe_single_service()` — async, runs `initialize` + `notifications/initialized` + `tools/list` MCP handshake, **always** reaps child process in `finally` block (no orphans)
- `probe_all_services()` — concurrent via `asyncio.gather`, total latency ≤1.5s regardless of service count
- `probe_all_services_sync()` — sync wrapper with event-loop conflict detection, never raises

**Modified: `src/claude_mpm/services/trusty_status.py`**
- `get_trusty_capabilities_live()` — calls the probe module, returns same `dict[str, str]` shape as original; falls back to `get_trusty_capabilities()` on any error
- `get_probe_hint(service)` — returns actionable hint string for DEGRADED services
- `_PROBE_HINTS` module-level dict for cross-function hint storage

**Modified: `src/claude_mpm/core/framework_loader.py`**
- `_generate_tool_status_section()` now calls `get_trusty_capabilities_live()` with try/except fallback
- DEGRADED state renders as `⚠ DEGRADED` in the status table
- DEGRADED services included in "Skip the following this session" list with actionable hint in parentheses
- All existing behaviour for `on`, `configured`, `not_running`, `absent` preserved

### Probe design

| Property | Value |
|---|---|
| Concurrency | `asyncio.gather` — all 4 probes run in parallel |
| Timeout | 1.5s per probe (configurable) |
| Total added latency | ≤1.5s (not 4×) |
| Sentinel tool | `console_metrics`; fallback: any tools returned = ON |
| Process safety | `finally` block kills + waits subprocess unconditionally |
| Fail-safe | Any exception → DEGRADED with hint; never raises out of probe |

### Sample rendered block (DEGRADED + ABSENT states)

```markdown
## Available Tool Services (auto-detected at session start)

This OVERRIDES the unconditional tool guidance elsewhere in these instructions.

| Service | Status | Impact |
| --- | --- | --- |
| trusty-memory | ON | Context-First Protocol active: query `mcp__trusty-memory__memory_recall` first. |
| trusty-search | ⚠ DEGRADED | trusty-search is NOT available — SKIP code search; delegate directly to Research. |
| trusty-analyze | ABSENT | trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls. |
| trusty-review | ⚠ DEGRADED | code review via trusty-review unavailable; fall back to `openrouter-code-reviewer`. |

**Skip the following this session:**

- trusty-search is NOT available — SKIP code search; delegate directly to Research. (trusty-search reachable but no tools exposed — check `serve` wiring / restart daemon)
- trusty-analyze is NOT available — SKIP `mcp__trusty-analyze__*` calls.
- code review via trusty-review unavailable; fall back to `openrouter-code-reviewer`. (trusty-review initialize handshake timed out after 1.5s — check daemon / binary)
```

### Test plan

- [x] 32 new tests in `tests/services/test_tool_service_probe.py` covering:
  - ABSENT (binary not on PATH), ON with `console_metrics` sentinel, ON without sentinel (any tools = ON), DEGRADED (empty tools, garbage response, stdout closed, crash)
  - Timeout safety: hanging subprocess → DEGRADED after timeout, never raises
  - Process reaping: kill/terminate called even when probe raises
  - Concurrency: 4 concurrent probes complete in ~1× timeout, not 4×
  - Fail-safe: `probe_all_services_sync` never raises regardless of errors
- [x] 8 existing framework loader tests updated for new imports — all pass
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy --strict --ignore-missing-imports` — clean on `tool_service_probe.py`
- [x] 40/40 tests pass: `pytest tests/services/test_tool_service_probe.py tests/test_framework_loader_tool_status.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)