### PR TITLE
feat: mutation testing framework service — Phase 1 core mutmut runner

### DIFF
--- a/src/claude_mpm/services/mutation/__init__.py
+++ b/src/claude_mpm/services/mutation/__init__.py
@@ -1,0 +1,22 @@
+"""Mutation testing framework service.
+
+WHAT: Public surface for the mutation testing service — re-exports the mutmut
+      runner and its result dataclasses.
+WHY:  Phase 1 de-risking slice. The mutmut interface is the riskiest component
+      (mutmut 2.5.1 has two Python 3.13 bugs), so it ships as a standalone,
+      importable runner before any CLI command, parser, or agent wiring.
+
+References
+----------
+LINK: none  (feature introduced in this PR, tracked in GitHub issue #853)
+"""
+
+from __future__ import annotations
+
+from claude_mpm.services.mutation.runner import (
+    MutantSurvivor,
+    MutationResult,
+    run_mutation,
+)
+
+__all__ = ["MutantSurvivor", "MutationResult", "run_mutation"]

--- a/src/claude_mpm/services/mutation/runner.py
+++ b/src/claude_mpm/services/mutation/runner.py
@@ -1,0 +1,460 @@
+"""Standalone mutmut runner that hides mutmut 2.5.1's Python 3.13 bugs.
+
+WHAT: Run mutmut against a single target module + test file and return a
+      structured :class:`MutationResult` (counts, kill rate, parsed survivors),
+      reading results from the ``.mutmut-cache`` SQLite DB and restoring the
+      source on disk after every run.
+WHY:  mutmut 2.5.1 on Python 3.13 has two load-bearing bugs that make the
+      naive ``mutmut run`` + ``mutmut results`` workflow unusable:
+        1. ``mutmut results`` crashes (pony-orm ``QueryResultIterator not
+           iterable``) — so we read the SQLite cache directly instead.
+        2. ``mutmut show`` accepts only ONE mutant id per call — so we query
+           per survivor.
+      mutmut also mutates source IN PLACE; a crash mid-run can leave a mutant
+      on disk. We wrap the whole run in try/finally with a git-checkout restore
+      so a failure never corrupts the working tree. This is the Phase 1
+      de-risking slice: it proves the mutmut interface works in isolation
+      before any CLI command, parser, eligibility heuristic, or agent wiring.
+
+References
+----------
+LINK: none  (feature introduced in this PR, tracked in GitHub issue #853)
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Name of the mutmut SQLite cache file (lives at repo root after a run).
+CACHE_FILENAME = ".mutmut-cache"
+
+# mutmut status strings (confirmed by inspecting a real 2.5.1 cache on Py3.13).
+_STATUS_SURVIVED = "bad_survived"
+_STATUS_KILLED = "ok_killed"
+
+
+@dataclass(frozen=True)
+class MutantSurvivor:
+    """A single mutation that survived (the tests did not catch it).
+
+    WHAT: Holds the parsed location and before/after source of one survivor.
+    WHY:  Survivors are the actionable output of mutation testing — each names
+          a behaviour the test suite fails to assert.
+    """
+
+    id: int
+    file: str  # repo-relative path
+    line: int
+    original: str  # stripped original source line
+    mutant: str  # stripped mutated source line
+    mutation_type: str  # boundary | predicate | string | removal | arithmetic | other
+
+
+@dataclass(frozen=True)
+class MutationResult:
+    """Aggregate outcome of one mutation run over a single target file.
+
+    WHAT: Counts, kill rate, the list of survivors, and an optional error.
+    WHY:  Gives callers a single structured value to act on; ``error`` is set
+          only when mutmut itself failed (a clean run with survivors is NOT an
+          error — survivors are the expected, useful signal).
+    """
+
+    target_file: str
+    tests_file: str
+    total_mutants: int
+    killed: int
+    survived: int
+    kill_rate: float  # killed / total, 0.0 if total == 0
+    survivors: list[MutantSurvivor]
+    error: str | None  # set only if mutmut itself errored
+
+
+def _build_runner_command(tests_file: Path, exclude_tests: str | None) -> str:
+    """Build the pytest runner command string mutmut invokes per mutant.
+
+    WHAT: Compose ``uv run python -m pytest <tests_file> -p no:xdist -x -q``
+          plus an optional ``-k 'not (<exclude_tests>)'`` filter.
+    WHY:  ``-p no:xdist`` avoids parallel-test flakiness under mutation;
+          ``-x`` stops at the first failure (fastest kill detection); ``-q``
+          keeps output small. exclude_tests lets callers skip slow/irrelevant
+          tests by pattern.
+    """
+    cmd = f"uv run python -m pytest {tests_file} -p no:xdist -x -q"
+    if exclude_tests:
+        cmd += f" -k 'not ({exclude_tests})'"
+    return cmd
+
+
+def _classify_mutation(original: str, mutant: str) -> str:
+    """Infer a mutation category from the original/mutant source pair.
+
+    WHAT: Map a before/after line pair to one of boundary | predicate | string
+          | removal | arithmetic | other.
+    WHY:  A coarse category helps callers triage survivors without re-reading
+          the diff. Ordering matters: a deletion ("removal") is checked first
+          because an empty mutant has no operators to inspect.
+
+    :spec: SPEC-MUTATION-01~1
+    """
+    orig = original.strip()
+    mut = mutant.strip()
+
+    # Removal: the mutant blanked the line (mutmut's statement deletion).
+    if mut in {"", "pass"}:
+        return "removal"
+
+    # Compare the symmetric difference of tokens to see what actually changed.
+    changed = f"{orig} {mut}"
+
+    # Boundary: comparison-operator flips (<= >= < >).
+    boundary_ops = ("<=", ">=", "<", ">")
+    if any(op in orig or op in mut for op in boundary_ops) and orig != mut:
+        # Distinguish from arithmetic: only treat as boundary if a comparison
+        # operator is present (arithmetic handled below otherwise).
+        if any(op in changed for op in ("<", ">")):
+            return "boundary"
+
+    # Predicate: boolean-logic operators.
+    for token in ("and", "or", "not"):
+        if f" {token} " in f" {orig} " or f" {token} " in f" {mut} ":
+            return "predicate"
+
+    # String: a quoted literal appears on either side.
+    if ('"' in orig or "'" in orig) and ('"' in mut or "'" in mut):
+        return "string"
+
+    # Arithmetic: binary arithmetic operators.
+    if any(op in changed for op in ("+", "-", "*", "/")):
+        return "arithmetic"
+
+    return "other"
+
+
+def _parse_show_diff(
+    mutant_id: int, diff_text: str, repo_root: Path | None = None
+) -> MutantSurvivor | None:
+    """Parse one ``mutmut show <id>`` unified diff into a MutantSurvivor.
+
+    WHAT: Extract file (from the ``--- <file>`` header, normalized to a
+          repo-relative path when ``repo_root`` is given), the changed line
+          number (from the ``@@`` hunk header plus the offset of the removed
+          line), and the original/mutant source lines.
+    WHY:  ``mutmut show`` is the only Py3.13-safe way to get per-mutant detail
+          in 2.5.1 (``mutmut results`` crashes). The diff is a stable unified
+          format: ``--- file`` / ``+++ file`` / ``@@ -start,n +start,n @@`` /
+          context lines, with ``-`` = original and ``+`` = mutant. mutmut
+          echoes back whatever path we passed to ``--paths-to-mutate`` (often
+          absolute), so we normalize to repo-relative to honor the
+          :class:`MutantSurvivor` contract.
+
+    :spec: SPEC-MUTATION-01~1
+    """
+    file_name: str | None = None
+    hunk_start: int | None = None
+    pos_in_hunk = 0  # 0-based offset of the next old/context line within hunk
+    removed_line: str | None = None
+    removed_offset: int | None = None
+    added_line: str | None = None
+
+    for raw in diff_text.splitlines():
+        if raw.startswith("--- "):
+            file_name = raw[4:].strip()
+            continue
+        if raw.startswith("+++ "):
+            continue
+        if raw.startswith("@@"):
+            # Format: @@ -old_start,old_count +new_start,new_count @@
+            try:
+                old_part = raw.split(" ")[1]  # e.g. "-1,5"
+                hunk_start = int(old_part.lstrip("-").split(",")[0])
+            except (IndexError, ValueError):
+                hunk_start = None
+            pos_in_hunk = 0
+            continue
+        if hunk_start is None:
+            continue
+        if raw.startswith("-"):
+            if removed_line is None:
+                removed_line = raw[1:]
+                removed_offset = pos_in_hunk
+            pos_in_hunk += 1  # removed lines exist in the OLD file
+        elif raw.startswith("+"):
+            if added_line is None:
+                added_line = raw[1:]
+            # added lines do NOT advance the OLD-file position
+        else:
+            # context line (leading space) — exists in both files
+            pos_in_hunk += 1
+
+    if file_name is None or removed_line is None or added_line is None:
+        logger.warning("Could not parse mutmut show diff for id=%s", mutant_id)
+        return None
+
+    line_number = 0
+    if hunk_start is not None and removed_offset is not None:
+        line_number = hunk_start + removed_offset
+
+    # Normalize an absolute path back to repo-relative (the dataclass contract).
+    if repo_root is not None:
+        try:
+            file_name = str(Path(file_name).resolve().relative_to(repo_root.resolve()))
+        except ValueError:
+            pass  # already relative or outside the repo — leave as-is
+
+    original = removed_line.strip()
+    mutant = added_line.strip()
+    return MutantSurvivor(
+        id=mutant_id,
+        file=file_name,
+        line=line_number,
+        original=original,
+        mutant=mutant,
+        mutation_type=_classify_mutation(original, mutant),
+    )
+
+
+def _read_cache(cache_path: Path) -> tuple[list[int], int, int]:
+    """Read survivor ids and killed/survived counts from the mutmut SQLite cache.
+
+    WHAT: Return (survivor_ids, killed_count, survived_count) by querying the
+          ``Mutant`` table for ``bad_survived`` / ``ok_killed`` statuses.
+    WHY:  ``mutmut results`` crashes on Py3.13, so the SQLite cache is the
+          authoritative source. We assert the ``Mutant`` table exists and has a
+          ``status`` column first, raising a clear error if the schema differs —
+          this guards against silently reporting a 100% kill rate when the
+          schema has changed under us.
+
+    :spec: SPEC-MUTATION-01~1
+    """
+    con = sqlite3.connect(str(cache_path), timeout=5.0)
+    try:
+        cur = con.cursor()
+        # Schema guard: the Mutant table with a status column must exist.
+        tables = {
+            row[0]
+            for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        if "Mutant" not in tables:
+            raise ValueError(
+                "mutmut cache schema mismatch: expected a 'Mutant' table, "
+                f"found tables={sorted(tables)}"
+            )
+        columns = {row[1] for row in cur.execute("PRAGMA table_info(Mutant)")}
+        if "status" not in columns or "id" not in columns:
+            raise ValueError(
+                "mutmut cache schema mismatch: 'Mutant' table missing "
+                f"'id'/'status' columns, found columns={sorted(columns)}"
+            )
+
+        survivor_ids = [
+            row[0]
+            for row in cur.execute(
+                "SELECT id FROM Mutant WHERE status = ? ORDER BY id",
+                (_STATUS_SURVIVED,),
+            )
+        ]
+        survived = len(survivor_ids)
+        killed = next(
+            cur.execute(
+                "SELECT COUNT(*) FROM Mutant WHERE status = ?",
+                (_STATUS_KILLED,),
+            )
+        )[0]
+        return survivor_ids, killed, survived
+    finally:
+        con.close()
+
+
+def _show_survivor(mutant_id: int, repo_root: Path) -> MutantSurvivor | None:
+    """Run ``mutmut show <id>`` for one survivor and parse its diff.
+
+    WHAT: Invoke mutmut show for a single id (2.5.1 takes one id per call) and
+          delegate parsing to :func:`_parse_show_diff`.
+    WHY:  Isolated here so the per-survivor subprocess call is easy to stub in
+          tests and so a single bad diff degrades to a skipped survivor rather
+          than failing the whole run.
+    """
+    proc = subprocess.run(
+        ["uv", "run", "mutmut", "show", str(mutant_id)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(repo_root),
+    )
+    return _parse_show_diff(mutant_id, proc.stdout, repo_root=repo_root)
+
+
+def _restore_target(target: Path, repo_root: Path) -> None:
+    """Restore the target file if mutmut left a mutant on disk.
+
+    WHAT: If ``git diff --exit-code -- <target>`` reports changes, run
+          ``git checkout HEAD -- <target>`` to restore the original source.
+    WHY:  mutmut mutates in place; a crash must never leave a mutant on disk.
+          ``git -C`` isolates the subprocess to the repo so cwd state cannot
+          leak. We log whether a restore was actually needed.
+
+    :spec: SPEC-MUTATION-01~1
+    """
+    rel = target
+    try:
+        rel = target.relative_to(repo_root)
+    except ValueError:
+        rel = target
+
+    diff = subprocess.run(
+        ["git", "-C", str(repo_root), "diff", "--exit-code", "--", str(rel)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if diff.returncode == 0:
+        logger.debug("Safety restore: target clean, no restore needed (%s)", rel)
+        return
+
+    logger.warning("Safety restore: mutant left on disk, restoring %s", rel)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "HEAD", "--", str(rel)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _repo_root() -> Path:
+    """Return the repo root (where ``.mutmut-cache`` lives).
+
+    WHAT: Resolve the git top-level directory.
+    WHY:  Everything must run from the repo root because mutmut writes its
+          cache there; we never rely on the caller's cwd.
+    """
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return Path(proc.stdout.strip())
+    return Path.cwd()
+
+
+def run_mutation(
+    target: Path,
+    tests_file: Path,
+    exclude_tests: str | None = None,
+) -> MutationResult:
+    """Run mutmut against ``target`` using ``tests_file`` and return results.
+
+    WHAT: Scope mutation via mutmut CLI flags (never editing setup.cfg), read
+          counts and survivor ids from the SQLite cache, fetch per-survivor
+          diffs via ``mutmut show``, and ALWAYS restore the target source in a
+          finally block. Returns a structured :class:`MutationResult`.
+    WHY:  This is the de-risking slice — a single, safe, importable entry point
+          that hides mutmut 2.5.1's Py3.13 bugs (crashing ``results``,
+          one-id-per-call ``show``, in-place mutation) behind a clean API.
+          mutmut exits non-zero when survivors exist; that is NORMAL and not an
+          error. ``error`` is set only on a genuine mutmut/schema failure.
+
+    :spec: SPEC-MUTATION-01~1
+    """
+    repo_root = _repo_root()
+    target = target.resolve()
+    tests_file = tests_file.resolve()
+    cache_path = repo_root / CACHE_FILENAME
+
+    try:
+        rel_target = str(target.relative_to(repo_root))
+    except ValueError:
+        rel_target = str(target)
+    try:
+        rel_tests = str(tests_file.relative_to(repo_root))
+    except ValueError:
+        rel_tests = str(tests_file)
+
+    runner_cmd = _build_runner_command(tests_file, exclude_tests)
+
+    error: str | None = None
+    survivors: list[MutantSurvivor] = []
+    killed = 0
+    survived = 0
+
+    try:
+        # 1. Run mutmut. Non-zero exit means survivors exist — NOT an error.
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "mutmut",
+                "run",
+                f"--paths-to-mutate={target}",
+                f"--tests-dir={tests_file.parent}",
+                f"--runner={runner_cmd}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(repo_root),
+        )
+
+        # 2. The cache must exist after a run; if not, mutmut never ran.
+        if not cache_path.exists():
+            error = (
+                f"mutmut produced no cache at {cache_path}; mutmut likely "
+                "failed to start (check that target and tests exist)"
+            )
+            return MutationResult(
+                target_file=rel_target,
+                tests_file=rel_tests,
+                total_mutants=0,
+                killed=0,
+                survived=0,
+                kill_rate=0.0,
+                survivors=[],
+                error=error,
+            )
+
+        # 3. Read authoritative counts + survivor ids from the SQLite cache.
+        survivor_ids, killed, survived = _read_cache(cache_path)
+
+        # 4. Per-survivor detail (one mutmut show call per id in 2.5.1).
+        for sid in survivor_ids:
+            survivor = _show_survivor(sid, repo_root)
+            if survivor is not None:
+                survivors.append(survivor)
+
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        logger.error("Mutation run failed: %s", error)
+    finally:
+        # 5. Safety restore (load-bearing): never leave a mutant on disk.
+        _restore_target(target, repo_root)
+
+    total = killed + survived
+    kill_rate = (killed / total) if total else 0.0
+
+    return MutationResult(
+        target_file=rel_target,
+        tests_file=rel_tests,
+        total_mutants=total,
+        killed=killed,
+        survived=survived,
+        kill_rate=kill_rate,
+        survivors=survivors,
+        error=error,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke entry point
+    _target = Path(sys.argv[1])
+    _tests = Path(sys.argv[2])
+    _excl = sys.argv[3] if len(sys.argv) > 3 else None
+    result = run_mutation(_target, _tests, _excl)
+    print(result)

--- a/src/claude_mpm/services/mutation/runner.py
+++ b/src/claude_mpm/services/mutation/runner.py
@@ -24,9 +24,11 @@ LINK: none  (feature introduced in this PR, tracked in GitHub issue #853)
 from __future__ import annotations
 
 import logging
+import re
 import sqlite3
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,9 +37,21 @@ logger = logging.getLogger(__name__)
 # Name of the mutmut SQLite cache file (lives at repo root after a run).
 CACHE_FILENAME = ".mutmut-cache"
 
+# A safe pytest ``-k`` expression allowlist: identifiers/whitespace, the boolean
+# keywords and/or/not (as plain words), parentheses, ``.``, ``-`` and ``:``. This
+# deliberately REJECTS every shell metacharacter (``;`` ``&`` ``$`` backtick
+# ``>`` ``<`` a ``|`` pipe, quotes, newlines) because mutmut runs the
+# ``--runner`` string through a shell with exclude_tests embedded into it.
+_SAFE_EXCLUDE_TESTS = re.compile(r"^[\w\s().:-]+$")
+
 # mutmut status strings (confirmed by inspecting a real 2.5.1 cache on Py3.13).
 _STATUS_SURVIVED = "bad_survived"
 _STATUS_KILLED = "ok_killed"
+
+# Tolerance (seconds) subtracted from the run-start timestamp before comparing
+# it to the cache's mtime, to absorb coarse filesystem mtime granularity so a
+# fresh cache written within the same tick is not misread as stale.
+_CACHE_MTIME_TOLERANCE_S = 2.0
 
 
 @dataclass(frozen=True)
@@ -86,9 +100,25 @@ def _build_runner_command(tests_file: Path, exclude_tests: str | None) -> str:
           ``-x`` stops at the first failure (fastest kill detection); ``-q``
           keeps output small. exclude_tests lets callers skip slow/irrelevant
           tests by pattern.
+
+          SECURITY: mutmut runs this string through a shell, so exclude_tests
+          is validated against :data:`_SAFE_EXCLUDE_TESTS` — a strict allowlist
+          of benign pytest ``-k`` tokens (identifiers, whitespace, and/or/not,
+          parens, ``.``, ``-``, ``:``). Any shell metacharacter (``;`` ``&``
+          ``$`` backtick ``>`` ``<`` ``|`` quotes newlines) raises ValueError.
+
+    :raises ValueError: if exclude_tests contains characters outside the safe
+        pytest ``-k`` allowlist (shell-injection guard).
     """
     cmd = f"uv run python -m pytest {tests_file} -p no:xdist -x -q"
     if exclude_tests:
