### PR TITLE
test: convert bare os.chdir to monkeypatch.chdir for xdist isolation

### DIFF
--- a/tests/test_claude_mpm_loading.py
+++ b/tests/test_claude_mpm_loading.py
@@ -14,7 +14,7 @@ from claude_mpm.core.logger import get_logger
 logger = get_logger("test_claude_mpm")
 
 
-def test_claude_mpm_loading():
+def test_claude_mpm_loading(monkeypatch):
     """Test that framework loader correctly loads from .claude-mpm/ directories."""
 
     # Create a temporary directory for testing
@@ -79,110 +79,97 @@ Custom memory instructions from .claude-mpm/MEMORY.md
         (claude_dir / "MEMORY.md").write_text("SHOULD NOT BE LOADED")
 
         # Change to test directory
-        original_cwd = Path.cwd()
-        try:
-            import os
+        monkeypatch.chdir(test_dir)
 
-            os.chdir(test_dir)
+        # Initialize framework loader
+        loader = FrameworkLoader()
 
-            # Initialize framework loader
-            loader = FrameworkLoader()
+        # Check that custom instructions were loaded
+        content = loader.framework_content
 
-            # Check that custom instructions were loaded
-            content = loader.framework_content
+        print("\n=== Test Results ===\n")
 
-            print("\n=== Test Results ===\n")
+        # Test INSTRUCTIONS.md loading
+        if content.get("custom_instructions"):
+            print("✅ INSTRUCTIONS.md loaded from .claude-mpm/")
+            print(f"   Level: {content.get('custom_instructions_level', 'unknown')}")
+            if "Test Project Instructions" in content["custom_instructions"]:
+                print("   ✅ Correct content loaded")
+            else:
+                print("   ❌ Wrong content loaded")
+        else:
+            print("❌ INSTRUCTIONS.md NOT loaded")
 
-            # Test INSTRUCTIONS.md loading
-            if content.get("custom_instructions"):
-                print("✅ INSTRUCTIONS.md loaded from .claude-mpm/")
-                print(
-                    f"   Level: {content.get('custom_instructions_level', 'unknown')}"
-                )
-                if "Test Project Instructions" in content["custom_instructions"]:
-                    print("   ✅ Correct content loaded")
+        # Test WORKFLOW.md loading
+        if content.get("workflow_instructions"):
+            print("✅ WORKFLOW.md loaded")
+            print(f"   Level: {content.get('workflow_instructions_level', 'unknown')}")
+            if "Test Workflow" in content["workflow_instructions"]:
+                print("   ✅ Correct content loaded from .claude-mpm/")
+            elif "SHOULD NOT BE LOADED" in content["workflow_instructions"]:
+                print("   ❌ WRONG! Loaded from .claude/ directory")
+            else:
+                print("   ℹ️  Loaded from system defaults")  # noqa: RUF001
+        else:
+            print("❌ WORKFLOW.md NOT loaded")
+
+        # Test MEMORY.md loading
+        if content.get("memory_instructions"):
+            print("✅ MEMORY.md loaded")
+            print(f"   Level: {content.get('memory_instructions_level', 'unknown')}")
+            if "Test Memory Instructions" in content["memory_instructions"]:
+                print("   ✅ Correct content loaded from .claude-mpm/")
+            elif "SHOULD NOT BE LOADED" in content["memory_instructions"]:
+                print("   ❌ WRONG! Loaded from .claude/ directory")
+            else:
+                print("   ℹ️  Loaded from system defaults")  # noqa: RUF001
+        else:
+            print("❌ MEMORY.md NOT loaded")
+
+        # Test actual memories loading
+        if content.get("actual_memories"):
+            print("✅ PM_memories.md loaded")
+            if "This project uses Python 3.11" in content["actual_memories"]:
+                print("   ✅ Correct memory content loaded")
+            else:
+                print("   ❌ Wrong memory content")
+        else:
+            print("ℹ️  No PM memories loaded (expected if no deployed agents)")  # noqa: RUF001
+
+        # Verify .claude/ directory was NOT read
+        instructions_text = loader.get_framework_instructions()
+        if "SHOULD NOT BE LOADED" in instructions_text:
+            print("\n❌ ERROR: Content from .claude/ directory was loaded!")
+            print(
+                "   This is a critical bug - framework should NEVER read from .claude/"
+            )
+        else:
+            print("\n✅ Correctly ignored .claude/ directory")
+
+        print("\n=== User Home Directory Test ===\n")
+
+        # Now test user-level loading
+        user_claude_mpm = Path.home() / ".claude-mpm"
+        if user_claude_mpm.exists():
+            print(f"Found user .claude-mpm at: {user_claude_mpm}")
+
+            # Check what files exist
+            for file in ["INSTRUCTIONS.md", "WORKFLOW.md", "MEMORY.md"]:
+                file_path = user_claude_mpm / file
+                if file_path.exists():
+                    print(f"   ✅ {file} exists")
                 else:
