### PR TITLE
refactor: Q&A capture review cleanups

### DIFF
--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -834,9 +834,9 @@ def _read_qa_state_with_mtime(session_id: str) -> tuple[str, float] | None:
             content = fh.read().strip()
             mtime = os.fstat(fh.fileno()).st_mtime
         return (content, mtime)
-    except FileNotFoundError:
-        return None
     except Exception:
+        # Covers FileNotFoundError (file absent), PermissionError (unreadable),
+        # and any other OS-level failure — all map to the same "no state" result.
         return None
 
 

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -1063,9 +1063,13 @@ def handle_user_prompt_submit(
 
             threading.Thread(target=_bg_store_qa, daemon=True).start()
         elif is_qa_reply:
-            # qa_pairs capture is disabled.  State file was already deleted
-            # synchronously (consume-once) above — nothing left to do here.
-            pass
+            # qa_pairs capture is disabled, but this prompt IS a reply to a PM
+            # turn.  The state file was already deleted synchronously above
+            # (consume-once).  We deliberately do NOT fall through to the
+            # standalone path: the prompt is a conversational reply, not a new
+            # standalone prompt, so storing it as "User prompt: ..." would be
+            # misleading.  The pair is simply not captured when qa_pairs=false.
+            pass  # intentional: no storage, no fallthrough (see comment above)
         else:
             # Standalone prompt — existing behaviour.
             snippet = prompt[:_PROMPT_CAPTURE_MAX_CHARS].strip()

--- a/src/claude_mpm/hooks/memory_capture.py
+++ b/src/claude_mpm/hooks/memory_capture.py
@@ -21,6 +21,30 @@ Design goals
   start/end metadata. We deliberately do NOT store full tool JSON, file
   contents, or assistant reasoning.
 
+Design note: consume-once semantics for Q&A pair capture
+---------------------------------------------------------
+Q&A pair capture uses a filesystem state file as a cross-process bridge:
+the Stop handler writes the last PM response to
+``~/.claude-mpm/state/{session_id}_last_response.txt``; the next
+UserPromptSubmit reads it and stores a paired ``"PM: ...\\nUser: ..."``
+fact.
+
+The state file is **deleted on the first consumption attempt regardless
+of whether backend.store() later succeeds** (see
+``handle_user_prompt_submit``).  This is intentional:
+
+* If we kept the file until a *successful* store, a transient backend
+  outage (daemon restart, timeout spike) would leave the file in place.
+  Every subsequent UserPromptSubmit within the 600-second window would
+  then pair a **new** user reply with the **same stale PM turn** —
+  fabricating incorrect paired facts that corrupt the memory store.
+* Losing *one* pair on a transient failure is strictly preferable to
+  mis-pairing every subsequent prompt for up to 10 minutes.
+
+**Do not "fix" the eager deletion back to preserve-on-failure.**  If you
+need higher durability, introduce a separate retry queue; do not reuse
+the state file for that purpose.
+
 Invocation: ``python3 -m claude_mpm.hooks.memory_capture`` from
 ``.claude/settings.json`` (PostToolUse, Stop, SubagentStop, SessionStart).
 

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -634,8 +634,19 @@ class TestHandleUserPromptSubmitQaPairs:
         ), f"Expected 'User prompt:' fact; got: {stored}"
 
     def test_qa_pairs_config_disabled_skips_paired_store(self, tmp_path: Path) -> None:
