### PR TITLE
feat: claude-mpm mutate CLI command (mutation testing Phase 1b)

### DIFF
--- a/docs/specs/mutation.md
+++ b/docs/specs/mutation.md
@@ -1,0 +1,131 @@
+# Mutation Testing Subsystem — Spec-Linked Documentation
+
+This spec governs the mutation-testing framework: the standalone mutmut runner
+(Phase 1, PR #854) and the advisory `claude-mpm mutate` CLI command that wraps
+it (Phase 1b). It establishes the behavior contracts that the implementing
+modules link back to via `SPEC-MUTATION-NN~1` references in their docstrings.
+
+The IDs below use the `{#SPEC-MUTATION-NN~1}` anchor form that the traceability
+checker (`tests/test_spec_traceability.py`) parses.
+
+## Table of Contents
+
+| ID | Section | Implementing function(s) |
+|----|---------|--------------------------|
+| SPEC-MUTATION-01~1 | [Standalone mutmut runner](#standalone-mutmut-runner-spec-mutation-011) | `run_mutation`, `_read_cache`, `_parse_show_diff`, `_classify_mutation`, `_restore_target` |
+| SPEC-MUTATION-02~1 | [Advisory mutate CLI command](#advisory-mutate-cli-command-spec-mutation-021) | `manage_mutate`, `is_eligible_for_mutation`, `get_changed_files_vs_main`, `infer_tests_file`, `MutateParser` |
+
+## Implementing Modules
+
+| Module | Spec | Role |
+|--------|------|------|
+| `src/claude_mpm/services/mutation/runner.py` | SPEC-MUTATION-01~1 | mutmut runner: safe, importable entry point hiding mutmut 2.5.1 Py3.13 bugs |
+| `src/claude_mpm/cli/commands/mutate.py` | SPEC-MUTATION-02~1 | CLI handler: eligibility, scoping, output, advisory threshold |
+| `src/claude_mpm/cli/parsers/mutate_parser.py` | SPEC-MUTATION-02~1 | CLI argument surface and validation |
+
+---
+
+## Standalone mutmut runner {#SPEC-MUTATION-01~1}
+
+**Status:** Active
+
+### Behavior Contract (WHAT)
+
+- **Inputs:** a target `.py` module `Path`, a paired test-file `Path`, and an
+  optional pytest `-k` `exclude_tests` expression.
+
+- **Scoping:** mutation is scoped purely via mutmut CLI flags
+  (`--paths-to-mutate`, `--tests-dir`, `--runner`) — never by editing
+  `setup.cfg`.
+
+- **Result reading:** survivor ids and killed/survived counts are read directly
+  from the `.mutmut-cache` SQLite DB (the `Mutant` table's `status` column),
+  because mutmut 2.5.1's `mutmut results` crashes on Python 3.13. A schema guard
+  raises if the `Mutant` table or its `id`/`status` columns are absent.
+
+- **Per-survivor detail:** each survivor is fetched with a single
+  `mutmut show <id>` call (2.5.1 accepts only one id per call) and its unified
+  diff is parsed into a `MutantSurvivor` (file, line, original, mutant, and a
+  coarse `mutation_type` of boundary | predicate | string | removal |
+  arithmetic | other).
+
+- **Run-scope guard:** the cache mtime must be newer than the run-start
+  timestamp (minus a small filesystem-granularity tolerance); a stale cache is
+  refused rather than reported, so counts never describe the wrong target.
+
+- **Safety restore:** mutmut mutates source in place. The whole run is wrapped
+  in try/finally; on exit `git checkout HEAD -- <target>` restores the file if a
+  mutant was left on disk, so a crash never corrupts the working tree.
+
+- **Shell-injection guard:** `exclude_tests` is embedded into a shell `--runner`
+  string, so it is validated against a strict pytest `-k` allowlist
+  (identifiers, whitespace, `and`/`or`/`not`, parens, `.`, `-`, `:`); any shell
+  metacharacter raises `ValueError`.
+
+- **Outputs:** a frozen `MutationResult` (target, tests, total/killed/survived
+  counts, kill rate, survivor list, optional `error`). `error` is set only when
+  mutmut itself failed — a clean run *with* survivors is the expected, useful
+  signal, not an error.
+
+### Rationale (WHY)
+
+This is the de-risking slice: a single, safe, importable API that proves the
+mutmut interface works in isolation before any CLI, eligibility heuristic, or
+agent wiring is built on top of it. It absorbs mutmut 2.5.1's three load-bearing
+Python 3.13 bugs (crashing `results`, one-id-per-call `show`, in-place mutation)
+so callers never have to.
+
+---
+
+## Advisory mutate CLI command {#SPEC-MUTATION-02~1}
+
+**Status:** Active
+
+### Behavior Contract (WHAT)
+
+- **Target resolution:** an explicit `TARGET` (an existing `.py` file under
+  `src/`) is used directly; otherwise targets are auto-discovered from files
+  changed vs `--base` (default `origin/main`) via
+  `git diff --name-only <base>...HEAD`, filtered to existing `.py` files under
+  `src/`, filtered by the eligibility heuristic, and truncated to `--max-files`
+  (default 1). Truncation is always reported — never a silent cap.
+
+- **Eligibility heuristic:** a file is ineligible if it is `__init__.py`; lives
+  under `tests/`, `cli/`, `scripts/`, `migrations/`, or any dashboard path; or
+  has any top-level import in the I/O-heavy set (`subprocess`, `asyncio`,
+  `aiohttp`, `httpx`, `sqlalchemy`, `fastapi`, `click`, `socket`, `paramiko`,
+  `boto3`). The rejection reason names the triggering import so the engineer can
+  judge a `--force` override. Ineligible targets are reported informationally
+  (exit 0), not as errors.
+
+- **Test-file inference:** when `--tests-file` is omitted, a unique
+  `tests/**/test_<stem>.py` match for the target's module stem is used; zero or
+  ambiguous matches produce a clear error telling the user to pass
+  `--tests-file`.
+
+- **Dry-run:** `--dry-run` prints the resolved targets, inferred test files, and
+  the exact `uv run mutmut run …` command that would execute, then exits 0
+  without invoking mutmut.
+
+- **Execution:** for each resolved (target, tests-file) pair, the command calls
+  `run_mutation(target, tests_file, exclude_tests)` — the runner is imported and
+  used, never reimplemented.
+
+- **Output:** `--output text` renders a readable per-target summary (kill rate,
+  killed/survived counts, and one line per survivor as
+  `file:line  original→mutant  [type]`); `--output json` emits
+  `json.dumps([dataclasses.asdict(r) for r in results], indent=2)`.
+
+- **Exit code:** advisory by default — with no `--threshold` the command always
+  exits 0. With `--threshold N` it exits 1 when any result's survivor count
+  exceeds N. A non-`None` `MutationResult.error` always yields a non-zero exit,
+  regardless of threshold.
+
+### Rationale (WHY)
+
+Mutation testing is expensive and only produces actionable survivors on
+pure-logic modules, so the command gatekeeps cost with the eligibility
+heuristic and changed-file scoping, and keeps the engineer in control (explicit
+truncation reporting, `--force` override, `--dry-run` preview). Advisory-by-
+default lets it run in CI as pure signal until a team opts into a `--threshold`
+gate.

--- a/src/claude_mpm/cli/commands/mutate.py
+++ b/src/claude_mpm/cli/commands/mutate.py
@@ -1,0 +1,385 @@
+"""Advisory ``claude-mpm mutate`` command — a thin CLI over the mutmut runner.
+
+WHAT: Resolve one (or a capped set of) eligible source target(s), infer the
+      paired test file, and invoke the merged ``run_mutation`` runner, then
+      render a readable or JSON summary. Default behaviour is advisory: with no
+      ``--threshold`` the command always exits 0; survivors are signal, not
+      failure.
+WHY:  Mutation testing is expensive and only meaningful on pure-logic modules,
+      so the command gatekeeps with an eligibility heuristic (skips I/O-heavy
+      and infra files), scopes auto-discovery to files changed vs a base ref,
+      and never silently caps — keeping engineers in control of cost. The
+      runner itself (counts, survivor parsing, safety-restore, shell-injection
+      validation of ``--exclude-tests``) is imported, never reimplemented.
+
+References
+----------
+LINK: SPEC-MUTATION-02~1 : docs/specs/mutation.md#SPEC-MUTATION-02~1
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ...services.mutation.runner import run_mutation
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from ...services.mutation.runner import MutationResult
+
+logger = logging.getLogger(__name__)
+
+# Top-level imports that mark a module as I/O-heavy / infra-bound and therefore
+# a poor mutation-testing candidate (mutants here are dominated by environment,
+# not by the test suite's assertions).
+_IO_HEAVY_IMPORTS = frozenset(
+    {
+        "subprocess",
+        "asyncio",
+        "aiohttp",
+        "httpx",
+        "sqlalchemy",
+        "fastapi",
+        "click",
+        "socket",
+        "paramiko",
+        "boto3",
+    }
+)
+
+# Path components that disqualify a file outright (infra, tooling, generated,
+# or test code — none are worthwhile mutation targets).
+_REJECTED_PATH_PARTS = frozenset({"tests", "cli", "scripts", "migrations"})
+
+
+def is_eligible_for_mutation(path: Path) -> tuple[bool, str]:
+    """Decide whether a source file is a worthwhile mutation-testing target.
+
+    WHAT: Reject ``__init__.py``; reject paths under tests/cli/scripts/
+          migrations or anything dashboard-flavoured; AST-parse the file and
+          reject when any top-level import is in :data:`_IO_HEAVY_IMPORTS`,
+          naming the triggering import(s) in the reason. Otherwise accept.
+    WHY:  Mutation testing only yields actionable survivors on pure-logic code;
+          I/O-heavy and infra modules produce noise and slow runs. Naming the
+          offending import in the rejection lets the engineer judge whether a
+          ``--force`` override is justified.
+
+    Args:
+        path: Source file to evaluate (need not be resolved).
+
+    Returns:
+        ``(True, "eligible")`` or ``(False, reason)``.
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    name = path.name
+    if name == "__init__.py":
+        return False, "skipped: __init__.py (no meaningful logic to mutate)"
+
+    parts = set(path.parts)
+    rejected = parts & _REJECTED_PATH_PARTS
+    if rejected:
+        part = sorted(rejected)[0]
+        return False, f"skipped: path under {part}/ (infra/test/tooling code)"
+
+    if any("dashboard" in part.lower() for part in path.parts):
+        return False, "skipped: dashboard code (UI, not unit-testable logic)"
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, f"skipped: could not read file ({exc})"
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return False, f"skipped: file did not parse ({exc})"
+
+    found: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root in _IO_HEAVY_IMPORTS:
+                    found.add(root)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                root = node.module.split(".")[0]
+                if root in _IO_HEAVY_IMPORTS:
+                    found.add(root)
+
+    if found:
+        names = ", ".join(sorted(found))
+        return (
+            False,
+            f"skipped: I/O-heavy top-level import(s): {names} "
+            f"(use --force to override)",
+        )
+
+    return True, "eligible"
+
+
+def get_changed_files_vs_main(base: str) -> list[Path]:
+    """Return source files changed vs ``base`` that exist as ``.py`` under src/.
+
+    WHAT: Run ``git diff --name-only <base>...HEAD`` and return the existing
+          ``.py`` paths that live under a ``src/`` component.
+    WHY:  Auto-discovery should only consider real, mutatable source files.
+          The ``...`` (merge-base) form scopes to changes introduced on this
+          branch. This is the repo's only branch-diff helper — the existing
+          ``enhanced_analyzer._get_changed_files`` is time-based, not a
+          substitute.
+
+    Args:
+        base: Base git ref (e.g. ``origin/main``).
+
+    Returns:
+        List of changed source ``Path`` objects (may be empty).
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        logger.warning(
+            "git diff vs %s failed (rc=%s): %s",
+            base,
+            proc.returncode,
+            proc.stderr.strip(),
+        )
+        return []
+
+    results: list[Path] = []
+    for line in proc.stdout.splitlines():
+        rel = line.strip()
+        if not rel.endswith(".py"):
+            continue
+        path = Path(rel)
+        if "src" not in path.parts:
+            continue
+        if not path.exists():
+            continue
+        results.append(path)
+    return results
+
+
+def infer_tests_file(target: Path) -> tuple[Path | None, str | None]:
+    """Infer the unit test file paired with a target module.
+
+    WHAT: Search ``tests/**/test_<stem>.py`` for the target's module stem;
+          return the single match, or ``(None, error)`` when there are zero or
+          multiple matches.
+    WHY:  Convenience for the common case (one obvious test file) while
+          refusing to guess when ambiguous — an ambiguous guess could mutate
+          against the wrong suite and report a misleading kill rate.
+
+    Args:
+        target: The source module whose test file we want.
+
+    Returns:
+        ``(test_path, None)`` on a unique match, else ``(None, error_message)``.
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    tests_root = Path("tests")
+    if not tests_root.exists():
+        return None, (
+            "no tests/ directory found; pass --tests-file explicitly "
+            f"for target {target}"
+        )
+
+    pattern = f"test_{target.stem}.py"
+    matches = sorted(tests_root.rglob(pattern))
+    if len(matches) == 1:
+        return matches[0], None
+    if not matches:
+        return None, (
+            f"could not infer a test file for {target} "
+            f"(no tests/**/{pattern}); pass --tests-file explicitly"
+        )
+    listed = ", ".join(str(m) for m in matches)
+    return None, (
+        f"ambiguous test files for {target} (found {len(matches)}: {listed}); "
+        "pass --tests-file explicitly"
+    )
+
+
+def _build_dry_run_command(target: Path, tests_file: Path) -> str:
+    """Render the mutmut command the runner would execute, for ``--dry-run``.
+
+    WHAT: Compose the human-readable ``uv run mutmut run`` invocation showing
+          ``--paths-to-mutate`` / ``--tests-dir`` so the engineer can preview
+          scope without running anything.
+    WHY:  Dry-run must show concrete, copy-pasteable scope rather than a vague
+          "would run mutmut" so the preview is trustworthy.
+    """
+    return (
+        f"uv run mutmut run --paths-to-mutate={target} --tests-dir={tests_file.parent}"
+    )
+
+
+def _render_text(results: list[MutationResult]) -> None:
+    """Print a readable per-target summary table and survivor list.
+
+    WHAT: For each result print target, kill rate, killed/survived counts, any
+          runner error, and one line per survivor
+          (``file:line  original→mutant  [type]``).
+    WHY:  Survivors are the actionable output; a flat, greppable line format is
+          friendlier for terminals and CI logs than a nested structure.
+    """
+    for result in results:
+        print(f"\nTarget: {result.target_file}")
+        print(f"  Tests: {result.tests_file}")
+        if result.error:
+            print(f"  ERROR: {result.error}")
+            continue
+        print(
+            f"  Mutants: {result.total_mutants}  "
+            f"killed={result.killed}  survived={result.survived}  "
+            f"kill_rate={result.kill_rate:.1%}"
+        )
+        if result.survivors:
+            print("  Survivors:")
+            for s in result.survivors:
+                print(
+                    f"    {s.file}:{s.line}  "
+                    f"{s.original} → {s.mutant}  [{s.mutation_type}]"
+                )
+
+
+def _resolve_targets(args: Namespace) -> tuple[list[Path], int]:
+    """Resolve the list of target files to mutate from the parsed args.
+
+    WHAT: Use an explicit ``TARGET`` if given; otherwise auto-discover changed
+          eligible files vs ``--base``, truncated to ``--max-files`` (returning
+          the dropped count so the caller can log the truncation).
+    WHY:  Auto-discovery must never silently cap — the dropped count is
+          surfaced to the user so they know more candidates existed.
+
+    Returns:
+        ``(targets, dropped_count)``.
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    if args.target is not None:
+        return [Path(args.target)], 0
+
+    changed = get_changed_files_vs_main(args.base)
+    eligible = [p for p in changed if is_eligible_for_mutation(p)[0]]
+    max_files = args.max_files or 1
+    dropped = max(0, len(eligible) - max_files)
+    return eligible[:max_files], dropped
+
+
+def manage_mutate(args: Namespace) -> int:
+    """Entry point for ``claude-mpm mutate``.
+
+    WHAT: Resolve targets, gate them through the eligibility heuristic (unless
+          ``--force``), infer/validate test files, and either preview
+          (``--dry-run``) or invoke ``run_mutation`` per target, then render
+          text/JSON output and compute the exit code.
+    WHY:  Advisory by default — with no ``--threshold`` the command always
+          returns 0 so it can run in CI as pure signal. A set ``--threshold``
+          turns survivors into a gate; a genuine runner ``error`` is always a
+          non-zero failure regardless of threshold.
+
+    Args:
+        args: Parsed CLI namespace from :class:`MutateParser`.
+
+    Returns:
+        Process exit code (0 advisory/pass, 1 on threshold breach or error).
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    targets, dropped = _resolve_targets(args)
+
+    if dropped:
+        print(
+            f"Note: {dropped} additional eligible file(s) not shown "
+            f"(capped by --max-files {args.max_files}). "
+            "Raise --max-files to include them."
+        )
+
+    if not targets:
+        print(
+            "No eligible mutation targets found "
+            f"(checked changes vs {args.base}). Nothing to do."
+        )
+        return 0
+
+    # Eligibility gate (skipped under --force). Ineligible targets are
+    # informational, not errors.
+    runnable: list[Path] = []
+    for target in targets:
+        if args.force:
+            runnable.append(target)
+            continue
+        eligible, reason = is_eligible_for_mutation(target)
+        if eligible:
+            runnable.append(target)
+        else:
+            print(f"{target}: {reason}")
+
+    if not runnable:
+        print("No eligible targets after the eligibility check. Nothing to do.")
+        return 0
+
+    # Resolve each target's test file (inference or the explicit --tests-file).
+    planned: list[tuple[Path, Path]] = []
+    for target in runnable:
+        if args.tests_file is not None:
+            tests_file = Path(args.tests_file)
+            if not tests_file.exists():
+                print(f"ERROR: --tests-file does not exist: {tests_file}")
+                return 1
+        else:
+            tests_file, err = infer_tests_file(target)
+            if tests_file is None:
+                print(f"ERROR: {err}")
+                return 1
+        planned.append((target, tests_file))
+
+    if args.dry_run:
+        print("Dry run — resolved scope (mutmut NOT executed):")
+        for target, tests_file in planned:
+            print(f"\nTarget: {target}")
+            print(f"  Tests: {tests_file}")
+            print(f"  Would run: {_build_dry_run_command(target, tests_file)}")
+        return 0
+
+    results: list[MutationResult] = [
+        run_mutation(target, tests_file, args.exclude_tests)
+        for target, tests_file in planned
+    ]
+
+    if args.output == "json":
+        print(
+            json.dumps(
+                [dataclasses.asdict(r) for r in results],
+                indent=2,
+            )
+        )
+    else:
+        _render_text(results)
+
+    # Exit code: runner errors are always failures; threshold gates survivors.
+    if any(r.error is not None for r in results):
+        return 1
+
+    if args.threshold is None:
+        return 0
+
+    if any(r.survived > args.threshold for r in results):
+        return 1
+    return 0

--- a/src/claude_mpm/cli/commands/mutate.py
+++ b/src/claude_mpm/cli/commands/mutate.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...services.mutation.runner import run_mutation
+from ..parsers.mutate_parser import MutateParser
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -35,6 +36,40 @@ if TYPE_CHECKING:
     from ...services.mutation.runner import MutationResult
 
 logger = logging.getLogger(__name__)
+
+
+def _repo_root() -> Path:
+    """Resolve the git repository root, independent of the current directory.
+
+    WHAT: Run ``git rev-parse --show-toplevel`` and return the resulting path;
+          raise :class:`RuntimeError` if git fails (not a repo / git missing).
+    WHY:  Auto-discovery and test-file inference must anchor to the repo root,
+          not the CWD — agents may invoke the CLI from any subdirectory, and a
+          CWD-relative ``tests/`` search or changed-file existence check would
+          silently miss everything when run from a subdir.
+
+    Returns:
+        Absolute path to the repository root.
+
+    Raises:
+        RuntimeError: If the command is not run inside a git repository.
+
+    :spec: SPEC-MUTATION-02~1
+    """
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "could not resolve the git repository root "
+            f"(git rev-parse failed: {proc.stderr.strip()}); "
+            "claude-mpm mutate must run inside a git repository"
+        )
+    return Path(proc.stdout.strip())
+
 
 # Top-level imports that mark a module as I/O-heavy / infra-bound and therefore
 # a poor mutation-testing candidate (mutants here are dominated by environment,
@@ -130,10 +165,14 @@ def get_changed_files_vs_main(base: str) -> list[Path]:
     """Return source files changed vs ``base`` that exist as ``.py`` under src/.
 
     WHAT: Run ``git diff --name-only <base>...HEAD`` and return the existing
-          ``.py`` paths that live under a ``src/`` component.
+          ``.py`` paths that live under a ``src/`` component. Existence is
+          checked against the git repo root, not the current directory.
     WHY:  Auto-discovery should only consider real, mutatable source files.
           The ``...`` (merge-base) form scopes to changes introduced on this
-          branch. This is the repo's only branch-diff helper — the existing
+          branch. ``git diff`` emits repo-root-relative paths, so the existence
+          check must anchor to the repo root — otherwise it silently drops every
+          file when the CLI is invoked from a subdirectory. This is the repo's
+          only branch-diff helper — the existing
           ``enhanced_analyzer._get_changed_files`` is time-based, not a
           substitute.
 
@@ -141,10 +180,14 @@ def get_changed_files_vs_main(base: str) -> list[Path]:
         base: Base git ref (e.g. ``origin/main``).
 
     Returns:
-        List of changed source ``Path`` objects (may be empty).
+        List of changed source ``Path`` objects (repo-relative, may be empty).
+
+    Raises:
+        RuntimeError: If not run inside a git repository (via :func:`_repo_root`).
 
     :spec: SPEC-MUTATION-02~1
     """
+    root = _repo_root()
     proc = subprocess.run(
         ["git", "diff", "--name-only", f"{base}...HEAD"],
         capture_output=True,
@@ -168,7 +211,7 @@ def get_changed_files_vs_main(base: str) -> list[Path]:
         path = Path(rel)
         if "src" not in path.parts:
             continue
-        if not path.exists():
+        if not (root / path).exists():
             continue
         results.append(path)
     return results
@@ -177,12 +220,14 @@ def get_changed_files_vs_main(base: str) -> list[Path]:
 def infer_tests_file(target: Path) -> tuple[Path | None, str | None]:
     """Infer the unit test file paired with a target module.
 
-    WHAT: Search ``tests/**/test_<stem>.py`` for the target's module stem;
-          return the single match, or ``(None, error)`` when there are zero or
-          multiple matches.
+    WHAT: Search ``<repo-root>/tests/**/test_<stem>.py`` for the target's
+          module stem; return the single match (as a repo-relative path), or
+          ``(None, error)`` when there are zero or multiple matches.
     WHY:  Convenience for the common case (one obvious test file) while
           refusing to guess when ambiguous — an ambiguous guess could mutate
-          against the wrong suite and report a misleading kill rate.
+          against the wrong suite and report a misleading kill rate. The search
+          is anchored to the git repo root, not the CWD, so inference keeps
+          working when the CLI is invoked from a subdirectory.
 
     Args:
         target: The source module whose test file we want.
@@ -190,9 +235,13 @@ def infer_tests_file(target: Path) -> tuple[Path | None, str | None]:
     Returns:
         ``(test_path, None)`` on a unique match, else ``(None, error_message)``.
 
+    Raises:
+        RuntimeError: If not run inside a git repository (via :func:`_repo_root`).
+
     :spec: SPEC-MUTATION-02~1
     """
-    tests_root = Path("tests")
+    root = _repo_root()
+    tests_root = root / "tests"
     if not tests_root.exists():
         return None, (
             "no tests/ directory found; pass --tests-file explicitly "
@@ -200,7 +249,7 @@ def infer_tests_file(target: Path) -> tuple[Path | None, str | None]:
         )
 
     pattern = f"test_{target.stem}.py"
-    matches = sorted(tests_root.rglob(pattern))
+    matches = sorted(m.relative_to(root) for m in tests_root.rglob(pattern))
     if len(matches) == 1:
         return matches[0], None
     if not matches:
@@ -258,28 +307,34 @@ def _render_text(results: list[MutationResult]) -> None:
                 )
 
 
-def _resolve_targets(args: Namespace) -> tuple[list[Path], int]:
+def _resolve_targets(args: Namespace) -> tuple[list[tuple[Path, bool]], int]:
     """Resolve the list of target files to mutate from the parsed args.
 
-    WHAT: Use an explicit ``TARGET`` if given; otherwise auto-discover changed
-          eligible files vs ``--base``, truncated to ``--max-files`` (returning
-          the dropped count so the caller can log the truncation).
+    WHAT: Use an explicit ``TARGET`` if given (flagged ``pre_filtered=False`` so
+          the caller still runs the eligibility gate on it); otherwise
+          auto-discover changed eligible files vs ``--base`` (each flagged
+          ``pre_filtered=True``), truncated to ``--max-files`` (returning the
+          dropped count so the caller can log the truncation).
     WHY:  Auto-discovery must never silently cap — the dropped count is
-          surfaced to the user so they know more candidates existed.
+          surfaced to the user so they know more candidates existed. Returning
+          the ``pre_filtered`` flag lets :func:`manage_mutate` skip a redundant
+          second AST parse on auto-discovered targets (already filtered here)
+          while still gating an explicitly-named ineligible file.
 
     Returns:
-        ``(targets, dropped_count)``.
+        ``(targets, dropped_count)`` where each target is
+        ``(path, pre_filtered)``.
 
     :spec: SPEC-MUTATION-02~1
     """
     if args.target is not None:
-        return [Path(args.target)], 0
+        return [(Path(args.target), False)], 0
 
     changed = get_changed_files_vs_main(args.base)
     eligible = [p for p in changed if is_eligible_for_mutation(p)[0]]
     max_files = args.max_files or 1
     dropped = max(0, len(eligible) - max_files)
-    return eligible[:max_files], dropped
+    return [(p, True) for p in eligible[:max_files]], dropped
 
 
 def manage_mutate(args: Namespace) -> int:
@@ -302,6 +357,13 @@ def manage_mutate(args: Namespace) -> int:
 
     :spec: SPEC-MUTATION-02~1
     """
+    # Validate the parsed args up front (target exists / is .py / under src/,
+    # --max-files >= 1). A validation failure is a usage error, not advisory.
+    validation_error = MutateParser().validate_args(args)
+    if validation_error is not None:
+        print(f"ERROR: {validation_error}")
+        return 2
+
     targets, dropped = _resolve_targets(args)
 
     if dropped:
@@ -319,10 +381,12 @@ def manage_mutate(args: Namespace) -> int:
         return 0
 
     # Eligibility gate (skipped under --force). Ineligible targets are
-    # informational, not errors.
+    # informational, not errors. Auto-discovered targets are already filtered
+    # by _resolve_targets (pre_filtered=True), so we don't re-parse them; only
+    # an explicitly-named target (pre_filtered=False) is checked here.
     runnable: list[Path] = []
-    for target in targets:
-        if args.force:
+    for target, pre_filtered in targets:
+        if args.force or pre_filtered:
             runnable.append(target)
             continue
         eligible, reason = is_eligible_for_mutation(target)

--- a/src/claude_mpm/cli/executor.py
+++ b/src/claude_mpm/cli/executor.py
@@ -504,6 +504,13 @@ def execute_command(command: str, args) -> int:
 
         return run_session_report(args)
 
+    # Handle mutate command (advisory mutation testing) with lazy import
+    if command == "mutate":
+        from .commands.mutate import manage_mutate
+
+        result = manage_mutate(args)
+        return result if result is not None else 0
+
     # Map stable commands to their implementations
     command_map = {
         CLICommands.RUN.value: run_session,

--- a/src/claude_mpm/cli/executor.py
+++ b/src/claude_mpm/cli/executor.py
@@ -505,7 +505,7 @@ def execute_command(command: str, args) -> int:
         return run_session_report(args)
 
     # Handle mutate command (advisory mutation testing) with lazy import
-    if command == "mutate":
+    if command == CLICommands.MUTATE.value:
         from .commands.mutate import manage_mutate
 
         result = manage_mutate(args)

--- a/src/claude_mpm/cli/parsers/base_parser.py
+++ b/src/claude_mpm/cli/parsers/base_parser.py
@@ -737,6 +737,17 @@ def create_parser(
     except ImportError:
         pass
 
+    # Add mutate command parser
+    try:
+        from .mutate_parser import MutateParser
+
+        parser_obj = MutateParser()
+        mutate_p = subparsers.add_parser("mutate", help=parser_obj.help_text)
+        parser_obj.add_arguments(mutate_p)
+        mutate_p.set_defaults(command="mutate")
+    except ImportError:
+        pass
+
     # Add mpm-init command parser
     try:
         from .mpm_init_parser import add_mpm_init_subparser

--- a/src/claude_mpm/cli/parsers/mutate_parser.py
+++ b/src/claude_mpm/cli/parsers/mutate_parser.py
@@ -114,8 +114,11 @@ class MutateParser:
             metavar="N",
             default=None,
             help=(
-                "If set, exit 1 when survivors > N. If UNSET (default), the "
-                "command is purely advisory and ALWAYS exits 0."
+                "Survivor gate. --threshold 0 means zero survivors tolerated "
+                "(ANY survivor fails, exit 1); --threshold N exits 1 when "
+                "survivors > N. If UNSET (default), the command is purely "
+                "advisory and ALWAYS exits 0 (survivors are signal, not "
+                "failure)."
             ),
         )
         behavior_group.add_argument(

--- a/src/claude_mpm/cli/parsers/mutate_parser.py
+++ b/src/claude_mpm/cli/parsers/mutate_parser.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Mutate Parser
+=============
+
+WHAT: Define and validate the argument surface for the ``claude-mpm mutate``
+      CLI command — an advisory wrapper over the merged mutation runner that
+      scopes a mutmut run to a single eligible source file plus its test file.
+WHY:  Centralizes the CLI contract (target resolution, auto-discovery base,
+      exclude expression, advisory-by-default threshold, dry-run, output
+      format) so the executor and command handler share one validated shape,
+      mirroring the existing ``AnalyzeCodeParser`` inline-class pattern.
+
+References
+----------
+LINK: SPEC-MUTATION-02~1 : docs/specs/mutation.md#SPEC-MUTATION-02~1
+"""
+
+import argparse
+from pathlib import Path
+
+
+class MutateParser:
+    """Parser for the ``mutate`` command arguments.
+
+    WHAT: Configures the ``mutate`` subparser and validates the parsed
+          namespace (target must be an existing ``.py`` file under ``src/``;
+          ``--max-files`` must be >= 1).
+    WHY:  Keeps argument definition and validation next to each other and
+          consistent with the other CLI parsers so the command behaves
+          predictably and fails fast on bad input.
+    """
+
+    def __init__(self):
+        self.command_name = "mutate"
+        self.help_text = (
+            "Run advisory mutation testing on an eligible source file "
+            "(wraps the mutmut runner)"
+        )
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Add ``mutate``-specific arguments to the parser.
+
+        WHAT: Register the positional ``target`` plus the scope options
+              (``--tests-file``, ``--base``, ``--exclude-tests``,
+              ``--max-files``, ``--force``) and behavior options
+              (``--threshold``, ``--dry-run``, ``--output``).
+        WHY:  Grouping the flags into scope vs behavior keeps ``--help`` legible
+              and matches the command's two concerns: *what* to mutate and *how*
+              to report/gate. Defaults encode the advisory-by-default contract
+              (``--threshold`` unset, ``--max-files`` 1, ``--base`` origin/main).
+
+        Args:
+            parser: Argument parser to configure.
+
+        :spec: SPEC-MUTATION-02~1
+        """
+        parser.add_argument(
+            "target",
+            type=str,
+            nargs="?",
+            default=None,
+            help=(
+                "Optional .py file under src/ to mutate. If omitted, "
+                "auto-discover changed eligible files vs --base (git diff)."
+            ),
+        )
+
+        scope_group = parser.add_argument_group("scope options")
+        scope_group.add_argument(
+            "--tests-file",
+            type=str,
+            metavar="PATH",
+            default=None,
+            help=(
+                "Paired unit test file. If omitted, auto-infer from the "
+                "target module stem (tests/**/test_<stem>.py)."
+            ),
+        )
+        scope_group.add_argument(
+            "--base",
+            type=str,
+            metavar="BRANCH",
+            default="origin/main",
+            help="Base ref for auto-discovery (default: origin/main).",
+        )
+        scope_group.add_argument(
+            "--exclude-tests",
+            type=str,
+            metavar="EXPR",
+            default=None,
+            help=(
+                "pytest -k expression to drop slow suites (passed to the "
+                "runner, which validates it against shell-injection)."
+            ),
+        )
+        scope_group.add_argument(
+            "--max-files",
+            type=int,
+            metavar="N",
+            default=1,
+            help="Cap on auto-discovered targets (default: 1).",
+        )
+        scope_group.add_argument(
+            "--force",
+            action="store_true",
+            help="Bypass the eligibility heuristic (human override).",
+        )
+
+        behavior_group = parser.add_argument_group("behavior options")
+        behavior_group.add_argument(
+            "--threshold",
+            type=int,
+            metavar="N",
+            default=None,
+            help=(
+                "If set, exit 1 when survivors > N. If UNSET (default), the "
+                "command is purely advisory and ALWAYS exits 0."
+            ),
+        )
+        behavior_group.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print resolved scope + the would-run command, then exit 0.",
+        )
+        behavior_group.add_argument(
+            "--output",
+            choices=["text", "json"],
+            default="text",
+            help=(
+                "Output format (default: text). json emits "
+                "dataclasses.asdict(MutationResult)."
+            ),
+        )
+
+    def validate_args(self, args: argparse.Namespace) -> str | None:
+        """Validate parsed arguments.
+
+        Args:
+            args: Parsed arguments.
+
+        Returns:
+            Error message string if validation fails, ``None`` otherwise.
+        """
+        if args.target is not None:
+            target = Path(args.target)
+            if not target.exists():
+                return f"Target does not exist: {target}"
+            if target.suffix != ".py":
+                return f"Target must be a .py file: {target}"
+            # Must live under a src/ path component.
+            if "src" not in target.parts:
+                return f"Target must be under src/: {target}"
+
+        if args.max_files is not None and args.max_files < 1:
+            return "--max-files must be at least 1"
+
+        return None
+
+    def get_examples(self) -> list:
+        """Get usage examples.
+
+        Returns:
+            List of example command strings.
+        """
+        return [
+            "claude-mpm mutate",
+            "claude-mpm mutate src/claude_mpm/services/foo.py",
+            "claude-mpm mutate src/claude_mpm/services/foo.py "
+            "--tests-file tests/services/test_foo.py",
+            "claude-mpm mutate --base origin/main --max-files 3",
+            "claude-mpm mutate src/claude_mpm/services/foo.py --dry-run",
+            "claude-mpm mutate src/claude_mpm/services/foo.py --output json",
+            "claude-mpm mutate src/claude_mpm/services/foo.py --threshold 0",
+            "claude-mpm mutate src/claude_mpm/cli/commands/bar.py --force",
+        ]

--- a/src/claude_mpm/constants.py
+++ b/src/claude_mpm/constants.py
@@ -77,6 +77,7 @@ class CLICommands(StrEnum):
     AGGREGATE = "aggregate"
     ANALYZE = "analyze"
     ANALYZE_CODE = "analyze-code"
+    MUTATE = "mutate"
     CLEANUP = "cleanup-memory"
     MCP = "mcp"
     DOCTOR = "doctor"

--- a/tests/cli/commands/test_mutate.py
+++ b/tests/cli/commands/test_mutate.py
@@ -120,17 +120,20 @@ def test_eligibility_accepts_pure_logic_file(tmp_path):
 
 
 def test_changed_file_scanner_filters_to_existing_src_py(monkeypatch, tmp_path):
-    # Two src .py files (one exists, one does not), a non-src py, and a non-py.
+    # git diff emits repo-root-relative paths; existence is checked against the
+    # repo root (here stubbed to tmp_path), NOT the CWD.
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
+
     existing = tmp_path / "src" / "pkg" / "real.py"
     existing.parent.mkdir(parents=True)
     existing.write_text("x = 1\n")
 
     diff_output = "\n".join(
         [
-            str(existing),  # src + .py + exists  -> kept
+            "src/pkg/real.py",  # src + .py + exists  -> kept
             "src/pkg/missing.py",  # src + .py + NOT exists -> dropped
             "docs/notes.py",  # .py but not under src/ -> dropped
-            str(tmp_path / "src" / "pkg" / "data.txt"),  # not .py -> dropped
+            "src/pkg/data.txt",  # not .py -> dropped
         ]
     )
 
@@ -142,10 +145,12 @@ def test_changed_file_scanner_filters_to_existing_src_py(monkeypatch, tmp_path):
     monkeypatch.setattr(mutate_mod.subprocess, "run", lambda *a, **k: _Proc())
 
     result = get_changed_files_vs_main("origin/main")
-    assert result == [existing]
+    assert result == [Path("src/pkg/real.py")]
 
 
-def test_changed_file_scanner_returns_empty_on_git_failure(monkeypatch):
+def test_changed_file_scanner_returns_empty_on_git_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
+
     class _Proc:
         returncode = 1
         stdout = ""
@@ -161,7 +166,7 @@ def test_changed_file_scanner_returns_empty_on_git_failure(monkeypatch):
 
 
 def test_infer_tests_file_single_match(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
     tests_dir = tmp_path / "tests" / "services"
     tests_dir.mkdir(parents=True)
     test_file = tests_dir / "test_widget.py"
@@ -174,7 +179,7 @@ def test_infer_tests_file_single_match(monkeypatch, tmp_path):
 
 
 def test_infer_tests_file_no_match_errors(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
     (tmp_path / "tests").mkdir()
     target = Path("src/pkg/widget.py")
     inferred, err = infer_tests_file(target)
@@ -183,7 +188,7 @@ def test_infer_tests_file_no_match_errors(monkeypatch, tmp_path):
 
 
 def test_infer_tests_file_ambiguous_errors(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
     a = tmp_path / "tests" / "a"
     b = tmp_path / "tests" / "b"
     a.mkdir(parents=True)
@@ -335,6 +340,7 @@ def test_runner_error_exits_nonzero_even_when_advisory(monkeypatch, tmp_path):
 
 def test_max_files_truncation_is_reported(monkeypatch, tmp_path, capsys):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
     # Three eligible changed files, max_files=1 -> 2 dropped, must be noted.
     files = []
     for i in range(3):
@@ -359,3 +365,91 @@ def test_max_files_truncation_is_reported(monkeypatch, tmp_path, capsys):
     # 3 eligible - 1 cap = 2 dropped, surfaced (no silent capping).
     assert "2 additional eligible" in out
     assert "--max-files" in out
+
+
+# --------------------------------------------------------------------------- #
+# Argument validation (validate_args is wired into manage_mutate)
+# --------------------------------------------------------------------------- #
+
+
+def test_validation_nonexistent_target_errors(monkeypatch, tmp_path, capsys):
+    # A target under src/ that does not exist must be rejected up front with a
+    # non-zero exit code, never silently accepted.
+    missing = tmp_path / "src" / "pkg" / "ghost.py"
+
+    def _boom(*a, **k):
+        raise AssertionError("run_mutation must NOT run on a validation failure")
+
+    monkeypatch.setattr(mutate_mod, "run_mutation", _boom)
+
+    rc = manage_mutate(_args(target=str(missing)))
+    out = capsys.readouterr().out
+    assert rc != 0
+    assert "does not exist" in out.lower()
+
+
+def test_validation_max_files_zero_errors(monkeypatch, capsys):
+    # --max-files 0 is invalid (must be >= 1) and must fail, not silently cap.
+    def _boom(*a, **k):
+        raise AssertionError("run_mutation must NOT run on a validation failure")
+
+    monkeypatch.setattr(mutate_mod, "run_mutation", _boom)
+
+    rc = manage_mutate(_args(target=None, max_files=0))
+    out = capsys.readouterr().out
+    assert rc != 0
+    assert "--max-files" in out
+
+
+# --------------------------------------------------------------------------- #
+# Repo-root anchoring (works from a subdirectory, not just the repo root)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolution_anchored_to_repo_root_from_subdir(monkeypatch, tmp_path):
+    # Lay out a fake repo: src file changed vs base + its paired test file.
+    src_file = tmp_path / "src" / "pkg" / "widget.py"
+    src_file.parent.mkdir(parents=True)
+    src_file.write_text("def f(x):\n    return x + 1\n")
+    test_file = tmp_path / "tests" / "pkg" / "test_widget.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_f():\n    pass\n")
+
+    # The repo root is tmp_path; the CLI is invoked from a DEEP subdirectory.
+    monkeypatch.setattr(mutate_mod, "_repo_root", lambda: tmp_path)
+    subdir = tmp_path / "src" / "pkg" / "deep" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    # git diff emits repo-root-relative paths regardless of CWD.
+    class _Proc:
+        returncode = 0
+        stdout = "src/pkg/widget.py\n"
+        stderr = ""
+
+    monkeypatch.setattr(mutate_mod.subprocess, "run", lambda *a, **k: _Proc())
+
+    # Changed-file resolution still finds the file (existence anchored to root).
+    changed = get_changed_files_vs_main("origin/main")
+    assert changed == [Path("src/pkg/widget.py")]
+
+    # Test-file inference still finds the paired test (search anchored to root).
+    inferred, err = infer_tests_file(Path("src/pkg/widget.py"))
+    assert err is None
+    assert inferred == Path("tests/pkg/test_widget.py")
+
+
+def test_repo_root_raises_when_not_in_git_repo(monkeypatch):
+    # _repo_root must raise a clear RuntimeError when git can't find a repo.
+    class _Proc:
+        returncode = 128
+        stdout = ""
+        stderr = "fatal: not a git repository"
+
+    monkeypatch.setattr(mutate_mod.subprocess, "run", lambda *a, **k: _Proc())
+    try:
+        mutate_mod._repo_root()
+    except RuntimeError as exc:
+        assert "git" in str(exc).lower()
+    else:
+        raise AssertionError("_repo_root must raise RuntimeError on git failure")

--- a/tests/cli/commands/test_mutate.py
+++ b/tests/cli/commands/test_mutate.py
@@ -1,0 +1,361 @@
+"""Unit tests for the ``claude-mpm mutate`` command handler.
+
+WHAT: Exercise the eligibility heuristic, changed-file scanner, test-file
+      inference, dry-run, JSON output, threshold semantics, and --max-files
+      truncation in :mod:`claude_mpm.cli.commands.mutate`, with the real mutmut
+      runner, git, and subprocess calls fully stubbed.
+WHY:  The command is the cost gatekeeper and exit-code contract for mutation
+      testing; its decisions (skip/run, advisory vs gate) must be verified
+      without ever invoking real mutmut, which is slow and mutates source.
+
+References
+----------
+LINK: SPEC-MUTATION-02~1 : docs/specs/mutation.md#SPEC-MUTATION-02~1
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+from claude_mpm.cli.commands import mutate as mutate_mod
+from claude_mpm.cli.commands.mutate import (
+    get_changed_files_vs_main,
+    infer_tests_file,
+    is_eligible_for_mutation,
+    manage_mutate,
+)
+from claude_mpm.services.mutation.runner import MutantSurvivor, MutationResult
+
+
+def _args(**overrides) -> Namespace:
+    """Build a mutate Namespace with sensible defaults, overridable per test."""
+    defaults = {
+        "target": None,
+        "tests_file": None,
+        "base": "origin/main",
+        "exclude_tests": None,
+        "max_files": 1,
+        "force": False,
+        "threshold": None,
+        "dry_run": False,
+        "output": "text",
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def _result(survived: int = 0, error: str | None = None) -> MutationResult:
+    """Build a MutationResult with a controllable survivor count / error."""
+    survivors = [
+        MutantSurvivor(
+            id=i,
+            file="src/claude_mpm/foo.py",
+            line=10 + i,
+            original="x == 1",
+            mutant="x != 1",
+            mutation_type="boundary",
+        )
+        for i in range(survived)
+    ]
+    killed = 7
+    total = killed + survived
+    return MutationResult(
+        target_file="src/claude_mpm/foo.py",
+        tests_file="tests/test_foo.py",
+        total_mutants=total,
+        killed=killed,
+        survived=survived,
+        kill_rate=(killed / total) if total else 0.0,
+        survivors=survivors,
+        error=error,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Eligibility heuristic
+# --------------------------------------------------------------------------- #
+
+
+def test_eligibility_rejects_init_py(tmp_path):
+    init = tmp_path / "__init__.py"
+    init.write_text("x = 1\n")
+    eligible, reason = is_eligible_for_mutation(init)
+    assert eligible is False
+    assert "__init__" in reason
+
+
+def test_eligibility_rejects_cli_path(tmp_path):
+    cli_file = tmp_path / "cli" / "thing.py"
+    cli_file.parent.mkdir(parents=True)
+    cli_file.write_text("def f():\n    return 1\n")
+    eligible, reason = is_eligible_for_mutation(cli_file)
+    assert eligible is False
+    assert "cli" in reason
+
+
+def test_eligibility_rejects_asyncio_import_and_names_it(tmp_path):
+    mod = tmp_path / "service.py"
+    mod.write_text("import asyncio\n\n\ndef f():\n    return 1\n")
+    eligible, reason = is_eligible_for_mutation(mod)
+    assert eligible is False
+    # The rejection reason must NAME the triggering import.
+    assert "asyncio" in reason
+
+
+def test_eligibility_accepts_pure_logic_file(tmp_path):
+    mod = tmp_path / "pure.py"
+    mod.write_text(
+        "def classify(x):\n    if x > 0:\n        return 'pos'\n    return 'nonpos'\n"
+    )
+    eligible, reason = is_eligible_for_mutation(mod)
+    assert eligible is True
+    assert reason == "eligible"
+
+
+# --------------------------------------------------------------------------- #
+# Changed-file scanner
+# --------------------------------------------------------------------------- #
+
+
+def test_changed_file_scanner_filters_to_existing_src_py(monkeypatch, tmp_path):
+    # Two src .py files (one exists, one does not), a non-src py, and a non-py.
+    existing = tmp_path / "src" / "pkg" / "real.py"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("x = 1\n")
+
+    diff_output = "\n".join(
+        [
+            str(existing),  # src + .py + exists  -> kept
+            "src/pkg/missing.py",  # src + .py + NOT exists -> dropped
+            "docs/notes.py",  # .py but not under src/ -> dropped
+            str(tmp_path / "src" / "pkg" / "data.txt"),  # not .py -> dropped
+        ]
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = diff_output
+        stderr = ""
+
+    monkeypatch.setattr(mutate_mod.subprocess, "run", lambda *a, **k: _Proc())
+
+    result = get_changed_files_vs_main("origin/main")
+    assert result == [existing]
+
+
+def test_changed_file_scanner_returns_empty_on_git_failure(monkeypatch):
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "fatal: bad revision"
+
+    monkeypatch.setattr(mutate_mod.subprocess, "run", lambda *a, **k: _Proc())
+    assert get_changed_files_vs_main("origin/main") == []
+
+
+# --------------------------------------------------------------------------- #
+# Test-file inference
+# --------------------------------------------------------------------------- #
+
+
+def test_infer_tests_file_single_match(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    tests_dir = tmp_path / "tests" / "services"
+    tests_dir.mkdir(parents=True)
+    test_file = tests_dir / "test_widget.py"
+    test_file.write_text("def test_x():\n    pass\n")
+
+    target = Path("src/pkg/widget.py")
+    inferred, err = infer_tests_file(target)
+    assert err is None
+    assert inferred == Path("tests/services/test_widget.py")
+
+
+def test_infer_tests_file_no_match_errors(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    target = Path("src/pkg/widget.py")
+    inferred, err = infer_tests_file(target)
+    assert inferred is None
+    assert "--tests-file" in err
+
+
+def test_infer_tests_file_ambiguous_errors(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    a = tmp_path / "tests" / "a"
+    b = tmp_path / "tests" / "b"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    (a / "test_widget.py").write_text("")
+    (b / "test_widget.py").write_text("")
+
+    target = Path("src/pkg/widget.py")
+    inferred, err = infer_tests_file(target)
+    assert inferred is None
+    assert "ambiguous" in err.lower()
+    assert "--tests-file" in err
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_prints_command_and_does_not_invoke_runner(
+    monkeypatch, tmp_path, capsys
+):
+    target = tmp_path / "src" / "pkg" / "pure.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def f(x):\n    return x + 1\n")
+    tests_file = tmp_path / "tests" / "test_pure.py"
+    tests_file.parent.mkdir(parents=True)
+    tests_file.write_text("def test_f():\n    pass\n")
+
+    called = {"run": False}
+
+    def _boom(*a, **k):
+        called["run"] = True
+        raise AssertionError("run_mutation must NOT be called on --dry-run")
+
+    monkeypatch.setattr(mutate_mod, "run_mutation", _boom)
+
+    rc = manage_mutate(
+        _args(target=str(target), tests_file=str(tests_file), dry_run=True)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert called["run"] is False
+    assert "mutmut run" in out
+    assert "--paths-to-mutate" in out
+
+
+# --------------------------------------------------------------------------- #
+# --output json
+# --------------------------------------------------------------------------- #
+
+
+def test_output_json_is_valid_and_has_result_fields(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "src" / "pkg" / "pure.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def f(x):\n    return x + 1\n")
+    tests_file = tmp_path / "tests" / "test_pure.py"
+    tests_file.parent.mkdir(parents=True)
+    tests_file.write_text("def test_f():\n    pass\n")
+
+    monkeypatch.setattr(mutate_mod, "run_mutation", lambda *a, **k: _result(survived=2))
+
+    rc = manage_mutate(
+        _args(target=str(target), tests_file=str(tests_file), output="json")
+    )
+    out = capsys.readouterr().out
+    assert rc == 0  # advisory: no threshold
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+    entry = payload[0]
+    for field in (
+        "target_file",
+        "tests_file",
+        "total_mutants",
+        "killed",
+        "survived",
+        "kill_rate",
+        "survivors",
+        "error",
+    ):
+        assert field in entry
+    assert entry["survived"] == 2
+    assert entry["survivors"][0]["mutation_type"] == "boundary"
+
+
+# --------------------------------------------------------------------------- #
+# Threshold semantics
+# --------------------------------------------------------------------------- #
+
+
+def _run_with_survivors(monkeypatch, tmp_path, *, survived, threshold):
+    target = tmp_path / "src" / "pkg" / "pure.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def f(x):\n    return x + 1\n")
+    tests_file = tmp_path / "tests" / "test_pure.py"
+    tests_file.parent.mkdir(parents=True)
+    tests_file.write_text("def test_f():\n    pass\n")
+
+    monkeypatch.setattr(
+        mutate_mod, "run_mutation", lambda *a, **k: _result(survived=survived)
+    )
+    return manage_mutate(
+        _args(
+            target=str(target),
+            tests_file=str(tests_file),
+            threshold=threshold,
+        )
+    )
+
+
+def test_threshold_unset_is_advisory_exit_zero(monkeypatch, tmp_path):
+    rc = _run_with_survivors(monkeypatch, tmp_path, survived=3, threshold=None)
+    assert rc == 0
+
+
+def test_threshold_zero_with_survivors_exits_one(monkeypatch, tmp_path):
+    rc = _run_with_survivors(monkeypatch, tmp_path, survived=2, threshold=0)
+    assert rc == 1
+
+
+def test_threshold_above_survivors_exits_zero(monkeypatch, tmp_path):
+    rc = _run_with_survivors(monkeypatch, tmp_path, survived=3, threshold=5)
+    assert rc == 0
+
+
+def test_runner_error_exits_nonzero_even_when_advisory(monkeypatch, tmp_path):
+    target = tmp_path / "src" / "pkg" / "pure.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def f(x):\n    return x + 1\n")
+    tests_file = tmp_path / "tests" / "test_pure.py"
+    tests_file.parent.mkdir(parents=True)
+    tests_file.write_text("def test_f():\n    pass\n")
+
+    monkeypatch.setattr(
+        mutate_mod,
+        "run_mutation",
+        lambda *a, **k: _result(error="mutmut blew up"),
+    )
+    rc = manage_mutate(
+        _args(target=str(target), tests_file=str(tests_file), threshold=None)
+    )
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------- #
+# --max-files truncation
+# --------------------------------------------------------------------------- #
+
+
+def test_max_files_truncation_is_reported(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    # Three eligible changed files, max_files=1 -> 2 dropped, must be noted.
+    files = []
+    for i in range(3):
+        f = tmp_path / "src" / "pkg" / f"mod{i}.py"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("def f(x):\n    return x + 1\n")
+        files.append(f)
+
+    monkeypatch.setattr(
+        mutate_mod, "get_changed_files_vs_main", lambda base: list(files)
+    )
+    # Provide a matching test file so inference succeeds for the single target.
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "test_mod0.py").write_text("def test():\n    pass\n")
+
+    monkeypatch.setattr(mutate_mod, "run_mutation", lambda *a, **k: _result(survived=0))
+
+    rc = manage_mutate(_args(target=None, max_files=1))
+    out = capsys.readouterr().out
+    assert rc == 0
+    # 3 eligible - 1 cap = 2 dropped, surfaced (no silent capping).
+    assert "2 additional eligible" in out
+    assert "--max-files" in out


### PR DESCRIPTION
## Summary

Phase 1b of the mutation testing framework: the `claude-mpm mutate` CLI command. It is a thin, advisory wrapper over the **already-merged** Phase 1 core runner (PR #854, `src/claude_mpm/services/mutation/runner.py`). The command **imports and uses** `run_mutation(target, tests_file, exclude_tests) -> MutationResult` — it does not reimplement any mutation logic.

Closes #855

## What this slice adds

- **Eligibility heuristic** (`is_eligible_for_mutation`) — rejects `__init__.py`, paths under `tests/`/`cli/`/`scripts/`/`migrations/`/dashboard, and modules whose top-level imports are I/O-heavy (`subprocess`, `asyncio`, `aiohttp`, `httpx`, `sqlalchemy`, `fastapi`, `click`, `socket`, `paramiko`, `boto3`). The rejection reason **names the triggering import** so the engineer knows whether `--force` is warranted.
- **Changed-file scoping** (`get_changed_files_vs_main`) — auto-discovers changed eligible `.py` files under `src/` via `git diff --name-only <base>...HEAD` (default base `origin/main`), capped by `--max-files` (default 1) with **explicit truncation reporting** — no silent capping.
- **Test-file inference** (`infer_tests_file`) — unique `tests/**/test_<stem>.py` match, clear error on zero/ambiguous.
- **Structured output** — `--output text` (summary + per-survivor `file:line  original→mutant  [type]`) or `--output json` (`dataclasses.asdict(MutationResult)`).
- **Advisory-by-default threshold** — no `--threshold` ⇒ always exit 0. `--threshold N` ⇒ exit 1 when any result's survivors exceed N. A runner `error` always exits non-zero.
- **`--dry-run`** — prints resolved scope + the would-run mutmut command, exits 0, never invokes mutmut.

## Files (7)

| File | Change |
|------|--------|
| `src/claude_mpm/constants.py` | add `MUTATE` to `CLICommands` |
| `src/claude_mpm/cli/parsers/mutate_parser.py` | new parser (inline-class pattern) |
| `src/claude_mpm/cli/parsers/base_parser.py` | register `mutate` subparser |
| `src/claude_mpm/cli/executor.py` | lazy-import dispatch (experimental tier) |
| `src/claude_mpm/cli/commands/mutate.py` | `manage_mutate(args)` |
| `tests/cli/commands/test_mutate.py` | 16 unit tests (runner/git/subprocess stubbed) |
| `docs/specs/mutation.md` | **SLD spec** declaring `SPEC-MUTATION-01~1`/`02~1` |

> **Note on the 7th file:** the task scoped 6 files. The repo's active Spec-Linked-Documentation CI gate (`tests/test_spec_traceability.py`) was already failing on `main` because the merged runner references `SPEC-MUTATION-01~1` with no declaring spec doc. `docs/specs/mutation.md` declares that spec (plus `SPEC-MUTATION-02~1` for the CLI), resolving the orphaned references for the whole subsystem and keeping CI green.

## Tests

`uv run pytest tests/cli/commands/test_mutate.py -p no:xdist` → **16 passed**. SLD gates (`test_spec_traceability.py`, `test_wwl_granularity.py`) pass.

## Smoke tests

`uv run claude-mpm mutate --help`:

```
usage: claude-mpm mutate [-h] [--tests-file PATH] [--base BRANCH]
                         [--exclude-tests EXPR] [--max-files N] [--force]
                         [--threshold N] [--dry-run] [--output {text,json}]
                         [target]

positional arguments:
  target                Optional .py file under src/ to mutate. If omitted,
                        auto-discover changed eligible files vs --base (git diff).

behavior options:
  --threshold N         If set, exit 1 when survivors > N. If UNSET (default),
                        the command is purely advisory and ALWAYS exits 0.
  --dry-run             Print resolved scope + the would-run command, then exit 0.
  --output {text,json}  Output format (default: text). json emits
                        dataclasses.asdict(MutationResult).
```

`uv run claude-mpm mutate src/claude_mpm/services/trusty_search_allowlist.py --tests-file tests/services/test_trusty_search_allowlist.py --dry-run`:

```
Dry run — resolved scope (mutmut NOT executed):

Target: src/claude_mpm/services/trusty_search_allowlist.py
  Tests: tests/services/test_trusty_search_allowlist.py
  Would run: uv run mutmut run --paths-to-mutate=src/claude_mpm/services/trusty_search_allowlist.py --tests-dir=tests/services
```

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)