+        if not _SAFE_EXCLUDE_TESTS.fullmatch(exclude_tests):
+            raise ValueError(
+                "exclude_tests contains characters outside the safe pytest "
+                "-k allowlist (identifiers, whitespace, and/or/not, parens, "
+                f"'.', '-', ':'); refusing to embed in shell command: "
+                f"{exclude_tests!r}"
+            )
         cmd += f" -k 'not ({exclude_tests})'"
     return cmd
 
@@ -111,16 +141,15 @@ def _classify_mutation(original: str, mutant: str) -> str:
     if mut in {"", "pass"}:
         return "removal"
 
-    # Compare the symmetric difference of tokens to see what actually changed.
-    changed = f"{orig} {mut}"
-
-    # Boundary: comparison-operator flips (<= >= < >).
-    boundary_ops = ("<=", ">=", "<", ">")
-    if any(op in orig or op in mut for op in boundary_ops) and orig != mut:
-        # Distinguish from arithmetic: only treat as boundary if a comparison
-        # operator is present (arithmetic handled below otherwise).
-        if any(op in changed for op in ("<", ">")):
-            return "boundary"
+    # Boundary: a COMPARISON OPERATOR actually changed between original and
+    # mutant (e.g. ``<``→``<=``, ``>``→``>=``, ``<``→``>``). We compare the
+    # multiset of comparison-operator tokens on each side and only classify
+    # boundary when that multiset differs. Merely *containing* ``<``/``>`` is
+    # not enough — those characters also appear in type subscripts and bit
+    # shifts, and an arithmetic/predicate/string edit on such a line must still
+    # reach its own branch below.
+    if _comparison_operators(orig) != _comparison_operators(mut):
+        return "boundary"
 
     # Predicate: boolean-logic operators.
     for token in ("and", "or", "not"):