-        """When qa_pairs capture is disabled, paired fact is not stored but state file
-        IS deleted (Finding 4) so it cannot linger and mis-pair with a later prompt.
+        """When qa_pairs is disabled, a PM-reply prompt stores NOTHING and the state
+        file IS deleted.
+
+        Chosen behavior: when qa_pairs=false and the prompt is a reply to a PM turn
+        (is_qa_reply=True), the hook deliberately stores nothing — neither a qa-pair
+        fact nor a standalone "User prompt: ..." fact.  The prompt is a conversational
+        reply, not a new standalone prompt, so storing it as "User prompt: ..." would
+        be semantically misleading.  The state file is still deleted (consume-once) to
+        prevent stale mis-pairing on any subsequent prompt.
+
+        This is an explicit, intentional no-op — not a missing feature.  If the
+        desired behavior changes to "store as standalone when qa_pairs=false", update
+        the elif branch in handle_user_prompt_submit and this test together.
         """
         backend = _make_mock_backend()
         session_id = "sess-qa-disabled"

--- a/tests/test_memory_capture_qa_pairs.py
+++ b/tests/test_memory_capture_qa_pairs.py
@@ -1029,32 +1029,37 @@ class TestHandleSessionEndWithQaCapture:
 
         Verifies the item-4 fix: capture is hoisted to main() dispatch level so
         it runs exactly once regardless of backend count.
+
+        sys patch scope: only sys.stdin is patched (the sole sys attribute that
+        main() touches, via _read_event()).  select.select is patched to return a
+        truthy ready-list so _read_event() proceeds to json.load(sys.stdin).
+        print() is patched via builtins to silence stdout during the test.
+        sys.stdout is NOT patched because main() never accesses it directly.
         """
+        import builtins
+        import io
+        import json as _json
+
         backend = _make_mock_backend()
         event = {
             "hook_event_name": "Stop",
             "session_id": "sess-main-dispatch",
             "cwd": str(tmp_path),
         }
-
-        import io
-        import json as _json
-
         event_json = _json.dumps(event)
+        fake_stdin = io.StringIO(event_json)
 
         with (
             patch.object(mc, "_BACKEND", backend),
             patch.object(mc, "_capture_pm_turn_on_stop") as mock_capture,
-            patch.object(mc, "sys") as mock_sys,
-            patch("select.select", return_value=([mock_sys.stdin], [], [])),
+            # Patch only the sys.stdin attribute that _read_event() reads.
+            patch.object(mc.sys, "stdin", fake_stdin),
+            # Make select.select report stdin as ready so _read_event() proceeds.
+            patch("select.select", return_value=([fake_stdin], [], [])),
+            # Silence the JSON continue-payload written by _emit_continue().
+            patch.object(builtins, "print"),
         ):
-            mock_sys.stdin = io.StringIO(event_json)
-            mock_sys.stdout = io.StringIO()
-            # Redirect print to avoid actual stdout writes in tests.
-            import builtins
-
-            with patch.object(builtins, "print"):
-                mc.main()
+            mc.main()
 
         assert mock_capture.call_count == 1, (
             "main() must call _capture_pm_turn_on_stop exactly once per Stop event"


### PR DESCRIPTION
## Summary

Non-functional cosmetic follow-ups from the trusty-review of PR #880. These are advisory cleanups with no correctness changes:

1. **Merge redundant except clauses**: Collapsed two identical exception handlers in `_read_qa_state_with_mtime` into a single clause.
2. **Replace dead no-op with intent comment**: Replaced the `elif is_qa_reply: pass` branch (dead code when qa_pairs disabled) with an explicit comment documenting the intent — behavior preserved (stores nothing when qa_pairs disabled and is_qa_reply is true).
3. **Narrow test sys patch**: Restricted the `sys` mock in the Stop dispatch test to only `sys.stdin`, avoiding accidental MagicMock masking of unexpected sys access patterns.
4. **Document consume-once semantics**: Added module docstring to `memory_capture.py` documenting the consume-once design trade-off and rationale (CHANGELOG.md is commitizen-autogenerated, so module docstring is the right home).

## Files Changed
- `src/claude_mpm/hooks/memory_capture.py`
- `tests/test_memory_capture_qa_pairs.py`

## Test Results
88 tests pass (memory_capture + stop_handler suite).

## Notes
These are trivial cosmetic improvements — no new behavior, no new tests. Following up on review feedback from PR #880 closure.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)