-                    print("   ❌ Wrong content loaded")
-            else:
-                print("❌ INSTRUCTIONS.md NOT loaded")
+                    print(f"   ℹ️  {file} not found")  # noqa: RUF001
 
-            # Test WORKFLOW.md loading
-            if content.get("workflow_instructions"):
-                print("✅ WORKFLOW.md loaded")
-                print(
-                    f"   Level: {content.get('workflow_instructions_level', 'unknown')}"
-                )
-                if "Test Workflow" in content["workflow_instructions"]:
-                    print("   ✅ Correct content loaded from .claude-mpm/")
-                elif "SHOULD NOT BE LOADED" in content["workflow_instructions"]:
-                    print("   ❌ WRONG! Loaded from .claude/ directory")
-                else:
-                    print("   ℹ️  Loaded from system defaults")  # noqa: RUF001
-            else:
-                print("❌ WORKFLOW.md NOT loaded")
-
-            # Test MEMORY.md loading
-            if content.get("memory_instructions"):
-                print("✅ MEMORY.md loaded")
-                print(
-                    f"   Level: {content.get('memory_instructions_level', 'unknown')}"
-                )
-                if "Test Memory Instructions" in content["memory_instructions"]:
-                    print("   ✅ Correct content loaded from .claude-mpm/")
-                elif "SHOULD NOT BE LOADED" in content["memory_instructions"]:
-                    print("   ❌ WRONG! Loaded from .claude/ directory")
-                else:
-                    print("   ℹ️  Loaded from system defaults")  # noqa: RUF001
-            else:
-                print("❌ MEMORY.md NOT loaded")
-
-            # Test actual memories loading
-            if content.get("actual_memories"):
-                print("✅ PM_memories.md loaded")
-                if "This project uses Python 3.11" in content["actual_memories"]:
-                    print("   ✅ Correct memory content loaded")
-                else:
-                    print("   ❌ Wrong memory content")
-            else:
-                print("ℹ️  No PM memories loaded (expected if no deployed agents)")  # noqa: RUF001
-
-            # Verify .claude/ directory was NOT read
-            instructions_text = loader.get_framework_instructions()
-            if "SHOULD NOT BE LOADED" in instructions_text:
-                print("\n❌ ERROR: Content from .claude/ directory was loaded!")
-                print(
-                    "   This is a critical bug - framework should NEVER read from .claude/"
-                )
-            else:
-                print("\n✅ Correctly ignored .claude/ directory")
-
-            print("\n=== User Home Directory Test ===\n")
-
-            # Now test user-level loading
-            user_claude_mpm = Path.home() / ".claude-mpm"
-            if user_claude_mpm.exists():
-                print(f"Found user .claude-mpm at: {user_claude_mpm}")
-
-                # Check what files exist
-                for file in ["INSTRUCTIONS.md", "WORKFLOW.md", "MEMORY.md"]:
-                    file_path = user_claude_mpm / file
-                    if file_path.exists():
-                        print(f"   ✅ {file} exists")
-                    else:
-                        print(f"   ℹ️  {file} not found")  # noqa: RUF001
-
-                # Check memories directory
-                memories_dir = user_claude_mpm / "memories"
-                if memories_dir.exists():
-                    print("   ✅ memories/ directory exists")
-                    pm_memories = memories_dir / "PM_memories.md"
-                    if pm_memories.exists():
-                        print("      ✅ PM_memories.md exists")
-            else:
-                print(f"ℹ️  No user .claude-mpm directory at: {user_claude_mpm}")  # noqa: RUF001
-
-        finally:
-            os.chdir(original_cwd)
+            # Check memories directory
+            memories_dir = user_claude_mpm / "memories"
+            if memories_dir.exists():
+                print("   ✅ memories/ directory exists")
+                pm_memories = memories_dir / "PM_memories.md"
+                if pm_memories.exists():
+                    print("      ✅ PM_memories.md exists")
+        else:
+            print(f"ℹ️  No user .claude-mpm directory at: {user_claude_mpm}")  # noqa: RUF001
 
     print("\n=== Test Complete ===\n")
 