@@ -131,11 +160,30 @@ def _classify_mutation(original: str, mutant: str) -> str:
     if ('"' in orig or "'" in orig) and ('"' in mut or "'" in mut):
         return "string"
 
-    # Arithmetic: binary arithmetic operators.
+    # Arithmetic: binary arithmetic operators (checked on the combined pair).
+    changed = f"{orig} {mut}"
     if any(op in changed for op in ("+", "-", "*", "/")):
         return "arithmetic"
 
     return "other"
+
+
+# Comparison operators ordered longest-first so ``<=``/``>=`` are matched before
+# the bare ``<``/``>`` they contain.
+_COMPARISON_OP_RE = re.compile(r"<=|>=|==|!=|<|>")
+
+
+def _comparison_operators(line: str) -> tuple[str, ...]:
+    """Return the ordered tuple of comparison-operator tokens in a source line.
+
+    WHAT: Tokenize ``<= >= == != < >`` occurrences (longest-match first) into a
+          stable ordered tuple.
+    WHY:  :func:`_classify_mutation` compares the operator multiset of original
+          vs mutant; a boundary mutation is exactly one where this tuple
+          *changes*, which avoids false positives from ``<``/``>`` that appear
+          in type subscripts or arithmetic but are not comparison flips.
+    """
+    return tuple(_COMPARISON_OP_RE.findall(line))
 
 
 def _parse_show_diff(
@@ -289,6 +337,14 @@ def _show_survivor(mutant_id: int, repo_root: Path) -> MutantSurvivor | None:
         check=False,
         cwd=str(repo_root),
     )
