### PR TITLE
fix(services): sanitize probe hints to prevent raw exception/path leakage into PM prompt

### DIFF
--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -79,6 +79,19 @@ _TOOLS_LIST_REQUEST: dict[str, object] = {
 }
 
 
+def _safe_hint(text: str, max_len: int = 120) -> str:
+    """Sanitize a probe hint for safe injection into the PM prompt.
+
+    Strips newlines/carriage returns and truncates to ``max_len`` chars so raw
+    exception text, multi-line tracebacks, or long absolute paths cannot bloat
+    or leak into the framework prompt. Returns the cleaned, bounded string.
+    """
+    cleaned = text.replace("\n", " ").replace("\r", " ").strip()
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 3] + "..."
+    return cleaned
+
+
 @dataclass(frozen=True)
 class ProbeResult:
     """Result of a single service probe.
@@ -161,7 +174,9 @@ async def _probe_single_service(
         except json.JSONDecodeError as exc:
             return ProbeResult(
                 state="degraded",
-                hint=f"{service} returned non-JSON initialize response: {exc}",
+                hint=_safe_hint(
+                    f"{service} returned non-JSON initialize response: {exc}"
+                ),
             )
 
         if not isinstance(init_resp, dict) or "result" not in init_resp:
@@ -216,7 +231,9 @@ async def _probe_single_service(
         except json.JSONDecodeError as exc:
             return ProbeResult(
                 state="degraded",
-                hint=f"{service} returned non-JSON tools/list response: {exc}",
+                hint=_safe_hint(
+                    f"{service} returned non-JSON tools/list response: {exc}"
+                ),
             )
 
         if not isinstance(tools_resp, dict) or "result" not in tools_resp:
@@ -253,7 +270,7 @@ async def _probe_single_service(
         logger.debug("_probe_single_service(%s): unexpected error: %s", service, exc)
         return ProbeResult(
             state="degraded",
-            hint=f"{service} probe failed unexpectedly: {exc}",
+            hint=_safe_hint(f"{service} probe failed unexpectedly: {exc}"),
         )
     finally:
         # Always reap the subprocess — no orphans, even on timeout or crash.
@@ -293,7 +310,9 @@ async def probe_all_services(
     except Exception as exc:  # pragma: no cover - gather itself cannot normally raise
         logger.debug("probe_all_services: gather failed: %s", exc)
         return {
-            svc: ProbeResult(state="degraded", hint=f"probe gather failed: {exc}")
+            svc: ProbeResult(
+                state="degraded", hint=_safe_hint(f"probe gather failed: {exc}")
+            )
             for svc in SERVICE_PROBE_COMMANDS
         }
 
@@ -302,7 +321,7 @@ async def probe_all_services(
         if isinstance(result, BaseException):
             results[svc] = ProbeResult(
                 state="degraded",
-                hint=f"{svc} probe raised: {result}",
+                hint=_safe_hint(f"{svc} probe raised: {result}"),
             )
         elif isinstance(result, ProbeResult):
             results[svc] = result
@@ -310,7 +329,9 @@ async def probe_all_services(
             # Should never happen — _probe_single_service always returns ProbeResult
             results[svc] = ProbeResult(
                 state="degraded",
-                hint=f"{svc} probe returned unexpected type: {type(result)}",
+                hint=_safe_hint(
+                    f"{svc} probe returned unexpected type: {type(result)}"
+                ),
             )
     return results
 
@@ -339,14 +360,16 @@ def probe_all_services_sync(
         # or when called from inside an async context.
         # DEGRADED (not ABSENT): the probe couldn't run; we don't know whether
         # the binaries are installed or not.
-        hint = f"probe skipped (event loop conflict) — tool availability unknown: {exc}"
+        hint = _safe_hint(
+            f"probe skipped (event loop conflict) — tool availability unknown: {exc}"
+        )
         logger.debug("probe_all_services_sync: %s", hint)
         return {
             svc: ProbeResult(state="degraded", hint=hint)
             for svc in SERVICE_PROBE_COMMANDS
         }
     except Exception as exc:  # pragma: no cover - defensive catch-all
-        hint = f"sync probe wrapper failed: {exc}"
+        hint = _safe_hint(f"sync probe wrapper failed: {exc}")
         logger.debug("probe_all_services_sync: %s", hint)
         return {
             svc: ProbeResult(state="degraded", hint=hint)

--- a/src/claude_mpm/services/tool_service_probe.py
+++ b/src/claude_mpm/services/tool_service_probe.py
@@ -87,9 +87,12 @@ def _safe_hint(text: str, max_len: int = 120) -> str:
     or leak into the framework prompt. Returns the cleaned, bounded string.
     """
     cleaned = text.replace("\n", " ").replace("\r", " ").strip()
-    if len(cleaned) > max_len:
-        cleaned = cleaned[: max_len - 3] + "..."
-    return cleaned
+    if len(cleaned) <= max_len:
+        return cleaned
+    # For very small budgets there's no room for the "..." marker; hard-truncate.
+    if max_len < 4:
+        return cleaned[:max_len]
+    return cleaned[: max_len - 3] + "..."
 
 
 @dataclass(frozen=True)

