### PR TITLE
test: repair remaining pytest failure from #818 (deployment-context env isolation)

### DIFF
--- a/tests/services/core/test_path_resolver.py
+++ b/tests/services/core/test_path_resolver.py
@@ -479,6 +479,10 @@ class TestPathResolver:
         self, resolver, tmp_path, monkeypatch
     ):
         """Test detecting development deployment context."""
+        # Clear CLAUDE_MPM_USER_PWD so _get_working_dir() uses Path.cwd(),
+        # not an ambient shell variable that may point to a directory without
+        # pyproject.toml (causing spurious UNKNOWN instead of DEVELOPMENT).
+        monkeypatch.delenv("CLAUDE_MPM_USER_PWD", raising=False)
         # Create pyproject.toml in current directory
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").touch()


### PR DESCRIPTION
## Summary

Issue #818 listed 8 failures as of main@3a7d1c022. Since then, 7 of the 8 were already fixed on main by the CI-repair work in #821/#823/#825:
- trusty banner tests
- sdk_flags background-services tests (including the #819 regression)
- cargo-git package-installer tests

All of these now pass on current main.

The one remaining failure, `tests/services/core/test_path_resolver.py::test_detect_deployment_context_development`, is fixed here: the test now isolates `CLAUDE_MPM_USER_PWD` via `monkeypatch.delenv(..., raising=False)` so a stray env var pointing at a non-pyproject dir can't flip the detected deployment context from DEVELOPMENT to UNKNOWN.

## Verification

Verified: all 8 originally-listed target tests pass in serial mode (`-p no:xdist`): 16 passed.

**Note:** a separate PRE-EXISTING failure `tests/test_agent_registry_dynamic.py::test_non_conforming_names_preserved` (real-user agent missing display-name override) fails on both main and this branch — out of scope, tracked separately.

Closes #818
Closes #819

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)