### PR TITLE
fix: apply native-field and color migrations to deployed code-critic agent

### DIFF
--- a/.claude/agents/code-critic.md
+++ b/.claude/agents/code-critic.md
@@ -1,17 +1,46 @@
 ---
 name: code-critic
-description: "Adversarial code reviewer that operates in strict context isolation to prevent anchoring bias. Receives only the spec and the code — never the implementer's rationale — and outputs a structured verdict (APPROVE / WARN / BLOCK) with severity-ranked findings (CRITICAL / HIGH / MEDIUM / LOW). Applies an 80% confidence filter so every finding is actionable. Use this agent after an engineer delivers an implementation and you need an independent second opinion, not a test-writing pass.\n\n<example>\nContext: Engineer has implemented a feature and you need an adversarial review before merge.\nuser: \"Review the auth middleware implementation against the spec\"\nassistant: \"I'll use the code-critic agent to perform an adversarial review against the spec.\"\n<commentary>\ncode-critic ignores implementer rationale and reviews code against the spec only, producing APPROVE/WARN/BLOCK verdicts with evidence-backed findings.\n</commentary>\n</example>"
+description: 'Adversarial code reviewer that operates in strict context isolation
+  to prevent anchoring bias. Receives only the spec and the code — never the implementer''s
+  rationale — and outputs a structured verdict (APPROVE / WARN / BLOCK) with severity-ranked
+  findings (CRITICAL / HIGH / MEDIUM / LOW). Applies an 80% confidence filter so every
+  finding is actionable. Use this agent after an engineer delivers an implementation
+  and you need an independent second opinion, not a test-writing pass.
+
+
+  <example>
+
+  Context: Engineer has implemented a feature and you need an adversarial review before
+  merge.
+
+  user: "Review the auth middleware implementation against the spec"
+
+  assistant: "I''ll use the code-critic agent to perform an adversarial review against
+  the spec."
+
+  <commentary>
+
+  code-critic ignores implementer rationale and reviews code against the spec only,
+  producing APPROVE/WARN/BLOCK verdicts with evidence-backed findings.
+
+  </commentary>
+
+  </example>'
 model: sonnet
 effort: balanced
 agent_type: qa
-version: "1.0.0"
+version: 1.0.0
 skills:
 - code-review-standards
 - code-production-process
 - software-patterns
 - systematic-debugging
 - verification-before-completion
-initialPrompt: "Begin verification. Read the task context and start testing immediately."
+initialPrompt: Begin verification. Read the task context and start testing immediately.
+permissionMode: acceptEdits
+maxTurns: 50
+memory: project
+color: blue
 ---
 # Code Critic
 


### PR DESCRIPTION
## Root cause

Two startup migrations rewrite `.claude/agents/code-critic.md` on every fresh migration state:

- `v6_3_0_native_agent_fields` — adds `permissionMode`, `maxTurns`, `memory` (and round-trips the frontmatter through `yaml.dump`)
- `v6_3_2_agent_color_prompt` — appends `color: blue`

The committed `code-critic.md` was never updated to its post-migration form (26833 bytes vs the 26927 the migrations produce). So every fresh startup re-applies the migration and **mutates the real deployed agent file**.

In CI (clean migration state), the `python -m claude_mpm analyze-code` subprocess in `tests/dashboard/test_analyze_subprocess.py` triggers startup migrations, which mutate `code-critic.md` mid-test. The test-isolation guard then fails deterministically:

```
Real deployed agents were modified during test: code-critic.md
```

## Fix

Bring the committed file up to the exact bytes the two migrations produce, applied in registry order (native fields → color). After this change the migrations find every field already present and leave the file untouched — the migration becomes a no-op, so tests never observe a modification.

## Verification

- **Idempotent / converges:** running both migrations a second time produces byte-identical output (no change, no backup file created).
- **No-op on updated file:** migrations applied to the new committed bytes leave it unchanged (26927 → 26927).
- **Tests pass clean:** `tests/cli/commands/test_run_comprehensive.py` and `tests/dashboard/test_analyze_subprocess.py` (45 passed); `git status` shows `code-critic.md` is not left dirty by the run.
- **Scope:** only the frontmatter changed — 4 new fields plus `yaml.dump` canonical re-serialization of the existing description/version/initialPrompt (semantically identical). The agent body is byte-identical.

This unblocks the Test Suite CI and is a prerequisite for PR #840 going green.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)