### PR TITLE
fix: resolve trusty-search index per-project instead of hardcoded claude-mpm (#872)

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -50,7 +50,7 @@ Before delegating to Research or reading files, query project memory and code se
 
 **Code search (use whichever is available):**
 
-- **trusty-search** (primary, recommended): `mcp__trusty-search__search` (index: claude-mpm)
+- **trusty-search** (primary, recommended): `mcp__trusty-search__search` (index: {{trusty_search_index}})
 
 Sequence:
 

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -41,6 +41,63 @@ class SystemInstructionsDeployer:
         self.logger = logger
         self.working_directory = working_directory
 
+    def _resolve_trusty_search_index(self) -> str:
+        """Resolve the per-project trusty-search index name.
+
+        WHAT: Returns the index id to substitute into the
+              ``{{trusty_search_index}}`` placeholder in PM_INSTRUCTIONS.md.
+              Precedence: (1) ``trusty_search.index_id`` from the project's
+              ``.claude-mpm/configuration.yaml`` if set; (2) otherwise the
+              working-directory basename (``self.working_directory.name``), which
+              is the same default trusty-search itself uses for an unnamed index.
+        WHY:  The index name was previously hardcoded to ``claude-mpm`` in
+              PM_INSTRUCTIONS.md and composed verbatim into every project's
+              deployed prompt, so agents in ANY project were told to search the
+              ``claude-mpm`` index (GitHub issue #872). Resolving per-project
+              points each project's PM at its own index.
+
+        Never raises: a missing/unreadable/malformed configuration.yaml falls
+        back to the directory basename.
+
+        :spec: SPEC-AGENTS-07~1
+        """
+        config_path = self.working_directory / ".claude-mpm" / "configuration.yaml"
+        try:
+            import yaml
+
+            with config_path.open(encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                section = data.get("trusty_search", {})
+                if isinstance(section, dict):
+                    override = section.get("index_id")
+                    if isinstance(override, str) and override.strip():
+                        return override.strip()
+        except Exception:
+            # Missing file, unreadable, parse error, or yaml unavailable — fall
+            # through to the directory-basename default below.
+            pass
+        return self.working_directory.name
+
+    def _apply_template_substitutions(self, text: str) -> str:
+        """Substitute ``{{...}}`` placeholders in merged system-instruction text.
+
+        WHAT: Replaces the ``{{trusty_search_index}}`` placeholder with the
+              per-project index resolved by :meth:`_resolve_trusty_search_index`.
+              Idempotent and a no-op when the placeholder is absent.
+        WHY:  Centralizing the substitution over the fully merged content (rather
+              than per-block) means the placeholder works regardless of which
+              block contains it, and keeps the deployed
+              ``PM_INSTRUCTIONS_DEPLOYED.md`` free of leaked ``{{...}}`` tokens.
+
+        :spec: SPEC-AGENTS-07~1
+        """
+        if "{{trusty_search_index}}" not in text:
+            return text
+        return text.replace(
+            "{{trusty_search_index}}", self._resolve_trusty_search_index()
+        )
+
     def _detect_stale_override(self, block_name: str, content: str) -> bool:
         """Detect if an override file contains content from other blocks.
 
@@ -511,7 +568,8 @@ class SystemInstructionsDeployer:
             header = BANNER_DEPLOYED
             if version_tag:
                 header = f"{header}{version_tag}\n\n"
-            target_file.write_text(header + "\n\n".join(merged_content))
+            body = self._apply_template_substitutions("\n\n".join(merged_content))
+            target_file.write_text(header + body)
 
             source_desc = ", ".join(str(p) for p in watched_paths if p.exists())
             deployment_info = {

--- a/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/system_instructions_deployer.py
@@ -49,15 +49,20 @@ class SystemInstructionsDeployer:
               Precedence: (1) ``trusty_search.index_id`` from the project's
               ``.claude-mpm/configuration.yaml`` if set; (2) otherwise the
               working-directory basename (``self.working_directory.name``), which
-              is the same default trusty-search itself uses for an unnamed index.
+              is the same default trusty-search itself uses for an unnamed index;
+              (3) finally the sentinel ``"default"`` when neither yields a
+              non-blank name (e.g. ``Path('/')`` has an empty ``.name``).
         WHY:  The index name was previously hardcoded to ``claude-mpm`` in
               PM_INSTRUCTIONS.md and composed verbatim into every project's
               deployed prompt, so agents in ANY project were told to search the
               ``claude-mpm`` index (GitHub issue #872). Resolving per-project
-              points each project's PM at its own index.
+              points each project's PM at its own index. The ``"default"``
+              sentinel guards against deploying an empty ``index:`` value when
+              the working directory has no basename.
 
         Never raises: a missing/unreadable/malformed configuration.yaml falls
-        back to the directory basename.
+        back to the directory basename, and an empty basename falls back to the
+        ``"default"`` sentinel.
 
         :spec: SPEC-AGENTS-07~1
         """
@@ -77,7 +82,9 @@ class SystemInstructionsDeployer:
             # Missing file, unreadable, parse error, or yaml unavailable — fall
             # through to the directory-basename default below.
             pass
-        return self.working_directory.name
+        # Final guard: an empty/whitespace basename (e.g. Path('/').name == '')
+        # would render `index: ` with no value, so fall back to a safe sentinel.
+        return self.working_directory.name.strip() or "default"
 
     def _apply_template_substitutions(self, text: str) -> str:
         """Substitute ``{{...}}`` placeholders in merged system-instruction text.
@@ -94,9 +101,10 @@ class SystemInstructionsDeployer:
         """
         if "{{trusty_search_index}}" not in text:
             return text
-        return text.replace(
-            "{{trusty_search_index}}", self._resolve_trusty_search_index()
-        )
+        # Resolve once into a local so adding more placeholders later does not
+        # re-read configuration.yaml per placeholder.
+        index = self._resolve_trusty_search_index()
+        return text.replace("{{trusty_search_index}}", index)
 
     def _detect_stale_override(self, block_name: str, content: str) -> bool:
         """Detect if an override file contains content from other blocks.

--- a/tests/services/agents/deployment/test_trusty_search_index_substitution.py
+++ b/tests/services/agents/deployment/test_trusty_search_index_substitution.py
@@ -1,0 +1,210 @@
+"""Tests for per-project trusty-search index substitution in the deployer.
+
+Regression coverage for GitHub issue #872:
+
+PM_INSTRUCTIONS.md previously hardcoded the trusty-search index name as
+``claude-mpm`` and that literal was composed VERBATIM into every project's
+``PM_INSTRUCTIONS_DEPLOYED.md``. Agents in ANY project were therefore told to
+search the ``claude-mpm`` index instead of their own.
+
+The fix replaces the literal with a ``{{trusty_search_index}}`` placeholder in
+the source PM_INSTRUCTIONS.md and resolves it per-project in
+``SystemInstructionsDeployer`` with precedence:
+  1. ``trusty_search.index_id`` from ``.claude-mpm/configuration.yaml`` if set;
+  2. otherwise the working-directory basename.
+
+These tests assert that:
+  (a) an explicit config override is honoured;
+  (b) the directory basename is used when no config is present;
+  (c) the ``{{trusty_search_index}}`` placeholder never leaks into the output.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+from claude_mpm.config.paths import ClaudeMPMPaths
+from claude_mpm.services.agents.deployment.system_instructions_deployer import (
+    SystemInstructionsDeployer,
+)
+
+
+def _make_system_files(agents_path: Path) -> None:
+    """Create minimal system-level framework files in *agents_path*.
+
+    The system PM_INSTRUCTIONS.md contains the ``{{trusty_search_index}}``
+    placeholder so the deployer has something to substitute, plus a
+    ``## Identity`` marker so it passes the override/marker validation paths.
+    """
+    (agents_path / "PM_INSTRUCTIONS.md").write_text(
+        "<!-- PM_INSTRUCTIONS_VERSION: 0016 -->\n"
+        "# PM Instructions\n\n## Identity\n"
+        "- **trusty-search**: `mcp__trusty-search__search` "
+        "(index: {{trusty_search_index}})\n",
+        encoding="utf-8",
+    )
+    (agents_path / "AGENT_DELEGATION.md").write_text(
+        "# Agent Delegation\n\n## When to Delegate to Each Agent\nDelegation.\n",
+        encoding="utf-8",
+    )
+    (agents_path / "WORKFLOW.md").write_text(
+        "# Workflow\n\n## Mandatory 5-Phase Sequence\nPhases.\n",
+        encoding="utf-8",
+    )
+    (agents_path / "MEMORY.md").write_text(
+        "# Memory\n\n## Memory System\nMemory content.\n",
+        encoding="utf-8",
+    )
+
+
+def _deploy(tmp_path: Path, working_directory: Path, agents_path: Path) -> str:
+    """Run deploy_system_instructions and return the deployed file contents.
+
+    A non-existent fake home guarantees no user-level override leaks in from the
+    real ``~/.claude-mpm``, keeping the test isolated from the developer's CWD.
+    """
+    fake_home = tmp_path / "fakehome"  # non-existent → no user override
+
+    logger = logging.getLogger("test_trusty_search_index_substitution")
+    deployer = SystemInstructionsDeployer(logger, working_directory)
+    results: dict = {"deployed": [], "updated": [], "errors": []}
+
+    with (
+        patch.object(
+            ClaudeMPMPaths,
+            "agents_dir",
+            new_callable=PropertyMock,
+            return_value=agents_path,
+        ),
+        patch(
+            "claude_mpm.services.agents.deployment.system_instructions_deployer.Path.home",
+            return_value=fake_home,
+        ),
+    ):
+        deployer.deploy_system_instructions(
+            target_dir=tmp_path,
+            force_rebuild=True,
+            results=results,
+        )
+
+    assert not results["errors"], f"Deployment errors: {results['errors']}"
+
+    deployed_file = working_directory / ".claude-mpm" / "PM_INSTRUCTIONS_DEPLOYED.md"
+    assert deployed_file.exists(), "PM_INSTRUCTIONS_DEPLOYED.md was not created"
+    return deployed_file.read_text(encoding="utf-8")
+
+
+class TestTrustySearchIndexSubstitution:
+    """Per-project resolution of the {{trusty_search_index}} placeholder."""
+
+    def test_config_index_id_override_is_used(self, tmp_path: Path) -> None:
+        """``trusty_search.index_id`` from configuration.yaml wins."""
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "my-project"
+        working_dir.mkdir()
+
+        # Project configuration.yaml with an explicit index override.
+        project_mpm_dir = working_dir / ".claude-mpm"
+        project_mpm_dir.mkdir()
+        (project_mpm_dir / "configuration.yaml").write_text(
+            "trusty_search:\n  index_id: foo\n",
+            encoding="utf-8",
+        )
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        assert "index: foo" in deployed
+        assert "{{trusty_search_index}}" not in deployed
+
+    def test_directory_basename_fallback_when_no_config(self, tmp_path: Path) -> None:
+        """With no config, the working-directory basename is used."""
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "some-other-repo"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        assert "index: some-other-repo" in deployed
+        # The historical hardcoded value must NOT appear when the dir differs.
+        assert "index: claude-mpm" not in deployed
+        assert "{{trusty_search_index}}" not in deployed
+
+    def test_directory_basename_fallback_on_malformed_config(
+        self, tmp_path: Path
+    ) -> None:
+        """A malformed configuration.yaml falls back to the basename, no crash."""
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "broken-config-repo"
+        working_dir.mkdir()
+
+        project_mpm_dir = working_dir / ".claude-mpm"
+        project_mpm_dir.mkdir()
+        (project_mpm_dir / "configuration.yaml").write_text(
+            "trusty_search: [this, is, not, a, mapping\n",  # invalid YAML
+            encoding="utf-8",
+        )
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        assert "index: broken-config-repo" in deployed
+        assert "{{trusty_search_index}}" not in deployed
+
+    def test_placeholder_never_leaks(self, tmp_path: Path) -> None:
+        """The raw placeholder must never survive into the deployed output."""
+        agents_path = tmp_path / "agents"
+        agents_path.mkdir()
+        working_dir = tmp_path / "leak-check-repo"
+        working_dir.mkdir()
+
+        _make_system_files(agents_path)
+        deployed = _deploy(tmp_path, working_dir, agents_path)
+
+        assert "{{trusty_search_index}}" not in deployed
+
+
+class TestResolveTrustySearchIndexUnit:
+    """Direct unit coverage of the resolver helper."""
+
+    def _deployer(self, working_directory: Path) -> SystemInstructionsDeployer:
+        logger = logging.getLogger("test_resolve_trusty_search_index")
+        return SystemInstructionsDeployer(logger, working_directory)
+
+    def test_resolver_prefers_config_override(self, tmp_path: Path) -> None:
+        working_dir = tmp_path / "proj"
+        (working_dir / ".claude-mpm").mkdir(parents=True)
+        (working_dir / ".claude-mpm" / "configuration.yaml").write_text(
+            "trusty_search:\n  index_id: custom-index\n",
+            encoding="utf-8",
+        )
+        assert (
+            self._deployer(working_dir)._resolve_trusty_search_index() == "custom-index"
+        )
+
+    def test_resolver_falls_back_to_dir_name(self, tmp_path: Path) -> None:
+        working_dir = tmp_path / "named-dir"
+        working_dir.mkdir()
+        assert self._deployer(working_dir)._resolve_trusty_search_index() == "named-dir"
+
+    def test_resolver_ignores_blank_override(self, tmp_path: Path) -> None:
+        working_dir = tmp_path / "blank-override-dir"
+        (working_dir / ".claude-mpm").mkdir(parents=True)
+        (working_dir / ".claude-mpm" / "configuration.yaml").write_text(
+            'trusty_search:\n  index_id: "   "\n',
+            encoding="utf-8",
+        )
+        assert (
+            self._deployer(working_dir)._resolve_trusty_search_index()
+            == "blank-override-dir"
+        )
+
+    def test_substitution_is_noop_without_placeholder(self, tmp_path: Path) -> None:
+        working_dir = tmp_path / "noop-dir"
+        working_dir.mkdir()
+        text = "no placeholder here"
+        assert self._deployer(working_dir)._apply_template_substitutions(text) == text

--- a/tests/services/agents/deployment/test_trusty_search_index_substitution.py
+++ b/tests/services/agents/deployment/test_trusty_search_index_substitution.py
@@ -11,12 +11,15 @@ The fix replaces the literal with a ``{{trusty_search_index}}`` placeholder in
 the source PM_INSTRUCTIONS.md and resolves it per-project in
 ``SystemInstructionsDeployer`` with precedence:
   1. ``trusty_search.index_id`` from ``.claude-mpm/configuration.yaml`` if set;
-  2. otherwise the working-directory basename.
+  2. otherwise the working-directory basename;
+  3. finally the ``"default"`` sentinel when neither yields a non-blank name.
 
 These tests assert that:
   (a) an explicit config override is honoured;
   (b) the directory basename is used when no config is present;
-  (c) the ``{{trusty_search_index}}`` placeholder never leaks into the output.
+  (c) the ``{{trusty_search_index}}`` placeholder never leaks into the output;
+  (d) an empty/whitespace working-directory basename falls back to ``"default"``
+      so the deployed file never renders an empty ``index:`` value.
 """
 
 import logging
@@ -177,6 +180,7 @@ class TestResolveTrustySearchIndexUnit:
 
     def test_resolver_prefers_config_override(self, tmp_path: Path) -> None:
         working_dir = tmp_path / "proj"
+        working_dir.mkdir()
         (working_dir / ".claude-mpm").mkdir(parents=True)
         (working_dir / ".claude-mpm" / "configuration.yaml").write_text(
             "trusty_search:\n  index_id: custom-index\n",
@@ -208,3 +212,28 @@ class TestResolveTrustySearchIndexUnit:
         working_dir.mkdir()
         text = "no placeholder here"
         assert self._deployer(working_dir)._apply_template_substitutions(text) == text
+
+    def test_resolver_falls_back_to_default_for_empty_dir_name(self) -> None:
+        """An empty working-directory basename (e.g. ``Path('/')``) resolves to
+        the ``"default"`` sentinel rather than an empty string.
+
+        Uses ``Path('/')`` directly: ``Path('/').name == ''``. No filesystem
+        writes occur (the resolver only reads ``.name`` after the config lookup
+        misses), so this stays isolated from the real root directory.
+        """
+        deployer = self._deployer(Path("/"))
+        assert Path("/").name == ""  # guards the precondition this test relies on
+        assert deployer._resolve_trusty_search_index() == "default"
+
+    def test_substitution_renders_default_for_empty_dir_name(self) -> None:
+        """End-to-end of the substitution: an empty basename must produce
+        ``index: default`` in the output — never ``index: `` (empty value) and
+        never a leaked ``{{trusty_search_index}}`` placeholder.
+        """
+        deployer = self._deployer(Path("/"))
+        rendered = deployer._apply_template_substitutions(
+            "- **trusty-search** (index: {{trusty_search_index}})\n"
+        )
+        assert "index: default" in rendered
+        assert "{{trusty_search_index}}" not in rendered
+        assert "index: )" not in rendered  # no empty value leaked


### PR DESCRIPTION
## The bug (#872)

`src/claude_mpm/agents/PM_INSTRUCTIONS.md` hardcoded the trusty-search index name as `claude-mpm`:

```
- **trusty-search** (primary, recommended): `mcp__trusty-search__search` (index: claude-mpm)
```

`SystemInstructionsDeployer` reads PM_INSTRUCTIONS.md raw with no templating and composes it verbatim into each project's `.claude-mpm/PM_INSTRUCTIONS_DEPLOYED.md`. As a result, agents in **every other project** were told to search the `claude-mpm` index instead of their own — so the Context-First Protocol's code-search step queried the wrong index everywhere except this repo.

## The fix (Option 1 — per-project templating)

1. **PM_INSTRUCTIONS.md**: replaced the literal `claude-mpm` with a `{{trusty_search_index}}` placeholder.
2. **SystemInstructionsDeployer**:
   - `_resolve_trusty_search_index()` resolves the index per-project with precedence: (i) `trusty_search.index_id` from the project's `.claude-mpm/configuration.yaml` if set; (ii) else `self.working_directory.name` (the same default trusty-search uses for an unnamed index). It never raises — a missing/unreadable/malformed config falls back to the directory basename.
   - `_apply_template_substitutions()` runs a single centralized pass over the fully merged content in `deploy_system_instructions()` **before** the file is written, so the placeholder works regardless of which block contains it. It is idempotent and a no-op when the placeholder is absent.

The deployed file rebuilds on every startup, so no generated artifact is committed.

## trusty-search SKILL.md

I checked for a SOURCE trusty-search skill under `src/claude_mpm/` (including `src/claude_mpm/skills/bundled/`) — **none exists**; MPM does not ship a trusty-search SKILL.md. The only copy is `.claude/skills/trusty-search/SKILL.md`, which is a **project-local deployed artifact** installed by the external `trusty-mpm`/`trusty-services` tooling, and its hardcoded `claude-mpm` index examples are actually **correct for this repo** (this repo's index genuinely is `claude-mpm`). Per scope, I left it untouched. If those upstream skill examples should be templatized for other projects, that belongs in the `trusty-services` source tree — a separate follow-up, out of scope here.

## Tests

`tests/services/agents/deployment/test_trusty_search_index_substitution.py` (8 tests, all passing), using `tmp_path` + a fake home/working_directory so they never depend on the real cwd/`.claude`:

- config `trusty_search.index_id: foo` → output contains `index: foo`;
- no config → output contains `index: <working_dir_name>` and **not** `index: claude-mpm`;
- malformed config → falls back to dir name, no crash;
- the `{{trusty_search_index}}` placeholder never leaks;
- direct resolver unit coverage (override wins, dir-name fallback, blank override ignored, substitution no-op without placeholder).

Existing deployer regression suites (`test_deployed_version_propagation`, `test_workflow_lazy_load_in_deployer`, `test_stale_override_detection`, `test_trusty_search_index`) still pass. `ruff format` + `ruff check` clean.

Closes #872

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)