--- a/tests/test_framework_loader_memory.py
+++ b/tests/test_framework_loader_memory.py
@@ -22,7 +22,7 @@ from claude_mpm.core.framework_loader import FrameworkLoader
     "PM_memories.md, causing 'Test PM memory' assertion to fail. Needs singleton isolation "
     "or FrameworkLoader cache reset between tests."
 )
-def test_memory_loading():
+def test_memory_loading(monkeypatch):
     """Test that memory loading works correctly with the new glob pattern."""
 
     print("=" * 60)
@@ -59,70 +59,63 @@ def test_memory_loading():
         (agents_dir / "QA.md").write_text("# QA Agent")
 
         # Create a FrameworkLoader with the temp directory as cwd
-        import os
+        monkeypatch.chdir(tmpdir)
+        loader = FrameworkLoader()
 
-        old_cwd = os.getcwd()
-        os.chdir(tmpdir)
+        print(f"\nTest directory: {memories_dir}")
+        print("Deployed agents: Engineer, QA")
+        print()
 
-        try:
-            loader = FrameworkLoader()
+        # Load framework content which will trigger memory loading
+        content = loader._load_framework_content()
+        loader._load_actual_memories(content)
 
-            print(f"\nTest directory: {memories_dir}")
-            print("Deployed agents: Engineer, QA")
-            print()
+        # Get the loaded memories
+        has_pm = bool(content.get("actual_memories"))
+        agent_memories = content.get("agent_memories", {})
 
-            # Load framework content which will trigger memory loading
-            content = loader._load_framework_content()
-            loader._load_actual_memories(content)
+        print(f"PM memory loaded: {has_pm}")
+        print(f"Agent memories in framework content: {list(agent_memories.keys())}")
 
-            # Get the loaded memories
-            has_pm = bool(content.get("actual_memories"))
-            agent_memories = content.get("agent_memories", {})
+        # Verify results
+        print("\n" + "=" * 60)
+        print("Verification:")
+        print("=" * 60)
 
-            print(f"PM memory loaded: {has_pm}")
-            print(f"Agent memories in framework content: {list(agent_memories.keys())}")
+        # Check that PM memory was loaded
+        print(f"✓ PM_memories.md loaded: {has_pm}")
+        assert has_pm, "PM_memories.md should always be loaded"
+        assert "Test PM memory" in content["actual_memories"], (
+            "PM memory content not found"
+        )
 
-            # Verify results
-            print("\n" + "=" * 60)
-            print("Verification:")
-            print("=" * 60)
+        # NEW ARCHITECTURE: Agent memories are NOT loaded at framework time
+        # They are loaded at agent deployment time and appended to each agent file
+        print("\n✓ Agent memories NOT in framework content (expected behavior)")
+        print("  Agent memories are now loaded at deployment time")
+        assert len(agent_memories) == 0, (
+            "Agent memories should NOT be loaded at framework time anymore. "
+            "They are now appended to agent files at deployment time."
+        )
 
