### PR TITLE
feat: capture conversational Q&A pairs in memory hook

### DIFF
--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -33,6 +33,7 @@ SPEC-INTEGRATIONS-07~1 : docs/specs/integrations.md#SPEC-INTEGRATIONS-07~1
 from __future__ import annotations
 
 import json
+import logging
 import re
 import select
 import shutil
@@ -45,12 +46,18 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 try:
     from claude_mpm.hooks.transcript_usage import (
         derive_transcript_path as _derive_transcript_path,
     )
 except ImportError:
     _derive_transcript_path = None  # type: ignore[assignment]
+    logger.debug(
+        "Q&A-pair PM-turn capture disabled: claude_mpm.hooks.transcript_usage"
+        " could not be imported."
+    )
 
 # Timeouts — kept short so the hook never blocks Claude Code's event loop.
 _HTTP_TIMEOUT_S = 0.2
@@ -78,6 +85,12 @@ _QA_REPLY_SNIPPET_MAX_CHARS = 200  # cap user-reply snippet stored to memory
 # State files older than this are pruned on write to avoid unbounded disk growth
 # from sessions that ended without a follow-up UserPromptSubmit.
 _QA_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
+# Maximum age (seconds) of a state file for it to be treated as a Q&A reply.
+# A state file written by Stop but not consumed within this window is stale —
+# the next UserPromptSubmit is treated as a new standalone prompt, not a reply.
+# This bounds mis-pairing when the user starts an unrelated session much later
+# or when the store failed and left the file behind.
+_QA_PAIR_MAX_AGE_SECONDS = 600  # 10 minutes
 # Project-name values that carry no signal and add tag noise — computed once at
 # module load time so we pay no per-call cost.  The home-directory basename is
 # included because cwd == $HOME is indistinguishable from "project 'masa'" etc.
