### PR TITLE
fix: ETag cache portability + shell-fallback hardening (#884)

### DIFF
--- a/scripts/sync_agent_skills_repos.sh
+++ b/scripts/sync_agent_skills_repos.sh
@@ -100,13 +100,26 @@ sync_repo() {
     # This is a conservative clean: only well-known untracked cache files are
     # removed; tracked files and any other untracked files are left alone.
     # (fix #882 — skills sync used to leave .etag_cache.json in the clone tree)
+    #
+    # Hardened (fix #884): delete ONLY the exact paths reported by git as
+    # untracked, not every .etag_cache.json found by find.  This prevents
+    # accidental removal of a hypothetically tracked nested copy elsewhere in
+    # the repository.  git ls-files --others --exclude-standard --z outputs
+    # NUL-delimited untracked paths that pass .gitignore rules, which we
+    # filter to .etag_cache.json entries and remove one by one.
     print_message "$YELLOW" "Step 0b: Removing stale cache artefacts from working tree..."
-    UNTRACKED_ETAG=$(git status --porcelain 2>/dev/null | grep '^\?\?' | grep '\.etag_cache\.json' || true)
-    if [ -n "$UNTRACKED_ETAG" ]; then
-        print_message "$YELLOW" "  Found untracked .etag_cache.json file(s), removing..."
-        # Delete every untracked .etag_cache.json file (safe: only untracked copies)
-        find . -name '.etag_cache.json' -not -path './.git/*' -exec rm -f {} + 2>/dev/null || true
-        print_message "$GREEN" "  ✓ Stale ETag cache artefacts removed"
+    REMOVED_COUNT=0
+    while IFS= read -r -d '' untracked_path; do
+        case "$untracked_path" in
+            *'.etag_cache.json')
+                print_message "$YELLOW" "  Removing untracked cache artefact: $untracked_path"
+                rm -f -- "$untracked_path"
+                REMOVED_COUNT=$((REMOVED_COUNT + 1))
+                ;;
+        esac
+    done < <(git ls-files --others --exclude-standard -z 2>/dev/null || true)
+    if [ "$REMOVED_COUNT" -gt 0 ]; then
+        print_message "$GREEN" "  ✓ Removed $REMOVED_COUNT stale ETag cache artefact(s)"
     else
         print_message "$GREEN" "  ✓ No stale cache artefacts found"
     fi

--- a/src/claude_mpm/services/skills/git_skill_source_manager.py
+++ b/src/claude_mpm/services/skills/git_skill_source_manager.py
@@ -848,9 +848,8 @@ class GitSkillSourceManager:
         )
 
         try:
-            with (
-                self._etag_cache_lock
-            ):  # Intentional: brief once-per-upgrade hold (see docstring)
+            # Intentional: brief once-per-upgrade hold (see docstring)
+            with self._etag_cache_lock:
                 # Read legacy in-tree cache
                 legacy_data: dict[str, str] = {}
                 try:

--- a/src/claude_mpm/services/skills/git_skill_source_manager.py
+++ b/src/claude_mpm/services/skills/git_skill_source_manager.py
@@ -810,16 +810,25 @@ class GitSkillSourceManager:
 
         WHAT: Checks for a legacy ``.etag_cache.json`` file inside the git-clone
         working tree at ``cache_path/.etag_cache.json``; if found, reads its
