### PR TITLE
feat: stamp X-MPM-Version git trailer on every MPM-authored commit

### DIFF
--- a/src/claude_mpm/hooks/commit_cost_tracker.py
+++ b/src/claude_mpm/hooks/commit_cost_tracker.py
@@ -64,6 +64,18 @@ from claude_mpm.hooks.transcript_usage import (
     parse_transcript_usage,
 )
 
+# Module-level resolution of the installed claude-mpm version (issue #859).
+# Resolved once at import time so the code path that reads it is explicit and
+# directly patchable in tests (patch commit_cost_tracker._MPM_VERSION).  No
+# circular-import risk: this module is a submodule of claude_mpm, so the package
+# __init__ (which defines __version__) is already fully loaded by the time this
+# import runs.  Any failure degrades to None → the trailer is omitted, never a
+# crash.
+try:
+    from claude_mpm import __version__ as _MPM_VERSION
+except Exception:  # pragma: no cover - defensive
+    _MPM_VERSION = None
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -118,6 +130,12 @@ _COAUTHORED_CANONICAL_RE = re.compile(
 # Matches lines like "X-AI-Tokens-In: 123" or "X-AI-Model: claude-opus-4-8".
 # The pattern anchors at line start (MULTILINE) and matches any content on the
 # line.  Using .*  rather than [^\n]+ to ensure blank-value lines are stripped.
+#
+# NOTE: This regex covers ONLY the X-AI-* trailers.  The other two trailer
+# families this hook manages — X-MPM-Version and Co-Authored-By — are NOT
+# stripped here; they are stripped line-by-line inside amend_commit_message()'s
+# normalisation loop (see the re.match guards there).  All trailer-stripping for
+# idempotent re-amend therefore lives in that loop, not in this regex.
 _XAI_TRAILER_RE = re.compile(r"^X-AI-[A-Za-z-]+:.*$", re.MULTILINE)
 
 # Git trailer key recording the installed claude-mpm version (issue #859).
@@ -492,25 +510,19 @@ def _get_mpm_version() -> str | None:
     never crash the hook: on any failure we return None and the caller omits the
     trailer rather than emitting a malformed line.
 
-    WHAT: Reads ``claude_mpm.__version__`` — the VERSION-file single source of
-    truth for this project (the same source ``cli/startup._get_package_version``
-    uses).  Returns the stripped version string, or None when the import fails
-    or the value is empty.
+    WHAT: Reads the module-level ``_MPM_VERSION`` (resolved once at import time
+    from ``claude_mpm.__version__`` — the VERSION-file single source of truth,
+    the same source ``cli/startup._get_package_version`` uses).  Returns the
+    stripped version string, or None when the value is unset or empty.
 
-    TEST: Patch the resolver to return a known version and assert the trailer
-    equals it; patch it to return None and assert no X-MPM-Version line appears
-    and the hook does not raise.
+    TEST: Patch ``_MPM_VERSION`` to a known value and assert the trailer equals
+    it; patch it to None/empty and assert no X-MPM-Version line appears and the
+    hook does not raise.
 
     :spec: N/A
     """
-    try:
-        from claude_mpm import __version__
-
-        version = (__version__ or "").strip()
-        return version or None
-    except Exception as exc:  # pragma: no cover - defensive
-        _debug(f"_get_mpm_version: could not resolve version: {exc}")
-        return None
+    version = (_MPM_VERSION or "").strip()
+    return version or None
 
 
 def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> None:

--- a/src/claude_mpm/hooks/commit_cost_tracker.py
+++ b/src/claude_mpm/hooks/commit_cost_tracker.py
@@ -38,6 +38,12 @@ DESIGN DECISIONS:
 - ZERO-SKIP (fix for #696): When the resolved delta is still 0/0 after all
   fallbacks, the X-AI-Tokens-In / X-AI-Tokens-Out trailers are omitted entirely
   rather than emitting useless zeros.
+- VERSION STAMP (issue #859): X-MPM-Version records the installed claude-mpm
+  version on EVERY commit the hook processes, including zero-delta commits.
+  Unlike the token trailers it is NOT gated on a non-empty delta, so a commit
+  with no token activity is still stamped.  The value comes from
+  claude_mpm.__version__ (the VERSION-file single source of truth); if it cannot
+  be resolved the trailer is omitted rather than crashing the hook.
 """
 
 from __future__ import annotations
@@ -113,6 +119,12 @@ _COAUTHORED_CANONICAL_RE = re.compile(
 # The pattern anchors at line start (MULTILINE) and matches any content on the
 # line.  Using .*  rather than [^\n]+ to ensure blank-value lines are stripped.
 _XAI_TRAILER_RE = re.compile(r"^X-AI-[A-Za-z-]+:.*$", re.MULTILINE)
+
+# Git trailer key recording the installed claude-mpm version (issue #859).
+# Stamped on EVERY commit the hook processes, decoupled from the token-delta
+# gate.  Stripped on re-amend (alongside the X-AI-* / Co-Authored-By lines) so
+# it is never duplicated.
+_MPM_VERSION_TRAILER_KEY = "X-MPM-Version"
 
 # Regex to extract the short SHA from a successful `git commit` output.
 # Example: "[main abc1234] Add feature"
@@ -471,6 +483,36 @@ def _format_models_trailer(model_delta: dict[str, dict[str, int]]) -> str | None
     return "; ".join(parts)
 
 
+def _get_mpm_version() -> str | None:
+    """Return the installed claude-mpm version string, or None on failure.
+
+    WHY: Every commit the hook processes should record which claude-mpm version
+    produced it (issue #859) so commits are self-documenting for provenance and
+    so behavior changes can be correlated with MPM releases.  Resolution must
+    never crash the hook: on any failure we return None and the caller omits the
+    trailer rather than emitting a malformed line.
+
+    WHAT: Reads ``claude_mpm.__version__`` — the VERSION-file single source of
+    truth for this project (the same source ``cli/startup._get_package_version``
+    uses).  Returns the stripped version string, or None when the import fails
+    or the value is empty.
+
+    TEST: Patch the resolver to return a known version and assert the trailer
+    equals it; patch it to return None and assert no X-MPM-Version line appears
+    and the hook does not raise.
+
+    :spec: N/A
+    """
+    try:
+        from claude_mpm import __version__
+
+        version = (__version__ or "").strip()
+        return version or None
+    except Exception as exc:  # pragma: no cover - defensive
+        _debug(f"_get_mpm_version: could not resolve version: {exc}")
+        return None
+
+
 def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> None:
     """Amend the latest commit to add token trailers and normalise Co-Authored-By.
 
@@ -478,14 +520,17 @@ def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> No
     1. Retrieve current commit message via ``git log``.
     2. Strip any generic Co-Authored-By: Claude (not MPM) lines.
     3. Ensure exactly one canonical Co-Authored-By: Claude MPM trailer.
-    4. Append X-AI-Tokens-In, X-AI-Tokens-Out, and model trailers.
+    4. Append X-AI-Tokens-In, X-AI-Tokens-Out, and model trailers (token trailers
+       gated on a non-empty delta), then ALWAYS append X-MPM-Version (issue #859).
     5. Amend commit with ``git commit --amend --no-edit -m <msg> --no-verify``.
 
     WHY: Decorates every commit with token usage so teams can audit AI cost per
-    commit without separate tooling.
+    commit without separate tooling, and records the installed claude-mpm
+    version on every commit (including zero-delta commits) for provenance.
 
-    WHAT: Retrieves the commit message, strips old X-AI-* and Co-Authored-By
-    trailers, then appends fresh trailers from *delta*.
+    WHAT: Retrieves the commit message, strips old X-AI-*, X-MPM-Version, and
+    Co-Authored-By trailers, then appends fresh trailers from *delta* plus the
+    resolved claude-mpm version.
 
     TEST: Mock subprocess.run to return a known commit message, call
     amend_commit_message(), assert the amended message contains X-AI-Tokens-In
@@ -530,6 +575,9 @@ def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> No
             # Skip any line that is an X-AI-* trailer.
             if re.match(r"^X-AI-[A-Za-z-]+:", stripped_line):
                 continue
+            # Skip any existing X-MPM-Version trailer (idempotency for re-amend).
+            if re.match(rf"^{re.escape(_MPM_VERSION_TRAILER_KEY)}:", stripped_line):
+                continue
             # Skip any Co-Authored-By: Claude ... trailer (canonical or generic).
             if re.match(r"^Co-Authored-By:\s+Claude\b", stripped_line, re.IGNORECASE):
                 continue
@@ -573,6 +621,19 @@ def amend_commit_message(commit_sha: str, delta: dict[str, Any], cwd: str) -> No
             trailers.append(f"X-AI-Model: {primary_model}")
         if models_trailer:
             trailers.append(f"X-AI-Models: {models_trailer}")
+
+        # X-MPM-Version (issue #859): stamped on EVERY commit, decoupled from the
+        # token-delta gate above — present even when the X-AI-* trailers are
+        # omitted (zero-delta commit).  Omitted only when the version cannot be
+        # resolved, so the trailer is never malformed.
+        mpm_version = _get_mpm_version()
+        if mpm_version:
+            trailers.append(f"{_MPM_VERSION_TRAILER_KEY}: {mpm_version}")
+        else:
+            _debug(
+                "amend_commit_message: skipping X-MPM-Version trailer "
+                "— claude-mpm version could not be resolved"
+            )
 
         new_msg = "\n".join(normalised_lines + trailers)
 

--- a/tests/test_commit_cost_tracker.py
+++ b/tests/test_commit_cost_tracker.py
@@ -1400,36 +1400,55 @@ _VERSION_RESOLVER = "claude_mpm.hooks.commit_cost_tracker._get_mpm_version"
 
 
 class TestGetMpmVersion:
-    """Tests for the _get_mpm_version() resolver."""
+    """Tests for the _get_mpm_version() resolver.
+
+    The resolver reads the module-level ``_MPM_VERSION`` (resolved once at import
+    time), so these tests patch that exact name — patching ``claude_mpm.__version__``
+    would be VACUOUS because the resolver never re-imports it.
+    """
 
     def test_returns_package_version(self) -> None:
-        """Resolver returns the claude_mpm.__version__ value (stripped)."""
-        with patch("claude_mpm.__version__", "9.9.9"):
+        """Resolver returns the module-level _MPM_VERSION value (stripped)."""
+        with patch("claude_mpm.hooks.commit_cost_tracker._MPM_VERSION", "9.9.9"):
             assert _get_mpm_version() == "9.9.9"
 
     def test_strips_whitespace(self) -> None:
         """Surrounding whitespace in the version string is stripped."""
-        with patch("claude_mpm.__version__", "  6.5.44\n"):
+        with patch("claude_mpm.hooks.commit_cost_tracker._MPM_VERSION", "  6.5.44\n"):
             assert _get_mpm_version() == "6.5.44"
 
     def test_empty_version_returns_none(self) -> None:
         """An empty/whitespace version resolves to None (no malformed trailer)."""
-        with patch("claude_mpm.__version__", "   "):
+        with patch("claude_mpm.hooks.commit_cost_tracker._MPM_VERSION", "   "):
             assert _get_mpm_version() is None
 
-    def test_import_failure_returns_none(self) -> None:
-        """If reading the version raises, the resolver returns None (no crash)."""
-        # Simulate the version attribute being unavailable: with __version__
-        # removed, the ``from claude_mpm import __version__`` inside
-        # _get_mpm_version raises ImportError, which the resolver swallows → None.
-        import claude_mpm as _pkg
+    def test_none_version_returns_none(self) -> None:
+        """If _MPM_VERSION is None (import-time failure), resolver returns None.
 
-        original = _pkg.__version__
-        try:
-            del _pkg.__version__
+        This is the equivalent of the old ``test_import_failure_returns_none``
+        under the module-level import: when the import at module load fails,
+        ``_MPM_VERSION`` is None and the resolver must degrade to None (no crash,
+        trailer omitted) rather than raising.
+        """
+        with patch("claude_mpm.hooks.commit_cost_tracker._MPM_VERSION", None):
             assert _get_mpm_version() is None
-        finally:
-            _pkg.__version__ = original
+
+    def test_module_level_import_path_is_clean(self) -> None:
+        """The module-level import that feeds _MPM_VERSION must not have failed.
+
+        Guards against an import-time circular-import regression: if importing
+        ``claude_mpm.__version__`` at module load had blown up, _MPM_VERSION would
+        be None even though the real package exposes a version.  Re-import the
+        module fresh and assert it resolved a non-empty string.
+        """
+        import importlib
+
+        import claude_mpm
+        from claude_mpm.hooks import commit_cost_tracker as cct
+
+        importlib.reload(cct)
+        assert claude_mpm.__version__ == cct._MPM_VERSION
+        assert isinstance(cct._MPM_VERSION, str) and cct._MPM_VERSION.strip()
 
 
 class TestMpmVersionTrailer:
@@ -1463,9 +1482,24 @@ class TestMpmVersionTrailer:
         return r
 
     def _amend_msg(self, mock_run: MagicMock) -> str:
-        """Extract the -m message from the amend (2nd) subprocess call."""
-        amend_call = mock_run.call_args_list[1]
-        argv = amend_call[0][0]
+        """Extract the -m message from the git --amend subprocess call.
+
+        Finds the call whose argv contains ``--amend`` (asserting exactly one)
+        rather than hard-coding ``call_args_list[1]`` — so a future preflight
+        subprocess call inserted before the amend cannot silently shift the
+        index and make this helper read the wrong call.
+        """
+        amend_argvs = [
+            call[0][0]
+            for call in mock_run.call_args_list
+            if call[0]
+            and isinstance(call[0][0], (list, tuple))
+            and "--amend" in call[0][0]
+        ]
+        assert len(amend_argvs) == 1, (
+            f"expected exactly one git --amend call, found {len(amend_argvs)}"
+        )
+        argv = amend_argvs[0]
         return argv[argv.index("-m") + 1]
 
     def test_version_present_with_token_delta(self) -> None:

--- a/tests/test_commit_cost_tracker.py
+++ b/tests/test_commit_cost_tracker.py
@@ -39,7 +39,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from claude_mpm.hooks.commit_cost_tracker import (
     _COAUTHORED_CANONICAL,
+    _MPM_VERSION_TRAILER_KEY,
     _append_jsonl_atomic,
+    _get_mpm_version,
     _read_json_safe,
     _write_json_atomic,
     amend_commit_message,
@@ -1388,3 +1390,253 @@ class TestRunAsGitHookWorktreeFallback:
 
         mock_resolve.assert_not_called()
         assert mock_delta.call_args[0][0] == str(project_root)
+
+
+# ---------------------------------------------------------------------------
+# Issue #859: X-MPM-Version trailer — stamped on EVERY commit (incl. zero-delta)
+# ---------------------------------------------------------------------------
+
+_VERSION_RESOLVER = "claude_mpm.hooks.commit_cost_tracker._get_mpm_version"
+
+
+class TestGetMpmVersion:
+    """Tests for the _get_mpm_version() resolver."""
+
+    def test_returns_package_version(self) -> None:
+        """Resolver returns the claude_mpm.__version__ value (stripped)."""
+        with patch("claude_mpm.__version__", "9.9.9"):
+            assert _get_mpm_version() == "9.9.9"
+
+    def test_strips_whitespace(self) -> None:
+        """Surrounding whitespace in the version string is stripped."""
+        with patch("claude_mpm.__version__", "  6.5.44\n"):
+            assert _get_mpm_version() == "6.5.44"
+
+    def test_empty_version_returns_none(self) -> None:
+        """An empty/whitespace version resolves to None (no malformed trailer)."""
+        with patch("claude_mpm.__version__", "   "):
+            assert _get_mpm_version() is None
+
+    def test_import_failure_returns_none(self) -> None:
+        """If reading the version raises, the resolver returns None (no crash)."""
+        # Simulate the version attribute being unavailable: with __version__
+        # removed, the ``from claude_mpm import __version__`` inside
+        # _get_mpm_version raises ImportError, which the resolver swallows → None.
+        import claude_mpm as _pkg
+
+        original = _pkg.__version__
+        try:
+            del _pkg.__version__
+            assert _get_mpm_version() is None
+        finally:
+            _pkg.__version__ = original
+
+
+class TestMpmVersionTrailer:
+    """Verify amend_commit_message stamps X-MPM-Version on every commit (#859)."""
+
+    _DELTA = {
+        "input_tokens": 500,
+        "output_tokens": 100,
+        "models": {},
+    }
+    _ZERO_DELTA = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "models": {},
+    }
+
+    def _make_log_result(self, message: str) -> MagicMock:
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = message
+        r.stderr = ""
+        return r
+
+    def _make_amend_result(self) -> MagicMock:
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = ""
+        r.stderr = ""
+        return r
+
+    def _amend_msg(self, mock_run: MagicMock) -> str:
+        """Extract the -m message from the amend (2nd) subprocess call."""
+        amend_call = mock_run.call_args_list[1]
+        argv = amend_call[0][0]
+        return argv[argv.index("-m") + 1]
+
+    def test_version_present_with_token_delta(self) -> None:
+        """X-MPM-Version appears alongside the X-AI-* trailers (non-zero delta)."""
+        with (
+            patch(_VERSION_RESOLVER, return_value="6.5.44"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result("feat: add something\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", self._DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert "X-AI-Tokens-In: 500" in new_msg
+        assert "X-MPM-Version: 6.5.44" in new_msg
+        # Placement: version trailer comes after the token trailers.
+        assert new_msg.index("X-AI-Tokens-In") < new_msg.index("X-MPM-Version")
+
+    def test_version_present_when_delta_is_zero(self) -> None:
+        """THE KEY BEHAVIOR (#859): zero-delta commit is still version-stamped.
+
+        Even though X-AI-Tokens-In / X-AI-Tokens-Out are omitted for a 0/0
+        delta, X-MPM-Version must still be present.
+        """
+        with (
+            patch(_VERSION_RESOLVER, return_value="6.5.44"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result("chore: no-op change\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", self._ZERO_DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert "X-AI-Tokens-In:" not in new_msg, "token trailers omitted on 0 delta"
+        assert "X-AI-Tokens-Out:" not in new_msg
+        assert "X-MPM-Version: 6.5.44" in new_msg, (
+            "X-MPM-Version must be stamped even when the token delta is 0/0"
+        )
+        # Co-Authored-By must still be present too.
+        assert _COAUTHORED_CANONICAL in new_msg
+
+    def test_version_value_equals_resolved_version(self) -> None:
+        """The trailer value equals whatever the resolver returns (mocked)."""
+        with (
+            patch(_VERSION_RESOLVER, return_value="1.2.3-rc1"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result("fix: bug\n"),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", self._ZERO_DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert f"{_MPM_VERSION_TRAILER_KEY}: 1.2.3-rc1" in new_msg
+
+    def test_version_not_duplicated_on_reamend(self) -> None:
+        """Idempotency: a message already carrying X-MPM-Version is not doubled."""
+        original = f"feat: thing\n\n{_COAUTHORED_CANONICAL}\nX-MPM-Version: 6.5.44\n"
+        with (
+            patch(_VERSION_RESOLVER, return_value="6.5.44"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result(original),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", self._ZERO_DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert new_msg.count("X-MPM-Version:") == 1, (
+            "X-MPM-Version must appear exactly once after re-amend"
+        )
+
+    def test_stale_version_replaced_on_reamend(self) -> None:
+        """Idempotency: an old version value is replaced, not kept alongside."""
+        original = "feat: thing\n\nX-MPM-Version: 6.0.0\n"
+        with (
+            patch(_VERSION_RESOLVER, return_value="6.5.44"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result(original),
+                self._make_amend_result(),
+            ]
+            amend_commit_message("abc1234", self._ZERO_DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert "X-MPM-Version: 6.0.0" not in new_msg, "stale version must be removed"
+        assert "X-MPM-Version: 6.5.44" in new_msg
+        assert new_msg.count("X-MPM-Version:") == 1
+
+    def test_version_resolution_failure_omits_trailer(self) -> None:
+        """Graceful degradation: resolver returns None → no trailer, no crash."""
+        with (
+            patch(_VERSION_RESOLVER, return_value=None),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                self._make_log_result("docs: update\n"),
+                self._make_amend_result(),
+            ]
+            # Must not raise.
+            amend_commit_message("abc1234", self._ZERO_DELTA, "/tmp")
+
+        new_msg = self._amend_msg(mock_run)
+        assert "X-MPM-Version" not in new_msg, (
+            "no X-MPM-Version line when the version cannot be resolved"
+        )
+        # And no malformed (value-less) trailer either.
+        assert "X-MPM-Version:" not in new_msg
+
+    def test_trailer_is_git_interpret_parseable(self, tmp_path: Path) -> None:
+        """Integration: the stamped trailer is recognised by git interpret-trailers.
+
+        Builds the amended message via a real (non-mocked) git repo so we prove
+        end-to-end that a zero-delta commit gets X-MPM-Version and that
+        ``git interpret-trailers --parse`` recognises it as a trailer.
+        """
+        import subprocess as real_subprocess
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@e.x",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@e.x",
+            # Prevent our own post-commit hook from re-entering during the amend.
+            "CLAUDE_MPM_COMMIT_COST_RUNNING": "1",
+        }
+
+        def _git(*args: str) -> real_subprocess.CompletedProcess:
+            return real_subprocess.run(
+                ["git", *args],
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            )
+
+        _git("init", "-q")
+        (repo / "f.txt").write_text("hello\n")
+        _git("add", "f.txt")
+        _git("commit", "-q", "-m", "chore: initial")
+
+        sha = _git("rev-parse", "--short", "HEAD").stdout.strip()
+
+        with patch(_VERSION_RESOLVER, return_value="6.5.44"):
+            amend_commit_message(sha, self._ZERO_DELTA, str(repo))
+
+        amended = _git("log", "-1", "--format=%B").stdout
+        assert "X-MPM-Version: 6.5.44" in amended
+
+        parsed = real_subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=amended,
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        # The parsed trailer block must contain our key as Key: Value.
+        assert "X-MPM-Version: 6.5.44" in parsed.stdout, (
+            "git interpret-trailers must recognise X-MPM-Version as a valid trailer; "
+            f"parsed output:\n{parsed.stdout!r}"
+        )


### PR DESCRIPTION
## Summary

Adds a new `X-MPM-Version` git trailer to every commit processed by the commit-cost-tracker post-commit hook, recording the installed claude-mpm version (resolved from `claude_mpm.__version__`, the VERSION-file single source of truth).

The key behavioral change: the version stamp is **decoupled from the token-delta gate**. The existing `X-AI-Tokens-*` trailers are omitted for zero-delta commits, but `X-MPM-Version` is stamped on **every** commit the hook processes — including zero-delta commits.

Closes #859

## What changed

- **`_get_mpm_version()`** — new resolver returning `claude_mpm.__version__` (stripped), or `None` on import failure / empty value. Never raises.
- **Trailer block** — appends `X-MPM-Version: <version>` after `X-AI-Model`/`X-AI-Models` when present; present on its own when token/model trailers are absent. Omitted (no malformed line) when the version can't be resolved.
- **Idempotency** — the existing strip pass now also removes any pre-existing `X-MPM-Version:` line, so re-amends update-in-place rather than duplicate.

## Preserved safety

`--no-verify` amend, git-log-failure no-raise, Co-Authored-By canonicalization/dedup, no `X-AI-Cache-*`/`X-AI-Est-Cost-USD` trailers, and the existing HEAD-only amend guard (only the just-created MPM commit is amended) are all unchanged and still green.

## Sample stamped messages

**With token delta** (alongside the X-AI-* trailers):

```
feat: with-delta demo

Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
X-AI-Tokens-In: 8954
X-AI-Tokens-Out: 572998
X-AI-Model: claude-opus-4-8
X-MPM-Version: 6.5.44
```

**Zero / empty delta** (no X-AI-* token trailers, still version-stamped):

```
chore: zero-delta demo

Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
X-MPM-Version: 6.5.44
```

`git interpret-trailers --parse` recognises `X-MPM-Version` as a valid `Key: Value` trailer in both cases (covered by an end-to-end test against a real temp repo).

## Tests

New `TestGetMpmVersion` + `TestMpmVersionTrailer` (11 tests): present-with-delta, **present-when-delta-zero**, value-equals-resolved-version, idempotent re-amend (no duplication + stale value replaced), graceful degradation on resolution failure, and the `git interpret-trailers --parse` integration test. All existing assertions remain green.

```
uv run pytest tests/test_commit_cost_tracker.py tests/test_stop_handler_transcript_usage.py -p no:xdist -q
104 passed
```

WWL + spec-traceability gates: `71 passed`.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