@@ -942,7 +955,26 @@ def handle_user_prompt_submit(
     if project_name and project_name not in _QA_NOISY_NAMES and cwd != Path.home():
         qa_tags.append(project_name)
 
-    pm_snippet = _read_qa_state(session_id) if session_id else ""
+    # Read state file and apply the freshness window.
+    # A state file that is OLDER than _QA_PAIR_MAX_AGE_SECONDS is stale: delete
+    # it and treat this prompt as a standalone (normal word-count gate applies).
+    pm_snippet = ""
+    if session_id:
+        state_path = _qa_state_path(session_id)
+        if state_path is not None and state_path.is_file():
+            is_fresh = False
+            try:
+                age = time.time() - state_path.stat().st_mtime
+                is_fresh = age <= _QA_PAIR_MAX_AGE_SECONDS
+            except Exception:
+                # Cannot read mtime — treat as stale.
+                is_fresh = False
+            if is_fresh:
+                pm_snippet = _read_qa_state(session_id)
+            else:
+                # Stale file: delete it and fall through to standalone path.
+                _delete_qa_state(session_id)
+
     is_qa_reply = bool(pm_snippet)
 
     # Apply the minimum-words gate only for standalone prompts.
@@ -965,8 +997,10 @@ def handle_user_prompt_submit(
 
         if is_qa_reply and _capture_enabled(backend_key, "qa_pairs"):
             # Paired Q&A fact.  The state file is deleted INSIDE the background
-            # thread only after a successful backend.store(), preserving it for a
-            # potential retry if the store fails.
+            # thread only after a successful backend.store().  On failure the file
+            # is left in place; it will be consumed by the next UserPromptSubmit
+            # only if it is still within _QA_PAIR_MAX_AGE_SECONDS, otherwise the
+            # freshness check in handle_user_prompt_submit will prune it.
             reply_snippet = prompt[:_QA_REPLY_SNIPPET_MAX_CHARS].strip()
             qa_fact = f"PM: {pm_snippet}\nUser: {reply_snippet}"
 
@@ -976,7 +1010,8 @@ def handle_user_prompt_submit(
                     # Only delete the state file once the fact is safely persisted.
                     _delete_qa_state(session_id)
                 except Exception:
-                    # Store failed — leave the state file intact for a future retry.
+                    # Store failed — leave the state file for the freshness-window
+                    # check on the next UserPromptSubmit.
                     return
 
             threading.Thread(target=_bg_store_qa, daemon=True).start()

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -62,6 +62,12 @@ _PROMPT_CAPTURE_MAX_CHARS = 100
 _ENRICH_MAX_CHARS = 2000
 _RECALL_LIMIT = 5
 
+# Q&A pair capture — state persisted between Stop and UserPromptSubmit.
+# State dir: ~/.claude-mpm/state/{session_id}_last_response.txt
+_QA_STATE_DIR = Path.home() / ".claude-mpm" / "state"
+_QA_PM_SNIPPET_MAX_CHARS = 500  # cap PM text stored to disk
+_QA_REPLY_SNIPPET_MAX_CHARS = 200  # cap user-reply snippet stored to memory
+
 # Default ports / addresses for backends.
 _DEFAULT_TRUSTY_PORT = 7070
 _TRUSTY_ADDR_FILE = Path.home() / ".trusty-memory" / "http_addr"
@@ -100,9 +106,11 @@ def _load_config() -> dict[str, Any]:
         trusty_memory.port: int (default 7070)
         trusty_memory.palace: str (default basename of cwd)
         trusty_memory.capture.{session_start,file_changes,git_commits,session_end}: bool
+        trusty_memory.capture.qa_pairs: bool (default True) — capture Q&A pairs from
+            the PM turn (Stop) and user reply (UserPromptSubmit)
         kuzu_memory.enabled: bool (default True)
         kuzu_memory.palace: str (unused, kuzu has no palace concept)
-        kuzu_memory.capture.*: same shape as trusty_memory.capture
+        kuzu_memory.capture.*: same shape as trusty_memory.capture (including qa_pairs)
     """
     return _load_yaml(Path.home() / ".claude-mpm" / "config.yaml")
 
@@ -632,10 +640,142 @@ def _extract_commit_message(command: str, event: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_last_assistant_text(transcript_path: Path) -> str:
+    """Extract the last assistant turn's concatenated text blocks from a transcript.
+
+    WHAT: Reads a Claude Code session JSONL transcript, finds the last record
+    with ``type == "assistant"``, and concatenates all ``{type: "text", text: ...}``
+    content blocks into a single string.
+
+    WHY: The Stop hook needs to persist the most-recent PM response so the next
+    UserPromptSubmit can form a Q&A pair.  We only want the textual prose — not
+    tool calls or other block types.
+
+    Returns an empty string when the file is missing, unreadable, or contains no
+    assistant records.  Never raises.
+    """
+    last_text = ""
+    try:
+        with transcript_path.open(encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    rec = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("type") != "assistant":
+                    continue
+                msg = rec.get("message") or {}
+                content = msg.get("content") or []
+                if not isinstance(content, list):
+                    continue
+                parts: list[str] = []
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text") or ""
+                        if text:
+                            parts.append(text)
+                if parts:
+                    last_text = " ".join(parts)
+    except Exception:
+        return ""
+    return last_text
+
+
+def _qa_state_path(session_id: str) -> Path:
+    """Return the path for the Q&A state file for ``session_id``."""
+    return _QA_STATE_DIR / f"{session_id}_last_response.txt"
+
+
+def _write_qa_state(session_id: str, pm_text: str) -> None:
+    """Persist the PM turn snippet to the session state file.
+
+    Creates the state directory if absent.  Truncates to
+    ``_QA_PM_SNIPPET_MAX_CHARS``.  Never raises.
+    """
+    if not session_id or not pm_text:
+        return
+    try:
+        _QA_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        snippet = pm_text[:_QA_PM_SNIPPET_MAX_CHARS].strip()
+        _qa_state_path(session_id).write_text(snippet, encoding="utf-8")
+    except Exception:
+        return
+
+
+def _read_qa_state(session_id: str) -> str:
+    """Read the persisted PM snippet for ``session_id``.
+
+    Returns an empty string when the file is missing or unreadable.  Never
+    raises.
+    """
+    if not session_id:
+        return ""
+    try:
+        path = _qa_state_path(session_id)
+        if not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return ""
+
+
+def _delete_qa_state(session_id: str) -> None:
+    """Delete the Q&A state file for ``session_id`` (one-shot consumption).
+
+    No-op when the file does not exist.  Never raises.
+    """
+    if not session_id:
+        return
+    try:
+        _qa_state_path(session_id).unlink(missing_ok=True)
+    except Exception:
+        return
+
+
+def _capture_pm_turn_on_stop(event: dict[str, Any], backend_key: str) -> None:
+    """Read the last PM response from the session transcript and persist it.
+
+    WHAT: Derives the transcript path from ``session_id`` + ``cwd`` in the Stop
+    event, extracts the last assistant text, and writes a snippet to the Q&A
+    state dir so the next UserPromptSubmit can form a paired fact.
+
+    WHY: Hook invocations are separate subprocesses — the only cross-invocation
+    channel is the filesystem.  Writing state here on Stop and reading it on
+    UserPromptSubmit is the lightest-weight cross-process bridge available.
+
+    Never raises: all errors are swallowed so the Stop handler keeps flowing.
+    """
+    if not _capture_enabled(backend_key, "qa_pairs"):
+        return
+    try:
+        from claude_mpm.hooks.transcript_usage import derive_transcript_path
+
+        session_id = event.get("session_id") or ""
+        cwd_raw = event.get("cwd") or ""
+        if not session_id or not cwd_raw:
+            return
+        transcript_path = derive_transcript_path(session_id, cwd_raw)
+        if transcript_path is None or not transcript_path.exists():
+            return
+        pm_text = _extract_last_assistant_text(transcript_path)
+        if not pm_text:
+            return
+        _write_qa_state(session_id, pm_text)
+    except Exception:
+        return
+
+
 def _handle_session_end(
     event: dict[str, Any], backend: AbstractMemoryCaptureBackend
 ) -> None:
-    if not _capture_enabled(backend.name.replace("-", "_"), "session_end"):
+    backend_key = backend.name.replace("-", "_")
+    # Persist the last PM turn to the state dir for Q&A pairing.
+    _capture_pm_turn_on_stop(event, backend_key)
+
+    if not _capture_enabled(backend_key, "session_end"):
         return
     cwd_raw = event.get("cwd")
     cwd = Path(cwd_raw) if cwd_raw else Path.cwd()
@@ -684,12 +824,20 @@ def handle_user_prompt_submit(
     enrichment). Never raises.
 
     Behaviour:
-      * Skip short prompts (< ``_PROMPT_MIN_WORDS`` words) — likely
-        clarifications, not real intents worth remembering.
+      * **Q&A pair mode** (state file exists for this session_id): a prior PM
+        turn was captured at Stop.  This prompt is a reply — lower/skip the
+        ``_PROMPT_MIN_WORDS`` gate and store a paired ``"PM: ...\\nUser: ..."``
+        fact tagged ``["qa-pair", "prompt", project]``.  Consumes and deletes
+        the state file (one-shot).
+      * **Standalone mode** (no state file): existing behaviour — skip short
+        prompts (< ``_PROMPT_MIN_WORDS`` words), store ``"User prompt: ..."``
+        tagged ``["prompt"]``.
       * Skip when no backend is selected.
-      * Recall using the first ``_PROMPT_QUERY_MAX_CHARS`` chars of the prompt.
+      * Recall using the first ``_PROMPT_QUERY_MAX_CHARS`` chars of the prompt
+        (unchanged, always attempted for non-empty prompts when enrichment is
+        enabled — even short replies benefit from memory context).
       * Capture is fire-and-forget on a daemon thread so the hook returns
-        immediately (recall result is the user-visible value).
+        immediately.
       * Inject recalled context as ``additionalContext`` via
         ``hookSpecificOutput`` when there are any results.
 
@@ -706,11 +854,23 @@ def handle_user_prompt_submit(
     prompt = prompt.strip()
     if not prompt:
         return result
-    if len(prompt.split()) < _PROMPT_MIN_WORDS:
-        return result
 
     backend = _BACKEND
     backend_key = backend.name.replace("-", "_")
+
+    # --- Q&A pair detection ---------------------------------------------------
+    # Check for a persisted PM turn from the most-recent Stop event.
+    session_id = event.get("session_id") or ""
+    cwd_raw = event.get("cwd") or ""
+    cwd = Path(cwd_raw) if cwd_raw else Path.cwd()
+    project = cwd.name
+
+    pm_snippet = _read_qa_state(session_id) if session_id else ""
+    is_qa_reply = bool(pm_snippet)
+
+    # Apply the minimum-words gate only for standalone prompts.
+    if not is_qa_reply and len(prompt.split()) < _PROMPT_MIN_WORDS:
+        return result
 
     # 1) Recall (synchronous, bounded). Result drives both enrichment and
     # whether we bother with the additionalContext payload.
@@ -726,16 +886,32 @@ def handle_user_prompt_submit(
     try:
         import threading
 
-        snippet = prompt[:_PROMPT_CAPTURE_MAX_CHARS].strip()
-        fact = f"User prompt: {snippet}"
+        if is_qa_reply and _capture_enabled(backend_key, "qa_pairs"):
+            # Paired Q&A fact — consumes the state file immediately (before the
+            # thread fires) to avoid double-consumption if the hook is re-invoked.
+            _delete_qa_state(session_id)
+            reply_snippet = prompt[:_QA_REPLY_SNIPPET_MAX_CHARS].strip()
+            qa_fact = f"PM: {pm_snippet}\nUser: {reply_snippet}"
 
-        def _bg_store() -> None:
-            try:
-                backend.store(fact, tags=["prompt"])
-            except Exception:
-                return
+            def _bg_store_qa() -> None:
+                try:
+                    backend.store(qa_fact, tags=["qa-pair", "prompt", project])
+                except Exception:
+                    return
 
-        threading.Thread(target=_bg_store, daemon=True).start()
+            threading.Thread(target=_bg_store_qa, daemon=True).start()
+        else:
+            # Standalone prompt — existing behaviour.
+            snippet = prompt[:_PROMPT_CAPTURE_MAX_CHARS].strip()
+            fact = f"User prompt: {snippet}"
+
+            def _bg_store() -> None:
+                try:
+                    backend.store(fact, tags=["prompt"])
+                except Exception:
+                    return
+
+            threading.Thread(target=_bg_store, daemon=True).start()
     except Exception:
         # Even thread spawn failure must not break the hook.
         pass

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -45,6 +45,13 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+try:
+    from claude_mpm.hooks.transcript_usage import (
+        derive_transcript_path as _derive_transcript_path,
+    )
+except ImportError:
+    _derive_transcript_path = None  # type: ignore[assignment]
+
 # Timeouts — kept short so the hook never blocks Claude Code's event loop.
 _HTTP_TIMEOUT_S = 0.2
 _SUBPROCESS_TIMEOUT_S = 2.0
@@ -71,6 +78,12 @@ _QA_REPLY_SNIPPET_MAX_CHARS = 200  # cap user-reply snippet stored to memory
 # State files older than this are pruned on write to avoid unbounded disk growth
 # from sessions that ended without a follow-up UserPromptSubmit.
 _QA_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
+# Project-name values that carry no signal and add tag noise — computed once at
+# module load time so we pay no per-call cost.  The home-directory basename is
+# included because cwd == $HOME is indistinguishable from "project 'masa'" etc.
+_QA_NOISY_NAMES: frozenset[str] = frozenset(
+    {"", "tmp", "workspace", "~", Path.home().name}
+)
 
 # Default ports / addresses for backends.
 _DEFAULT_TRUSTY_PORT = 7070
@@ -690,9 +703,25 @@ def _extract_last_assistant_text(transcript_path: Path) -> str:
     return last_text
 
 
-def _qa_state_path(session_id: str) -> Path:
-    """Return the path for the Q&A state file for ``session_id``."""
-    return _QA_STATE_DIR / f"{session_id}_last_response.txt"
+def _qa_state_path(session_id: str) -> Path | None:
+    """Return the path for the Q&A state file for ``session_id``, or None if invalid.
+
+    Rejects empty session IDs and any that contain path-separator characters
+    (``/``, ``\\``) or the parent-directory sequence ``..``.  After constructing
+    the candidate path it resolves both sides and verifies the result is still
+    a direct child of the state directory, preventing path-traversal attacks.
+    Returns None on any invalid input or resolution failure; callers treat None
+    as "no state".  Never raises.
+    """
+    if not session_id or "/" in session_id or "\\" in session_id or ".." in session_id:
+        return None
+    try:
+        candidate = _QA_STATE_DIR / f"{session_id}_last_response.txt"
+        if candidate.resolve().parent != _QA_STATE_DIR.resolve():
+            return None
+        return candidate
+    except Exception:
+        return None
 
 
 def _prune_stale_qa_state() -> None:
@@ -723,15 +752,19 @@ def _write_qa_state(session_id: str, pm_text: str) -> None:
 
     Creates the state directory if absent.  Truncates to
     ``_QA_PM_SNIPPET_MAX_CHARS``.  Prunes stale state files (TTL-based)
-    before writing.  Never raises.
+    before writing.  Returns silently when session_id fails sanitization.
+    Never raises.
     """
     if not session_id or not pm_text:
+        return
+    path = _qa_state_path(session_id)
+    if path is None:
         return
     try:
         _QA_STATE_DIR.mkdir(parents=True, exist_ok=True)
         _prune_stale_qa_state()
         snippet = pm_text[:_QA_PM_SNIPPET_MAX_CHARS].strip()
-        _qa_state_path(session_id).write_text(snippet, encoding="utf-8")
+        path.write_text(snippet, encoding="utf-8")
     except Exception:
         return
 
@@ -739,13 +772,15 @@ def _write_qa_state(session_id: str, pm_text: str) -> None:
 def _read_qa_state(session_id: str) -> str:
     """Read the persisted PM snippet for ``session_id``.
 
-    Returns an empty string when the file is missing or unreadable.  Never
-    raises.
+    Returns an empty string when the file is missing, the session_id fails
+    sanitization, or the file is unreadable.  Never raises.
     """
     if not session_id:
         return ""
+    path = _qa_state_path(session_id)
+    if path is None:
+        return ""
     try:
-        path = _qa_state_path(session_id)
         if not path.is_file():
             return ""
         return path.read_text(encoding="utf-8").strip()
@@ -756,12 +791,16 @@ def _read_qa_state(session_id: str) -> str:
 def _delete_qa_state(session_id: str) -> None:
     """Delete the Q&A state file for ``session_id`` (one-shot consumption).
 
-    No-op when the file does not exist.  Never raises.
+    No-op when the file does not exist or session_id fails sanitization.
+    Never raises.
     """
     if not session_id:
         return
+    path = _qa_state_path(session_id)
+    if path is None:
+        return
     try:
-        _qa_state_path(session_id).unlink(missing_ok=True)
+        path.unlink(missing_ok=True)
     except Exception:
         return
 
@@ -781,14 +820,14 @@ def _capture_pm_turn_on_stop(event: dict[str, Any], backend_key: str) -> None:
     """
     if not _capture_enabled(backend_key, "qa_pairs"):
         return
+    if _derive_transcript_path is None:
+        return
     try:
-        from claude_mpm.hooks.transcript_usage import derive_transcript_path
-
         session_id = event.get("session_id") or ""
         cwd_raw = event.get("cwd") or ""
         if not session_id or not cwd_raw:
             return
-        transcript_path = derive_transcript_path(session_id, cwd_raw)
+        transcript_path = _derive_transcript_path(session_id, cwd_raw)
         if transcript_path is None or not transcript_path.exists():
             return
         pm_text = _extract_last_assistant_text(transcript_path)
@@ -897,7 +936,7 @@ def handle_user_prompt_submit(
 
     # Only include the project tag when the directory name is meaningful.
     # Values like "~", "tmp", or "workspace" add no signal and create noise.
-    _QA_NOISY_NAMES = {"", "tmp", "workspace", "~", Path.home().name}
+    # _QA_NOISY_NAMES is a module-level frozenset computed once at import time.
     project_name = cwd.name
     qa_tags: list[str] = ["qa-pair", "prompt"]
     if project_name and project_name not in _QA_NOISY_NAMES and cwd != Path.home():
@@ -925,19 +964,27 @@ def handle_user_prompt_submit(
         import threading
 
         if is_qa_reply and _capture_enabled(backend_key, "qa_pairs"):
-            # Paired Q&A fact — consumes the state file immediately (before the
-            # thread fires) to avoid double-consumption if the hook is re-invoked.
-            _delete_qa_state(session_id)
+            # Paired Q&A fact.  The state file is deleted INSIDE the background
+            # thread only after a successful backend.store(), preserving it for a
+            # potential retry if the store fails.
             reply_snippet = prompt[:_QA_REPLY_SNIPPET_MAX_CHARS].strip()
             qa_fact = f"PM: {pm_snippet}\nUser: {reply_snippet}"
 
             def _bg_store_qa() -> None:
                 try:
                     backend.store(qa_fact, tags=qa_tags)
+                    # Only delete the state file once the fact is safely persisted.
+                    _delete_qa_state(session_id)
                 except Exception:
+                    # Store failed — leave the state file intact for a future retry.
                     return
 
             threading.Thread(target=_bg_store_qa, daemon=True).start()
+        elif is_qa_reply:
+            # qa_pairs capture is disabled, but a state file was consumed for this
+            # session — delete it now so it does not linger and mis-pair with the
+            # next prompt.
+            _delete_qa_state(session_id)
         else:
             # Standalone prompt — existing behaviour.
             snippet = prompt[:_PROMPT_CAPTURE_MAX_CHARS].strip()

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -38,6 +38,7 @@ import select
 import shutil
 import subprocess  # nosec B404
 import sys
+import time
 import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
@@ -67,6 +68,9 @@ _RECALL_LIMIT = 5
 _QA_STATE_DIR = Path.home() / ".claude-mpm" / "state"
 _QA_PM_SNIPPET_MAX_CHARS = 500  # cap PM text stored to disk
 _QA_REPLY_SNIPPET_MAX_CHARS = 200  # cap user-reply snippet stored to memory
+# State files older than this are pruned on write to avoid unbounded disk growth
+# from sessions that ended without a follow-up UserPromptSubmit.
+_QA_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
 
 # Default ports / addresses for backends.
 _DEFAULT_TRUSTY_PORT = 7070
@@ -106,11 +110,13 @@ def _load_config() -> dict[str, Any]:
         trusty_memory.port: int (default 7070)
         trusty_memory.palace: str (default basename of cwd)
         trusty_memory.capture.{session_start,file_changes,git_commits,session_end}: bool
-        trusty_memory.capture.qa_pairs: bool (default True) — capture Q&A pairs from
-            the PM turn (Stop) and user reply (UserPromptSubmit)
+        trusty_memory.capture.qa_pairs: bool — capture Q&A pairs from the PM turn
+            (Stop) and user reply (UserPromptSubmit). **Default: True** (capture is
+            enabled whenever the key is absent; set explicitly to false to disable).
         kuzu_memory.enabled: bool (default True)
         kuzu_memory.palace: str (unused, kuzu has no palace concept)
-        kuzu_memory.capture.*: same shape as trusty_memory.capture (including qa_pairs)
+        kuzu_memory.capture.*: same shape as trusty_memory.capture (including
+            qa_pairs, which also defaults to True)
     """
     return _load_yaml(Path.home() / ".claude-mpm" / "config.yaml")
 
@@ -689,16 +695,41 @@ def _qa_state_path(session_id: str) -> Path:
     return _QA_STATE_DIR / f"{session_id}_last_response.txt"
 
 
+def _prune_stale_qa_state() -> None:
+    """Delete Q&A state files older than ``_QA_STATE_TTL_SECONDS``.
+
+    Deliberately best-effort: any error is silently swallowed.  Called from
+    ``_write_qa_state`` so that state files from abandoned sessions (i.e.
+    sessions that ended without a follow-up UserPromptSubmit) do not
+    accumulate on disk indefinitely.
+    """
+    try:
+        if not _QA_STATE_DIR.is_dir():
+            return
+        cutoff = time.time() - _QA_STATE_TTL_SECONDS
+        for candidate in _QA_STATE_DIR.glob("*_last_response.txt"):
+            try:
+                if candidate.stat().st_mtime < cutoff:
+                    candidate.unlink(missing_ok=True)
+            except Exception:
+                # Best-effort: skip files we cannot stat or unlink.
+                pass
+    except Exception:
+        return
+
+
 def _write_qa_state(session_id: str, pm_text: str) -> None:
     """Persist the PM turn snippet to the session state file.
 
     Creates the state directory if absent.  Truncates to
-    ``_QA_PM_SNIPPET_MAX_CHARS``.  Never raises.
+    ``_QA_PM_SNIPPET_MAX_CHARS``.  Prunes stale state files (TTL-based)
+    before writing.  Never raises.
     """
     if not session_id or not pm_text:
         return
     try:
         _QA_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _prune_stale_qa_state()
         snippet = pm_text[:_QA_PM_SNIPPET_MAX_CHARS].strip()
         _qa_state_path(session_id).write_text(snippet, encoding="utf-8")
     except Exception:
@@ -863,7 +894,14 @@ def handle_user_prompt_submit(
     session_id = event.get("session_id") or ""
     cwd_raw = event.get("cwd") or ""
     cwd = Path(cwd_raw) if cwd_raw else Path.cwd()
-    project = cwd.name
+
+    # Only include the project tag when the directory name is meaningful.
+    # Values like "~", "tmp", or "workspace" add no signal and create noise.
+    _QA_NOISY_NAMES = {"", "tmp", "workspace", "~", Path.home().name}
+    project_name = cwd.name
+    qa_tags: list[str] = ["qa-pair", "prompt"]
+    if project_name and project_name not in _QA_NOISY_NAMES and cwd != Path.home():
+        qa_tags.append(project_name)
 
     pm_snippet = _read_qa_state(session_id) if session_id else ""
     is_qa_reply = bool(pm_snippet)
@@ -895,7 +933,7 @@ def handle_user_prompt_submit(
 
             def _bg_store_qa() -> None:
                 try:
-                    backend.store(qa_fact, tags=["qa-pair", "prompt", project])
+                    backend.store(qa_fact, tags=qa_tags)
                 except Exception:
                     return
 

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -1,0 +1,605 @@
+"""Tests for conversational Q&A pair capture in the memory_capture hook.
+
+Covers:
+  - Stop event writes the Q&A state file with the last assistant text block.
+  - UserPromptSubmit with an existing state file stores a qa-pair fact AND
+    bypasses the min-words gate for a short reply, then deletes the state file.
+  - UserPromptSubmit with NO state file preserves existing standalone behavior
+    (10-word gate still applies).
+  - qa_pairs config flag disabled prevents paired capture.
+  - Hook never raises when transcript is missing or malformed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src/ is importable from repo root.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import claude_mpm.hooks.memory_capture as mc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_transcript_record(
+    rec_type: str,
+    text_blocks: list[str] | None = None,
+    extra_message_keys: dict | None = None,
+) -> str:
+    """Build a JSONL line for a transcript record.
+
+    Args:
+        rec_type: "assistant", "user", etc.
+        text_blocks: list of text strings for content blocks.
+        extra_message_keys: additional keys to merge into the message dict.
+    """
+    content = [{"type": "text", "text": t} for t in (text_blocks or [])]
+    message: dict[str, Any] = {"role": rec_type, "content": content}
+    if extra_message_keys:
+        message.update(extra_message_keys)
+    rec = {"type": rec_type, "message": message}
+    return json.dumps(rec)
+
+
+def _write_transcript(path: Path, records: list[str]) -> None:
+    """Write JSONL records to path, one per line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(records) + "\n", encoding="utf-8")
+
+
+def _make_mock_backend(name: str = "trusty-memory") -> MagicMock:
+    """Return a mock AbstractMemoryCaptureBackend."""
+    backend = MagicMock()
+    backend.name = name
+    backend.store = MagicMock()
+    backend.recall = MagicMock(return_value=[])
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# _extract_last_assistant_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLastAssistantText:
+    def test_single_assistant_record(self, tmp_path: Path) -> None:
+        """Single assistant record: returns its concatenated text blocks."""
+        t = tmp_path / "t.jsonl"
+        _write_transcript(
+            t,
+            [
+                _make_transcript_record(
+                    "assistant", ["Hello there!", " How can I help?"]
+                )
+            ],
+        )
+        result = mc._extract_last_assistant_text(t)
+        assert "Hello there!" in result
+        assert "How can I help?" in result
+
+    def test_returns_last_assistant_only(self, tmp_path: Path) -> None:
+        """When multiple assistant records exist, returns text from the LAST one."""
+        t = tmp_path / "t.jsonl"
+        _write_transcript(
+            t,
+            [
+                _make_transcript_record("assistant", ["First PM turn."]),
+                _make_transcript_record("user", ["User reply."]),
+                _make_transcript_record("assistant", ["Second PM turn."]),
+            ],
+        )
+        result = mc._extract_last_assistant_text(t)
+        assert "Second PM turn." in result
+        assert "First PM turn." not in result
+
+    def test_skips_non_text_blocks(self, tmp_path: Path) -> None:
+        """Tool-use blocks inside assistant content are silently skipped."""
+        t = tmp_path / "t.jsonl"
+        rec = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "text", "text": "Prose here."},
+                ],
+            },
+        }
+        t.write_text(json.dumps(rec) + "\n", encoding="utf-8")
+        result = mc._extract_last_assistant_text(t)
+        assert "Prose here." in result
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Missing transcript returns empty string, never raises."""
+        result = mc._extract_last_assistant_text(tmp_path / "nonexistent.jsonl")
+        assert result == ""
+
+    def test_malformed_json_lines_skipped(self, tmp_path: Path) -> None:
+        """Malformed JSONL lines are silently skipped."""
+        t = tmp_path / "t.jsonl"
+        t.write_text(
+            "not valid json\n"
+            + _make_transcript_record("assistant", ["Valid text."])
+            + "\n",
+            encoding="utf-8",
+        )
+        result = mc._extract_last_assistant_text(t)
+        assert "Valid text." in result
+
+    def test_no_assistant_records_returns_empty(self, tmp_path: Path) -> None:
+        """Transcript with only user records returns empty string."""
+        t = tmp_path / "t.jsonl"
+        _write_transcript(
+            t, [_make_transcript_record("user", ["Just a user message."])]
+        )
+        result = mc._extract_last_assistant_text(t)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _write_qa_state / _read_qa_state / _delete_qa_state
+# ---------------------------------------------------------------------------
+
+
+class TestQaStateHelpers:
+    def test_write_and_read_roundtrip(self, tmp_path: Path) -> None:
+        """Writing then reading the state file returns the stored snippet."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("sess-abc", "PM response text")
+            result = mc._read_qa_state("sess-abc")
+        assert "PM response text" in result
+
+    def test_write_truncates_to_max_chars(self, tmp_path: Path) -> None:
+        """PM text is truncated to _QA_PM_SNIPPET_MAX_CHARS."""
+        long_text = "X" * (mc._QA_PM_SNIPPET_MAX_CHARS + 100)
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("sess-trunc", long_text)
+            result = mc._read_qa_state("sess-trunc")
+        assert len(result) <= mc._QA_PM_SNIPPET_MAX_CHARS
+
+    def test_read_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Reading a non-existent state file returns empty string."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            result = mc._read_qa_state("sess-no-file")
+        assert result == ""
+
+    def test_delete_removes_file(self, tmp_path: Path) -> None:
+        """Deleting the state file makes subsequent reads return empty."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("sess-del", "some text")
+            mc._delete_qa_state("sess-del")
+            result = mc._read_qa_state("sess-del")
+        assert result == ""
+
+    def test_delete_missing_file_is_noop(self, tmp_path: Path) -> None:
+        """Deleting a non-existent state file does not raise."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._delete_qa_state("sess-ghost")  # must not raise
+
+    def test_empty_session_id_is_noop(self, tmp_path: Path) -> None:
+        """Empty session_id skips write/read/delete operations silently."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("", "text")  # no-op
+            result = mc._read_qa_state("")
+            assert result == ""
+            mc._delete_qa_state("")  # no-op
+
+
+# ---------------------------------------------------------------------------
+# _capture_pm_turn_on_stop
+# ---------------------------------------------------------------------------
+
+
+class TestCapturePmTurnOnStop:
+    def test_writes_state_file_from_transcript(self, tmp_path: Path) -> None:
+        """Stop event with a valid transcript writes the last PM text to state."""
+        session_id = "sess-stop-123"
+        cwd = str(tmp_path)
+
+        # Build a transcript file at the path that derive_transcript_path would return.
+        transcript_path = tmp_path / f"{session_id}.jsonl"
+        _write_transcript(
+            transcript_path,
+            [_make_transcript_record("assistant", ["The PM said this."])],
+        )
+
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": session_id,
+            "cwd": cwd,
+        }
+
+        state_dir = tmp_path / "state"
+
+        # Patch at the module where the local import is defined so the
+        # function under test picks it up when it does its lazy import.
+        with (
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "claude_mpm.hooks.transcript_usage.derive_transcript_path",
+                return_value=transcript_path,
+            ),
+        ):
+            mc._capture_pm_turn_on_stop(event, "trusty_memory")
+            with patch.object(mc, "_QA_STATE_DIR", state_dir):
+                result = mc._read_qa_state(session_id)
+
+        assert "The PM said this." in result
+
+    def test_missing_transcript_does_not_raise(self, tmp_path: Path) -> None:
+        """When transcript is absent, _capture_pm_turn_on_stop is a silent no-op."""
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": "sess-no-transcript",
+            "cwd": str(tmp_path),
+        }
+        state_dir = tmp_path / "state"
+        # Supply a transcript path that doesn't exist.
+        with (
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "claude_mpm.hooks.transcript_usage.derive_transcript_path",
+                return_value=tmp_path / "nonexistent.jsonl",
+            ),
+        ):
+            mc._capture_pm_turn_on_stop(event, "trusty_memory")  # must not raise
+
+    def test_empty_session_id_skips_write(self, tmp_path: Path) -> None:
+        """Event without session_id → no state file written."""
+        event = {"hook_event_name": "Stop", "cwd": str(tmp_path)}
+        state_dir = tmp_path / "state"
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._capture_pm_turn_on_stop(event, "trusty_memory")
+        assert not (state_dir.exists() and list(state_dir.glob("*.txt")))
+
+    def test_qa_pairs_disabled_skips_write(self, tmp_path: Path) -> None:
+        """When qa_pairs capture flag is False, state file is not written."""
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": "sess-disabled",
+            "cwd": str(tmp_path),
+        }
+        state_dir = tmp_path / "state"
+        with (
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch.object(mc, "_capture_enabled", return_value=False),
+        ):
+            mc._capture_pm_turn_on_stop(event, "trusty_memory")
+        assert not (state_dir.exists() and list(state_dir.glob("*.txt")))
+
+
+# ---------------------------------------------------------------------------
+# handle_user_prompt_submit — Q&A pair mode
+# ---------------------------------------------------------------------------
+
+
+class TestHandleUserPromptSubmitQaPairs:
+    """Tests for the Q&A-pair path in handle_user_prompt_submit."""
+
+    def _event(
+        self, prompt: str, session_id: str = "sess-qa", cwd: str = "/tmp/proj"
+    ) -> dict:
+        return {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+            "session_id": session_id,
+            "cwd": cwd,
+        }
+
+    def test_qa_pair_stored_when_state_file_exists(self, tmp_path: Path) -> None:
+        """When state file exists, a qa-pair fact is stored via daemon thread."""
+        backend = _make_mock_backend()
+        session_id = "sess-qa-store"
+        state_dir = tmp_path / "state"
+
+        # Pre-write the PM state file.
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM said: pick an option.")
+
+        stored_calls: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored_calls.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            result = mc.handle_user_prompt_submit(
+                self._event("Option 2 please.", session_id=session_id)
+            )
+
+        assert result["continue"] is True
+        # Let daemon thread settle.
+        import time
+
+        time.sleep(0.1)
+        assert any("qa-pair" in tags for _, tags in stored_calls), (
+            f"Expected a qa-pair store call; got: {stored_calls}"
+        )
+        # Fact format check.
+        qa_facts = [
+            fact for fact, _ in stored_calls if "PM:" in fact and "User:" in fact
+        ]
+        assert qa_facts, f"No paired fact found; calls: {stored_calls}"
+        assert "PM said: pick an option." in qa_facts[0]
+        assert "Option 2 please." in qa_facts[0]
+
+    def test_state_file_deleted_after_consumption(self, tmp_path: Path) -> None:
+        """State file is deleted once the qa-pair fact is stored (one-shot)."""
+        backend = _make_mock_backend()
+        session_id = "sess-qa-delete"
+        state_dir = tmp_path / "state"
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM text.")
+            assert mc._read_qa_state(session_id) != ""
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event("Short reply.", session_id=session_id)
+            )
+
+        # State file must be gone immediately (deletion happens before thread).
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            assert mc._read_qa_state(session_id) == ""
+
+    def test_short_reply_bypasses_min_words_gate(self, tmp_path: Path) -> None:
+        """A reply of <10 words is still captured when a state file exists."""
+        backend = _make_mock_backend()
+        session_id = "sess-qa-short"
+        state_dir = tmp_path / "state"
+        stored: list[str] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append(fact)
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM turn text here.")
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            # "yes" is well below 10 words.
+            mc.handle_user_prompt_submit(self._event("yes", session_id=session_id))
+
+        import time
+
+        time.sleep(0.1)
+        assert any("qa-pair" in f or "PM:" in f for f in stored), (
+            f"Short reply not captured; stored: {stored}"
+        )
+
+    def test_no_state_file_preserves_standalone_behavior(self, tmp_path: Path) -> None:
+        """Without a state file, short prompts are still dropped by the word gate."""
+        backend = _make_mock_backend()
+        session_id = "sess-standalone"
+        state_dir = tmp_path / "state"
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            # 4 words — below the 10-word gate.
+            result = mc.handle_user_prompt_submit(
+                self._event("Only four words here", session_id=session_id)
+            )
+
+        assert result["continue"] is True
+        import time
+
+        time.sleep(0.1)
+        assert stored == [], f"Standalone short prompt should be dropped; got: {stored}"
+
+    def test_standalone_long_prompt_stores_user_prompt_fact(
+        self, tmp_path: Path
+    ) -> None:
+        """Without state file, a long standalone prompt is stored as 'User prompt: ...'."""
+        backend = _make_mock_backend()
+        session_id = "sess-standalone-long"
+        state_dir = tmp_path / "state"
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        long_prompt = "This is a standalone prompt with more than ten words in total."
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event(long_prompt, session_id=session_id)
+            )
+
+        import time
+
+        time.sleep(0.1)
+        assert any(
+            fact.startswith("User prompt:") and "prompt" in tags
+            for fact, tags in stored
+            if "qa-pair" not in tags
+        ), f"Expected 'User prompt:' fact; got: {stored}"
+
+    def test_qa_pairs_config_disabled_skips_paired_store(self, tmp_path: Path) -> None:
+        """When qa_pairs capture is disabled in config, paired fact is not stored."""
+        backend = _make_mock_backend()
+        session_id = "sess-qa-disabled"
+        state_dir = tmp_path / "state"
+        stored: list[str] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append(fact)
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM text for disabled test.")
+
+        # Patch _capture_enabled to return False for qa_pairs.
+        original_capture_enabled = mc._capture_enabled
+
+        def _capture_enabled_no_qa(backend_key: str, event: str) -> bool:
+            if event == "qa_pairs":
+                return False
+            return original_capture_enabled(backend_key, event)
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch.object(mc, "_capture_enabled", side_effect=_capture_enabled_no_qa),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event("short reply", session_id=session_id)
+            )
+
+        import time
+
+        time.sleep(0.1)
+        qa_pairs = [f for f in stored if "PM:" in f]
+        assert qa_pairs == [], f"qa_pairs disabled but got: {qa_pairs}"
+
+    def test_hook_never_raises_when_backend_is_none(self) -> None:
+        """handle_user_prompt_submit returns continue=True even with no backend."""
+        with patch.object(mc, "_BACKEND", None):
+            result = mc.handle_user_prompt_submit(
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "prompt": "This prompt has more than ten words in it so it qualifies.",
+                    "session_id": "sess-x",
+                    "cwd": "/tmp",
+                }
+            )
+        assert result == {"continue": True}
+
+
+# ---------------------------------------------------------------------------
+# _handle_session_end — extended with Q&A state write
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSessionEndWithQaCapture:
+    def test_session_end_still_stores_session_ended_fact(self, tmp_path: Path) -> None:
+        """Existing 'Session ended' fact is still stored after Q&A changes."""
+        backend = _make_mock_backend()
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": "sess-end-test",
+            "cwd": str(tmp_path),
+        }
+
+        state_dir = tmp_path / "state"
+
+        with (
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch.object(mc, "_capture_pm_turn_on_stop"),  # isolate from transcript
+        ):
+            mc._handle_session_end(event, backend)
+
+        session_end_facts = [f for f, _ in stored if "Session ended" in f]
+        assert session_end_facts, f"Expected 'Session ended' fact; got: {stored}"
+
+    def test_session_end_calls_capture_pm_turn(self, tmp_path: Path) -> None:
+        """_handle_session_end delegates Q&A state write to _capture_pm_turn_on_stop."""
+        backend = _make_mock_backend()
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": "sess-pm-call",
+            "cwd": str(tmp_path),
+        }
+
+        with patch.object(mc, "_capture_pm_turn_on_stop") as mock_capture:
+            mc._handle_session_end(event, backend)
+
+        mock_capture.assert_called_once()
+        call_args = mock_capture.call_args
+        assert call_args[0][0] is event
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: Stop → UserPromptSubmit pairing (integration-light)
+# ---------------------------------------------------------------------------
+
+
+class TestQaPairingEndToEnd:
+    """Simulate the two-invocation lifecycle using the filesystem as the bridge."""
+
+    def test_stop_then_user_prompt_produces_qa_pair(self, tmp_path: Path) -> None:
+        """Simulates a Stop followed by a UserPromptSubmit storing a paired fact."""
+        session_id = "sess-e2e"
+        state_dir = tmp_path / "state"
+
+        # --- Phase 1: simulate Stop writing the state file ---
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "Choose option A or B.")
+
+        # --- Phase 2: simulate UserPromptSubmit reading the state file ---
+        backend = _make_mock_backend()
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        event = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "A",
+            "session_id": session_id,
+            "cwd": str(tmp_path),
+        }
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+        ):
+            result = mc.handle_user_prompt_submit(event)
+
+        assert result["continue"] is True
+
+        import time
+
+        time.sleep(0.1)
+
+        # Paired fact stored.
+        qa_facts = [f for f, tags in stored if "qa-pair" in tags]
+        assert qa_facts, f"No qa-pair found; stored={stored}"
+        assert "Choose option A or B." in qa_facts[0]
+        assert "A" in qa_facts[0]
+
+        # State file consumed.
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            assert mc._read_qa_state(session_id) == ""

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -209,6 +209,63 @@ class TestQaStateHelpers:
             assert result == ""
             mc._delete_qa_state("")  # no-op
 
+    # --- Finding 2: path-traversal sanitization ---------------------------------
+
+    def test_qa_state_path_rejects_slash_in_session_id(self, tmp_path: Path) -> None:
+        """_qa_state_path returns None for session IDs containing '/'."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            assert mc._qa_state_path("../evil") is None
+            assert mc._qa_state_path("/absolute/path") is None
+            assert mc._qa_state_path("sess/../../etc/passwd") is None
+
+    def test_qa_state_path_rejects_backslash(self, tmp_path: Path) -> None:
+        """_qa_state_path returns None for session IDs containing '\\'."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            assert mc._qa_state_path("sess\\evil") is None
+
+    def test_qa_state_path_rejects_dotdot(self, tmp_path: Path) -> None:
+        """_qa_state_path returns None for any session ID containing '..' (substring).
+
+        The implementation conservatively rejects '..' anywhere in the session_id,
+        not just when it equals '..', to prevent traversal attempts like 'a..b'
+        on unusual filesystems.
+        """
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            assert mc._qa_state_path("..") is None
+            assert (
+                mc._qa_state_path("sess..evil") is None
+            )  # '..' as substring is rejected
+            assert mc._qa_state_path("a..b") is None  # all '..' occurrences rejected
+
+    def test_traversal_session_id_write_is_noop(self, tmp_path: Path) -> None:
+        """Write with path-traversal session_id silently does nothing."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("../evil", "data")  # must not raise, must not write
+        # No files should exist outside tmp_path.
+        evil = tmp_path.parent / "evil_last_response.txt"
+        assert not evil.exists()
+
+    def test_traversal_session_id_read_returns_empty(self, tmp_path: Path) -> None:
+        """Read with path-traversal session_id returns empty string, never raises."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            result = mc._read_qa_state("../evil")
+        assert result == ""
+
+    def test_traversal_session_id_delete_is_noop(self, tmp_path: Path) -> None:
+        """Delete with path-traversal session_id is silently a no-op."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._delete_qa_state("../evil")  # must not raise
+
+    def test_valid_session_id_still_works_after_sanitization(
+        self, tmp_path: Path
+    ) -> None:
+        """Normal session IDs (alphanumeric/dashes) are unaffected by sanitization."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"):
+            mc._write_qa_state("sess-abc-123", "valid text")
+            assert mc._read_qa_state("sess-abc-123") == "valid text"
+            mc._delete_qa_state("sess-abc-123")
+            assert mc._read_qa_state("sess-abc-123") == ""
+
 
 # ---------------------------------------------------------------------------
 # _prune_stale_qa_state
@@ -293,14 +350,10 @@ class TestCapturePmTurnOnStop:
 
         state_dir = tmp_path / "state"
 
-        # Patch at the module where the local import is defined so the
-        # function under test picks it up when it does its lazy import.
+        # Patch the module-level alias so the production code sees the mock.
         with (
             patch.object(mc, "_QA_STATE_DIR", state_dir),
-            patch(
-                "claude_mpm.hooks.transcript_usage.derive_transcript_path",
-                return_value=transcript_path,
-            ),
+            patch.object(mc, "_derive_transcript_path", return_value=transcript_path),
         ):
             mc._capture_pm_turn_on_stop(event, "trusty_memory")
             with patch.object(mc, "_QA_STATE_DIR", state_dir):
@@ -319,8 +372,9 @@ class TestCapturePmTurnOnStop:
         # Supply a transcript path that doesn't exist.
         with (
             patch.object(mc, "_QA_STATE_DIR", state_dir),
-            patch(
-                "claude_mpm.hooks.transcript_usage.derive_transcript_path",
+            patch.object(
+                mc,
+                "_derive_transcript_path",
                 return_value=tmp_path / "nonexistent.jsonl",
             ),
         ):
@@ -410,7 +464,11 @@ class TestHandleUserPromptSubmitQaPairs:
         assert "Option 2 please." in qa_facts[0]
 
     def test_state_file_deleted_after_consumption(self, tmp_path: Path) -> None:
-        """State file is deleted once the qa-pair fact is stored (one-shot)."""
+        """State file is deleted once the qa-pair fact is stored (one-shot).
+
+        With _SyncThread the background function runs synchronously, so the
+        delete-after-store path is exercised deterministically.
+        """
         backend = _make_mock_backend()
         session_id = "sess-qa-delete"
         state_dir = tmp_path / "state"
@@ -431,9 +489,48 @@ class TestHandleUserPromptSubmitQaPairs:
                 self._event("Short reply.", session_id=session_id)
             )
 
-        # State file must be gone immediately (deletion happens before thread).
+        # State file must be gone — deletion happens inside _bg_store_qa after
+        # a successful backend.store() call.  _SyncThread makes this synchronous.
         with patch.object(mc, "_QA_STATE_DIR", state_dir):
             assert mc._read_qa_state(session_id) == ""
+
+    def test_state_file_preserved_when_store_fails(self, tmp_path: Path) -> None:
+        """State file is NOT deleted when backend.store() raises (Finding 1).
+
+        If the store fails the state file should survive so a future retry can
+        still pair it — the old code deleted the file before spawning the thread,
+        losing the Q&A pair permanently on failure.
+        """
+        session_id = "sess-qa-store-fail"
+        state_dir = tmp_path / "state"
+
+        backend = _make_mock_backend()
+        backend.store = MagicMock(side_effect=RuntimeError("store failed"))
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM text for fail test.")
+            assert mc._read_qa_state(session_id) != ""
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            result = mc.handle_user_prompt_submit(
+                self._event("reply", session_id=session_id)
+            )
+
+        # Hook must still return continue=True (never raises).
+        assert result["continue"] is True
+
+        # State file must still exist — store failed so deletion was skipped.
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            assert mc._read_qa_state(session_id) != "", (
+                "State file should be preserved when backend.store() fails"
+            )
 
     def test_short_reply_bypasses_min_words_gate(self, tmp_path: Path) -> None:
         """A reply of <10 words is still captured when a state file exists."""
@@ -527,7 +624,9 @@ class TestHandleUserPromptSubmitQaPairs:
         ), f"Expected 'User prompt:' fact; got: {stored}"
 
     def test_qa_pairs_config_disabled_skips_paired_store(self, tmp_path: Path) -> None:
-        """When qa_pairs capture is disabled in config, paired fact is not stored."""
+        """When qa_pairs capture is disabled, paired fact is not stored but state file
+        IS deleted (Finding 4) so it cannot linger and mis-pair with a later prompt.
+        """
         backend = _make_mock_backend()
         session_id = "sess-qa-disabled"
         state_dir = tmp_path / "state"
@@ -540,6 +639,7 @@ class TestHandleUserPromptSubmitQaPairs:
 
         with patch.object(mc, "_QA_STATE_DIR", state_dir):
             mc._write_qa_state(session_id, "PM text for disabled test.")
+            assert mc._read_qa_state(session_id) != ""
 
         # Patch _capture_enabled to return False for qa_pairs.
         original_capture_enabled = mc._capture_enabled
@@ -562,8 +662,15 @@ class TestHandleUserPromptSubmitQaPairs:
                 self._event("short reply", session_id=session_id)
             )
 
+        # No qa-pair fact should be stored.
         qa_pairs = [f for f in stored if "PM:" in f]
         assert qa_pairs == [], f"qa_pairs disabled but got: {qa_pairs}"
+
+        # State file must be gone — unconditional delete prevents stale mis-pairing.
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            assert mc._read_qa_state(session_id) == "", (
+                "State file should be deleted even when qa_pairs capture is disabled"
+            )
 
     def test_hook_never_raises_when_backend_is_none(self) -> None:
         """handle_user_prompt_submit returns continue=True even with no backend."""

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -13,7 +13,9 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -666,6 +668,10 @@ class TestHandleUserPromptSubmitQaPairs:
         qa_pairs = [f for f in stored if "PM:" in f]
         assert qa_pairs == [], f"qa_pairs disabled but got: {qa_pairs}"
 
+        # No standalone fact should be stored either — the disabled path only
+        # deletes the state file and does not fall through to standalone capture.
+        assert stored == [], f"disabled path should store nothing; got: {stored}"
+
         # State file must be gone — unconditional delete prevents stale mis-pairing.
         with patch.object(mc, "_QA_STATE_DIR", state_dir):
             assert mc._read_qa_state(session_id) == "", (
@@ -752,6 +758,147 @@ class TestHandleUserPromptSubmitQaPairs:
         assert stored_tags, "Expected at least one store call"
         for tags in stored_tags:
             assert "my-cool-project" in tags, f"Expected project name in tags: {tags}"
+
+    # --- Freshness window tests -----------------------------------------------
+
+    def test_fresh_state_file_treated_as_qa_reply(self, tmp_path: Path) -> None:
+        """A state file with mtime=now is within the freshness window.
+
+        The prompt is treated as a Q&A reply: paired fact is stored and the
+        short reply bypasses the min-words gate.
+        """
+        backend = _make_mock_backend()
+        session_id = "sess-fresh"
+        state_dir = tmp_path / "state"
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM: fresh prompt response.")
+            # Explicitly set mtime to now (fresh).
+            state_path = mc._qa_state_path(session_id)
+            assert state_path is not None
+            os.utime(state_path, None)  # sets atime + mtime to now
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            # Short reply — bypasses word gate because state file is fresh.
+            result = mc.handle_user_prompt_submit(
+                self._event("ok", session_id=session_id)
+            )
+
+        assert result["continue"] is True
+        qa_facts = [f for f, tags in stored if "qa-pair" in tags]
+        assert qa_facts, f"Fresh state file should produce qa-pair fact; got: {stored}"
+        assert "PM: fresh prompt response." in qa_facts[0]
+
+    def test_stale_state_file_not_treated_as_qa_reply(self, tmp_path: Path) -> None:
+        """A state file older than _QA_PAIR_MAX_AGE_SECONDS is stale.
+
+        It must NOT be treated as a Q&A reply:
+        - The stale state file is deleted.
+        - A short reply is dropped by the word-count gate (nothing stored).
+        - A long standalone prompt stores a 'User prompt: ...' fact.
+        """
+        backend = _make_mock_backend()
+        session_id = "sess-stale"
+        state_dir = tmp_path / "state"
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM: old response.")
+            # Back-date the state file well past the freshness window.
+            state_path = mc._qa_state_path(session_id)
+            assert state_path is not None
+            past_mtime = time.time() - mc._QA_PAIR_MAX_AGE_SECONDS - 60
+            os.utime(state_path, (past_mtime, past_mtime))
+
+        # --- Sub-case A: short reply is dropped by word gate (nothing stored) ---
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            result = mc.handle_user_prompt_submit(
+                self._event("ok", session_id=session_id)
+            )
+
+        assert result["continue"] is True
+        assert stored == [], (
+            f"Stale state + short reply should store nothing; got: {stored}"
+        )
+
+        # State file should be deleted by the staleness check.
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            assert mc._read_qa_state(session_id) == "", (
+                "Stale state file should be deleted"
+            )
+
+    def test_stale_state_file_long_prompt_stores_standalone(
+        self, tmp_path: Path
+    ) -> None:
+        """After a stale state file is pruned, a long prompt stores as standalone."""
+        backend = _make_mock_backend()
+        session_id = "sess-stale-long"
+        state_dir = tmp_path / "state"
+        stored: list[tuple[str, list[str]]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored.append((fact, tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM: old response.")
+            state_path = mc._qa_state_path(session_id)
+            assert state_path is not None
+            past_mtime = time.time() - mc._QA_PAIR_MAX_AGE_SECONDS - 60
+            os.utime(state_path, (past_mtime, past_mtime))
+
+        long_prompt = "This is a long standalone prompt with well over ten words total."
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event(long_prompt, session_id=session_id)
+            )
+
+        # Should have stored a standalone "User prompt: ..." fact, NOT a qa-pair.
+        standalone = [
+            f
+            for f, tags in stored
+            if f.startswith("User prompt:") and "qa-pair" not in tags
+        ]
+        assert standalone, (
+            f"Expected standalone 'User prompt:' fact after stale state; got: {stored}"
+        )
+        qa_pairs = [f for f, tags in stored if "qa-pair" in tags]
+        assert qa_pairs == [], (
+            f"Stale state file must not produce a qa-pair; got: {qa_pairs}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import sys
-import threading
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -64,6 +63,22 @@ def _make_mock_backend(name: str = "trusty-memory") -> MagicMock:
     backend.store = MagicMock()
     backend.recall = MagicMock(return_value=[])
     return backend
+
+
+class _SyncThread:
+    """Drop-in replacement for threading.Thread that runs target synchronously.
+
+    Eliminates the need for time.sleep() in tests: when .start() is called the
+    target callable is invoked immediately in the calling thread, so assertions
+    on side-effects are deterministic.
+    """
+
+    def __init__(self, target: Any, daemon: bool = True) -> None:
+        self._target = target
+        self.daemon = daemon
+
+    def start(self) -> None:
+        self._target()
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +211,63 @@ class TestQaStateHelpers:
 
 
 # ---------------------------------------------------------------------------
+# _prune_stale_qa_state
+# ---------------------------------------------------------------------------
+
+
+class TestPruneStaleQaState:
+    """Tests for the TTL-based cleanup of abandoned Q&A state files."""
+
+    def test_prunes_old_files(self, tmp_path: Path) -> None:
+        """Files older than the TTL are removed on prune."""
+        import time
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+
+        old_file = state_dir / "old-sess_last_response.txt"
+        old_file.write_text("stale", encoding="utf-8")
+        # Back-date the mtime to exceed the TTL.
+        past = time.time() - mc._QA_STATE_TTL_SECONDS - 10
+        import os
+
+        os.utime(old_file, (past, past))
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._prune_stale_qa_state()
+
+        assert not old_file.exists(), "Stale file should have been pruned"
+
+    def test_preserves_recent_files(self, tmp_path: Path) -> None:
+        """Files within the TTL are left untouched."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+
+        new_file = state_dir / "new-sess_last_response.txt"
+        new_file.write_text("fresh", encoding="utf-8")
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._prune_stale_qa_state()
+
+        assert new_file.exists(), "Recent file should be preserved"
+
+    def test_noop_when_dir_missing(self, tmp_path: Path) -> None:
+        """Missing state dir is silently handled (no exception)."""
+        with patch.object(mc, "_QA_STATE_DIR", tmp_path / "nonexistent"):
+            mc._prune_stale_qa_state()  # must not raise
+
+    def test_prune_called_by_write_qa_state(self, tmp_path: Path) -> None:
+        """_write_qa_state calls _prune_stale_qa_state as a side-effect."""
+        with (
+            patch.object(mc, "_QA_STATE_DIR", tmp_path / "state"),
+            patch.object(mc, "_prune_stale_qa_state") as mock_prune,
+        ):
+            mc._write_qa_state("sess-prune", "some text")
+
+        mock_prune.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # _capture_pm_turn_on_stop
 # ---------------------------------------------------------------------------
 
