### PR TITLE
feat: add --instructions-override flag to inject custom instructions at session start

### DIFF
--- a/src/claude_mpm/cli/commands/run.py
+++ b/src/claude_mpm/cli/commands/run.py
@@ -106,6 +106,8 @@ def filter_claude_mpm_args(claude_args):
         "-d",  # --debug (MPM-specific, not Claude CLI)
         # SDK oneshot flag (MPM-specific)
         "--prompt",
+        # Instructions override (MPM-specific, consumed before ClaudeRunner)
+        "--instructions-override",
     }
 
     filtered_args = []
@@ -133,6 +135,7 @@ def filter_claude_mpm_args(claude_args):
                 "-i",
                 "--input",
                 "--prompt",
+                "--instructions-override",
             }
             optional_value_flags = {
                 "--mpm-resume"
@@ -563,6 +566,15 @@ class RunCommand(BaseCommand):
         # Add --no-chrome if flag is set
         if getattr(args, "no_chrome", False) and "--no-chrome" not in claude_args:
             claude_args.insert(0, "--no-chrome")
+
+        # Propagate --instructions-override to FrameworkLoader via env var.
+        # The flag value takes precedence over any pre-existing env var so that
+        # a per-invocation override is always honoured.
+        instructions_override = getattr(args, "instructions_override", None)
+        if instructions_override is None:
+            instructions_override = os.environ.get("CLAUDE_MPM_INSTRUCTIONS_OVERRIDE")
+        if instructions_override:
+            os.environ["CLAUDE_MPM_INSTRUCTIONS_OVERRIDE"] = instructions_override
 
         # Create runner
         runner = ClaudeRunner(

--- a/src/claude_mpm/cli/parsers/base_parser.py
+++ b/src/claude_mpm/cli/parsers/base_parser.py
@@ -414,6 +414,14 @@ def add_top_level_run_arguments(parser: argparse.ArgumentParser) -> None:
         dest="debug_ztk",
         help="Enable ztk debug logging to stderr (env: CLAUDE_MPM_ZTK_DEBUG=1)",
     )
+    run_group.add_argument(
+        "--instructions-override",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to a file whose contents replace INSTRUCTIONS.md for this session "
+        "(env: CLAUDE_MPM_INSTRUCTIONS_OVERRIDE)",
+    )
 
     # Dependency checking options (for backward compatibility at top level)
     dep_group_top = parser.add_argument_group(

--- a/src/claude_mpm/cli/parsers/run_parser.py
+++ b/src/claude_mpm/cli/parsers/run_parser.py
@@ -244,6 +244,17 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         "Overrides CLAUDE_MPM_PM_MODEL env var. Example: --model opus",
     )
 
+    # Instructions override option
+    instructions_group = parser.add_argument_group("instructions options")
+    instructions_group.add_argument(
+        "--instructions-override",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to a file whose contents replace INSTRUCTIONS.md for this session "
+        "(env: CLAUDE_MPM_INSTRUCTIONS_OVERRIDE)",
+    )
+
     # Claude CLI arguments
     parser.add_argument(
         "claude_args",

--- a/src/claude_mpm/core/framework/loaders/instruction_loader.py
+++ b/src/claude_mpm/core/framework/loaders/instruction_loader.py
@@ -14,14 +14,23 @@ from .workflow_constants import MEMORY_SYSTEM_REFERENCE, WORKFLOW_SYSTEM_REFEREN
 class InstructionLoader:
     """Handles loading of INSTRUCTIONS, WORKFLOW, and MEMORY files."""
 
-    def __init__(self, framework_path: Path | None = None):
+    def __init__(
+        self,
+        framework_path: Path | None = None,
+        instructions_override_path: Path | None = None,
+    ):
         """Initialize the instruction loader.
 
         Args:
             framework_path: Path to framework installation
+            instructions_override_path: Optional path to a file whose contents
+                replace INSTRUCTIONS.md for this session.  When set and the file
+                exists, load_custom_instructions() uses it instead of the normal
+                .claude-mpm/INSTRUCTIONS.md resolution.
         """
         self.logger = get_logger("instruction_loader")
         self.framework_path = framework_path
+        self.instructions_override_path = instructions_override_path
         self.file_loader = FileLoader()
         self.packaged_loader = PackagedLoader()
         self.current_dir = Path.cwd()
@@ -66,9 +75,33 @@ class InstructionLoader:
     def load_custom_instructions(self, content: dict[str, Any]) -> None:
         """Load custom INSTRUCTIONS.md from .claude-mpm directories.
 
+        When ``instructions_override_path`` is set on this loader (populated from
+        the ``--instructions-override`` CLI flag or ``CLAUDE_MPM_INSTRUCTIONS_OVERRIDE``
+        env var), the file at that path is used in place of the normal
+        .claude-mpm/INSTRUCTIONS.md tier resolution.  The override is labelled
+        level="override" so callers can distinguish it from project/user sources.
+        If the override path does not exist or cannot be read, a warning is logged
+        and the normal resolution proceeds as a fallback.
+
         Args:
             content: Dictionary to update with loaded instructions
         """
+        if self.instructions_override_path is not None:
+            override_path = self.instructions_override_path
+            loaded = self.file_loader.try_load_file(
+                override_path, "instructions override"
+            )
+            if loaded:
+                self.logger.info(f"Using --instructions-override file: {override_path}")
+                content["custom_instructions"] = loaded
+                content["custom_instructions_level"] = "override"
+                return
+            # Override file absent or unreadable — fall through to normal resolution.
+            self.logger.warning(
+                f"--instructions-override path not found or unreadable: {override_path}; "
+                "falling back to normal INSTRUCTIONS.md resolution"
+            )
+
         instructions, level = self.file_loader.load_instructions_file(self.current_dir)
         if instructions:
             content["custom_instructions"] = instructions

--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -96,6 +96,14 @@ class FrameworkLoader:
         self.framework_last_modified = None
         self.config = config or {}
 
+        # Resolve instructions override: read from env var set by CLI.
+        # CLAUDE_MPM_INSTRUCTIONS_OVERRIDE holds an absolute or cwd-relative path
+        # to a file whose contents replace INSTRUCTIONS.md for this session.
+        _override_env = os.environ.get("CLAUDE_MPM_INSTRUCTIONS_OVERRIDE")
+        self.instructions_override_path: Path | None = (
+            Path(_override_env) if _override_env else None
+        )
+
         # Validate API keys on startup (before any other initialization)
         self._validate_api_keys()
 
@@ -165,7 +173,10 @@ class FrameworkLoader:
         # Loaders
         self.file_loader = FileLoader()
         self.packaged_loader = PackagedLoader()
-        self.instruction_loader = InstructionLoader(self.framework_path)
+        self.instruction_loader = InstructionLoader(
+            self.framework_path,
+            instructions_override_path=self.instructions_override_path,
+        )
         self.agent_loader = AgentLoader(self.framework_path)
 
         # Formatters


### PR DESCRIPTION
## Summary

Adds a new `--instructions-override` flag to allow injecting custom instructions at session start, bypassing the normal `.claude-mpm/INSTRUCTIONS.md` tier resolution.

**Key additions:**
- **CLI layer**: `--instructions-override PATH` flag available on both top-level (`claude-mpm --instructions-override ...`) and `run` subcommand (`claude-mpm run --instructions-override ...`)
- **Flag threading**: Flag is filtered from Claude CLI args and passed to `FrameworkLoader` via `CLAUDE_MPM_INSTRUCTIONS_OVERRIDE` env var
- **Core wiring**: `FrameworkLoader` reads the env var and passes `instructions_override_path` to `InstructionLoader`
- **Override behavior**: When set and the file exists, `InstructionLoader.load_custom_instructions()` loads the override file with `level="override"`, bypassing normal resolution. If the file is absent or unreadable, a warning is logged and normal resolution proceeds (fail-open)

## Test Plan

- [x] Verify `--instructions-override` flag appears in help: `claude-mpm --help` and `claude-mpm run --help`
- [x] Test override with existing file: `claude-mpm run --instructions-override /path/to/custom.md` — should load custom instructions
- [x] Test override with missing file: Verify fallback to normal INSTRUCTIONS.md resolution with logged warning
- [x] Test env var passthrough: Set `CLAUDE_MPM_INSTRUCTIONS_OVERRIDE=/path/to/file` and verify it's honored without the flag
- [x] Test flag takes precedence: When both env var and flag are set, flag value should be used

Closes #770