+    if proc.returncode != 0:
+        logger.warning(
+            "mutmut show id=%s exited non-zero (%s); stderr: %s",
+            mutant_id,
+            proc.returncode,
+            proc.stderr.strip(),
+        )
+        return None
     return _parse_show_diff(mutant_id, proc.stdout, repo_root=repo_root)
 
 
@@ -331,9 +387,15 @@ def _restore_target(target: Path, repo_root: Path) -> None:
 def _repo_root() -> Path:
     """Return the repo root (where ``.mutmut-cache`` lives).
 
-    WHAT: Resolve the git top-level directory.
+    WHAT: Resolve the git top-level directory, raising if git is unavailable.
     WHY:  Everything must run from the repo root because mutmut writes its
-          cache there; we never rely on the caller's cwd.
+          cache there; we never rely on the caller's cwd. The runner REQUIRES
+          git for both the safety-restore (``git checkout HEAD -- <target>``)
+          and cache pathing, so a silent ``Path.cwd()`` fallback would point the
+          cache/restore at the wrong tree. We fail loudly instead.
+
+    :raises RuntimeError: if ``git rev-parse --show-toplevel`` fails (git not
+        installed, or not inside a git work tree).
     """
     proc = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
@@ -343,7 +405,11 @@ def _repo_root() -> Path:
     )
     if proc.returncode == 0 and proc.stdout.strip():
         return Path(proc.stdout.strip())
