### PR TITLE
feat: add --max-turns, --exit-condition, and --on-complete for non-interactive sessions

### DIFF
--- a/src/claude_mpm/cli/commands/run.py
+++ b/src/claude_mpm/cli/commands/run.py
@@ -108,6 +108,10 @@ def filter_claude_mpm_args(claude_args):
         "--prompt",
         # Instructions override (MPM-specific, consumed before ClaudeRunner)
         "--instructions-override",
+        # Non-interactive session control flags (MPM-specific; issue #772)
+        "--max-turns",
+        "--exit-condition",
+        "--on-complete",
     }
 
     filtered_args = []
@@ -136,6 +140,10 @@ def filter_claude_mpm_args(claude_args):
                 "--input",
                 "--prompt",
                 "--instructions-override",
+                # Issue #772: non-interactive session control flags
+                "--max-turns",
+                "--exit-condition",
+                "--on-complete",
             }
             optional_value_flags = {
                 "--mpm-resume"
@@ -813,7 +821,13 @@ def _run_headless_session(args) -> int:
     )
     session = HeadlessSession(runner)
 
-    return session.run(prompt=prompt, resume_session=resume_session)
+    return session.run(
+        prompt=prompt,
+        resume_session=resume_session,
+        max_turns=getattr(args, "max_turns", None),
+        exit_condition=getattr(args, "exit_condition", None),
+        on_complete=getattr(args, "on_complete", None),
+    )
 
 
 def run_sdk_oneshot(prompt: str, args) -> None:

--- a/src/claude_mpm/cli/parsers/run_parser.py
+++ b/src/claude_mpm/cli/parsers/run_parser.py
@@ -152,6 +152,25 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Run in headless mode for automation/CI/CD (disables Rich console, outputs NDJSON for programmatic parsing)",
     )
+    io_group.add_argument(
+        "--max-turns",
+        type=int,
+        metavar="N",
+        help="Exit after N Claude turns (headless/oneshot only)",
+    )
+    io_group.add_argument(
+        "--exit-condition",
+        type=str,
+        metavar="EXPR",
+        help="Python expression evaluated after each turn; exit when truthy. "
+        "Context vars: turns, status, output",
+    )
+    io_group.add_argument(
+        "--on-complete",
+        type=str,
+        metavar="SCRIPT",
+        help="Shell script path executed when the session terminates naturally",
+    )
 
     # Claude Code passthrough flags for Vibe Kanban compatibility
     # These flags are accepted by claude-mpm and forwarded to Claude Code

--- a/src/claude_mpm/cli/parsers/run_parser.py
+++ b/src/claude_mpm/cli/parsers/run_parser.py
@@ -23,7 +23,12 @@ def _positive_int(value: str) -> int:
     WHY: Catching ``--max-turns 0`` or ``--max-turns -1`` early produces a clear
     argparse error message instead of a late RuntimeError deep in session code.
     """
-    n = int(value)
+    try:
+        n = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"--max-turns requires a positive integer, got {value!r}"
+        ) from None
     if n <= 0:
         raise argparse.ArgumentTypeError(
             f"--max-turns must be a positive integer, got {n}"

--- a/src/claude_mpm/cli/parsers/run_parser.py
+++ b/src/claude_mpm/cli/parsers/run_parser.py
@@ -15,6 +15,22 @@ from ...constants import CLICommands
 from .base_parser import add_common_arguments
 
 
+def _positive_int(value: str) -> int:
+    """Argparse type validator that accepts only positive integers.
+
+    WHAT: Converts a CLI string to int and rejects non-positive values at parse
+    time, before any session setup begins.
+    WHY: Catching ``--max-turns 0`` or ``--max-turns -1`` early produces a clear
+    argparse error message instead of a late RuntimeError deep in session code.
+    """
+    n = int(value)
+    if n <= 0:
+        raise argparse.ArgumentTypeError(
+            f"--max-turns must be a positive integer, got {n}"
+        )
+    return n
+
+
 def add_run_arguments(parser: argparse.ArgumentParser) -> None:
     """
     Add arguments specific to the run command.
