### PR TITLE
docs: reconcile documented minimum Claude Code version (closes #849)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **A comprehensive workflow and agent management framework for Claude Code** that transforms your AI coding assistant into a full-featured development platform with multi-agent orchestration, skills system, MCP integration, session management, and semantic code search.
 
-> **⚠️ Important**: Claude MPM **requires Claude Code CLI** (v2.1.3+), not Claude Desktop (app). All MCP integrations work with Claude Code's CLI interface only.
+> **⚠️ Important**: Claude MPM **requires Claude Code CLI** (v1.0.92+; v2.1.3+ to use Skills features), not Claude Desktop (app). All MCP integrations work with Claude Code's CLI interface only.
 >
 > **Don't have Claude Code?** Install from: https://docs.anthropic.com/en/docs/claude-code
 >
@@ -103,7 +103,7 @@ Claude MPM transforms Claude Code into a **comprehensive AI development platform
 ### Prerequisites
 
 1. **Python 3.11-3.13** (Python 3.13 recommended; 3.14 NOT yet supported)
-2. **Claude Code CLI v2.1.3+** (required!)
+2. **Claude Code CLI v1.0.92+** (required!; v2.1.3+ to use Skills features)
 3. **GitHub Token** (recommended for skill sources)
 
 > **Python Version Warning**:

--- a/docs/agents/research-agent.md
+++ b/docs/agents/research-agent.md
@@ -459,7 +459,7 @@ for skill in recommendations:
 **Solutions:**
 1. Restart Claude Code (skills load at startup only)
 2. Verify skill installation: `/plugin list`
-3. Check Claude Code version: `claude --version` (need v1.0.92+)
+3. Check Claude Code version: `claude --version` (need v2.1.3+ to use Skills features; v1.0.92+ for base Claude MPM)
 4. Review installation logs for errors
 
 ## Related Documentation

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -283,7 +283,7 @@ See [../user/MIGRATION.md](../user/MIGRATION.md) for version-specific migration 
 
 ## Deployment Checklist
 
-- [ ] Install Claude Code CLI (v1.0.92+)
+- [ ] Install Claude Code CLI (v1.0.92+; v2.1.3+ to use Skills features)
 - [ ] Install Claude MPM with monitoring
 - [ ] Run `claude-mpm doctor` diagnostics
 - [ ] Configure user settings

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ Install Claude MPM and verify Claude Code CLI is available.
 
 ## Requirements
 
-- **Claude Code CLI v1.0.92+**: https://docs.anthropic.com/en/docs/claude-code
+- **Claude Code CLI v1.0.92+** (v2.1.3+ to use Skills features): https://docs.anthropic.com/en/docs/claude-code
 - **Python 3.11 - 3.13** (Python 3.13 recommended)
 - **GitHub Token** (recommended): For skill sources from GitHub repositories
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -5,7 +5,7 @@ Get Claude MPM running in under 5 minutes.
 ## Prerequisites
 
 - **Python 3.11-3.13** (Python 3.13 recommended; 3.14 NOT supported yet)
-- **Claude Code CLI v1.0.92+**: `claude --version`
+- **Claude Code CLI v1.0.92+** (v2.1.3+ to use Skills features): `claude --version`
   - Install: https://docs.anthropic.com/en/docs/claude-code
 - **GitHub Token** (recommended): Avoid rate limits when using skill sources
   ```bash

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -21,7 +21,7 @@ Before starting, ensure you have:
 
 ### Required Software
 
-- **Claude Code CLI v1.0.92+** - [Installation guide](https://docs.anthropic.com/en/docs/claude-code)
+- **Claude Code CLI v1.0.92+** (v2.1.3+ to use Skills features) - [Installation guide](https://docs.anthropic.com/en/docs/claude-code)
   - ⚠️ Note: This is Claude *Code* CLI, not Claude Desktop app
   - Verify: `claude --version`
 - **Python 3.11+** - Check with `python --version`

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -8,7 +8,7 @@ Claude MPM extends Claude Code CLI with multi-agent workflows, session managemen
 
 ### Do I need Claude Desktop or Claude Code?
 
-You need **Claude Code CLI** (v1.0.92+). Claude Desktop is not supported.
+You need **Claude Code CLI** (v1.0.92+; v2.1.3+ to use Skills features). Claude Desktop is not supported.
 
 Install: https://docs.anthropic.com/en/docs/claude-code
 

--- a/docs/integrations/mcp-session-server.md
+++ b/docs/integrations/mcp-session-server.md
@@ -24,7 +24,7 @@ The MCP Session Server provides:
 
 1. **claude-mpm installed** (v5.0+)
 2. **ANTHROPIC_API_KEY** environment variable set
-3. **Claude Code CLI** (v2.1.3+) installed
+3. **Claude Code CLI** (v1.0.92+; v2.1.3+ to use Skills features) installed
 
 ### Entry Point
 

--- a/docs/reference/skills-quick-reference.md
+++ b/docs/reference/skills-quick-reference.md
@@ -263,7 +263,7 @@ claude-mpm skills check-deployed
 
 # 3. Check Claude Code version
 claude --version
-# Need v1.0.92+ for skills support
+# Need v2.1.3+ to use Skills features (v1.0.92+ for base Claude MPM)
 
 # 4. Verify skill files exist
 ls -la ~/.claude/skills/
@@ -527,7 +527,7 @@ Need skills for your project?
 **Last Updated:** 2025-01-21
 **Compatible with:**
 - Claude MPM 5.4.68+
-- Claude Code v1.0.92+
+- Claude Code v1.0.92+ (v2.1.3+ to use Skills features)
 - claude-mpm-skills repository (latest)
 
 **Changelog:**

--- a/docs/usecases/teams.md
+++ b/docs/usecases/teams.md
@@ -29,7 +29,7 @@ This guide shows how teams can leverage Claude MPM for effective collaboration, 
 ### Prerequisites
 
 **All team members need:**
-1. Claude Code CLI (v2.0.30+)
+1. Claude Code CLI (v1.0.92+; v2.1.3+ to use Skills features)
 2. Claude MPM installed via pipx
 3. Shared GitHub repository access
 4. Anthropic API key (team or individual)

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -48,7 +48,7 @@ Common issues and solutions for Claude MPM.
 
 **Problem**: `claude: command not found` or Claude MPM reports Claude Code missing.
 
-**Why This Matters**: Claude MPM requires Claude Code CLI (v1.0.92+) to function. It's not the same as Claude Desktop.
+**Why This Matters**: Claude MPM requires Claude Code CLI (v1.0.92+; v2.1.3+ to use Skills features) to function. It's not the same as Claude Desktop.
 
 **Solutions:**
 
@@ -75,6 +75,7 @@ claude-mpm doctor
 
 **Version Requirements:**
 - **Minimum**: v1.0.92 (hooks support)
+- **Skills features**: v2.1.3+ (required to use Skills)
 - **Recommended**: v2.0.30+ (latest features)
 
 ### Claude Code Version Outdated
@@ -110,6 +111,7 @@ claude-mpm doctor --checks updates
 | Basic hooks support | v1.0.92 | v2.0.30+ |
 | Full MCP integration | v2.0.12 | v2.0.30+ |
 | Update checking | v1.0.92 | v2.0.30+ |
+| Skills features | v2.1.3 | v2.1.3+ |
 
 ### "command not found: claude-mpm"
 


### PR DESCRIPTION
## Summary
Resolves #849. Reconciles inconsistent "minimum Claude Code version" statements across 11 public docs. Several docs incorrectly stated the *base* floor as v2.1.3+ or v2.0.30+.

Canonical framing now applied everywhere: **Claude Code v1.0.92+ required; v2.1.3+ required to use Skills features.**

These map to the real code constants:
- `MIN_CLAUDE_VERSION = "1.0.92"` (hooks/claude_hooks/installer.py:206, hook_handler.py:189)
- `MIN_SKILLS_VERSION = "2.1.3"` (installer.py:210, hook_handler.py:191)

## Docs updated (11)
README.md, getting-started/{quick-start,installation,tutorial}.md, guides/FAQ.md, deployment/overview.md, integrations/mcp-session-server.md, usecases/teams.md, user/troubleshooting.md, reference/skills-quick-reference.md, agents/research-agent.md.

## Deliberately unchanged
Feature-specific gates (PreToolUse hooks v2.0.30+, skills design-target docs), the agent-repo `min_cli_version` concept, the release-compatibility matrix, and historical docs (`docs/research/`, `docs/_archive/`, CHANGELOG).

## Verified
Final grep confirms no bare/conflicting base-minimum claims remain in public docs.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)