### PR TITLE
refactor(skills): post-#831 review polish — rename opaque locals, add clarifying comments

### DIFF
--- a/src/claude_mpm/skills/skills_service.py
+++ b/src/claude_mpm/skills/skills_service.py
@@ -285,6 +285,8 @@ class SkillsService(LoggerMixin):
                 # is just the directory name — identical to what name would be.
                 superpowers_canonical_id = skill_dir.name
                 # Intentional: bundled skills take precedence over Superpowers skills with the same leaf name.
+                # TODO: once callers migrate to canonical_id, revisit this heuristic — a Superpowers skill is
+                # currently suppressed if ANY bundled skill shares its leaf name, regardless of category.
                 if skill_md.exists() and skill_dir.name not in existing_leaf_names:
                     metadata = self._parse_skill_metadata(skill_md)
                     skills.append(
@@ -611,11 +613,11 @@ class SkillsService(LoggerMixin):
 
         # Warn when bundled skills share a leaf name — the update-check loop uses leaf
         # names and will silently skip all but one skill with a colliding name.
-        _name_counts_cfu = Counter(s["name"] for s in bundled.values())
-        _collisions_cfu = [n for n, c in _name_counts_cfu.items() if c > 1]
-        if _collisions_cfu:
+        name_counts = Counter(s["name"] for s in bundled.values())
+        collisions = [n for n, c in name_counts.items() if c > 1]
+        if collisions:
             self.logger.warning(
-                f"check_for_updates: ambiguous leaf names {_collisions_cfu}; "
+                f"check_for_updates: ambiguous leaf names {collisions}; "
                 "pass canonical_id to update a specific skill."
             )
 
@@ -686,6 +688,8 @@ class SkillsService(LoggerMixin):
         bundled_by_canonical = {
             s["canonical_id"]: s for s in self.discover_bundled_skills()
         }
+        # Lossy on leaf-name collision: only the last skill with a given name survives.
+        # The collision guard below makes ambiguous caller lookups safe by rejecting them explicitly.
         bundled_by_name = {s["name"]: s for s in bundled_by_canonical.values()}
 
         name_counts = Counter(s["name"] for s in bundled_by_canonical.values())


### PR DESCRIPTION
## Summary

Cosmetic follow-ups from trusty-review on PR #831. No behavior change.

- **Variable rename** in `check_for_updates`: `_name_counts_cfu`/`_collisions_cfu` → `name_counts`/`collisions`. These were given opaque suffixed names to avoid shadowing but are method-local, so plain names are fine and now match the `update_skills` style.
- **TODO comment** added on the Superpowers dedup guard in `discover_bundled_skills`: notes that once callers migrate to `canonical_id`, the leaf-name suppression heuristic should be revisited (a Superpowers skill is currently suppressed if ANY bundled skill shares its leaf name, regardless of category).
- **Clarifying comment** on `bundled_by_name` dict in `update_skills`: notes it is lossy on leaf-name collision (last colliding skill survives), and that the collision guard below is what makes ambiguous caller lookups safe.

## Test plan

- [x] `uv run pytest -p no:xdist tests/skills/` — 87 passed, 0 failures (unchanged from `main`)
- [x] `uv run ruff format` and `uv run ruff check --fix` — clean
- [x] All pre-commit hooks passed

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)