### PR TITLE
fix: deterministic git identity in commit_cost_tracker temp-repo tests

### DIFF
--- a/tests/test_commit_cost_tracker.py
+++ b/tests/test_commit_cost_tracker.py
@@ -1648,6 +1648,16 @@ class TestMpmVersionTrailer:
             )
 
         _git("init", "-q")
+        # Configure a LOCAL git identity on the temp repo itself.  The test's
+        # _git() helper passes GIT_AUTHOR_*/GIT_COMMITTER_* via ``env``, but the
+        # production amend_commit_message() shells out to ``git commit --amend``
+        # with the inherited process environment (no GIT_COMMITTER_* set).  On CI
+        # runners there is no global/system git identity, so that amend fails with
+        # "fatal: empty ident name (...) not allowed" and the X-MPM-Version trailer
+        # is never written.  A repo-local identity makes the amend deterministic
+        # regardless of the runner's global git config.
+        _git("config", "user.email", "test@example.com")
+        _git("config", "user.name", "Test User")
         (repo / "f.txt").write_text("hello\n")
         _git("add", "f.txt")
         _git("commit", "-q", "-m", "chore: initial")


### PR DESCRIPTION
## Problem

`tests/test_commit_cost_tracker.py::TestMpmVersionTrailer::test_trailer_is_git_interpret_parseable` flaked on CI (failing intermittently) while always passing locally. This was the test blocking PR #866's CI.

It is the only test in `TestMpmVersionTrailer` that exercises a **real, non-mocked** git repo (the other six mock `subprocess.run`), so it was the only one exposed to the runner's git environment.

## Root cause

The test's `_git()` helper passes `GIT_AUTHOR_*` / `GIT_COMMITTER_*` via its `env` dict, so the test's own `init` / `add` / `commit` calls succeed. But the production code under test, `amend_commit_message()`, shells out to `git commit --amend` with the **inherited process environment** (no `GIT_COMMITTER_*` set) and relies on the repo's configured git identity.

The temp repo had no `user.name` / `user.email`, so on CI runners that lack a global/system git identity the amend failed with:

```
Committer identity unknown
fatal: empty ident name (for <>) not allowed
```

Because the amend failed, the `X-MPM-Version` trailer was never written and `assert "X-MPM-Version: 6.5.44" in amended` failed (the message was just `chore: initial`). Locally it passed only because the developer has a global git identity (or macOS auto-derives one from username/hostname — Linux CI runners do not).

## Fix (test-only)

Configure a repo-local identity immediately after `git init`:

```python
_git("config", "user.email", "test@example.com")
_git("config", "user.name", "Test User")
```

Now the production amend derives its identity from the repo config regardless of the runner's global git config. **Production code is unchanged** — real repos correctly have a configured identity, and `amend_commit_message()` is right to rely on it.

## Reproduce / verify

Faithful CI condition = identity env vars **unset** (not empty), no global/system config, and auto-derivation disabled:

```bash
env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME \
    -u GIT_COMMITTER_EMAIL -u EMAIL \
    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.useConfigOnly GIT_CONFIG_VALUE_0=true \
    uv run pytest -p no:xdist \
    tests/test_commit_cost_tracker.py::TestMpmVersionTrailer -v
```

- **Before the fix:** `test_trailer_is_git_interpret_parseable` FAILS (`'chore: initial\n\n'`, no trailer).
- **After the fix:** all 7 pass.

Other verification:
- CI-like (vars unset, no global identity): **7 passed**
- Normal serial (`-p no:xdist`, full file): **69 passed**
- Full file under xdist: **69 passed**
- `ruff format` + `ruff check`: clean, only `tests/test_commit_cost_tracker.py` touched.

This unblocks PR #866, whose CI was hitting this flaky test.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