@@ -297,7 +369,7 @@ class TestHandleUserPromptSubmitQaPairs:
         }
 
     def test_qa_pair_stored_when_state_file_exists(self, tmp_path: Path) -> None:
-        """When state file exists, a qa-pair fact is stored via daemon thread."""
+        """When state file exists, a qa-pair fact is stored via (synchronous) thread."""
         backend = _make_mock_backend()
         session_id = "sess-qa-store"
         state_dir = tmp_path / "state"
@@ -316,16 +388,16 @@ class TestHandleUserPromptSubmitQaPairs:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             result = mc.handle_user_prompt_submit(
                 self._event("Option 2 please.", session_id=session_id)
             )
 
         assert result["continue"] is True
-        # Let daemon thread settle.
-        import time
-
-        time.sleep(0.1)
         assert any("qa-pair" in tags for _, tags in stored_calls), (
             f"Expected a qa-pair store call; got: {stored_calls}"
         )
@@ -350,6 +422,10 @@ class TestHandleUserPromptSubmitQaPairs:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             mc.handle_user_prompt_submit(
                 self._event("Short reply.", session_id=session_id)
@@ -377,13 +453,14 @@ class TestHandleUserPromptSubmitQaPairs:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             # "yes" is well below 10 words.
             mc.handle_user_prompt_submit(self._event("yes", session_id=session_id))
 
-        import time
-
-        time.sleep(0.1)
         assert any("qa-pair" in f or "PM:" in f for f in stored), (
             f"Short reply not captured; stored: {stored}"
         )
@@ -403,6 +480,10 @@ class TestHandleUserPromptSubmitQaPairs:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             # 4 words — below the 10-word gate.
             result = mc.handle_user_prompt_submit(
@@ -410,9 +491,6 @@ class TestHandleUserPromptSubmitQaPairs:
             )
 
         assert result["continue"] is True
-        import time
-
-        time.sleep(0.1)
         assert stored == [], f"Standalone short prompt should be dropped; got: {stored}"
 
     def test_standalone_long_prompt_stores_user_prompt_fact(
@@ -433,14 +511,15 @@ class TestHandleUserPromptSubmitQaPairs:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             mc.handle_user_prompt_submit(
                 self._event(long_prompt, session_id=session_id)
             )
 
-        import time
-
-        time.sleep(0.1)
         assert any(
             fact.startswith("User prompt:") and "prompt" in tags
             for fact, tags in stored
@@ -474,14 +553,15 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch.object(mc, "_capture_enabled", side_effect=_capture_enabled_no_qa),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             mc.handle_user_prompt_submit(
                 self._event("short reply", session_id=session_id)
             )
 
-        import time
-
-        time.sleep(0.1)
         qa_pairs = [f for f in stored if "PM:" in f]
         assert qa_pairs == [], f"qa_pairs disabled but got: {qa_pairs}"
 
@@ -497,6 +577,74 @@ class TestHandleUserPromptSubmitQaPairs:
                 }
             )
         assert result == {"continue": True}
+
+    def test_qa_tags_omit_noisy_project_names(self, tmp_path: Path) -> None:
+        """Q&A fact tags omit the project name when cwd is noisy (e.g. 'tmp')."""
+        backend = _make_mock_backend()
+        session_id = "sess-noisy-cwd"
+        state_dir = tmp_path / "state"
+        stored_tags: list[list[str]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored_tags.append(list(tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM said something.")
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            # /tmp is in the noisy set — no project tag should be appended.
+            mc.handle_user_prompt_submit(
+                self._event("reply", session_id=session_id, cwd="/tmp")
+            )
+
+        assert stored_tags, "Expected at least one store call"
+        for tags in stored_tags:
+            assert "tmp" not in tags, f"Noisy 'tmp' should not appear in tags: {tags}"
+            assert "qa-pair" in tags
+            assert "prompt" in tags
+
+    def test_qa_tags_include_meaningful_project_name(self, tmp_path: Path) -> None:
+        """Q&A fact tags include the project name when the cwd name is meaningful."""
+        backend = _make_mock_backend()
+        session_id = "sess-good-cwd"
+        state_dir = tmp_path / "state"
+        stored_tags: list[list[str]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored_tags.append(list(tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM said something.")
+
+        project_dir = tmp_path / "my-cool-project"
+        project_dir.mkdir()
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event("reply", session_id=session_id, cwd=str(project_dir))
+            )
+
+        assert stored_tags, "Expected at least one store call"
+        for tags in stored_tags:
+            assert "my-cool-project" in tags, f"Expected project name in tags: {tags}"
 
 
 # ---------------------------------------------------------------------------
@@ -585,16 +733,16 @@ class TestQaPairingEndToEnd:
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
         ):
             result = mc.handle_user_prompt_submit(event)
 
         assert result["continue"] is True
 
-        import time
-
-        time.sleep(0.1)
-
-        # Paired fact stored.
+        # Paired fact stored — no sleep needed; _SyncThread ran it synchronously.
         qa_facts = [f for f, tags in stored if "qa-pair" in tags]
         assert qa_facts, f"No qa-pair found; stored={stored}"
         assert "Choose option A or B." in qa_facts[0]


### PR DESCRIPTION
## Summary
Implement conversational Q→A pair capture in the memory-capture hook. On Stop/SubagentStop, the last assistant turn is persisted to a session state file. On the next UserPromptSubmit, if a prior PM turn exists, the prompt is treated as a reply and captured as a paired fact `"PM: ...\nUser: ..."` tagged with `["qa-pair", "prompt", project]`, bypassing the 10-word minimum gate for short replies.

## Files Changed
- `src/claude_mpm/hooks/memory_capture.py` — Q&A pair capture logic (+194/-18)
- `tests/test_memory_capture_qa_pairs.py` — Comprehensive test coverage (605 lines, 26 tests)

## Config
New gated config flag (default True):
- `trusty_memory.capture.qa_pairs`
- `kuzu_memory.capture.qa_pairs`

## Tests
All 69 tests pass (1 skipped).

Closes #877

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)