-            # Check that PM memory was loaded
-            print(f"✓ PM_memories.md loaded: {has_pm}")
-            assert has_pm, "PM_memories.md should always be loaded"
-            assert "Test PM memory" in content["actual_memories"], (
-                "PM memory content not found"
-            )
+        # Check that README and NOTES were not loaded as memories
+        all_memory_content = content.get("actual_memories", "")
+        assert "README" not in all_memory_content, "README.md should NOT be loaded"
+        assert "Notes" not in all_memory_content, "NOTES.md should NOT be loaded"
+        print("✓ README.md and NOTES.md NOT loaded")
 
-            # NEW ARCHITECTURE: Agent memories are NOT loaded at framework time
-            # They are loaded at agent deployment time and appended to each agent file
-            print("\n✓ Agent memories NOT in framework content (expected behavior)")
-            print("  Agent memories are now loaded at deployment time")
-            assert len(agent_memories) == 0, (
-                "Agent memories should NOT be loaded at framework time anymore. "
-                "They are now appended to agent files at deployment time."
-            )
+        # Verify count (PM only)
+        total_loaded = 1 if has_pm else 0
+        expected_count = 1
+        print(
+            f"\n✓ Expected {expected_count} memory source (PM only), loaded {total_loaded}"
+        )
+        assert total_loaded == expected_count, (
+            f"Expected {expected_count} memory sources (PM only), got {total_loaded}"
+        )
 
-            # Check that README and NOTES were not loaded as memories
-            all_memory_content = content.get("actual_memories", "")
-            assert "README" not in all_memory_content, "README.md should NOT be loaded"
-            assert "Notes" not in all_memory_content, "NOTES.md should NOT be loaded"
-            print("✓ README.md and NOTES.md NOT loaded")
-
-            # Verify count (PM only)
-            total_loaded = 1 if has_pm else 0
-            expected_count = 1
-            print(
-                f"\n✓ Expected {expected_count} memory source (PM only), loaded {total_loaded}"
-            )
-            assert total_loaded == expected_count, (
-                f"Expected {expected_count} memory sources (PM only), got {total_loaded}"
-            )
-
-            print("\n✅ All tests passed! Memory filtering is working correctly.")
-            print("=" * 60)
-        finally:
-            os.chdir(old_cwd)
+        print("\n✅ All tests passed! Memory filtering is working correctly.")
+        print("=" * 60)
 
 
 if __name__ == "__main__":

--- a/tests/test_local_agent_templates.py
+++ b/tests/test_local_agent_templates.py
@@ -382,7 +382,7 @@ def test_unified_registry_discovers_local_templates(mock_path_manager):
     reason="Creates .json template file but discover_local_templates() only reads .md files "
     "(v4.26.0+ migration); local agent is not discovered and not included in capabilities."
 )
-def test_framework_loader_includes_local_agents():
+def test_framework_loader_includes_local_agents(monkeypatch):
     """Test that FrameworkLoader properly includes local agents in capabilities."""
     from claude_mpm.core.framework_loader import FrameworkLoader
 
@@ -416,21 +416,15 @@ def test_framework_loader_includes_local_agents():
             MockCache.__name__ = "CacheManager"  # Fix mock attribute issue
 
             # Change working directory to our test project
-            import os
+            # (monkeypatch restores CWD after the test)
+            monkeypatch.chdir(project_dir)
 
-            original_cwd = os.getcwd()
-            try:
-                os.chdir(project_dir)
+            loader = FrameworkLoader()
 
-                loader = FrameworkLoader()
+            # Generate capabilities
+            capabilities = loader._generate_agent_capabilities_section()
 
-                # Generate capabilities
-                capabilities = loader._generate_agent_capabilities_section()
-
-                # Verify local agent is included
-                assert "local_test" in capabilities
-                assert "Local Test Agent" in capabilities
-                assert "[LOCAL-PROJECT]" in capabilities or "LOCAL" in capabilities
-
-            finally:
-                os.chdir(original_cwd)
+            # Verify local agent is included
+            assert "local_test" in capabilities
+            assert "Local Test Agent" in capabilities
+            assert "[LOCAL-PROJECT]" in capabilities or "LOCAL" in capabilities