--- a/tests/services/test_tool_service_probe.py
+++ b/tests/services/test_tool_service_probe.py
@@ -199,6 +199,14 @@ class TestSafeHint:
         result = _safe_hint(text)
         assert result == "some error message"
 
+    def test_tiny_max_len_no_overflow(self) -> None:
+        result = _safe_hint("abcdefgh", max_len=2)
+        assert len(result) <= 2
+
+    def test_tiny_max_len_3_no_overflow(self) -> None:
+        result = _safe_hint("abcdefgh", max_len=3)
+        assert len(result) <= 3
+
 
 # ---------------------------------------------------------------------------
 # _probe_single_service: ABSENT

--- a/tests/services/test_tool_service_probe.py
+++ b/tests/services/test_tool_service_probe.py
@@ -25,6 +25,7 @@ from claude_mpm.services.tool_service_probe import (
     SERVICE_PROBE_COMMANDS,
     ProbeResult,
     _probe_single_service,
+    _safe_hint,
     probe_all_services,
     probe_all_services_sync,
 )
@@ -127,6 +128,76 @@ class TestProbeResult:
         r = ProbeResult(state="on")
         with pytest.raises((AttributeError, TypeError)):
             r.state = "absent"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _safe_hint: sanitization helper
+# ---------------------------------------------------------------------------
+
+
+class TestSafeHint:
+    """_safe_hint strips newlines, truncates, and passes short strings unchanged."""
+
+    def test_short_string_passes_through_unchanged(self) -> None:
+        text = "trusty-memory probe failed: connection refused"
+        assert _safe_hint(text) == text
+
+    def test_newline_stripped(self) -> None:
+        text = "error line 1\nerror line 2\nerror line 3"
+        result = _safe_hint(text)
+        assert "\n" not in result
+        assert "error line 1" in result
+
+    def test_carriage_return_stripped(self) -> None:
+        text = "error\r\nwith CRLF\r\nlinebreaks"
+        result = _safe_hint(text)
+        assert "\r" not in result
+        assert "\n" not in result
+
+    def test_truncation_at_max_len(self) -> None:
+        long_text = "x" * 200
+        result = _safe_hint(long_text, max_len=120)
+        assert len(result) <= 120
+        assert result.endswith("...")
+
+    def test_truncation_suffix_present(self) -> None:
+        long_text = "a" * 200
+        result = _safe_hint(long_text, max_len=50)
+        assert result.endswith("...")
+        assert len(result) == 50
+
+    def test_exactly_max_len_not_truncated(self) -> None:
+        text = "a" * 120
+        result = _safe_hint(text, max_len=120)
+        # Exactly at limit: no truncation needed
+        assert result == text
+        assert not result.endswith("...")
+
+    def test_multiline_traceback_sanitized(self) -> None:
+        traceback_text = (
+            "Traceback (most recent call last):\n"
+            '  File "/home/user/.local/lib/python3.13/site-packages/foo.py", line 42\n'
+            '    raise ValueError("boom")\n'
+            "ValueError: boom"
+        )
+        result = _safe_hint(traceback_text, max_len=120)
+        assert "\n" not in result
+        assert len(result) <= 120
+        assert result.endswith("...")
+
+    def test_custom_max_len(self) -> None:
+        text = "b" * 80
+        result = _safe_hint(text, max_len=40)
+        assert len(result) == 40
+        assert result.endswith("...")
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _safe_hint("") == ""
+
+    def test_leading_trailing_whitespace_stripped(self) -> None:
+        text = "  some error message  "
+        result = _safe_hint(text)
+        assert result == "some error message"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-up hardening for the live tools/list probe (#814, shipped in #815). Adds a `_safe_hint()` sanitizer to `tool_service_probe.py` and wraps every dynamic probe hint that interpolates exception text/objects.

Probe hints are rendered directly into the framework/PM prompt. Several hints interpolate raw `{exc}` / `{result}` / `{type(result)}`, which can contain multi-line tracebacks, absolute file paths, or environment details — noisy and a minor info-leak risk. `_safe_hint()` strips newlines and truncates to 120 chars before the hint reaches the prompt.

This salvages the one hardening bit that the merged #815 implementation lacked (parallel-implementation divergence — PR #816 is being closed as superseded by #815).

## Changes
- Add `_safe_hint(text, max_len=120)` — strips `\n`/`\r`, trims, truncates with `...` suffix
- Wrap all dynamic hints in `_probe_single_service`, `probe_all_services`, `probe_all_services_sync`
- No change to ON/DEGRADED/ABSENT classification — purely sanitizes hint strings
- Add `TestSafeHint` (10 cases): pass-through, newline/CR stripping, truncation boundary, multiline traceback, custom max_len, empty string, whitespace trim

## Test plan
- [x] Targeted: 51/51 pass (`test_tool_service_probe.py` + `test_framework_loader_tool_status.py`)
- [x] Broader: `tests/services/` + framework loader — 2754 passed, no new failures
- [x] `ruff format` + `ruff check` clean

Note: the "Test Suite" CI job has pre-existing environmental e2e failures (require the `claude` CLI binary, plus allowlist/PM-memory tests) that are unrelated to this change and already red on main.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)