### PR TITLE
docs: Phase 3 — mutation framework service docs + bundled skill alignment

### DIFF
--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -126,6 +126,9 @@ claude-mpm mutate [TARGET]
 changed versus `--base` (via `git diff --name-only <base>...HEAD`), filters them
 through the eligibility heuristic, and mutates up to `--max-files` of them.
 
+Raise `--max-files` to mutate more than one changed file per auto-discovery
+invocation (default 1).
+
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `--tests-file PATH` | inferred | Paired unit test file. If omitted, inferred from the target's module stem (`tests/**/test_<stem>.py`); refuses to guess on zero or multiple matches. |

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -94,6 +94,211 @@ block access).
 `src/claude_mpm/hooks/hook_dedup.py` (issue #677, now merged to main) is the
 recommended next candidate: small module, high-value logic, easy to scope.
 
+---
+
+## The framework service (current tooling)
+
+The single-module `make mutation-test` pilot above proved mutmut works in this
+environment. The mutation **framework service** generalizes it: instead of a
+hand-maintained `setup.cfg` block per module, a runner and CLI scope mutmut to a
+single eligible file on demand, hide mutmut's Python 3.13 bugs, and emit a
+structured result an agent can act on.
+
+- Runner: `src/claude_mpm/services/mutation/runner.py` (issue #854, merged)
+- CLI: `claude-mpm mutate` — `src/claude_mpm/cli/commands/mutate.py` +
+  `src/claude_mpm/cli/parsers/mutate_parser.py` (issue #856, merged)
+
+`claude-mpm mutate` is the preferred entry point. It hides every mutmut
+workaround documented below — **do not call `mutmut run` / `mutmut results`
+directly** unless you are debugging the runner itself.
+
+## Using `claude-mpm mutate`
+
+```text
+claude-mpm mutate [TARGET]
+                  [--tests-file PATH] [--base BRANCH] [--exclude-tests EXPR]
+                  [--max-files N] [--force]
+                  [--threshold N] [--dry-run] [--output {text,json}]
+```
+
+`TARGET` is **optional**. When given it must be an existing `.py` file under a
+`src/` path. When omitted, the command **auto-discovers** the source files
+changed versus `--base` (via `git diff --name-only <base>...HEAD`), filters them
+through the eligibility heuristic, and mutates up to `--max-files` of them.
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--tests-file PATH` | inferred | Paired unit test file. If omitted, inferred from the target's module stem (`tests/**/test_<stem>.py`); refuses to guess on zero or multiple matches. |
+| `--base BRANCH` | `origin/main` | Base ref for auto-discovery. |
+| `--exclude-tests EXPR` | none | pytest `-k` expression to drop slow suites. The runner validates it against a strict shell-injection allowlist before embedding it. |
+| `--max-files N` | `1` | Cap on auto-discovered targets. If more eligible files exist, the command prints how many it dropped (it never silently caps). |
+| `--force` | off | Bypass the eligibility heuristic (human override) for an explicitly-named `TARGET`. |
+| `--threshold N` | unset | Survivor gate — see below. |
+| `--dry-run` | off | Print resolved scope + the would-run command, then exit 0. mutmut is **not** executed. |
+| `--output {text,json}` | `text` | `json` emits `dataclasses.asdict(MutationResult)` per target. |
+
+### Advisory-by-default threshold
+
+- `--threshold` **unset** (default): the command is purely advisory and
+  **always exits 0**. Survivors are signal, not failure — safe to run in CI as
+  pure information.
+- `--threshold 0`: zero survivors tolerated — **any** survivor fails (exit 1).
+- `--threshold N`: exits 1 when a target's survivor count is **greater than N**.
+
+A genuine runner *error* (mutmut failed to start, stale cache, schema mismatch)
+is **always** a non-zero failure, regardless of `--threshold`.
+
+### `--dry-run` example
+
+```bash
+claude-mpm mutate src/claude_mpm/services/foo.py --dry-run
+```
+
+```text
+Dry run — resolved scope (mutmut NOT executed):
+
+Target: src/claude_mpm/services/foo.py
+  Tests: tests/services/test_foo.py
+  Would run: uv run mutmut run --paths-to-mutate=src/claude_mpm/services/foo.py --tests-dir=tests/services
+```
+
+### `--output json` example
+
+```bash
+claude-mpm mutate src/claude_mpm/services/foo.py --output json
+```
+
+```json
+[
+  {
+    "target_file": "src/claude_mpm/services/foo.py",
+    "tests_file": "tests/services/test_foo.py",
+    "total_mutants": 42,
+    "killed": 38,
+    "survived": 4,
+    "kill_rate": 0.9047619047619048,
+    "survivors": [
+      {
+        "id": 17,
+        "file": "src/claude_mpm/services/foo.py",
+        "line": 88,
+        "original": "if count <= limit:",
+        "mutant": "if count < limit:",
+        "mutation_type": "boundary"
+      }
+    ],
+    "error": null
+  }
+]
+```
+
+The CLI emits a JSON **list** (one `MutationResult` object per target), so
+multi-file auto-discovery runs are handled uniformly.
+
+## mutmut 2.5.1 / Python 3.13 bug workarounds
+
+mutmut is pinned to **2.5.1** (`pyproject.toml` `[dependency-groups.dev]`). On
+Python 3.13 that release has two load-bearing bugs that make the naive
+`mutmut run` + `mutmut results` workflow unusable. The runner
+(`src/claude_mpm/services/mutation/runner.py`) hides all of this:
+
+1. **`mutmut results` crashes** with a pony-orm `QueryResultIterator not
+   iterable` error. The runner does **not** call `mutmut results`. Instead it
+   reads survivors and counts directly from the `.mutmut-cache` SQLite database
+   at the repo root, querying the `Mutant` table by `status`:
+   - `bad_survived` → survived
+   - `ok_killed` → killed
+
+   The runner asserts the `Mutant` table and its `id`/`status` columns exist
+   first, raising a clear schema-mismatch error rather than silently reporting a
+   bogus 100% kill rate if mutmut's cache layout ever changes.
+
+2. **`mutmut show` accepts only one mutant id per call** in 2.5.1, so the runner
+   queries per survivor — one `mutmut show <id>` subprocess per surviving mutant
+   — and parses each unified diff into a survivor record.
+
+Additional runner safeguards:
+
+- **Scope via CLI flags, never `setup.cfg`.** The runner passes
+  `--paths-to-mutate`, `--tests-dir`, and `--runner` on the mutmut command line.
+  It does not read or edit `setup.cfg` (that file's `[mutmut]` block is the old
+  pilot's config and is independent of the service).
+- **In-place mutation → `finally`-block restore.** mutmut mutates source on
+  disk in place. The runner wraps the whole run in `try/finally` and, in the
+  `finally`, checks `git diff --exit-code -- <target>` and runs
+  `git checkout HEAD -- <target>` if a mutant was left behind — so a crash mid-run
+  never corrupts the working tree.
+- **Stale-cache guard.** The runner timestamps the run start and refuses a
+  `.mutmut-cache` whose mtime predates it, rather than reporting a prior run's
+  counts for the wrong target.
+
+> Warning: do not call `mutmut results` directly on this project under Python
+> 3.13 — it will crash. Use `claude-mpm mutate`, which reads the SQLite cache
+> for you.
+
+## Eligibility heuristic
+
+Mutation testing only produces actionable survivors on **pure-logic modules
+that have a dedicated unit test**. The CLI gates targets through
+`is_eligible_for_mutation()` (`src/claude_mpm/cli/commands/mutate.py`) before
+running mutmut. A file is **rejected** when:
+
+- it is `__init__.py` (no meaningful logic), or
+- it lives under a `tests/`, `cli/`, `scripts/`, or `migrations/` path
+  component, or contains a `dashboard` path component (UI, not unit-testable
+  logic), or
+- any **top-level import** is I/O-heavy / infra-bound — currently
+  `subprocess`, `asyncio`, `aiohttp`, `httpx`, `sqlalchemy`, `fastapi`,
+  `click`, `socket`, `paramiko`, `boto3`. Mutants in such modules are dominated
+  by the environment, not by the test suite's assertions.
+
+The rejection reason names the offending import or path so you can judge whether
+an override is warranted. `--force` bypasses the heuristic for an
+explicitly-named `TARGET` (auto-discovered targets are always pre-filtered).
+
+This is deliberately **targeted, not blanket**: in the validation experiment only
+~4.9% of changed modules were eligible. The point is to mutate the few
+pure-logic files where survivors are real test gaps, not to mutate everything.
+
+## Structured survivor schema (`--output json`)
+
+`--output json` serializes the runner's frozen dataclasses
+(`src/claude_mpm/services/mutation/runner.py`):
+
+**`MutationResult`** — one per target:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `target_file` | `str` | Repo-relative path of the mutated source file. |
+| `tests_file` | `str` | Repo-relative path of the test file used as the runner. |
+| `total_mutants` | `int` | `killed + survived`. |
+| `killed` | `int` | Mutants caught by the tests (`ok_killed`). |
+| `survived` | `int` | Mutants the tests missed (`bad_survived`). |
+| `kill_rate` | `float` | `killed / total`, or `0.0` when `total == 0`. |
+| `survivors` | `list[MutantSurvivor]` | One entry per surviving mutant. |
+| `error` | `str \| null` | Set **only** when mutmut itself failed. A clean run with survivors is **not** an error. |
+
+**`MutantSurvivor`** — one per surviving mutant:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `id` | `int` | mutmut's mutant id (usable with `mutmut show <id>`). |
+| `file` | `str` | Repo-relative path of the mutated file. |
+| `line` | `int` | Line number of the mutated source line. |
+| `original` | `str` | The original source line (stripped). |
+| `mutant` | `str` | The mutated source line (stripped). |
+| `mutation_type` | `str` | One of `boundary`, `predicate`, `string`, `removal`, `arithmetic`, `other`. |
+
+## QA closed-loop
+
+The QA agent has a **Mutation Testing Sub-Loop** that consumes this service:
+run `claude-mpm mutate` on the changed pure-logic modules → triage the
+structured survivors → write killing tests for genuine gaps → have `code-critic`
+run a gaming-check on those tests (so the new tests strengthen behavior rather
+than merely silencing the survivor). The loop is **advisory**, mirroring the
+policy below, and ships via the external agents repo rather than the bundled
+agent templates.
+
 ## Policy
 
 Mutation testing is **advisory and on-demand**.  It is NOT a blocking CI gate.
@@ -102,3 +307,9 @@ Rationale: mutmut 2.x runtime is ~30 s for this scoped target but would scale to
 minutes on larger modules.  Requiring green mutation scores in CI would make the suite
 fragile and slow.  Instead, run it manually when strengthening a test module or
 reviewing test coverage confidence.
+
+The advisory policy is enforced at the CLI level by `--threshold` being
+**unset by default**: with no threshold, `claude-mpm mutate` always exits 0, so
+it can run in pipelines as pure signal. Opting into a gate is explicit —
+`--threshold 0` fails on any survivor, `--threshold N` fails above N — and is the
+caller's deliberate choice, not the default.

--- a/src/claude_mpm/skills/bundled/mutation-testing.md
+++ b/src/claude_mpm/skills/bundled/mutation-testing.md
@@ -9,6 +9,12 @@ tags: [testing, quality-assurance, mutation-testing, test-effectiveness, advisor
 effort: high
 ---
 
+<!-- Changelog
+0.3.0 — added mutmut 2.5.1 / Python 3.13 tool-bug workarounds and the
+        `claude-mpm mutate` preferred interface.
+0.2.0 — initial bundled skill.
+-->
+
 # Mutation Testing
 
 A second-order test-quality signal: instead of asking "do my tests run?", it asks

--- a/src/claude_mpm/skills/bundled/mutation-testing.md
+++ b/src/claude_mpm/skills/bundled/mutation-testing.md
@@ -1,10 +1,10 @@
 ---
 skill_id: mutation-testing
-skill_version: 0.2.0
+skill_version: 0.3.0
 name: mutation-testing
 when_to_use: when auditing test suite effectiveness on a critical module, evaluating whether green tests actually protect behavior, or deciding whether to invest more in test coverage
 description: Audit whether a test suite actually detects regressions (not just whether it runs) by introducing small code mutations and measuring how many your tests catch. Apply when hardening a critical, logic-dense module's tests, evaluating coverage confidence after a near-miss bug, or deciding if "green tests" really mean "protected behavior". Advisory and on-demand — not a blocking CI gate.
-updated_at: 2026-06-09T00:00:00Z
+updated_at: 2026-06-17T00:00:00Z
 tags: [testing, quality-assurance, mutation-testing, test-effectiveness, advisory]
 effort: high
 ---
@@ -222,3 +222,88 @@ the pipeline slow and fragile, and tempts teams to chase an unreachable 100%. In
 - Keep it scoped to high-value pure-logic modules; expand the mutated set one pilot
   at a time.
 - Track kill rate per critical module as a trend, not a gate.
+
+## Tool bugs & workarounds (mutmut 2.5.1 / Python 3.13)
+
+If you run **mutmut 2.5.1 on Python 3.13 manually**, two bugs will bite you. They
+are load-bearing — without the workarounds you cannot read survivors at all:
+
+1. **`mutmut results` crashes** with a pony-orm `QueryResultIterator not
+   iterable` error. Do not call it. Read survivors and counts directly from the
+   `.mutmut-cache` **SQLite database** written at the repo root after a run. Query
+   the `Mutant` table by `status`:
+   - `bad_survived` → the mutant **survived** (a test gap)
+   - `ok_killed` → the mutant was **killed**
+
+   ```sql
+   -- survivor ids (feed each to `mutmut show <id>`)
+   SELECT id FROM Mutant WHERE status = 'bad_survived' ORDER BY id;
+   -- counts
+   SELECT status, COUNT(*) FROM Mutant GROUP BY status;
+   ```
+
+   Guard for a schema change: if the `Mutant` table or its `id`/`status` columns
+   are absent, fail loudly rather than reporting a bogus 100% kill rate.
+
+2. **`mutmut show` accepts only ONE mutant id per call** in 2.5.1. Loop over the
+   survivor ids and call `mutmut show <id>` once per id, parsing each unified diff
+   (`--- file` / `@@ -start,n @@` / `-original` / `+mutant`) for the location and
+   the before/after source.
+
+Scope the run via mutmut **CLI flags** (`--paths-to-mutate`, `--tests-dir`,
+`--runner`) rather than editing `setup.cfg`, and because mutmut mutates source
+**in place**, always restore in a `finally` (`git diff --exit-code -- <target>`
+then `git checkout HEAD -- <target>`) so a crash never leaves a mutant on disk.
+
+## Preferred interface in this project: `claude-mpm mutate`
+
+In **claude-mpm**, do not invoke mutmut by hand — use the `claude-mpm mutate`
+command. It hides every workaround above (SQLite survivor read, per-id
+`mutmut show`, CLI-flag scoping, in-place restore, stale-cache guard) and gates
+targets through an eligibility heuristic (pure-logic modules with a dedicated
+unit test only; I/O-heavy / infra files are skipped).
+
+```bash
+# Auto-discover changed eligible files vs origin/main, structured output:
+claude-mpm mutate --output json
+
+# Mutate one explicit file:
+claude-mpm mutate src/claude_mpm/services/foo.py --output json
+```
+
+It is **advisory by default** (no `--threshold` → always exits 0; survivors are
+signal). Opt into a gate with `--threshold 0` (any survivor fails) or
+`--threshold N` (fails above N).
+
+`--output json` emits a list of structured results an agent can triage directly:
+
+```json
+[
+  {
+    "target_file": "src/claude_mpm/services/foo.py",
+    "tests_file": "tests/services/test_foo.py",
+    "total_mutants": 42,
+    "killed": 38,
+    "survived": 4,
+    "kill_rate": 0.9047619047619048,
+    "survivors": [
+      {
+        "id": 17,
+        "file": "src/claude_mpm/services/foo.py",
+        "line": 88,
+        "original": "if count <= limit:",
+        "mutant": "if count < limit:",
+        "mutation_type": "boundary"
+      }
+    ],
+    "error": null
+  }
+]
+```
+
+Schema — `MutationResult`: `target_file`, `tests_file`, `total_mutants`,
+`killed`, `survived`, `kill_rate` (`killed/total`, `0.0` when empty),
+`survivors[]`, `error` (set only on a genuine mutmut failure — survivors are
+**not** an error). Each `MutantSurvivor`: `id`, `file`, `line`, `original`,
+`mutant`, `mutation_type` (one of `boundary`, `predicate`, `string`, `removal`,
+`arithmetic`, `other`).


### PR DESCRIPTION
## Summary

Phase 3 of the mutation testing framework service: bring the docs and bundled skill in line with the **merged** tooling (runner #854, `claude-mpm mutate` CLI #856). Markdown-only — no code changes.

### `docs/developer/mutation-testing.md`
Kept the existing single-module `make mutation-test` pilot history and extended it with:
- **Using `claude-mpm mutate`** — full CLI signature, a flag table (`--tests-file`, `--base`, `--exclude-tests`, `--max-files`, `--force`, `--threshold`, `--dry-run`, `--output`), optional auto-discovering `TARGET`, plus `--dry-run` and `--output json` examples.
- **mutmut 2.5.1 / Python 3.13 workarounds** — crashing `mutmut results` → SQLite `.mutmut-cache` read (`bad_survived`/`ok_killed`), one-id `mutmut show`, CLI-flag scoping (never `setup.cfg`), `finally`-block restore, stale-cache guard; warning against calling `mutmut results` directly.
- **Eligibility heuristic** — pure-logic + dedicated test; rejected I/O-heavy imports + infra paths; `--force` override; ~4.9% eligible in validation.
- **Structured survivor schema** — `MutationResult` / `MutantSurvivor` field tables.
- **QA closed-loop** — Mutation Testing Sub-Loop note (advisory, external agents repo).
- **Policy** extended: `--threshold` unset-by-default enforces advisory at the CLI level.

### `src/claude_mpm/skills/bundled/mutation-testing.md`
Appended (kept the good cross-language content):
- **Tool bugs & workarounds** (mutmut 2.5.1 / Py3.13) with example SQLite queries.
- **`claude-mpm mutate` as the preferred interface**, with the `--output json` structured-survivor schema.
- Bumped `skill_version` 0.2.0 → 0.3.0 and `updated_at` → 2026-06-17.

## Verification
- Every CLI flag, runner workaround, and JSON field name cross-checked against the merged code (`mutate_parser.py`, `mutate.py`, `runner.py`). No mismatches found.
- `test_skills_frontmatter`, `test_skills_verification`, `test_804_user_level_bundled_skills`, `test_frontmatter_format`: **44 passed**.
- `test_spec_traceability`, `test_wwl_granularity`: **71 passed** (markdown-only changes don't trip the Python gates).
- `git diff origin/main` touches only the two doc files.

Closes #864

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)