-        ETag entries, merges them into the new external per-source cache file
-        (external entries win on key collision — they are at least as fresh),
-        then deletes the in-tree copy so the clone remains clean.  All errors
-        are caught and logged; the method never raises.
+        ETag entries, normalises any absolute-path keys to portable relative
+        filename keys (fix #884), merges them into the new external per-source
+        cache file (external entries win on key collision — they are at least as
+        fresh), then deletes the in-tree copy so the clone remains clean.  All
+        errors are caught and logged; the method never raises.
 
         WHY: Older versions of this manager wrote the ETag cache directly into
         the git-clone working tree.  That untracked file dirtied the clone and
         caused ``git pull --rebase`` to emit warnings (issue #882).  Migration
         preserves existing cache hits across the upgrade so the first sync after
-        the upgrade does not re-download every file.
+        the upgrade does not re-download every file.  Keys are normalised to
+        filenames so the migrated cache is portable across machine renames and
+        CI/Docker environments (issue #884).
+
+        Note: ``_etag_cache_lock`` is held across the file I/O inside this
+        method.  That is intentional — the migration runs at most once per
+        source per upgrade, so the brief lock duration is acceptable and avoids
+        a race with concurrent ``_download_file_with_etag`` calls that share the
+        same lock.
 
         Args:
             source_id: ID of the skill source.
@@ -839,7 +848,9 @@ class GitSkillSourceManager:
         )
 
         try:
-            with self._etag_cache_lock:
+            with (
+                self._etag_cache_lock
+            ):  # Intentional: brief once-per-upgrade hold (see docstring)
                 # Read legacy in-tree cache
                 legacy_data: dict[str, str] = {}
                 try:
@@ -855,9 +866,22 @@ class GitSkillSourceManager:
                     legacy_data = {}
 
                 if legacy_data:
-                    # Merge into the new external cache (external wins on collision)
+                    # Normalise legacy keys: old caches may use absolute paths as keys
+                    # (e.g. "/home/user/.claude-mpm/cache/skills/system/foo.md").
+                    # Convert each to just the filename so the migrated cache is
+                    # portable — consistent with the new relative-key scheme (#884).
+                    normalised: dict[str, str] = {}
+                    for key, etag_val in legacy_data.items():
+                        relative = Path(key).name  # e.g. "foo.md"
+                        # Later entries for the same filename win (mimics external-wins logic)
+                        normalised[relative] = etag_val
+
+                    # Merge into the new external cache (external entries win on collision
+                    # — they are at least as fresh as the in-tree legacy copy)
                     external_file = self._get_etag_cache_file(source_id)
-                    merged: dict[str, str] = dict(legacy_data)  # start with legacy
+                    merged: dict[str, str] = dict(
+                        normalised
+                    )  # start with normalised legacy
                     if external_file.exists():
                         try:
                             with open(external_file, encoding="utf-8") as fh:
@@ -964,11 +988,17 @@ class GitSkillSourceManager:
                 except Exception:  # nosec B110 - intentional: proceed without cache on read failure
                     pass
 
-            # TODO: absolute-path keys make this cache non-portable if ~/.claude-mpm
-            # is relocated or shared across machines.  A future refactor should key
-            # on a path relative to the cache root (e.g. relative to self.cache_dir
-            # or self.etag_dir) so that the JSON file remains valid after a move.
-            cached_etag = etag_cache.get(str(local_path))
+            # Key on the filename (relative key) for portability: each cache
+            # file lives in its own per-source directory, so local_path.name is
+            # unique within it and stays valid when ~/.claude-mpm is relocated or
+            # shared across CI/Docker machines (fix #884).
+            # Backward-compat: fall back to the legacy absolute-path key so
+            # pre-existing caches still produce a 304 hit on the first run after
+            # upgrade — a missed lookup is only a harmless re-download.
+            relative_key = local_path.name
+            cached_etag = etag_cache.get(relative_key) or etag_cache.get(
+                str(local_path)
+            )
 
         # Make conditional request (no lock needed - independent HTTP call)
         headers: dict[str, str] = {}
@@ -1004,7 +1034,10 @@ class GitSkillSourceManager:
                         except Exception:
                             etag_cache = {}
 
-                    etag_cache[str(local_path)] = response.headers["ETag"]
+                    # Always write the portable relative key (fix #884).
+                    # The legacy absolute-path key is intentionally NOT written
+                    # so migrated caches converge to the new scheme on next sync.
+                    etag_cache[local_path.name] = response.headers["ETag"]
                     etag_cache_file.parent.mkdir(parents=True, exist_ok=True)
                     with open(etag_cache_file, "w", encoding="utf-8") as f:
                         json.dump(etag_cache, f, indent=2)

--- a/src/claude_mpm/services/skills/git_skill_source_manager.py
+++ b/src/claude_mpm/services/skills/git_skill_source_manager.py
@@ -875,8 +875,12 @@ class GitSkillSourceManager:
                         # Later entries for the same filename win (mimics external-wins logic)
                         normalised[relative] = etag_val
 
-                    # Merge into the new external cache (external entries win on collision
-                    # — they are at least as fresh as the in-tree legacy copy)
+                    # Merge into the new external cache.
+                    # Precedence: external cache wins on key collision — external entries
+                    # are at least as fresh as the in-tree legacy copy.
+                    # ALL keys (both legacy and external) are normalised to relative
+                    # filenames (Path(k).name) before merging so the result contains
+                    # only portable relative-filename keys (#884).
                     external_file = self._get_etag_cache_file(source_id)
                     merged: dict[str, str] = dict(
                         normalised
@@ -885,7 +889,12 @@ class GitSkillSourceManager:
                         try:
                             with open(external_file, encoding="utf-8") as fh:
                                 existing = json.load(fh)
-                            merged.update(existing)  # external entries win
+                            # Normalise external keys too so ALL keys in the result
+                            # are relative filenames — prevents a mix of absolute-path
+                            # and relative-filename keys after the merge (#884).
+                            for key, etag_val in existing.items():
+                                relative_key = Path(key).name
+                                merged[relative_key] = etag_val  # external wins
                         except Exception as exc:  # nosec B110
                             self.logger.warning(
                                 "Could not read external ETag cache %s during migration: %s",

--- a/tests/services/skills/test_git_skill_source_manager.py
+++ b/tests/services/skills/test_git_skill_source_manager.py
@@ -1001,3 +1001,199 @@ skill_version: 1.0.0
 
         assert result2["removed_count"] == 1
         assert "skill-c" in result2["removed_skills"]
+
+
+class TestETagCachePortability:
+    """Tests for ETag cache portability and backward-compatibility (issue #884).
+
+    Covers:
+    - Cache entries are written with relative (filename-only) keys.
+    - A 304 cache-hit still works when the cache directory is moved/renamed.
+    - Backward-compat: a cache file with a legacy absolute-path key still
+      yields a 304 hit (no needless re-download on first run after upgrade).
+    """
+
+    @pytest.fixture
+    def temp_cache_dir(self):
+        """Temporary cache directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def temp_config_file(self):
+        """Temporary config file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            config_path = Path(f.name)
+        yield config_path
+        if config_path.exists():
+            config_path.unlink()
+
+    @pytest.fixture
+    def manager(self, temp_config_file, temp_cache_dir):
+        """GitSkillSourceManager instance with a single system source."""
+        config = SkillSourceConfiguration(config_path=temp_config_file)
+        source = SkillSource(
+            id="system",
+            type="git",
+            url="https://github.com/bobmatnyc/claude-mpm-skills",
+            priority=0,
+            enabled=True,
+        )
+        config.save([source])
+        return GitSkillSourceManager(config=config, cache_dir=temp_cache_dir)
+
+    @patch("requests.get")
+    def test_etag_written_with_relative_key(self, mock_get, manager, temp_cache_dir):
+        """ETag cache entries must be written with local_path.name as the key.
+
+        The absolute path MUST NOT appear as a key so the cache file is
+        portable across machine renames, CI environments, and Docker volumes.
+        """
+        import json
+
+        # Arrange: simulate a fresh 200 response with an ETag header
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"# skill content"
+        mock_response.headers = {"ETag": '"abc123"'}
+        mock_get.return_value = mock_response
+
+        local_path = temp_cache_dir / "system" / "some-skill.md"
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        etag_cache_file = manager._get_etag_cache_file("system")
+
+        # Act
+        manager._download_file_with_etag(
+            url="https://raw.githubusercontent.com/owner/repo/main/some-skill.md",
+            local_path=local_path,
+            etag_cache_file=etag_cache_file,
+        )
+
+        # Assert: cache file must exist and use relative key
+        assert etag_cache_file.exists(), "ETag cache file was not created"
+        with open(etag_cache_file, encoding="utf-8") as fh:
+            cache_data = json.load(fh)
+
+        assert "some-skill.md" in cache_data, (
+            f"Expected relative key 'some-skill.md' in cache, got keys: {list(cache_data.keys())}"
+        )
+        assert cache_data["some-skill.md"] == '"abc123"'
+
+        # Absolute path key must NOT be present
+        assert str(local_path) not in cache_data, (
+            "Absolute-path key must not be written — it breaks portability"
+        )
+
+    @patch("requests.get")
+    def test_cache_hit_after_directory_relocation(self, mock_get, manager):
+        """Cache hit (304) works when the cache directory is relocated.
+
+        Simulate relocation by writing a cache file with relative keys at one
+        path, then pointing the manager at a copy of the file in a different
+        directory — the relative key must still match.
+        """
+        import json
+        import shutil
+
+        with (
+            tempfile.TemporaryDirectory() as original_dir,
+            tempfile.TemporaryDirectory() as relocated_dir,
+        ):
+            original_path = Path(original_dir)
+            relocated_path = Path(relocated_dir)
+
+            # Write a cache file with the relative key at the "original" location
+            original_cache = original_path / "system.json"
+            local_path_original = original_path / "skills" / "some-skill.md"
+            (original_path / "skills").mkdir()
+            local_path_original.write_text("# original", encoding="utf-8")
+
+            cache_data = {"some-skill.md": '"etag-v1"'}
+            with open(original_cache, "w", encoding="utf-8") as fh:
+                json.dump(cache_data, fh)
+
+            # "Relocate": copy the cache file to a new directory
+            relocated_cache = relocated_path / "system.json"
+            shutil.copy(original_cache, relocated_cache)
+
+            # The local_path in the relocated environment has a DIFFERENT absolute path
+            relocated_skill_dir = relocated_path / "skills"
+            relocated_skill_dir.mkdir()
+            local_path_relocated = relocated_skill_dir / "some-skill.md"
+            local_path_relocated.write_text("# relocated", encoding="utf-8")
+
+            # Arrange mock: return 304 (we expect this because the relative key matches)
+            mock_response = MagicMock()
+            mock_response.status_code = 304
+            mock_get.return_value = mock_response
+
+            # Act: download with the relocated cache file
+            result = manager._download_file_with_etag(
+                url="https://raw.githubusercontent.com/owner/repo/main/some-skill.md",
+                local_path=local_path_relocated,
+                etag_cache_file=relocated_cache,
+            )
+
+        # Assert: got a cache hit (False = not updated = 304)
+        assert result is False, (
+            "Expected cache hit (False) after directory relocation — "
+            "relative key must survive the move"
+        )
+        # Verify the If-None-Match header was sent with the right ETag
+        call_kwargs = mock_get.call_args[1]
+        sent_headers = call_kwargs.get("headers", {})
+        assert sent_headers.get("If-None-Match") == '"etag-v1"', (
+            f"Expected If-None-Match: '\"etag-v1\"', got headers: {sent_headers}"
+        )
+
+    @patch("requests.get")
+    def test_backward_compat_legacy_absolute_key_yields_304(
+        self, mock_get, manager, temp_cache_dir
+    ):
+        """A cache file containing a legacy absolute-path key still yields a 304 hit.
+
+        When a user upgrades from a version that wrote absolute-path keys, the
+        first sync after upgrade must send If-None-Match (not trigger a full
+        re-download) so the upgrade is quiet.
+        """
+        import json
+
+        # Arrange: pre-populate the cache file with a LEGACY absolute-path key
+        etag_cache_file = manager._get_etag_cache_file("system")
+        etag_cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        local_path = temp_cache_dir / "system" / "legacy-skill.md"
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_text("# legacy content", encoding="utf-8")
+
+        # Write the legacy key (absolute path)
+        legacy_cache = {str(local_path): '"legacy-etag-v0"'}
+        with open(etag_cache_file, "w", encoding="utf-8") as fh:
+            json.dump(legacy_cache, fh)
+
+        # Arrange mock: server acknowledges the ETag → 304
+        mock_response = MagicMock()
+        mock_response.status_code = 304
+        mock_get.return_value = mock_response
+
+        # Act
+        result = manager._download_file_with_etag(
+            url="https://raw.githubusercontent.com/owner/repo/main/legacy-skill.md",
+            local_path=local_path,
+            etag_cache_file=etag_cache_file,
+        )
+
+        # Assert: cache hit was returned
+        assert result is False, (
+            "Expected cache hit (False) for legacy absolute-path key — "
+            "backward-compat fallback must send If-None-Match"
+        )
+        # Verify If-None-Match was sent (not an unconditional GET)
+        call_kwargs = mock_get.call_args[1]
+        sent_headers = call_kwargs.get("headers", {})
+        assert "If-None-Match" in sent_headers, (
+            "If-None-Match header must be sent for legacy absolute-path key"
+        )
+        assert sent_headers["If-None-Match"] == '"legacy-etag-v0"', (
+            f"Expected the legacy ETag value, got: {sent_headers}"
+        )

--- a/tests/services/skills/test_git_skill_source_phase2.py
+++ b/tests/services/skills/test_git_skill_source_phase2.py
@@ -281,13 +281,30 @@ class TestPhase2CacheArchitecture:
         )
 
     def test_migrate_legacy_etag_cache(self, manager):
-        """Legacy in-tree .etag_cache.json is migrated to external location and deleted (#882)."""
+        """Legacy in-tree .etag_cache.json is migrated to external location with relative keys (#882, #884).
+
+        New contract (fix #884): migrated cache keys are relative filenames
+        (e.g. ``skill.md``), NOT absolute paths.  This makes the cache
+        portable across machine renames and CI/Docker environments.
+
+        This test verifies the no-collision path: no pre-existing external
+        cache, so every legacy entry is migrated as-is (after normalisation).
+        """
         import json
 
         source = manager.config.get_source("test-source")
         cache_path = manager._get_source_cache_path(source)
         cache_path.mkdir(parents=True, exist_ok=True)
 
+        # Ensure no pre-existing external cache for this source so we test
+        # the simple migration path (no collision).  The etag_dir is shared
+        # across tests (it resolves to a sibling of the OS temp dir), so a
+        # prior test may have written it — remove it explicitly.
+        external_file = manager._get_etag_cache_file(source.id)
+        if external_file.exists():
+            external_file.unlink()
+
+        # Legacy cache uses absolute-path keys (old format)
         legacy_entries = {
             str(cache_path / "skill.md"): '"etag-legacy"',
             str(cache_path / "other.md"): '"etag-other"',
@@ -306,47 +323,88 @@ class TestPhase2CacheArchitecture:
             "Legacy in-tree .etag_cache.json was not removed"
         )
 
-        # External file must contain migrated entries
-        external_file = manager._get_etag_cache_file(source.id)
+        # External file must contain migrated entries with RELATIVE filename keys
         assert external_file.exists(), "External ETag file was not created"
         migrated = json.loads(external_file.read_text())
-        for key, val in legacy_entries.items():
-            assert key in migrated, f"Key {key!r} missing from migrated cache"
-            assert migrated[key] == val
+
+        # Keys must be relative filenames, not absolute paths (#884)
+        assert "skill.md" in migrated, (
+            f"Relative key 'skill.md' missing from migrated cache; got keys: {list(migrated)}"
+        )
+        assert "other.md" in migrated, (
+            f"Relative key 'other.md' missing from migrated cache; got keys: {list(migrated)}"
+        )
+        assert migrated["skill.md"] == '"etag-legacy"'
+        assert migrated["other.md"] == '"etag-other"'
+
+        # No absolute-path keys must remain in the migrated cache
+        for key in migrated:
+            assert not key.startswith("/"), (
+                f"Absolute-path key found in migrated cache: {key!r} — expected relative filenames only"
+            )
 
     def test_migrate_legacy_etag_cache_merges_with_existing(self, manager):
-        """Migration merges legacy entries with existing external cache; external wins on collision."""
+        """Migration merges legacy + external caches; ALL keys are normalised to relative filenames.
+
+        Precedence rule (documented in _migrate_legacy_etag_cache docstring):
+        external cache wins on key collision.  Both the legacy in-tree entries
+        AND the pre-existing external entries are normalised to relative
+        filenames before merging, so the result must contain ONLY relative-
+        filename keys — no absolute paths (#884).
+        """
         import json
 
         source = manager.config.get_source("test-source")
         cache_path = manager._get_source_cache_path(source)
         cache_path.mkdir(parents=True, exist_ok=True)
 
-        skill_path = str(cache_path / "skill.md")
-
-        # Legacy in-tree cache
+        # Legacy in-tree cache uses absolute-path keys (old format).
+        # "skill.md" appears in both legacy and external — collision case.
+        # "old.md" appears only in legacy — must be preserved.
         legacy_file = cache_path / ".etag_cache.json"
         legacy_file.write_text(
             json.dumps(
-                {skill_path: '"etag-legacy"', str(cache_path / "old.md"): '"old-etag"'}
+                {
+                    str(cache_path / "skill.md"): '"etag-legacy"',
+                    str(cache_path / "old.md"): '"old-etag"',
+                }
             )
         )
 
-        # Pre-existing external cache (has newer ETag for skill.md)
+        # Pre-existing external cache also uses absolute-path keys (old format).
+        # After migration this entry must be normalised to a relative key too.
         external_file = manager._get_etag_cache_file(source.id)
         external_file.parent.mkdir(parents=True, exist_ok=True)
-        external_file.write_text(json.dumps({skill_path: '"etag-external"'}))
+        external_file.write_text(
+            json.dumps({str(cache_path / "skill.md"): '"etag-external"'})
+        )
 
         manager._migrate_legacy_etag_cache(source.id, cache_path)
 
-        # Legacy file removed
+        # Legacy file must be removed
         assert not legacy_file.exists()
 
         merged = json.loads(external_file.read_text())
-        # External wins for skill_path
-        assert merged[skill_path] == '"etag-external"'
-        # Legacy-only key is preserved
-        assert str(cache_path / "old.md") in merged
+
+        # No absolute-path keys may remain — the whole cache must use relative filenames
+        for key in merged:
+            assert not key.startswith("/"), (
+                f"Absolute-path key found in merged cache: {key!r} — expected relative filenames only"
+            )
+
+        # Collision: external wins → "skill.md" → '"etag-external"'
+        assert "skill.md" in merged, (
+            f"Relative key 'skill.md' missing from merged cache; got: {list(merged)}"
+        )
+        assert merged["skill.md"] == '"etag-external"', (
+            f"Expected external ETag to win on collision; got: {merged['skill.md']}"
+        )
+
+        # Legacy-only entry "old.md" must be preserved with relative key
+        assert "old.md" in merged, (
+            f"Relative key 'old.md' missing from merged cache; got: {list(merged)}"
+        )
+        assert merged["old.md"] == '"old-etag"'
 
     def test_migrate_legacy_etag_cache_no_legacy_file(self, manager):
         """Migration is a no-op when no legacy file exists (fast path)."""


### PR DESCRIPTION
Resolves the advisory follow-ups from PR #883 review (issue #884).

## Changes
1. **ETag cache portability** (`git_skill_source_manager.py`) — `_download_file_with_etag` now keys the per-directory `.etag_cache.json` on the relative filename (`local_path.name`) instead of the absolute `str(local_path)`. This keeps the cache valid when `~/.claude-mpm` is relocated/renamed or shared across machines (CI/Docker). A backward-compat read fallback to the legacy absolute key keeps existing caches producing 304 hits on upgrade. `_migrate_legacy_etag_cache` kept consistent.
2. **Shell cleanup hardening** (`scripts/sync_agent_skills_repos.sh`) — replaced the broad `find . -name '.etag_cache.json' -exec rm` with deletion of only the exact untracked paths reported by `git ls-files --others --exclude-standard -z`, eliminating the risk of removing a hypothetically tracked nested file.
3. **Lock-scope note** (minor) — documented that holding `_etag_cache_lock` across migration file I/O is intentional (once per source per upgrade).

## Verification
- `ruff format` / `ruff check`: clean
- `pytest tests/services/skills/test_git_skill_source_manager.py`: 40 passed (incl. 3 new portability tests: relative-key write, cache-hit-after-relocation, backward-compat legacy-absolute-key 304)
- WWL / spec-linked-docs gates: 71 passed

Closes #884

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)