-    return Path.cwd()
+    raise RuntimeError(
+        "git is required by the mutation runner (for safety-restore and cache "
+        "pathing) but `git rev-parse --show-toplevel` failed "
+        f"(returncode={proc.returncode}); stderr: {proc.stderr.strip()}"
+    )
 
 
 def run_mutation(
@@ -387,7 +453,14 @@ def run_mutation(
     survived = 0
 
     try:
-        # 1. Run mutmut. Non-zero exit means survivors exist — NOT an error.
+        # 1. Capture a run-start timestamp BEFORE invoking mutmut so we can
+        #    detect a stale ``.mutmut-cache`` left by a prior run afterwards.
+        #    The small tolerance absorbs coarse filesystem mtime granularity
+        #    (some filesystems round to whole seconds), avoiding a false stale
+        #    verdict when mutmut writes the cache within the same tick.
+        run_start = time.time() - _CACHE_MTIME_TOLERANCE_S
+
+        # 1b. Run mutmut. Non-zero exit means survivors exist — NOT an error.
         subprocess.run(
             [
                 "uv",
@@ -409,6 +482,28 @@ def run_mutation(
             error = (
                 f"mutmut produced no cache at {cache_path}; mutmut likely "
                 "failed to start (check that target and tests exist)"
+            )
+            return MutationResult(
+                target_file=rel_target,
+                tests_file=rel_tests,
+                total_mutants=0,
+                killed=0,
+                survived=0,
+                kill_rate=0.0,
+                survivors=[],
+                error=error,
+            )
+
+        # 2b. Run-scope guard: the cache must have been (re)written by THIS run.
+        #     A stale cache from a prior run would report counts/survivors for
+        #     the wrong target, so we refuse it rather than return wrong results.
+        cache_mtime = cache_path.stat().st_mtime
+        if cache_mtime < run_start:
+            error = (
+                f"mutmut cache at {cache_path} is stale (mtime {cache_mtime} "
+                f"predates run start {run_start}); a prior run's cache would "
+                "report counts/survivors for the wrong target. Refusing to "
+                "report possibly-wrong results."
             )
             return MutationResult(
                 target_file=rel_target,

--- a/tests/services/mutation/__init__.py
+++ b/tests/services/mutation/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for the mutation testing framework service."""

--- a/tests/services/mutation/test_runner.py
+++ b/tests/services/mutation/test_runner.py
@@ -1,0 +1,449 @@
+"""Tests for the standalone mutmut runner.
+
+WHAT: Unit tests (subprocess + sqlite stubbed) for the diff parser, the cache
+      reader, the safety-restore-in-finally guarantee, kill-rate math, and the
+      schema-mismatch error path; plus one on-demand integration test that runs
+      real mutmut against the pilot module.
+WHY:  The runner is the Phase 1 de-risking slice — its correctness is the
+      go/no-go gate for the rest of the mutation testing service, so the parser
+      and SQLite contract are pinned by fast, hermetic unit tests, and the real
+      mutmut behaviour is validated once by a skippable integration test.
+
+References
+----------
+LINK: none  (feature introduced in this PR, tracked in GitHub issue #853)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from claude_mpm.services.mutation import runner as runner_mod
+from claude_mpm.services.mutation.runner import (
+    MutantSurvivor,
+    MutationResult,
+    _build_runner_command,
+    _classify_mutation,
+    _parse_show_diff,
+    _read_cache,
+    run_mutation,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: a fake mutmut show diff, identical in shape to real 2.5.1 output.
+# ---------------------------------------------------------------------------
+
+BOUNDARY_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -1,5 +1,5 @@
+ def add(a, b):
+-    if a > 0:
++    if a >= 0:
+         return a + b
+     return b
+"""
+
+ARITHMETIC_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -1,5 +1,5 @@
+ def add(a, b):
+     if a > 0:
+-        return a + b
++        return a - b
+     return b
+"""
+
+STRING_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -10,3 +10,3 @@
+ def greet():
+-    return "hello"
++    return "XXhelloXX"
+"""
+
+PREDICATE_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -3,3 +3,3 @@
+ def check(a, b):
+-    return a and b
++    return a or b
+"""
+
+REMOVAL_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -7,3 +7,3 @@
+ def side_effect():
+-    log_it()
++    pass
+"""
+
+
+# ---------------------------------------------------------------------------
+# Diff parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_show_diff_extracts_all_fields():
+    survivor = _parse_show_diff(42, BOUNDARY_DIFF)
+    assert survivor is not None
+    assert survivor.id == 42
+    assert survivor.file == "src/pkg/mod.py"
+    # Hunk starts at line 1; the changed `-` line is the 2nd line of the hunk.
+    assert survivor.line == 2
+    assert survivor.original == "if a > 0:"
+    assert survivor.mutant == "if a >= 0:"
+    assert survivor.mutation_type == "boundary"
+
+
+def test_parse_show_diff_line_number_uses_hunk_offset():
+    # STRING_DIFF hunk starts at line 10; the `-` line is the 2nd hunk line.
+    survivor = _parse_show_diff(1, STRING_DIFF)
+    assert survivor is not None
+    assert survivor.line == 11
+
+
+def test_parse_show_diff_returns_none_on_garbage():
+    assert _parse_show_diff(1, "not a diff at all") is None
+
+
+def test_parse_show_diff_normalizes_absolute_path_to_repo_relative(tmp_path):
+    # mutmut echoes back whatever path we passed (often absolute); the parser
+    # must normalize it to repo-relative when given a repo_root.
+    abs_target = tmp_path / "src" / "pkg" / "mod.py"
+    abs_diff = (
+        f"--- {abs_target}\n"
+        f"+++ {abs_target}\n"
+        "@@ -1,5 +1,5 @@\n"
+        " def add(a, b):\n"
+        "-    if a > 0:\n"
+        "+    if a >= 0:\n"
+        "         return a + b\n"
+        "     return b\n"
+    )
+    survivor = _parse_show_diff(1, abs_diff, repo_root=tmp_path)
+    assert survivor is not None
+    assert survivor.file == "src/pkg/mod.py"
+
+
+@pytest.mark.parametrize(
+    ("diff", "expected_type"),
+    [
+        (BOUNDARY_DIFF, "boundary"),
+        (ARITHMETIC_DIFF, "arithmetic"),
+        (STRING_DIFF, "string"),
+        (PREDICATE_DIFF, "predicate"),
+        (REMOVAL_DIFF, "removal"),
+    ],
+)
+def test_mutation_type_inference(diff, expected_type):
+    survivor = _parse_show_diff(1, diff)
+    assert survivor is not None
+    assert survivor.mutation_type == expected_type
+
+
+def test_classify_mutation_other_fallback():
+    assert _classify_mutation("foo = bar", "foo = baz") == "other"
+
+
+# ---------------------------------------------------------------------------
+# Runner command construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_runner_command_basic():
+    cmd = _build_runner_command(Path("tests/test_x.py"), None)
+    assert "uv run python -m pytest tests/test_x.py" in cmd
+    assert "-p no:xdist" in cmd
+    assert "-x" in cmd
+    assert "-k" not in cmd
+
+
+def test_build_runner_command_with_exclude():
+    cmd = _build_runner_command(Path("tests/test_x.py"), "slow or flaky")
+    assert "-k 'not (slow or flaky)'" in cmd
+
+
+# ---------------------------------------------------------------------------
+# SQLite cache reader
+# ---------------------------------------------------------------------------
+
+
+def _make_cache(tmp_path: Path, mutants: list[tuple[int, str]]) -> Path:
+    """Build a temp .mutmut-cache with the real 2.5.1 Mutant-table schema."""
+    cache = tmp_path / ".mutmut-cache"
+    con = sqlite3.connect(str(cache))
+    con.execute(
+        'CREATE TABLE "Mutant" ('
+        '"id" INTEGER PRIMARY KEY, "line" INTEGER NOT NULL, '
+        '"index" INTEGER NOT NULL, "tested_against_hash" TEXT NOT NULL, '
+        '"status" TEXT NOT NULL)'
+    )
+    for mid, status in mutants:
+        con.execute(
+            'INSERT INTO "Mutant" VALUES (?, 1, 0, ?, ?)',
+            (mid, "hash", status),
+        )
+    con.commit()
+    con.close()
+    return cache
+
+
+def test_read_cache_returns_only_survivor_ids(tmp_path):
+    cache = _make_cache(
+        tmp_path,
+        [
+            (1, "bad_survived"),
+            (2, "ok_killed"),
+            (3, "bad_survived"),
+            (4, "ok_killed"),
+            (5, "ok_killed"),
+        ],
+    )
+    survivor_ids, killed, survived = _read_cache(cache)
+    assert survivor_ids == [1, 3]
+    assert killed == 3
+    assert survived == 2
+
+
+def test_read_cache_schema_mismatch_raises(tmp_path):
+    # A cache with the wrong table name must raise (guards against silent 100%).
+    cache = tmp_path / ".mutmut-cache"
+    con = sqlite3.connect(str(cache))
+    con.execute('CREATE TABLE "Wrong" ("id" INTEGER PRIMARY KEY)')
+    con.commit()
+    con.close()
+    with pytest.raises(ValueError, match="schema mismatch"):
+        _read_cache(cache)
+
+
+def test_read_cache_schema_mismatch_propagates_into_error(tmp_path, monkeypatch):
+    """A schema mismatch surfaces in MutationResult.error, not as a crash."""
+    cache = tmp_path / ".mutmut-cache"
+    con = sqlite3.connect(str(cache))
+    con.execute('CREATE TABLE "Wrong" ("id" INTEGER PRIMARY KEY)')
+    con.commit()
+    con.close()
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "run",
+        _fake_subprocess_run(show_output=""),
+    )
+
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    assert result.error is not None
+    assert "schema mismatch" in result.error
+    assert result.kill_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# run_mutation: stubbed subprocess + sqlite end to end
+# ---------------------------------------------------------------------------
+
+
+def _fake_subprocess_run(show_output: str = "", run_raises: bool = False):
+    """Return a fake subprocess.run that mimics mutmut/git calls."""
+
+    def _fake(cmd, *args, **kwargs):
+        # Identify which command this is by its mutmut SUBCOMMAND (the token
+        # right after "mutmut"). Checking "run"/"show" membership directly is
+        # wrong: every command starts with "uv run", so "run" is always present.
+        if isinstance(cmd, list) and "mutmut" in cmd:
+            sub = (
+                cmd[cmd.index("mutmut") + 1]
+                if cmd.index("mutmut") + 1 < len(cmd)
+                else ""
+            )
+            if sub == "show":
+                return subprocess.CompletedProcess(cmd, 0, show_output, "")
+            if sub == "run":
+                if run_raises:
+                    raise RuntimeError("mutmut exploded")
+                return subprocess.CompletedProcess(cmd, 1, "", "")
+        if isinstance(cmd, list) and "git" in cmd:
+            if "diff" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            if "checkout" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            if "rev-parse" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    return _fake
+
+
+def test_run_mutation_happy_path(tmp_path, monkeypatch):
+    cache_dir = tmp_path
+    _make_cache(
+        cache_dir,
+        [(1, "bad_survived"), (2, "ok_killed"), (3, "ok_killed")],
+    )
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        runner_mod.subprocess, "run", _fake_subprocess_run(show_output=BOUNDARY_DIFF)
+    )
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    assert isinstance(result, MutationResult)
+    assert result.error is None
+    assert result.total_mutants == 3
+    assert result.killed == 2
+    assert result.survived == 1
+    assert result.kill_rate == pytest.approx(2 / 3)
+    assert len(result.survivors) == 1
+    assert isinstance(result.survivors[0], MutantSurvivor)
+    assert result.survivors[0].mutation_type == "boundary"
+
+
+def test_run_mutation_kill_rate_zero_when_no_mutants(tmp_path, monkeypatch):
+    _make_cache(tmp_path, [])  # empty Mutant table
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake_subprocess_run())
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    assert result.total_mutants == 0
+    assert result.kill_rate == 0.0
+    assert result.error is None
+
+
+def test_run_mutation_missing_cache_sets_error(tmp_path, monkeypatch):
+    # No cache file created → mutmut never produced results.
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake_subprocess_run())
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    assert result.error is not None
+    assert "no cache" in result.error
+
+
+def test_safety_restore_called_in_finally_even_on_exception(tmp_path, monkeypatch):
+    """If the mutmut subprocess raises, the restore must still run."""
+    _make_cache(tmp_path, [(1, "bad_survived")])
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    restore_calls: list[Path] = []
+
+    def _spy_restore(t, repo_root):
+        restore_calls.append(t)
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(runner_mod, "_restore_target", _spy_restore)
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "run",
+        _fake_subprocess_run(run_raises=True),
+    )
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    # Restore was invoked exactly once despite the exception.
+    assert len(restore_calls) == 1
+    # And the failure was captured into error, not propagated.
+    assert result.error is not None
+    assert "mutmut exploded" in result.error
+
+
+def test_restore_target_runs_checkout_when_dirty(tmp_path, monkeypatch):
+    """_restore_target issues git checkout only when git diff reports changes."""
+    calls: list[list[str]] = []
+
+    def _fake(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if "diff" in cmd:
+            # Non-zero exit = dirty (mutant left on disk).
+            return subprocess.CompletedProcess(cmd, 1, "mutated", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake)
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    runner_mod._restore_target(target, tmp_path)
+    # A checkout call must have been issued.
+    assert any("checkout" in c for c in calls)
+
+
+def test_restore_target_skips_checkout_when_clean(tmp_path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def _fake(cmd, *args, **kwargs):
+        calls.append(cmd)
+        # diff exit 0 = clean.
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake)
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    runner_mod._restore_target(target, tmp_path)
+    assert not any("checkout" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: real mutmut against the pilot module (on demand only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(0)  # real mutmut over the full module takes minutes; the
+# default 120s pytest-timeout would SIGALRM-kill the process mid-run, bypassing
+# the runner's finally-block restore and leaving a mutant on disk.
+@pytest.mark.skipif(
+    not Path("src/claude_mpm/services/trusty_search_allowlist.py").exists(),
+    reason="pilot module not present (run from repo root)",
+)
+def test_integration_real_mutmut_against_pilot():
+    """Decision-checkpoint: run real mutmut on the pilot module.
+
+    WHAT: Invoke run_mutation against trusty_search_allowlist.py and assert a
+          healthy kill rate, non-empty parsed survivors, and a clean error.
+    WHY:  This is the go/no-go evidence that the runner works end to end with
+          real mutmut 2.5.1 on Python 3.13 before we build the CLI/agent slices.
+    """
+    target = Path("src/claude_mpm/services/trusty_search_allowlist.py").resolve()
+    tests_file = Path("tests/services/test_trusty_search_allowlist.py").resolve()
+
+    result = run_mutation(target, tests_file)
+
+    assert result.error is None, f"mutmut errored: {result.error}"
+    assert result.total_mutants > 0
+    assert result.kill_rate > 0.5, f"kill rate too low: {result.kill_rate}"
+    assert result.survivors, "expected at least one survivor to inspect"
+
+    sample = result.survivors[0]
+    assert sample.file
+    # File must be repo-relative, not an absolute path.
+    assert not sample.file.startswith("/")
+    assert sample.file.endswith("trusty_search_allowlist.py")
+    assert sample.line > 0
+    assert sample.original
+    assert sample.mutant

--- a/tests/services/mutation/test_runner.py
+++ b/tests/services/mutation/test_runner.py
@@ -16,6 +16,7 @@ LINK: none  (feature introduced in this PR, tracked in GitHub issue #853)
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -86,6 +87,20 @@ REMOVAL_DIFF = """\
 +    pass
 """
 
+# An ARITHMETIC mutation on a line that *contains* a ``<`` (unchanged). The
+# ``<`` belongs to a comparison that is identical on both sides, so the only
+# thing that changed is the ``+``→``-`` arithmetic operator. This must classify
+# as "arithmetic", NOT "boundary" — the prior classifier misfired here because
+# it flagged boundary whenever ``<``/``>`` merely appeared on the line.
+ARITHMETIC_WITH_LT_DIFF = """\
+--- src/pkg/mod.py
++++ src/pkg/mod.py
+@@ -1,3 +1,3 @@
+ def scaled(a, b):
+-    return (a + b) if a < 10 else 0
++    return (a - b) if a < 10 else 0
+"""
+
 
 # ---------------------------------------------------------------------------
 # Diff parser
@@ -139,6 +154,9 @@ def test_parse_show_diff_normalizes_absolute_path_to_repo_relative(tmp_path):
     [
         (BOUNDARY_DIFF, "boundary"),
         (ARITHMETIC_DIFF, "arithmetic"),
+        # Arithmetic edit on a line containing an UNCHANGED ``<`` must NOT be
+        # misclassified as boundary (finding #2 regression guard).
+        (ARITHMETIC_WITH_LT_DIFF, "arithmetic"),
         (STRING_DIFF, "string"),
         (PREDICATE_DIFF, "predicate"),
         (REMOVAL_DIFF, "removal"),
@@ -148,6 +166,41 @@ def test_mutation_type_inference(diff, expected_type):
     survivor = _parse_show_diff(1, diff)
     assert survivor is not None
     assert survivor.mutation_type == expected_type
+
+
+@pytest.mark.parametrize(
+    ("original", "mutant"),
+    [
+        ("if a < 0:", "if a <= 0:"),  # < -> <=
+        ("if a > 0:", "if a >= 0:"),  # > -> >=
+        ("if a < 0:", "if a > 0:"),  # < -> >
+        ("while x <= n:", "while x < n:"),  # <= -> <
+    ],
+)
+def test_classify_mutation_boundary_only_on_operator_change(original, mutant):
+    """A real comparison-operator flip classifies as boundary."""
+    assert _classify_mutation(original, mutant) == "boundary"
+
+
+def test_classify_mutation_unchanged_comparison_is_not_boundary():
+    """A line carrying ``<``/``>`` that did NOT change is not boundary.
+
+    Finding #2: arithmetic/predicate/string edits on a line that merely
+    *contains* a comparison operator must reach their own branch.
+    """
+    # Arithmetic edit, comparison ``<`` identical on both sides.
+    assert (
+        _classify_mutation(
+            "y = (a + b) if a < 10 else 0", "y = (a - b) if a < 10 else 0"
+        )
+        == "arithmetic"
+    )
+    # Type subscript ``dict[str, int]`` contains ``<``-free brackets but a
+    # string edit on a line with a comparison must still classify as string.
+    assert (
+        _classify_mutation('x = "v" if a < 1 else "w"', 'x = "XX" if a < 1 else "w"')
+        == "string"
+    )
 
 
 def test_classify_mutation_other_fallback():
@@ -170,6 +223,36 @@ def test_build_runner_command_basic():
 def test_build_runner_command_with_exclude():
     cmd = _build_runner_command(Path("tests/test_x.py"), "slow or flaky")
     assert "-k 'not (slow or flaky)'" in cmd
+
+
+def test_build_runner_command_allows_realistic_k_expressions():
+    """Benign pytest -k expressions (dots, colons, parens, hyphens) are kept."""
+    expr = "TestFoo and (not slow) or test_bar.py::test_baz-fast"
+    cmd = _build_runner_command(Path("tests/test_x.py"), expr)
+    assert f"-k 'not ({expr})'" in cmd
+
+
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "slow; rm -rf /",  # command separator
+        "slow && curl evil",  # logical-and shell op
+        "slow | tee out",  # pipe (vs the word 'or')
+        "$(whoami)",  # command substitution
+        "`id`",  # backtick substitution
+        "slow > /etc/passwd",  # redirect
+        "slow' ; echo pwned ; '",  # quote breakout
+        "slow\nrm -rf /",  # newline injection
+    ],
+)
+def test_build_runner_command_rejects_shell_metacharacters(evil):
+    """exclude_tests with shell metacharacters must raise ValueError.
+
+    mutmut runs the --runner string through a shell, so this is a shell-injection
+    guard (finding #1).
+    """
+    with pytest.raises(ValueError, match="exclude_tests"):
+        _build_runner_command(Path("tests/test_x.py"), evil)
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +320,7 @@ def test_read_cache_schema_mismatch_propagates_into_error(tmp_path, monkeypatch)
     monkeypatch.setattr(
         runner_mod.subprocess,
         "run",
-        _fake_subprocess_run(show_output=""),
+        _fake_subprocess_run(show_output="", fresh_cache=cache),
     )
 
     target = tmp_path / "src" / "mod.py"
@@ -255,8 +338,19 @@ def test_read_cache_schema_mismatch_propagates_into_error(tmp_path, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-def _fake_subprocess_run(show_output: str = "", run_raises: bool = False):
-    """Return a fake subprocess.run that mimics mutmut/git calls."""
+def _fake_subprocess_run(
+    show_output: str = "",
+    run_raises: bool = False,
+    fresh_cache: Path | None = None,
+):
+    """Return a fake subprocess.run that mimics mutmut/git calls.
+
+    If ``fresh_cache`` is given, the simulated ``mutmut run`` touches that cache
+    file so its mtime is current — mirroring real mutmut, which rewrites the
+    ``.mutmut-cache`` on every run. The runner's run-scope freshness guard
+    requires the cache to be newer than run-start, so happy-path tests mark the
+    cache fresh; the stale-cache test deliberately omits this.
+    """
 
     def _fake(cmd, *args, **kwargs):
         # Identify which command this is by its mutmut SUBCOMMAND (the token
@@ -273,6 +367,8 @@ def _fake_subprocess_run(show_output: str = "", run_raises: bool = False):
             if sub == "run":
                 if run_raises:
                     raise RuntimeError("mutmut exploded")
+                if fresh_cache is not None and fresh_cache.exists():
+                    fresh_cache.touch()  # mutmut rewrites the cache each run
                 return subprocess.CompletedProcess(cmd, 1, "", "")
         if isinstance(cmd, list) and "git" in cmd:
             if "diff" in cmd:
@@ -298,7 +394,11 @@ def test_run_mutation_happy_path(tmp_path, monkeypatch):
 
     monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(
-        runner_mod.subprocess, "run", _fake_subprocess_run(show_output=BOUNDARY_DIFF)
+        runner_mod.subprocess,
+        "run",
+        _fake_subprocess_run(
+            show_output=BOUNDARY_DIFF, fresh_cache=tmp_path / ".mutmut-cache"
+        ),
     )
 
     result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
@@ -320,7 +420,11 @@ def test_run_mutation_kill_rate_zero_when_no_mutants(tmp_path, monkeypatch):
     target.write_text("x = 1\n")
 
     monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(runner_mod.subprocess, "run", _fake_subprocess_run())
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "run",
+        _fake_subprocess_run(fresh_cache=tmp_path / ".mutmut-cache"),
+    )
 
     result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
     assert result.total_mutants == 0
@@ -340,6 +444,49 @@ def test_run_mutation_missing_cache_sets_error(tmp_path, monkeypatch):
     result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
     assert result.error is not None
     assert "no cache" in result.error
+
+
+def test_run_mutation_stale_cache_sets_error(tmp_path, monkeypatch):
+    """A pre-existing cache NOT rewritten by this run yields a stale error.
+
+    Finding #3: a leftover ``.mutmut-cache`` from a prior run would report
+    counts/survivors for the WRONG target. The run-scope freshness guard must
+    refuse it instead of returning possibly-wrong results.
+    """
+    cache = _make_cache(tmp_path, [(1, "bad_survived"), (2, "ok_killed")])
+    # Backdate the cache far into the past so it predates the run-start
+    # timestamp (and the mtime tolerance window) — i.e. it is unambiguously
+    # stale. The fake ``mutmut run`` does NOT touch it (no fresh_cache).
+    stale_time = cache.stat().st_mtime - 3600
+    os.utime(cache, (stale_time, stale_time))
+
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n")
+
+    monkeypatch.setattr(runner_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake_subprocess_run())
+
+    result = run_mutation(target, tmp_path / "tests" / "test_mod.py")
+    assert result.error is not None
+    assert "stale" in result.error
+    assert result.kill_rate == 0.0
+    assert result.total_mutants == 0
+
+
+def test_repo_root_raises_when_git_fails(monkeypatch):
+    """_repo_root raises RuntimeError when git is unavailable (finding #4).
+
+    The runner REQUIRES git for safety-restore and cache pathing; a silent
+    cwd fallback would point them at the wrong tree.
+    """
+
+    def _fake_git_fail(cmd, *args, **kwargs):
+        return subprocess.CompletedProcess(cmd, 128, "", "not a git repository")
+
+    monkeypatch.setattr(runner_mod.subprocess, "run", _fake_git_fail)
+    with pytest.raises(RuntimeError, match="git is required"):
+        runner_mod._repo_root()
 
 
 def test_safety_restore_called_in_finally_even_on_exception(tmp_path, monkeypatch):
@@ -434,9 +581,19 @@ def test_integration_real_mutmut_against_pilot():
 
     result = run_mutation(target, tests_file)
 
+    # Baseline kill rate measured on the pilot during the Phase-1 experiment was
+    # ~0.615. We assert a conservative floor (default 0.5) rather than the exact
+    # baseline so that legitimate future test-suite changes (which shift the kill
+    # rate) do not cause spurious failures. The floor is overridable via the
+    # MUTATION_PILOT_MIN_KILL_RATE env var for tuning/CI without editing code.
+    min_kill_rate = float(os.environ.get("MUTATION_PILOT_MIN_KILL_RATE", "0.5"))
+
     assert result.error is None, f"mutmut errored: {result.error}"
     assert result.total_mutants > 0
-    assert result.kill_rate > 0.5, f"kill rate too low: {result.kill_rate}"
+    assert result.kill_rate > min_kill_rate, (
+        f"kill rate {result.kill_rate} below floor {min_kill_rate} "
+        "(baseline ~0.615); set MUTATION_PILOT_MIN_KILL_RATE to adjust"
+    )
     assert result.survivors, "expected at least one survivor to inspect"
 
     sample = result.survivors[0]


### PR DESCRIPTION
Closes #853.

## Smallest first slice (de-risking)

A single importable module `src/claude_mpm/services/mutation/runner.py` (plus its package `__init__.py`) exposing `run_mutation(target, tests_file, exclude_tests=None) -> MutationResult`. This is the **de-risking slice** that proves the mutmut interface works in isolation before we invest in the CLI command, parser, eligibility heuristic, or agent wiring.

### How it hides mutmut 2.5.1's Python 3.13 bugs
- **Scope via CLI flags only** (`--paths-to-mutate`, `--tests-dir`, `--runner`) — never edits `setup.cfg`. mutmut exiting non-zero when survivors exist is treated as NORMAL, not an error.
- **Reads results from the `.mutmut-cache` SQLite DB directly** (`Mutant.status` = `bad_survived` / `ok_killed`) instead of the crashing `mutmut results` (pony-orm `QueryResultIterator not iterable`). A schema guard asserts the `Mutant` table + `id`/`status` columns exist, surfacing a clear error into `MutationResult.error` rather than silently reporting 100% kill rate.
- **Per-survivor detail via `mutmut show <id>`** (one id per call — the 2.5.1 limitation), parsing the unified diff for file / line / original / mutant and inferring `mutation_type` (boundary | predicate | string | removal | arithmetic | other). Absolute paths are normalized to repo-relative.
- **Safety restore (load-bearing):** the whole run is wrapped in try/finally; if `git diff` shows the target was mutated, `git checkout HEAD -- <target>` restores it. mutmut mutates in place — a crash must never leave a mutant on disk.

### Out of scope (later slices)
CLI command, output parser/formatter, eligibility heuristic, agent wiring.

## Tests
- **22 unit tests** with `subprocess` + `sqlite3` stubbed (no real mutmut): diff parser field extraction, hunk-offset line numbers, `mutation_type` inference, repo-relative path normalization, SQLite reader returns only `bad_survived` ids, schema-mismatch → `error`, kill-rate math (incl. 0-mutant → 0.0), and that the safety restore runs in `finally` even when the subprocess raises.
- **1 integration test** (`@pytest.mark.integration`, skipped in default CI) running real mutmut against the pilot module.

## Validation results (decision checkpoint — go/no-go)

Ran the integration test against the real pilot module `src/claude_mpm/services/trusty_search_allowlist.py` with `tests/services/test_trusty_search_allowlist.py` (real mutmut, 183s):

| Metric | Value |
| --- | --- |
| Total mutants | **161** |
| Killed | 99 |
| Survived | 62 |
| **Kill rate** | **0.6149** (> 0.5 threshold) |
| `error` | `None` |
| `git diff -- src/` after run | **clean** (finally-block restore worked) |

Sample parsed survivor (proves the schema works end to end, repo-relative path):
```
id=1
file='src/claude_mpm/services/trusty_search_allowlist.py'
line=49
original='logger = logging.getLogger(__name__)'
mutant='logger = None'
mutation_type=other
```

**Go decision:** the runner works end to end with real mutmut 2.5.1 on Python 3.13 — proceed to the CLI wiring slice.

> Note during validation: pytest-timeout's default 120s SIGALRM kill bypassed the finally-block restore on an early run and left a mutant on disk. The integration test now carries `@pytest.mark.timeout(0)` so the runner's own restore always executes. The restore logic itself is correct (verified clean tree on every completed run).

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)