--- a/tests/test_no_auto_deploy.py
+++ b/tests/test_no_auto_deploy.py
@@ -104,7 +104,7 @@ def test_no_automatic_deployment():
         return True
 
 
-def test_framework_loader_paths():
+def test_framework_loader_paths(monkeypatch):
     """Test that framework loader looks in correct directories."""
 
     logger.info("\nTesting framework loader search paths...")
@@ -126,36 +126,25 @@ def test_framework_loader_paths():
             "# Wrong Instructions\nShould not be loaded."
         )
 
-        # Change to temp directory for testing
-        original_cwd = Path.cwd()
-        try:
-            os.chdir(tmpdir_path)
+        # Change to temp directory (monkeypatch restores CWD after the test)
+        monkeypatch.chdir(tmpdir_path)
 
-            # Create framework loader
-            loader = FrameworkLoader()
+        # Create framework loader
+        loader = FrameworkLoader()
 
-            # Check if it loaded from .claude-mpm (correct) and not .claude (wrong)
-            custom_instructions = loader.framework_content.get(
-                "custom_instructions", ""
-            )
+        # Check if it loaded from .claude-mpm (correct) and not .claude (wrong)
+        custom_instructions = loader.framework_content.get("custom_instructions", "")
 
-            if "Test Instructions" in custom_instructions:
-                logger.info(
-                    "✅ PASS: Framework loader correctly reads from .claude-mpm/"
+        if "Test Instructions" in custom_instructions:
+            logger.info("✅ PASS: Framework loader correctly reads from .claude-mpm/")
+            if "Wrong Instructions" in custom_instructions:
+                logger.error(
+                    "❌ FAILED: Framework loader also read from .claude/ (should NOT)"
                 )
-                if "Wrong Instructions" in custom_instructions:
-                    logger.error(
-                        "❌ FAILED: Framework loader also read from .claude/ (should NOT)"
-                    )
-                    return False
-                return True
-            logger.warning(
-                "⚠️  Framework loader didn't find instructions in .claude-mpm/"
-            )
-            return False
-
-        finally:
-            os.chdir(original_cwd)
+                return False
+            return True
+        logger.warning("⚠️  Framework loader didn't find instructions in .claude-mpm/")
+        return False
 
 
 def main():
@@ -172,8 +161,18 @@ def main():
         all_passed = False
 
     # Test 2: Framework loader paths
-    if not test_framework_loader_paths():
-        all_passed = False
+    # test_framework_loader_paths() now takes a pytest monkeypatch fixture;
+    # provide a minimal shim so the standalone main() entry point still works.
+    class _FakeMonkeypatch:
+        def chdir(self, path):
+            os.chdir(path)
+
+    original_cwd = Path.cwd()
+    try:
+        if not test_framework_loader_paths(_FakeMonkeypatch()):
+            all_passed = False
+    finally:
+        os.chdir(original_cwd)
 
     logger.info("\n" + "=" * 60)
     if all_passed:

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -321,10 +321,8 @@ skills:
         assert manager.is_skill_enabled("toolchains-java-frameworks-spring") is False
 
 
-def test_find_profiles_dir_in_parent():
+def test_find_profiles_dir_in_parent(monkeypatch):
     """Test that ProfileManager can find profiles directory in parent directories."""
-    import os
-
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create project structure:
         # tmpdir/
@@ -350,45 +348,33 @@ agents:
         deep_subdir = project_dir / "subdir" / "deep_subdir"
         deep_subdir.mkdir(parents=True)
 
-        # Change to deep subdirectory
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(deep_subdir)
+        # Change to deep subdirectory (monkeypatch restores CWD after the test)
+        monkeypatch.chdir(deep_subdir)
 
-            # ProfileManager should find profiles dir in parent
-            manager = ProfileManager()
-            # Compare resolved paths to handle symlinks
-            assert manager.profiles_dir.resolve() == profiles_dir.resolve()
-            assert manager.profiles_dir.exists()
+        # ProfileManager should find profiles dir in parent
+        manager = ProfileManager()
+        # Compare resolved paths to handle symlinks
+        assert manager.profiles_dir.resolve() == profiles_dir.resolve()
+        assert manager.profiles_dir.exists()
 
-            # Should be able to load profile
-            success = manager.load_profile("test")
-            assert success is True
-            assert manager.is_agent_enabled("python-engineer") is True
-
-        finally:
-            # Restore original directory
-            os.chdir(original_cwd)
+        # Should be able to load profile
+        success = manager.load_profile("test")
+        assert success is True
+        assert manager.is_agent_enabled("python-engineer") is True
 
 
-def test_find_profiles_dir_fallback():
+def test_find_profiles_dir_fallback(monkeypatch):
     """Test that ProfileManager falls back to cwd when no .claude-mpm found."""
-    import os
-
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create directory without .claude-mpm
         test_dir = Path(tmpdir).resolve() / "no_claude_mpm"
         test_dir.mkdir()
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(test_dir)
+        # monkeypatch restores CWD after the test
+        monkeypatch.chdir(test_dir)
 
-            # Should fallback to cwd/.claude-mpm/profiles
-            manager = ProfileManager()
-            expected = test_dir / ".claude-mpm" / "profiles"
-            # Compare resolved paths to handle symlinks
-            assert manager.profiles_dir.resolve() == expected.resolve()
-
-        finally:
-            os.chdir(original_cwd)
+        # Should fallback to cwd/.claude-mpm/profiles
+        manager = ProfileManager()
+        expected = test_dir / ".claude-mpm" / "profiles"
+        # Compare resolved paths to handle symlinks
+        assert manager.profiles_dir.resolve() == expected.resolve()


### PR DESCRIPTION
## Summary

Extends PR #838's CWD-isolation fix to the remaining test files that still used bare `os.chdir()`. Bare `os.chdir()` is a process-level call, so under `pytest-xdist` it leaks across workers: a worker that has `chdir`'d into a `tempfile.TemporaryDirectory()` causes `Path.cwd()` in production code (e.g. `FrameworkLoader`, `ProfileManager`) to resolve to that temp dir on another worker, which can write into the real `.claude/agents/` and produce flaky Test Suite failures (issue #834 family).

`monkeypatch.chdir()` wraps the OS call and registers a finalizer that restores the original CWD at test teardown — even on failure — making the tests safe under parallel execution.

## Changes (one file per commit)

- `tests/test_claude_mpm_loading.py` — `test_claude_mpm_loading()`
- `tests/test_framework_loader_memory.py` — `test_memory_loading()`
- `tests/test_no_auto_deploy.py` — `test_framework_loader_paths()` (standalone `main()` preserved via a minimal `_FakeMonkeypatch` shim)
- `tests/test_local_agent_templates.py` — `test_framework_loader_includes_local_agents()`
- `tests/test_profile_manager.py` — `test_find_profiles_dir_in_parent()` and `test_find_profiles_dir_fallback()`

Each site: added the `monkeypatch` fixture to the signature, replaced `os.chdir(x)` with `monkeypatch.chdir(x)`, and removed the now-redundant `original_cwd = ...` / `try` / `finally: os.chdir(original_cwd)` restore scaffolding (and the now-unused local `import os` where applicable). No production code changed; all other test logic preserved.

## Verification

Ran serially:

```
uv run pytest -p no:xdist \
  tests/test_claude_mpm_loading.py tests/test_framework_loader_memory.py \
  tests/test_no_auto_deploy.py tests/test_local_agent_templates.py \
  tests/test_profile_manager.py
# 32 passed, 5 skipped
```

The 5 skips are pre-existing (v4.26.0+ JSON→Markdown template migration and a documented order-dependency) and unrelated to this change. The four converted-and-collected tests pass explicitly, and `git status` shows **no** modification to `.claude/agents/` after the run. `ruff format` + `ruff check` clean on all five files.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)