### PR TITLE
fix: hermetically isolate agent-name-map test from real FS (#871)

### DIFF
--- a/tests/test_agent_registry_dynamic.py
+++ b/tests/test_agent_registry_dynamic.py
@@ -1,9 +1,6 @@
 """Test dynamic agent name registry refresh."""
 
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from claude_mpm.core.agent_name_registry import (
     AGENT_NAME_MAP,
@@ -11,6 +8,14 @@ from claude_mpm.core.agent_name_registry import (
     get_agent_name_map,
     invalidate_cache,
 )
+
+# Stable discovery result used to hermetically test name assertions.
+# Mirrors the canonical real-user.md frontmatter (name: Real User) so
+# that the test is not sensitive to what is or is not deployed on disk
+# during the test run.
+_STABLE_DISCOVERED: dict[str, str] = {
+    "real-user": "Real User",
+}
 
 
 class TestAgentNameRegistry:
@@ -56,14 +61,28 @@ class TestAgentNameRegistry:
         frontmatter ``name:`` field is the raw lowercase id (e.g.
         ``nestjs-engineer``), which diverges from the registry display name
         (``NestJS Engineer``) and is therefore not a stable assertion target.
+
+        Isolation: ``_discover_agents_from_paths`` is patched with a stable
+        dict so this test does not depend on the real ``.claude/agents/``
+        directory or ``~/.claude-mpm/cache/agents/``.  Without this patch,
+        a sibling test that writes a ``real-user.md`` with
+        ``name: real-user`` into any directory on the search path would
+        pollute the module-level cache and cause this assertion to fail
+        under ``pytest -n auto``.
         """
-        name_map = get_agent_name_map()
         non_conforming = {
             "real-user": "Real User",
         }
+        with patch(
+            "claude_mpm.core.agent_name_registry._discover_agents_from_paths",
+            return_value=_STABLE_DISCOVERED,
+        ):
+            invalidate_cache()
+            name_map = get_agent_name_map()
+
         for agent_id, expected_name in non_conforming.items():
-            if agent_id in name_map:
-                assert name_map[agent_id] == expected_name, (
-                    f"Non-conforming name for '{agent_id}': "
-                    f"expected '{expected_name}', got '{name_map[agent_id]}'"
-                )
+            assert agent_id in name_map, f"Agent '{agent_id}' missing from name map"
+            assert name_map[agent_id] == expected_name, (
+                f"Non-conforming name for '{agent_id}': "
+                f"expected '{expected_name}', got '{name_map[agent_id]}'"
+            )

--- a/tests/test_agent_registry_dynamic.py
+++ b/tests/test_agent_registry_dynamic.py
@@ -73,12 +73,17 @@ class TestAgentNameRegistry:
         non_conforming = {
             "real-user": "Real User",
         }
-        with patch(
-            "claude_mpm.core.agent_name_registry._discover_agents_from_paths",
-            return_value=_STABLE_DISCOVERED,
-        ):
+        try:
+            with patch(
+                "claude_mpm.core.agent_name_registry._discover_agents_from_paths",
+                return_value=_STABLE_DISCOVERED,
+            ):
+                invalidate_cache()
+                name_map = get_agent_name_map()
+        finally:
+            # Reset module-level cache so patched data never leaks to
+            # subsequent tests, regardless of pass/fail outcome.
             invalidate_cache()
-            name_map = get_agent_name_map()
 
         for agent_id, expected_name in non_conforming.items():
             assert agent_id in name_map, f"Agent '{agent_id}' missing from name map"


### PR DESCRIPTION
## Summary

Fixes a test isolation issue where `test_non_conforming_names_preserved` was non-deterministic when run under `pytest -n auto` due to cache pollution from sibling tests.

## Root Cause

`get_agent_name_map()` reads from `Path.cwd()/.claude/agents/` and `~/.claude-mpm/cache/agents/` at runtime and caches the result in a module-level sentinel. Under parallel test execution, a sibling test that changes `cwd` and creates a `real-user.md` would pollute the cache; the invalidation in `setup_method` clears the sentinel but the next call re-reads from the current `Path.cwd()`, making the test flaky.

Additionally, the old test had a silent `if agent_id in name_map:` guard that prevented the assertion from running when the key was absent, masking the real issue.

## Fix

- Mock `_discover_agents_from_paths` with a stable dict in `test_non_conforming_names_preserved`
- Replace silent guard with explicit existence check (now raises if key is missing)
- Removed unused imports flagged by ruff

This is a surgical scope fix targeting the specific test isolation. Broader autouse-fixture hardening to prevent similar issues across the test suite is deliberately deferred to follow-up work.

Closes #871