### PR TITLE
test: isolate agent-registry singleton resets for xdist stability

### DIFF
--- a/tests/test_agent_name_normalization.py
+++ b/tests/test_agent_name_normalization.py
@@ -287,6 +287,12 @@ def _agent_templates_available():
 _HAS_AGENT_TEMPLATES = _agent_templates_available()
 
 
+# xdist_group serializes the tests WITHIN this class onto a single worker as a
+# belt-and-suspenders guard for intra-process ordering. xdist runs each worker in
+# a separate process, so the registry/loader singletons are per-process; this
+# marker is NOT inter-process synchronization. Its only job is to keep these tests
+# from interleaving with sibling tests *on the same worker* that reset the
+# process-wide singleton mid-run. The autouse fixture below is the real fix.
 @pytest.mark.xdist_group("agent_registry")
 @unittest.skipUnless(
     _HAS_AGENT_TEMPLATES,
@@ -323,8 +329,8 @@ class TestAgentLoaderNormalization(unittest.TestCase):
              regardless of the current working directory.
           2. Reset both singletons via monkeypatch.setattr so a clean
              registry/loader is rebuilt for this test against that root.
-          3. Warm the loader so the singleton is populated before the
-             actual assertions run.
+          3. Warm the loader/registry singletons (agent-agnostic) so they are
+             populated against that root before the actual assertions run.
 
         monkeypatch automatically restores the env var and both globals at
         teardown, so this isolation never leaks into other tests.
@@ -332,12 +338,19 @@ class TestAgentLoaderNormalization(unittest.TestCase):
         import claude_mpm.agents.agent_loader as _loader_module
         import claude_mpm.core.unified_agent_registry as _reg_module
 
+        # TODO: remove this CLAUDE_MPM_USER_PWD workaround once
+        # UnifiedAgentRegistry._setup_discovery_paths honors the path manager
+        # instead of bare Path.cwd() (planned PR 3 / root-cause fix).
         monkeypatch.setenv("CLAUDE_MPM_USER_PWD", str(_REPO_ROOT))
         monkeypatch.setattr(_reg_module, "_agent_registry", None)
         monkeypatch.setattr(_loader_module, "_loader", None)
 
-        # Warm the loader so the singleton is built against the real repo root.
-        get_agent_prompt("engineer")
+        # Warm the loader/registry singletons against the real repo root.
+        # Use the agent-agnostic loader builder (which constructs AgentLoader,
+        # which calls get_agent_registry() and runs discovery) rather than
+        # looking up a specific agent. A future rename of any single agent must
+        # not make this warm-up error out and mask the real test failure.
+        _loader_module._get_loader()
 
     def test_capitalized_names_in_loader(self):
         """Test that agent loader handles capitalized names (as used by PM)."""

--- a/tests/test_agent_name_normalization.py
+++ b/tests/test_agent_name_normalization.py
@@ -7,12 +7,18 @@ lowercase names, aliases, and space-separated names.
 
 import logging
 import unittest
+from pathlib import Path
+
+import pytest
 
 from claude_mpm.agents.agent_loader import (
     get_agent_prompt,
     get_agent_prompt_with_model_info,
 )
 from claude_mpm.core.agent_name_normalizer import AgentNameNormalizer
+
+# Repo root, resolved from this file's location (CWD-independent, stable in CI).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Configure logging for tests
 logging.basicConfig(level=logging.DEBUG)
@@ -281,6 +287,7 @@ def _agent_templates_available():
 _HAS_AGENT_TEMPLATES = _agent_templates_available()
 
 
+@pytest.mark.xdist_group("agent_registry")
 @unittest.skipUnless(
     _HAS_AGENT_TEMPLATES,
     "Agent template files not available (archive removed; agents loaded from cache at runtime)",
@@ -291,7 +298,46 @@ class TestAgentLoaderNormalization(unittest.TestCase):
     These tests require agent template JSON files to be discoverable
     by the unified_agent_registry. They are skipped when templates
     are not available (e.g., after archive/ deletion).
+
+    The xdist_group marker keeps every test in this class on a single
+    xdist worker so they cannot interleave with sibling tests (e.g.
+    test_agent_registry_cache) that reset the process-wide registry
+    singleton mid-run. The autouse _isolate_agent_registry fixture below
+    is the primary defense: it pins the project root to the real repo and
+    rebuilds a clean singleton before each test, while monkeypatch restores
+    all globals/env at teardown.
     """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_agent_registry(self, monkeypatch):
+        """Build the loader/registry singletons against the REAL repo agents.
+
+        Root cause of the "No agent found with name: research" flakiness:
+        a concurrent xdist test resets the registry singleton, and a fresh
+        registry then gets built while CWD is a pytest tmp dir -- so its
+        discovery paths miss the real .claude/agents/ and lookups fail.
+
+        Defense (test-side only; production Path.cwd() fix is a separate PR):
+          1. Pin the project root to the repo via CLAUDE_MPM_USER_PWD so
+             UnifiedPathManager.project_root resolves the real agents dir
+             regardless of the current working directory.
+          2. Reset both singletons via monkeypatch.setattr so a clean
+             registry/loader is rebuilt for this test against that root.
+          3. Warm the loader so the singleton is populated before the
+             actual assertions run.
+
+        monkeypatch automatically restores the env var and both globals at
+        teardown, so this isolation never leaks into other tests.
+        """
+        import claude_mpm.agents.agent_loader as _loader_module
+        import claude_mpm.core.unified_agent_registry as _reg_module
+
+        monkeypatch.setenv("CLAUDE_MPM_USER_PWD", str(_REPO_ROOT))
+        monkeypatch.setattr(_reg_module, "_agent_registry", None)
+        monkeypatch.setattr(_loader_module, "_loader", None)
+
+        # Warm the loader so the singleton is built against the real repo root.
+        get_agent_prompt("engineer")
 
     def test_capitalized_names_in_loader(self):
         """Test that agent loader handles capitalized names (as used by PM)."""

--- a/tests/test_agent_registry_cache.py
+++ b/tests/test_agent_registry_cache.py
@@ -29,15 +29,18 @@ from claude_mpm.services.memory.cache.simple_cache import SimpleCacheService
     "both cache miss and hit complete in ~100-200μs (pure dict lookups), making "
     "the 2x ratio unpredictable. Cache correctness is verified by stats-based tests."
 )
-def test_basic_caching():
+def test_basic_caching(monkeypatch):
     """Test basic caching functionality."""
     import claude_mpm.core.unified_agent_registry as _reg_module
 
     print("\n=== Testing Basic Caching ===")
 
     # Reset global singleton to ensure first discovery is a fresh cache miss
-    # (other tests may have pre-warmed the singleton, making both calls equally fast)
-    _reg_module._agent_registry = None
+    # (other tests may have pre-warmed the singleton, making both calls equally fast).
+    # Use monkeypatch.setattr so pytest RESTORES the original singleton at teardown;
+    # a bare assignment would leak a reset singleton into other xdist tests sharing
+    # this process, causing "No agent found with name: research" flakiness.
+    monkeypatch.setattr(_reg_module, "_agent_registry", None)
 
     # Create registry with default cache
     registry = get_agent_registry()
@@ -90,9 +93,18 @@ def test_force_refresh():
     print("✓ Force refresh bypasses cache correctly")
 
 
-def test_file_modification_detection(tmp_path):
+def test_file_modification_detection(tmp_path, monkeypatch):
     """Test that cache invalidates when files are modified."""
+    import claude_mpm.core.unified_agent_registry as _reg_module
+
     print("\n=== Testing File Modification Detection ===")
+
+    # This test calls registry.add_discovery_path(tmp_path), permanently adding a
+    # temp path to the process-wide singleton. Reset the singleton via monkeypatch
+    # so this test builds (and pollutes) a throwaway registry; pytest restores the
+    # original singleton at teardown, preventing the temp path from leaking into
+    # other xdist tests that share this process.
+    monkeypatch.setattr(_reg_module, "_agent_registry", None)
 
     # Create a temporary directory with an agent file
     tmpdir = tmp_path


### PR DESCRIPTION
## Summary

Fixes the intermittent `ValueError: No agent found with name: research` flakiness
seen under `pytest -n auto`. The root cause on the test side: two module-level
singletons — `_agent_registry` (`core/unified_agent_registry.py`) and `_loader`
(`agents/agent_loader.py`) — were being **permanently mutated** by tests that
reset them mid-run. Under xdist, sibling tests share a worker process, so a reset
singleton (rebuilt later under a pytest tmp CWD that misses the real
`.claude/agents/`) leaked into unrelated tests and broke agent lookups
non-deterministically.

This is **PR 2 of the flaky-test stabilization** and is **test-side only** — no
production code is touched.

## Changes

**`tests/test_agent_registry_cache.py`**
- Convert every direct `_agent_registry` mutation to `monkeypatch.setattr(...)`
  so pytest **restores the original singleton at teardown** instead of leaking a
  reset/polluted registry into other xdist tests.
- `test_file_modification_detection` also reset via monkeypatch, since it calls
  `add_discovery_path(tmp_path)` on the shared singleton (another cross-test leak).

**`tests/test_agent_name_normalization.py` (`TestAgentLoaderNormalization`)**
- Add an autouse fixture that **pins the project root to the real repo** via
  `CLAUDE_MPM_USER_PWD`, rebuilds clean loader/registry singletons via
  `monkeypatch`, and **warms the loader** before each test — so
  `get_agent_prompt("Research")`-style lookups are robust even if a concurrent
  worker corrupted the singleton.
- Tag the class with `@pytest.mark.xdist_group("agent_registry")` so it stays on
  a single worker and cannot interleave with the registry-resetting tests
  (defense-in-depth alongside the fixture).

## Verification

- Serial: `23 passed, 2 skipped`
- Parallel (`-n auto`), 3 consecutive runs: `23 passed, 2 skipped` each
- `.claude/agents/` not dirtied; ruff format + check clean
- No production code modified

## Context

- PR 1 (#843) handled the CWD leaks.
- **This PR (PR 2)** restores the global singleton after test mutations
  (monkeypatch) and warms/groups the registry-dependent tests.
- PR 3 (planned) is the production-side root-cause fix for the bare
  `Path.cwd() / ".claude" / "agents"` in `_setup_discovery_paths`.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)