### PR TITLE
fix: Q&A capture hardening follow-ups (#879)

### DIFF
--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -39,6 +39,7 @@ import select
 import shutil
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -92,11 +93,12 @@ _QA_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
 # or when the store failed and left the file behind.
 _QA_PAIR_MAX_AGE_SECONDS = 600  # 10 minutes
 # Project-name values that carry no signal and add tag noise — computed once at
-# module load time so we pay no per-call cost.  The home-directory basename is
-# included because cwd == $HOME is indistinguishable from "project 'masa'" etc.
-_QA_NOISY_NAMES: frozenset[str] = frozenset(
-    {"", "tmp", "workspace", "~", Path.home().name}
-)
+# module load time so we pay no per-call cost.  We do NOT include the home-dir
+# basename here because a project legitimately named the same as the home-dir
+# basename (e.g. /projects/alice when home is /home/alice) should still be
+# tagged.  The actual home-dir path is handled by an explicit `cwd != Path.home()`
+# guard in handle_user_prompt_submit.
+_QA_NOISY_NAMES: frozenset[str] = frozenset({"", "tmp", "workspace", "~"})
 
 # Default ports / addresses for backends.
 _DEFAULT_TRUSTY_PORT = 7070
@@ -801,6 +803,44 @@ def _read_qa_state(session_id: str) -> str:
         return ""
 
 
+def _read_qa_state_with_mtime(session_id: str) -> tuple[str, float] | None:
+    """Open the Q&A state file ONCE, returning (content, mtime) or None.
+
+    WHAT: Reads both the file content and its mtime from a single ``open``
+    call using ``os.fstat`` on the open file handle, eliminating the TOCTOU
+    race between a separate ``stat()`` freshness check and a second ``open``
+    for the content.
+
+    WHY: The previous code did ``state_path.stat().st_mtime`` and then
+    separately called ``_read_qa_state(session_id)``  — two filesystem
+    operations on the same file.  Between them the file could be replaced or
+    deleted by a concurrent invocation, leading to inconsistent freshness
+    decisions.  A single ``open`` + ``os.fstat`` collapses both into one
+    atomic read.
+
+    Returns:
+        ``(content_str, mtime_float)`` when the file exists and is readable,
+        or ``None`` when the session_id fails sanitization, the file is
+        absent, or any read error occurs.  Never raises.
+    """
+    import os as _os
+
+    if not session_id:
+        return None
+    path = _qa_state_path(session_id)
+    if path is None:
+        return None
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            content = fh.read().strip()
+            mtime = _os.fstat(fh.fileno()).st_mtime
+        return (content, mtime)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
 def _delete_qa_state(session_id: str) -> None:
     """Delete the Q&A state file for ``session_id`` (one-shot consumption).
 
@@ -854,10 +894,12 @@ def _capture_pm_turn_on_stop(event: dict[str, Any], backend_key: str) -> None:
 def _handle_session_end(
     event: dict[str, Any], backend: AbstractMemoryCaptureBackend
 ) -> None:
+    # NOTE: _capture_pm_turn_on_stop is intentionally NOT called here.
+    # It is called once per Stop/SubagentStop event from main() — before the
+    # per-backend loop — so it runs exactly once regardless of how many active
+    # backends are configured.  Calling it here would write the state file once
+    # per backend (e.g. twice with trusty + kuzu both enabled).
     backend_key = backend.name.replace("-", "_")
-    # Persist the last PM turn to the state dir for Q&A pairing.
-    _capture_pm_turn_on_stop(event, backend_key)
-
     if not _capture_enabled(backend_key, "session_end"):
         return
     cwd_raw = event.get("cwd")
@@ -950,27 +992,36 @@ def handle_user_prompt_submit(
     # Only include the project tag when the directory name is meaningful.
     # Values like "~", "tmp", or "workspace" add no signal and create noise.
     # _QA_NOISY_NAMES is a module-level frozenset computed once at import time.
+    # The explicit `cwd != Path.home()` check handles the actual home directory;
+    # we do not put Path.home().name in _QA_NOISY_NAMES because a project
+    # coincidentally named the same as the home-dir basename (e.g. /projects/alice)
+    # should still receive the project tag.
     project_name = cwd.name
     qa_tags: list[str] = ["qa-pair", "prompt"]
     if project_name and project_name not in _QA_NOISY_NAMES and cwd != Path.home():
         qa_tags.append(project_name)
 
-    # Read state file and apply the freshness window.
-    # A state file that is OLDER than _QA_PAIR_MAX_AGE_SECONDS is stale: delete
-    # it and treat this prompt as a standalone (normal word-count gate applies).
+    # Read the state file and apply the freshness window in a SINGLE filesystem
+    # operation (TOCTOU fix): _read_qa_state_with_mtime opens the file once and
+    # returns both content and mtime via os.fstat on the open handle.
+    #
+    # Consume-once semantics: the state file is deleted here, in the synchronous
+    # path, immediately after reading — regardless of whether backend.store()
+    # later succeeds.  This prevents mis-pairing: if we kept the file until a
+    # successful store, a backend outage would leave it in place and every
+    # subsequent UserPromptSubmit within the 600s window would pair a NEW user
+    # reply with the SAME stale PM turn.  Losing one pair on a transient failure
+    # is strictly preferable to fabricating incorrect paired facts.
     pm_snippet = ""
     if session_id:
-        state_path = _qa_state_path(session_id)
-        if state_path is not None and state_path.is_file():
-            is_fresh = False
-            try:
-                age = time.time() - state_path.stat().st_mtime
-                is_fresh = age <= _QA_PAIR_MAX_AGE_SECONDS
-            except Exception:
-                # Cannot read mtime — treat as stale.
-                is_fresh = False
-            if is_fresh:
-                pm_snippet = _read_qa_state(session_id)
+        state_result = _read_qa_state_with_mtime(session_id)
+        if state_result is not None:
+            content, mtime = state_result
+            age = time.time() - mtime
+            if age <= _QA_PAIR_MAX_AGE_SECONDS:
+                pm_snippet = content
+                # Consume-once: delete synchronously before spawning the thread.
+                _delete_qa_state(session_id)
             else:
                 # Stale file: delete it and fall through to standalone path.
                 _delete_qa_state(session_id)
@@ -993,33 +1044,29 @@ def handle_user_prompt_submit(
 
     # 2) Capture (fire-and-forget). Never blocks the return.
     try:
-        import threading
-
         if is_qa_reply and _capture_enabled(backend_key, "qa_pairs"):
-            # Paired Q&A fact.  The state file is deleted INSIDE the background
-            # thread only after a successful backend.store().  On failure the file
-            # is left in place; it will be consumed by the next UserPromptSubmit
-            # only if it is still within _QA_PAIR_MAX_AGE_SECONDS, otherwise the
-            # freshness check in handle_user_prompt_submit will prune it.
+            # Paired Q&A fact.  The state file was already deleted synchronously
+            # (consume-once) before this branch — _bg_store_qa just stores the
+            # fact.  A store failure loses this one pair, which is acceptable for
+            # a best-effort memory system; it is strictly better than keeping the
+            # file and mis-pairing future prompts.
             reply_snippet = prompt[:_QA_REPLY_SNIPPET_MAX_CHARS].strip()
             qa_fact = f"PM: {pm_snippet}\nUser: {reply_snippet}"
 
             def _bg_store_qa() -> None:
                 try:
                     backend.store(qa_fact, tags=qa_tags)
-                    # Only delete the state file once the fact is safely persisted.
-                    _delete_qa_state(session_id)
                 except Exception:
-                    # Store failed — leave the state file for the freshness-window
-                    # check on the next UserPromptSubmit.
+                    # Store failed — pair is lost for this invocation.
+                    # The state file was already consumed (deleted synchronously),
+                    # so no mis-pairing will occur on the next UserPromptSubmit.
                     return
 
             threading.Thread(target=_bg_store_qa, daemon=True).start()
         elif is_qa_reply:
-            # qa_pairs capture is disabled, but a state file was consumed for this
-            # session — delete it now so it does not linger and mis-pair with the
-            # next prompt.
-            _delete_qa_state(session_id)
+            # qa_pairs capture is disabled.  State file was already deleted
+            # synchronously (consume-once) above — nothing left to do here.
+            pass
         else:
             # Standalone prompt — existing behaviour.
             snippet = prompt[:_PROMPT_CAPTURE_MAX_CHARS].strip()
@@ -1119,6 +1166,16 @@ def main() -> None:
         elif hook_event == "PostToolUse":
             _handle_post_tool_use(event, _BACKEND)
         elif hook_event in ("Stop", "SubagentStop"):
+            # Capture the last PM turn exactly ONCE per Stop event, before the
+            # per-backend loop in _handle_session_end.  _capture_pm_turn_on_stop
+            # was previously called inside _handle_session_end, which meant it
+            # ran once per active backend — writing the state file N times on
+            # Stop events when N backends (e.g. trusty + kuzu) are both enabled.
+            # We use _BACKEND's key here because _BACKEND is the single selected
+            # backend (the first available one), and qa_pairs capture is gated on
+            # that backend's config.  If the user disables qa_pairs for that
+            # backend, capture is skipped — consistent with how it worked before.
+            _capture_pm_turn_on_stop(event, _BACKEND.name.replace("-", "_"))
             _handle_session_end(event, _BACKEND)
         # All other events: no-op
     except Exception:

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import select
 import shutil
@@ -823,8 +824,6 @@ def _read_qa_state_with_mtime(session_id: str) -> tuple[str, float] | None:
         or ``None`` when the session_id fails sanitization, the file is
         absent, or any read error occurs.  Never raises.
     """
-    import os as _os
-
     if not session_id:
         return None
     path = _qa_state_path(session_id)
@@ -833,7 +832,7 @@ def _read_qa_state_with_mtime(session_id: str) -> tuple[str, float] | None:
     try:
         with path.open(encoding="utf-8", errors="replace") as fh:
             content = fh.read().strip()
-            mtime = _os.fstat(fh.fileno()).st_mtime
+            mtime = os.fstat(fh.fileno()).st_mtime
         return (content, mtime)
     except FileNotFoundError:
         return None

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -445,7 +445,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -483,7 +483,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -496,12 +496,18 @@ class TestHandleUserPromptSubmitQaPairs:
         with patch.object(mc, "_QA_STATE_DIR", state_dir):
             assert mc._read_qa_state(session_id) == ""
 
-    def test_state_file_preserved_when_store_fails(self, tmp_path: Path) -> None:
-        """State file is NOT deleted when backend.store() raises (Finding 1).
+    def test_state_file_deleted_after_consumption_even_when_store_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """State file is deleted on first consumption attempt even if store() fails.
 
-        If the store fails the state file should survive so a future retry can
-        still pair it — the old code deleted the file before spawning the thread,
-        losing the Q&A pair permanently on failure.
+        Consume-once semantics (item 2 of issue #879): the state file is deleted
+        synchronously in handle_user_prompt_submit BEFORE the background thread is
+        spawned — regardless of whether backend.store() later succeeds.  This
+        prevents a persistent backend outage from causing every subsequent
+        UserPromptSubmit within the 600s window to mis-pair a NEW user reply with
+        the SAME stale PM turn.  Losing one pair on a transient failure is
+        strictly preferable to fabricating incorrect paired facts.
         """
         session_id = "sess-qa-store-fail"
         state_dir = tmp_path / "state"
@@ -517,7 +523,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -528,10 +534,12 @@ class TestHandleUserPromptSubmitQaPairs:
         # Hook must still return continue=True (never raises).
         assert result["continue"] is True
 
-        # State file must still exist — store failed so deletion was skipped.
+        # State file must be gone — consume-once deletes it synchronously before
+        # the thread is spawned, so a store failure does not resurrect it.
         with patch.object(mc, "_QA_STATE_DIR", state_dir):
-            assert mc._read_qa_state(session_id) != "", (
-                "State file should be preserved when backend.store() fails"
+            assert mc._read_qa_state(session_id) == "", (
+                "State file should be deleted on first consumption attempt "
+                "regardless of backend.store() outcome (consume-once semantics)"
             )
 
     def test_short_reply_bypasses_min_words_gate(self, tmp_path: Path) -> None:
@@ -553,7 +561,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -580,7 +588,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -611,7 +619,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -656,7 +664,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch.object(mc, "_capture_enabled", side_effect=_capture_enabled_no_qa),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -710,7 +718,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -747,7 +755,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -758,6 +766,53 @@ class TestHandleUserPromptSubmitQaPairs:
         assert stored_tags, "Expected at least one store call"
         for tags in stored_tags:
             assert "my-cool-project" in tags, f"Expected project name in tags: {tags}"
+
+    def test_qa_tags_include_project_named_same_as_home_basename(
+        self, tmp_path: Path
+    ) -> None:
+        """Project whose name matches home-dir basename but path is NOT home is tagged.
+
+        Item 3 of issue #879: removing Path.home().name from _QA_NOISY_NAMES means
+        a project like /projects/alice (where home is /home/alice) no longer has its
+        tag suppressed.  Only the actual home dir (cwd == Path.home()) is suppressed,
+        via the explicit path-equality guard.
+        """
+        backend = _make_mock_backend()
+        session_id = "sess-home-basename"
+        state_dir = tmp_path / "state"
+        stored_tags: list[list[str]] = []
+
+        def fake_store(fact: str, tags: list[str] | None = None) -> None:
+            stored_tags.append(list(tags or []))
+
+        backend.store = fake_store
+
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
+            mc._write_qa_state(session_id, "PM said something.")
+
+        # Create a project directory whose basename matches the home-dir basename.
+        home_basename = Path.home().name
+        project_dir = tmp_path / home_basename  # e.g. /tmp/.../masa — NOT home
+        project_dir.mkdir(exist_ok=True)
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_QA_STATE_DIR", state_dir),
+            patch(
+                "claude_mpm.hooks.memory_capture.threading.Thread",
+                side_effect=lambda target, daemon: _SyncThread(target),
+            ),
+        ):
+            mc.handle_user_prompt_submit(
+                self._event("reply", session_id=session_id, cwd=str(project_dir))
+            )
+
+        assert stored_tags, "Expected at least one store call"
+        for tags in stored_tags:
+            assert home_basename in tags, (
+                f"Project named '{home_basename}' under non-home path should be tagged; "
+                f"got tags: {tags}"
+            )
 
     # --- Freshness window tests -----------------------------------------------
 
@@ -788,7 +843,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -833,7 +888,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -878,7 +933,7 @@ class TestHandleUserPromptSubmitQaPairs:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):
@@ -925,17 +980,22 @@ class TestHandleSessionEndWithQaCapture:
 
         state_dir = tmp_path / "state"
 
-        with (
-            patch.object(mc, "_QA_STATE_DIR", state_dir),
-            patch.object(mc, "_capture_pm_turn_on_stop"),  # isolate from transcript
-        ):
+        with patch.object(mc, "_QA_STATE_DIR", state_dir):
             mc._handle_session_end(event, backend)
 
         session_end_facts = [f for f, _ in stored if "Session ended" in f]
         assert session_end_facts, f"Expected 'Session ended' fact; got: {stored}"
 
-    def test_session_end_calls_capture_pm_turn(self, tmp_path: Path) -> None:
-        """_handle_session_end delegates Q&A state write to _capture_pm_turn_on_stop."""
+    def test_handle_session_end_does_not_call_capture_pm_turn(
+        self, tmp_path: Path
+    ) -> None:
+        """_handle_session_end no longer calls _capture_pm_turn_on_stop (item 4).
+
+        Since issue #879, _capture_pm_turn_on_stop is called once per Stop event
+        from main(), not once per backend inside _handle_session_end.  This test
+        asserts the new invariant: calling _handle_session_end directly must NOT
+        trigger _capture_pm_turn_on_stop.
+        """
         backend = _make_mock_backend()
         event = {
             "hook_event_name": "Stop",
@@ -946,9 +1006,52 @@ class TestHandleSessionEndWithQaCapture:
         with patch.object(mc, "_capture_pm_turn_on_stop") as mock_capture:
             mc._handle_session_end(event, backend)
 
-        mock_capture.assert_called_once()
-        call_args = mock_capture.call_args
-        assert call_args[0][0] is event
+        (
+            mock_capture.assert_not_called(),
+            (
+                "_capture_pm_turn_on_stop must not be called from _handle_session_end; "
+                "it is dispatched from main() to run exactly once per Stop event"
+            ),
+        )
+
+    def test_main_dispatch_calls_capture_pm_turn_once_for_stop(
+        self, tmp_path: Path
+    ) -> None:
+        """main() calls _capture_pm_turn_on_stop exactly once for Stop events.
+
+        Verifies the item-4 fix: capture is hoisted to main() dispatch level so
+        it runs exactly once regardless of backend count.
+        """
+        backend = _make_mock_backend()
+        event = {
+            "hook_event_name": "Stop",
+            "session_id": "sess-main-dispatch",
+            "cwd": str(tmp_path),
+        }
+
+        import io
+        import json as _json
+
+        event_json = _json.dumps(event)
+
+        with (
+            patch.object(mc, "_BACKEND", backend),
+            patch.object(mc, "_capture_pm_turn_on_stop") as mock_capture,
+            patch.object(mc, "sys") as mock_sys,
+            patch("select.select", return_value=([mock_sys.stdin], [], [])),
+        ):
+            mock_sys.stdin = io.StringIO(event_json)
+            mock_sys.stdout = io.StringIO()
+            # Redirect print to avoid actual stdout writes in tests.
+            import builtins
+
+            with patch.object(builtins, "print"):
+                mc.main()
+
+        (
+            mock_capture.assert_called_once(),
+            ("main() must call _capture_pm_turn_on_stop exactly once per Stop event"),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -988,7 +1091,7 @@ class TestQaPairingEndToEnd:
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_QA_STATE_DIR", state_dir),
             patch(
-                "threading.Thread",
+                "claude_mpm.hooks.memory_capture.threading.Thread",
                 side_effect=lambda target, daemon: _SyncThread(target),
             ),
         ):

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -1006,12 +1006,9 @@ class TestHandleSessionEndWithQaCapture:
         with patch.object(mc, "_capture_pm_turn_on_stop") as mock_capture:
             mc._handle_session_end(event, backend)
 
-        (
-            mock_capture.assert_not_called(),
-            (
-                "_capture_pm_turn_on_stop must not be called from _handle_session_end; "
-                "it is dispatched from main() to run exactly once per Stop event"
-            ),
+        assert not mock_capture.called, (
+            "_capture_pm_turn_on_stop must not be called from _handle_session_end; "
+            "it is dispatched from main() to run exactly once per Stop event"
         )
 
     def test_main_dispatch_calls_capture_pm_turn_once_for_stop(
@@ -1048,9 +1045,8 @@ class TestHandleSessionEndWithQaCapture:
             with patch.object(builtins, "print"):
                 mc.main()
 
-        (
-            mock_capture.assert_called_once(),
-            ("main() must call _capture_pm_turn_on_stop exactly once per Stop event"),
+        assert mock_capture.call_count == 1, (
+            "main() must call _capture_pm_turn_on_stop exactly once per Stop event"
         )
 
 


### PR DESCRIPTION
## Summary

This PR addresses advisory hardening follow-ups from PR #878 review (issue #879). Implements five key improvements:

1. **TOCTOU fix**: Single open-read-stat for Q&A state (`_read_qa_state_with_mtime`) eliminates time-of-check-time-of-use race conditions.
2. **Consume-once semantics**: State file deleted on first consumption attempt regardless of store success — avoids mis-pairing on persistent backend failure.
3. **Unified home-dir project-tag suppression**: Removed `Path.home().name` from `_QA_NOISY_NAMES`, kept the explicit `cwd != Path.home()` check (so a project legitimately named like the home basename is still tagged).
4. **Stop dispatch hardening**: `_capture_pm_turn_on_stop` now runs once per Stop event (hoisted to `main()` dispatch) instead of once per active backend.
5. **Test fragility fix**: `threading.Thread` patches module-scoped to `claude_mpm.hooks.memory_capture.threading.Thread`.

## Files Changed
- `src/claude_mpm/hooks/memory_capture.py` — hardening implementation
- `tests/test_memory_capture_qa_pairs.py` — test updates for new semantics

## Test Results
88 tests pass (memory_capture + stop_handler); 1 unrelated skip (pyngrok).

Closes #879

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)