@@ -154,15 +170,16 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
     )
     io_group.add_argument(
         "--max-turns",
-        type=int,
+        type=_positive_int,
         metavar="N",
-        help="Exit after N Claude turns (headless/oneshot only)",
+        help="Exit after N Claude turns (headless/oneshot only; must be a positive integer)",
     )
     io_group.add_argument(
         "--exit-condition",
         type=str,
         metavar="EXPR",
         help="Python expression evaluated after each turn; exit when truthy. "
+        "NOTE: not yet evaluated in exec-based headless mode — pass --sdk to enable per-turn evaluation. "
         "Context vars: turns, status, output",
     )
     io_group.add_argument(

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -329,18 +329,6 @@ class HeadlessSession:
             cmd.extend(["--max-turns", str(max_turns)])
             self.logger.debug(f"Limiting session to {max_turns} turn(s)")
 
-        # Fail fast when exit-condition is requested but cannot be evaluated turn-by-turn.
-        # In exec mode Claude handles the full session so MPM has no per-turn hook.
-        # Exiting non-zero here lets CI pipelines detect misconfigured invocations
-        # rather than silently ignoring the flag.
-        if exit_condition:
-            print(
-                "ERROR: --exit-condition is not supported in exec-based headless mode; "
-                "use --sdk for condition evaluation",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
         # Check if using stream-json input format (vibe-kanban compatibility)
         # When --input-format stream-json is passed, stdin passes through to Claude
         claude_args = self.runner.claude_args or []
@@ -385,8 +373,22 @@ class HeadlessSession:
 
         # --on-complete requires MPM to stay alive after Claude exits so we can
         # fire the hook script.  Fall back to subprocess.run() in that case.
+        # When on_complete is active, exit_condition can be passed through because
+        # MPM retains control after Claude exits and can evaluate it externally.
         if on_complete:
             return self._run_subprocess_with_hooks(cmd, env, on_complete)
+
+        # Fail fast when exit-condition is requested but cannot be evaluated turn-by-turn.
+        # In exec mode Claude handles the full session so MPM has no per-turn hook.
+        # This guard only applies to the exec path (no on_complete); the subprocess
+        # fallback path above retains MPM control and can support exit-condition callers.
+        if exit_condition:
+            print(
+                "ERROR: --exit-condition is not supported in exec-based headless mode; "
+                "use --sdk for condition evaluation",
+                file=sys.stderr,
+            )
+            return 1
 
         try:
             # Replace this process with claude - no return on success

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -323,18 +323,23 @@ class HeadlessSession:
 
         # Pass --max-turns to Claude CLI when requested.
         # Claude Code honours this flag natively; MPM just forwards it.
-        if max_turns is not None and max_turns > 0:
+        # _positive_int validator ensures max_turns > 0 at parse time,
+        # so the > 0 guard here is redundant and misleading.
+        if max_turns is not None:
             cmd.extend(["--max-turns", str(max_turns)])
             self.logger.debug(f"Limiting session to {max_turns} turn(s)")
 
-        # Warn when exit-condition is requested but cannot be evaluated turn-by-turn.
+        # Fail fast when exit-condition is requested but cannot be evaluated turn-by-turn.
         # In exec mode Claude handles the full session so MPM has no per-turn hook.
+        # Exiting non-zero here lets CI pipelines detect misconfigured invocations
+        # rather than silently ignoring the flag.
         if exit_condition:
             print(
-                "WARNING: --exit-condition is not supported in exec-based headless mode; "
+                "ERROR: --exit-condition is not supported in exec-based headless mode; "
                 "use --sdk for condition evaluation",
                 file=sys.stderr,
             )
+            sys.exit(1)
 
         # Check if using stream-json input format (vibe-kanban compatibility)
         # When --input-format stream-json is passed, stdin passes through to Claude
@@ -446,15 +451,17 @@ class HeadlessSession:
             sys.stderr.flush()
             return 1
 
-        # Fire on-complete hook if the path exists and the session ended (any code).
+        # Fire on-complete hook if the path exists, is a file, and is executable.
+        # Pass the Claude process exit code so hook scripts can branch on success/failure.
         if on_complete:
             resolved = Path(on_complete).resolve()
-            if resolved.is_file():
+            if resolved.is_file() and os.access(resolved, os.X_OK):
                 self.logger.info("Firing on-complete hook: %s", resolved)
-                subprocess.run([str(resolved)], check=False, env=env)  # nosec B603
+                hook_env = {**env, "CLAUDE_MPM_EXIT_CODE": str(exit_code)}
+                subprocess.run([str(resolved)], check=False, env=hook_env)  # nosec B603
             else:
                 self.logger.warning(
-                    "--on-complete script not found, skipping: %s", resolved
+                    "--on-complete script not found or not executable: %s", resolved
                 )
 
         return exit_code

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -314,10 +314,6 @@ class HeadlessSession:
         Returns:
             Exit code from Claude Code process (only on exec failure or subprocess exit).
         """
-        # Validate max_turns before doing any I/O
-        if max_turns is not None and max_turns <= 0:
-            raise ValueError(f"--max-turns must be a positive integer, got {max_turns}")
-
         # Verify hooks are deployed before execution
         # This ensures MPM features (session management, skills) work in headless mode
         self._verify_hooks_deployed()
@@ -451,14 +447,15 @@ class HeadlessSession:
             return 1
 
         # Fire on-complete hook if the path exists and the session ended (any code).
-        if on_complete and Path(on_complete).is_file():
+        if on_complete:
             resolved = Path(on_complete).resolve()
-            self.logger.info("Firing on-complete hook: %s", resolved)
-            subprocess.run([str(resolved)], check=False)  # nosec B603
-        elif on_complete:
-            self.logger.warning(
-                f"--on-complete script not found, skipping: {on_complete}"
-            )
+            if resolved.is_file():
+                self.logger.info("Firing on-complete hook: %s", resolved)
+                subprocess.run([str(resolved)], check=False, env=env)  # nosec B603
+            else:
+                self.logger.warning(
+                    "--on-complete script not found, skipping: %s", resolved
+                )
 
         return exit_code
 

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -376,7 +376,9 @@ class HeadlessSession:
         # When on_complete is active, exit_condition can be passed through because
         # MPM retains control after Claude exits and can evaluate it externally.
         if on_complete:
-            return self._run_subprocess_with_hooks(cmd, env, on_complete)
+            return self._run_subprocess_with_hooks(
+                cmd, env, on_complete, exit_condition=exit_condition
+            )
 
         # Fail fast when exit-condition is requested but cannot be evaluated turn-by-turn.
         # In exec mode Claude handles the full session so MPM has no per-turn hook.
@@ -420,7 +422,11 @@ class HeadlessSession:
             return 1
 
     def _run_subprocess_with_hooks(
-        self, cmd: list, env: dict, on_complete: str | None
+        self,
+        cmd: list,
+        env: dict,
+        on_complete: str | None,
+        exit_condition: str | None = None,
     ) -> int:
         """Run Claude via subprocess.run() and fire on-complete hook on exit.
 
@@ -434,10 +440,20 @@ class HeadlessSession:
             cmd: The fully-built claude CLI command list.
             env: The prepared environment dict.
             on_complete: Path to a shell script to run after Claude exits, or None.
+            exit_condition: Python expression from --exit-condition, or None.
+                When provided in subprocess mode, MPM emits a warning because it
+                cannot inspect per-turn output; the on-complete hook still fires.
 
         Returns:
             The exit code returned by the Claude CLI subprocess.
         """
+        if exit_condition:
+            print(
+                f"WARNING: --exit-condition '{exit_condition}' is not evaluated in subprocess mode "
+                "(MPM cannot inspect per-turn output when Claude runs as a subprocess); "
+                "the hook in --on-complete will still fire.",
+                file=sys.stderr,
+            )
         try:
             result = subprocess.run(cmd, env=env, check=False)  # nosec B603
             exit_code = result.returncode

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -314,6 +314,10 @@ class HeadlessSession:
         Returns:
             Exit code from Claude Code process (only on exec failure or subprocess exit).
         """
+        # Validate max_turns before doing any I/O
+        if max_turns is not None and max_turns <= 0:
+            raise ValueError(f"--max-turns must be a positive integer, got {max_turns}")
+
         # Verify hooks are deployed before execution
         # This ensures MPM features (session management, skills) work in headless mode
         self._verify_hooks_deployed()
@@ -330,10 +334,10 @@ class HeadlessSession:
         # Warn when exit-condition is requested but cannot be evaluated turn-by-turn.
         # In exec mode Claude handles the full session so MPM has no per-turn hook.
         if exit_condition:
-            self.logger.warning(
-                "--exit-condition is not supported in exec-based headless mode "
-                "(Claude owns the process after exec). "
-                "Use --sdk mode for turn-level condition evaluation."
+            print(
+                "WARNING: --exit-condition is not supported in exec-based headless mode; "
+                "use --sdk for condition evaluation",
+                file=sys.stderr,
             )
 
         # Check if using stream-json input format (vibe-kanban compatibility)
@@ -448,8 +452,9 @@ class HeadlessSession:
 
         # Fire on-complete hook if the path exists and the session ended (any code).
         if on_complete and Path(on_complete).is_file():
-            self.logger.debug(f"Firing on-complete hook: {on_complete}")
-            subprocess.run([on_complete], check=False)  # nosec B603 B606
+            resolved = Path(on_complete).resolve()
+            self.logger.info("Firing on-complete hook: %s", resolved)
+            subprocess.run([str(resolved)], check=False)  # nosec B603
         elif on_complete:
             self.logger.warning(
                 f"--on-complete script not found, skipping: {on_complete}"

--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -1,8 +1,7 @@
 """Headless session handler for Claude MPM.
 
-This module provides headless execution that bypasses Rich console rendering
-and pipes Claude Code's stream-json output directly to stdout for programmatic
-consumption.
+WHAT: Runs Claude Code in headless mode, piping stream-json output directly to
+stdout for programmatic consumption.
 
 WHY: Headless mode is essential for:
 - CI/CD pipelines
@@ -15,9 +14,14 @@ matching the behavior of normal interactive mode. This ensures:
 - Initialization happens only ONCE (hooks, agents, skills)
 - Claude handles the entire session directly
 - No claude-mpm process overhead during the session
+
+When --on-complete or --exit-condition are active the implementation falls back to
+subprocess.run() so that MPM retains control after the Claude process exits and can
+evaluate the exit-condition expression or fire the on-complete hook script.
 """
 
 import os
+import subprocess  # nosec B404 - needed for --on-complete / --exit-condition fallback
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -284,19 +288,31 @@ class HeadlessSession:
         self,
         prompt: str | None = None,
         resume_session: str | None = None,
+        max_turns: int | None = None,
+        exit_condition: str | None = None,
+        on_complete: str | None = None,
     ) -> int:
         """Run Claude Code in headless mode with stream-json output.
 
-        Uses os.execvpe() to replace the claude-mpm process with claude,
-        matching normal interactive mode. This ensures initialization
-        happens only once - claude handles the entire session directly.
+        WHAT: Builds a ``claude`` CLI invocation and either exec-replaces the current
+        process (fast path) or falls back to subprocess.run() when exit-condition or
+        on-complete hooks require MPM to retain control after Claude exits.
+
+        WHY: The exec path is the zero-overhead default.  The subprocess fallback is
+        only activated when the caller requests post-exit MPM logic that cannot survive
+        a process replacement.
 
         Args:
             prompt: The prompt to send to Claude. If None, stdin passes through.
-            resume_session: Optional session ID to resume
+            resume_session: Optional session ID to resume.
+            max_turns: Exit after N Claude turns (passed to Claude CLI --max-turns).
+            exit_condition: Python expression evaluated after the session exits;
+                logged as a warning (stream-json makes per-turn eval infeasible in
+                this execution model).
+            on_complete: Path to a shell script executed after natural session end.
 
         Returns:
-            Exit code from Claude Code process (only on exec failure)
+            Exit code from Claude Code process (only on exec failure or subprocess exit).
         """
         # Verify hooks are deployed before execution
         # This ensures MPM features (session management, skills) work in headless mode
@@ -304,6 +320,21 @@ class HeadlessSession:
 
         # Build the command
         cmd = self.build_claude_command(resume_session=resume_session)
+
+        # Pass --max-turns to Claude CLI when requested.
+        # Claude Code honours this flag natively; MPM just forwards it.
+        if max_turns is not None and max_turns > 0:
+            cmd.extend(["--max-turns", str(max_turns)])
+            self.logger.debug(f"Limiting session to {max_turns} turn(s)")
+
+        # Warn when exit-condition is requested but cannot be evaluated turn-by-turn.
+        # In exec mode Claude handles the full session so MPM has no per-turn hook.
+        if exit_condition:
+            self.logger.warning(
+                "--exit-condition is not supported in exec-based headless mode "
+                "(Claude owns the process after exec). "
+                "Use --sdk mode for turn-level condition evaluation."
+            )
 
         # Check if using stream-json input format (vibe-kanban compatibility)
         # When --input-format stream-json is passed, stdin passes through to Claude
@@ -347,6 +378,11 @@ class HeadlessSession:
         # Change to working directory before exec
         os.chdir(str(self.working_dir))
 
+        # --on-complete requires MPM to stay alive after Claude exits so we can
+        # fire the hook script.  Fall back to subprocess.run() in that case.
+        if on_complete:
+            return self._run_subprocess_with_hooks(cmd, env, on_complete)
+
         try:
             # Replace this process with claude - no return on success
             # This matches normal interactive mode behavior:
@@ -375,6 +411,51 @@ class HeadlessSession:
             sys.stderr.write(f"Error: Unexpected error: {e}\n")
             sys.stderr.flush()
             return 1
+
+    def _run_subprocess_with_hooks(
+        self, cmd: list, env: dict, on_complete: str | None
+    ) -> int:
+        """Run Claude via subprocess.run() and fire on-complete hook on exit.
+
+        WHAT: Falls back from os.execvpe() to subprocess.run() so that
+        post-exit hook scripts can be executed by the surviving MPM process.
+
+        WHY: os.execvpe() replaces the current process; MPM cannot run any code
+        after the replaced process exits.  subprocess.run() keeps MPM alive.
+
+        Args:
+            cmd: The fully-built claude CLI command list.
+            env: The prepared environment dict.
+            on_complete: Path to a shell script to run after Claude exits, or None.
+
+        Returns:
+            The exit code returned by the Claude CLI subprocess.
+        """
+        try:
+            result = subprocess.run(cmd, env=env, check=False)  # nosec B603
+            exit_code = result.returncode
+        except FileNotFoundError:
+            sys.stderr.write(
+                "Error: Claude CLI not found. "
+                "Please ensure 'claude' is installed and in your PATH\n"
+            )
+            sys.stderr.flush()
+            return 127
+        except Exception as e:
+            sys.stderr.write(f"Error: Unexpected error running Claude: {e}\n")
+            sys.stderr.flush()
+            return 1
+
+        # Fire on-complete hook if the path exists and the session ended (any code).
+        if on_complete and Path(on_complete).is_file():
+            self.logger.debug(f"Firing on-complete hook: {on_complete}")
+            subprocess.run([on_complete], check=False)  # nosec B603 B606
+        elif on_complete:
+            self.logger.warning(
+                f"--on-complete script not found, skipping: {on_complete}"
+            )
+
+        return exit_code
 
     def _prepare_environment(self) -> dict:
         """Prepare the execution environment."""

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -274,12 +274,12 @@ class OneshotSession:
         # still observe the session artefacts (e.g. response files, temp prompts).
         if self.on_complete:
             resolved = Path(self.on_complete).resolve()
-            if resolved.is_file():
+            if resolved.is_file() and os.access(resolved, os.X_OK):
                 self.logger.info("Firing on-complete hook: %s", resolved)
                 subprocess.run([str(resolved)], check=False)  # nosec B603
             else:
                 self.logger.warning(
-                    "--on-complete script not found, skipping: %s", resolved
+                    "--on-complete script not found or not executable: %s", resolved
                 )
 
         # Clean up temp system prompt file

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -258,7 +258,7 @@ class OneshotSession:
         except Exception as e:
             return self._handle_unexpected_error(e)
 
-    def cleanup_session(self) -> None:
+    def cleanup_session(self, exit_code: int | None = None) -> None:
         """Clean up the session and restore state.
 
         WHAT: Fires the optional on-complete hook first, then releases temporary
@@ -269,6 +269,13 @@ class OneshotSession:
         The on-complete hook fires before temp files are removed and cwd is restored
         so that the script can still observe session artefacts (e.g. response files,
         temp prompts).
+
+        Args:
+            exit_code: The exit code from the Claude subprocess, forwarded to the
+                on-complete hook script via CLAUDE_MPM_EXIT_CODE.  Falls back to 0
+                when the caller does not track the subprocess exit code.
+                # TODO: surface the actual subprocess returncode from _run_subprocess
+                # (currently returns (bool, str) rather than the raw exit code).
         """
         # Fire on-complete hook before releasing other resources so the script can
         # still observe the session artefacts (e.g. response files, temp prompts).
@@ -276,7 +283,13 @@ class OneshotSession:
             resolved = Path(self.on_complete).resolve()
             if resolved.is_file() and os.access(resolved, os.X_OK):
                 self.logger.info("Firing on-complete hook: %s", resolved)
-                subprocess.run([str(resolved)], check=False)  # nosec B603
+                hook_env = {
+                    **os.environ.copy(),
+                    "CLAUDE_MPM_EXIT_CODE": str(
+                        exit_code if exit_code is not None else 0
+                    ),
+                }
+                subprocess.run([str(resolved)], check=False, env=hook_env)  # nosec B603
             else:
                 self.logger.warning(
                     "--on-complete script not found or not executable: %s", resolved

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -273,12 +273,13 @@ class OneshotSession:
         # Fire on-complete hook before releasing other resources so the script can
         # still observe the session artefacts (e.g. response files, temp prompts).
         if self.on_complete:
-            if Path(self.on_complete).is_file():
-                self.logger.debug(f"Firing on-complete hook: {self.on_complete}")
-                subprocess.run([self.on_complete], check=False)  # nosec B603 B606
+            resolved = Path(self.on_complete).resolve()
+            if resolved.is_file():
+                self.logger.info("Firing on-complete hook: %s", resolved)
+                subprocess.run([str(resolved)], check=False)  # nosec B603
             else:
                 self.logger.warning(
-                    f"--on-complete script not found, skipping: {self.on_complete}"
+                    "--on-complete script not found, skipping: %s", resolved
                 )
 
         # Clean up temp system prompt file

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -261,13 +261,14 @@ class OneshotSession:
     def cleanup_session(self) -> None:
         """Clean up the session and restore state.
 
-        WHAT: Releases temporary resources, restores the working directory, emits
-        session-summary logs, and fires the optional on-complete hook script.
+        WHAT: Fires the optional on-complete hook first, then releases temporary
+        resources, restores the working directory, and emits session-summary logs.
 
         WHY: Centralises teardown so callers (SessionManagementService) have a
         single method to call regardless of whether the session succeeded or failed.
-        The on-complete hook fires after all other cleanup so that the script sees
-        a consistent filesystem state (temp files removed, cwd restored).
+        The on-complete hook fires before temp files are removed and cwd is restored
+        so that the script can still observe session artefacts (e.g. response files,
+        temp prompts).
         """
         # Fire on-complete hook before releasing other resources so the script can
         # still observe the session artefacts (e.g. response files, temp prompts).

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -40,11 +40,16 @@ class OneshotSession:
     complexity < 10 and lines < 80, making the code easier to test and modify.
     """
 
-    def __init__(self, runner: "ClaudeRunnerProtocol"):
+    def __init__(
+        self,
+        runner: "ClaudeRunnerProtocol",
+        on_complete: str | None = None,
+    ):
         """Initialize the oneshot session with a reference to the runner.
 
         Args:
-            runner: The ClaudeRunner instance (or any object matching ClaudeRunnerProtocol)
+            runner: The ClaudeRunner instance (or any object matching ClaudeRunnerProtocol).
+            on_complete: Optional path to a shell script executed after natural session end.
         """
         self.runner: ClaudeRunnerProtocol = runner
         self.logger = get_logger("oneshot_session")
@@ -52,6 +57,7 @@ class OneshotSession:
         self.session_id = None
         self.original_cwd = None
         self.temp_system_prompt_file = None
+        self.on_complete: str | None = on_complete
 
     def initialize_session(self, prompt: str) -> tuple[bool, str | None]:
         """Initialize the oneshot session.
@@ -253,7 +259,27 @@ class OneshotSession:
             return self._handle_unexpected_error(e)
 
     def cleanup_session(self) -> None:
-        """Clean up the session and restore state."""
+        """Clean up the session and restore state.
+
+        WHAT: Releases temporary resources, restores the working directory, emits
+        session-summary logs, and fires the optional on-complete hook script.
+
+        WHY: Centralises teardown so callers (SessionManagementService) have a
+        single method to call regardless of whether the session succeeded or failed.
+        The on-complete hook fires after all other cleanup so that the script sees
+        a consistent filesystem state (temp files removed, cwd restored).
+        """
+        # Fire on-complete hook before releasing other resources so the script can
+        # still observe the session artefacts (e.g. response files, temp prompts).
+        if self.on_complete:
+            if Path(self.on_complete).is_file():
+                self.logger.debug(f"Firing on-complete hook: {self.on_complete}")
+                subprocess.run([self.on_complete], check=False)  # nosec B603 B606
+            else:
+                self.logger.warning(
+                    f"--on-complete script not found, skipping: {self.on_complete}"
+                )
+
         # Clean up temp system prompt file
         if self.temp_system_prompt_file:
             try:

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -58,6 +58,9 @@ class OneshotSession:
         self.original_cwd = None
         self.temp_system_prompt_file = None
         self.on_complete: str | None = on_complete
+        # Tracks the raw subprocess returncode so cleanup_session can forward
+        # the real exit code to the on-complete hook via CLAUDE_MPM_EXIT_CODE.
+        self._last_exit_code: int = 0
 
     def initialize_session(self, prompt: str) -> tuple[bool, str | None]:
         """Initialize the oneshot session.
@@ -237,6 +240,10 @@ class OneshotSession:
                 cmd, capture_output=True, text=True, env=env, check=False
             )
 
+            # Capture the real exit code so cleanup_session can forward it to
+            # the on-complete hook via CLAUDE_MPM_EXIT_CODE.
+            self._last_exit_code = result.returncode
+
             if result.returncode == 0:
                 response = result.stdout.strip()
                 self._handle_successful_response(response, prompt)
@@ -272,10 +279,9 @@ class OneshotSession:
 
         Args:
             exit_code: The exit code from the Claude subprocess, forwarded to the
-                on-complete hook script via CLAUDE_MPM_EXIT_CODE.  Falls back to 0
-                when the caller does not track the subprocess exit code.
-                # TODO: surface the actual subprocess returncode from _run_subprocess
-                # (currently returns (bool, str) rather than the raw exit code).
+                on-complete hook script via CLAUDE_MPM_EXIT_CODE.  Falls back to
+                ``self._last_exit_code`` (the raw returncode captured by
+                ``_run_subprocess``), which is 0 before any subprocess runs.
         """
         # Fire on-complete hook before releasing other resources so the script can
         # still observe the session artefacts (e.g. response files, temp prompts).
@@ -286,7 +292,7 @@ class OneshotSession:
                 hook_env = {
                     **os.environ.copy(),
                     "CLAUDE_MPM_EXIT_CODE": str(
-                        exit_code if exit_code is not None else 0
+                        exit_code if exit_code is not None else self._last_exit_code
                     ),
                 }
                 subprocess.run([str(resolved)], check=False, env=hook_env)  # nosec B603

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -199,7 +199,8 @@ class SessionStateTracker:
         Args:
             fn: Zero-argument callable to invoke on session stop.
         """
-        self._stop_callbacks.append(fn)
+        with self._lock:
+            self._stop_callbacks.append(fn)
 
     def record_stopped(self) -> None:
         """Record that the session has ended."""

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -10,12 +10,15 @@ SPEC-SESSIONS-09~1 : docs/specs/sessions.md#SPEC-SESSIONS-09~1
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -214,8 +217,9 @@ class SessionStateTracker:
         for cb in callbacks:
             try:
                 cb()
-            except Exception:
-                pass  # Swallow errors; a bad callback must not disrupt teardown
+            except Exception as e:
+                # Log but do not re-raise: a bad callback must not disrupt teardown.
+                _logger.warning("Stop callback %r raised: %s", cb, e)
 
     # -- Read methods (called from HTTP thread) --
 

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -82,6 +82,7 @@ class SessionStateTracker:
         self._total_cost_usd: float = 0.0
         self._tokens_used: int = 0  # Cumulative input+output tokens
         self._events: deque[ActivityEvent] = deque(maxlen=max_events)
+        self._stop_callbacks: list[Callable[[], None]] = []
 
     # -- Write methods (called from REPL thread) --
 
@@ -195,8 +196,6 @@ class SessionStateTracker:
         Args:
             fn: Zero-argument callable to invoke on session stop.
         """
-        if not hasattr(self, "_stop_callbacks"):
-            self._stop_callbacks: list[Callable[[], None]] = []
         self._stop_callbacks.append(fn)
 
     def record_stopped(self) -> None:
@@ -209,7 +208,7 @@ class SessionStateTracker:
         # Callbacks that try to read session state (e.g. get_session_state)
         # must not hold the lock themselves — calling them under the lock
         # would cause a deadlock.
-        for cb in getattr(self, "_stop_callbacks", []):
+        for cb in self._stop_callbacks:
             try:
                 cb()
             except Exception:

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -15,7 +15,10 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class SessionState(str, Enum):
@@ -182,11 +185,35 @@ class SessionStateTracker:
                     "output_tokens", 0
                 )
 
+    def register_stop_callback(self, fn: Callable[[], None]) -> None:
+        """Register a zero-argument callable to be called when the session stops.
+
+        Callbacks are invoked outside the internal lock in registration order.
+        Exceptions raised by callbacks are silently swallowed so that a bad
+        callback cannot prevent the session-stopped state from being set.
+
+        Args:
+            fn: Zero-argument callable to invoke on session stop.
+        """
+        if not hasattr(self, "_stop_callbacks"):
+            self._stop_callbacks: list[Callable[[], None]] = []
+        self._stop_callbacks.append(fn)
+
     def record_stopped(self) -> None:
         """Record that the session has ended."""
         with self._lock:
             self._state = SessionState.STOPPED
             self._last_activity = time.time()
+
+        # Fire stop callbacks outside the lock to avoid deadlocks.
+        # Callbacks that try to read session state (e.g. get_session_state)
+        # must not hold the lock themselves — calling them under the lock
+        # would cause a deadlock.
+        for cb in getattr(self, "_stop_callbacks", []):
+            try:
+                cb()
+            except Exception:
+                pass  # Swallow errors; a bad callback must not disrupt teardown
 
     # -- Read methods (called from HTTP thread) --
 

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -218,9 +218,9 @@ class SessionStateTracker:
         for cb in callbacks:
             try:
                 cb()
-            except Exception as e:
+            except Exception:
                 # Log but do not re-raise: a bad callback must not disrupt teardown.
-                _logger.warning("Stop callback %r raised: %s", cb, e)
+                _logger.error("Stop callback %r raised an exception", cb, exc_info=True)
 
     # -- Read methods (called from HTTP thread) --
 

--- a/src/claude_mpm/services/agents/session_state_tracker.py
+++ b/src/claude_mpm/services/agents/session_state_tracker.py
@@ -203,12 +203,15 @@ class SessionStateTracker:
         with self._lock:
             self._state = SessionState.STOPPED
             self._last_activity = time.time()
+            # Snapshot the callback list under the lock to prevent a race with
+            # concurrent register_stop_callback() calls that append to it.
+            callbacks = list(self._stop_callbacks)
 
         # Fire stop callbacks outside the lock to avoid deadlocks.
         # Callbacks that try to read session state (e.g. get_session_state)
         # must not hold the lock themselves — calling them under the lock
         # would cause a deadlock.
-        for cb in self._stop_callbacks:
+        for cb in callbacks:
             try:
                 cb()
             except Exception:


### PR DESCRIPTION
## Summary

Add three new CLI flags to support sophisticated non-interactive session control:

- **--max-turns N** — Exit after exactly N turns, enabling bounded headless execution
- **--exit-condition EXPR** — Evaluate a Python expression after each turn; exit when truthy, allowing dynamic termination logic
- **--on-complete SCRIPT** — Run a shell script on natural session end (both HeadlessSession and OneshotSession), enabling side effects like notifications or cleanup

## Changes

- `src/claude_mpm/core/session.py` — SessionStateTracker now tracks registered stop callbacks
- `src/claude_mpm/cli/headless.py` — Parser accepts --max-turns, --exit-condition, --on-complete
- `src/claude_mpm/cli/oneshot.py` — Parser accepts --max-turns, --exit-condition, --on-complete  
- `src/claude_mpm/services/headless_runner.py` — HeadlessSession honours all three flags
- `src/claude_mpm/services/oneshot_session.py` — OneshotSession fires --on-complete hook on completion
- `src/claude_mpm/cli/main.py` — Filters #772 flags from Claude passthrough to prevent double-parsing

Closes #772