### PR TITLE
ci: fail-fast dirty-workspace guard + mutation-isolation finding (#887)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ name: Test Suite
 #   WWL baseline ratchet (and every other test) could silently rot — a stale
 #   baseline or a failing test would only be caught locally. This job is the
 #   server-side gate that keeps the ratchet honest (issue #801).
+#
+# Dirty-workspace guard (issue #887): the first step after checkout verifies
+# that no tracked source file is modified at job start.  mutmut (mutation
+# testing) mutates files in-place; a leftover mutant causes shifted line
+# numbers and cryptic TypeErrors at import time.  Note: CI does NOT currently
+# run mutmut in any workflow (the mutation-test Makefile target is on-demand
+# only).  This guard is defence-in-depth against any future leakage.
 
 on:
   push:
@@ -27,6 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Guard: fail immediately if any tracked source file is dirty at job
+      # start (e.g. a mutated file left by mutmut on a prior run).  This turns
+      # silent contamination into an obvious, early, actionable failure.
+      # See scripts/check_clean_workspace.sh and issue #887 for context.
+      - name: Guard — verify clean workspace before testing
+        run: bash scripts/check_clean_workspace.sh
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,12 @@ test-e2e: ## Run end-to-end tests only
 	@uv run pytest tests/e2e/ -n $(TEST_WORKERS) -v
 
 mutation-test: ## Run mutation tests against trusty_search_allowlist (advisory, on-demand only)
+	# CI ISOLATION NOTE (issue #887, 2026-06-22):
+	# This target is intentionally NOT wired into any CI workflow — it is
+	# on-demand only (run locally by developers).  CI runs scripts/check_clean_workspace.sh
+	# at the start of each pytest job to detect any mutated files that might
+	# have been left on disk, turning silent contamination into an obvious failure.
+	# .mutmut-cache and mutants/ are gitignored so local runs cannot leak to CI.
 	@echo "$(YELLOW)🧬 Running mutation tests (scope: trusty_search_allowlist)...$(NC)"
 	@echo "$(YELLOW)   Safety: pilot file will be verified/restored regardless of mutmut exit code.$(NC)"
 	@mutmut_rc=0; uv run mutmut run || mutmut_rc=$$?; \

--- a/scripts/check_clean_workspace.sh
+++ b/scripts/check_clean_workspace.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check_clean_workspace.sh — fail-fast dirty-workspace guard for CI
+#
+# WHAT: Exits with a non-zero status and a human-readable error message if any
+#       tracked source file is modified at the start of a CI job.
+# WHY:  mutmut (mutation testing) mutates source files in-place.  If a prior
+#       job or a local developer run left a mutated file behind — e.g. because
+#       the restore step was skipped on an aborted run — the pytest job would
+#       silently import a mutant instead of the real source.  The symptom is a
+#       shifted-line-number TypeError like the one seen on PR #885 (TypeError:
+#       unsupported operand type(s) for |: 'frozenset' and 'NoneType' in
+#       trusty_search_allowlist.py — issue #887).  An early, explicit failure
+#       here turns silent contamination into an obvious, actionable error.
+#
+# NOTE: CI does NOT currently run mutmut in any workflow (the mutation-test
+#       Makefile target is explicitly "on-demand only").  This guard is
+#       defence-in-depth: it also catches any other source of dirty-workspace
+#       contamination (e.g. a stale .pyc-level patch, a botched merge, or a
+#       future CI job that does run mutmut).
+#
+# Usage (in workflow):
+#   - name: Guard — fail if tracked source files are dirty at job start
+#     run: bash scripts/check_clean_workspace.sh
+#
+# Local dry-run (should PASS on a clean checkout):
+#   bash scripts/check_clean_workspace.sh
+#
+# Local failure test — simulate a mutant, then revert:
+#   echo "# mutant" >> src/claude_mpm/services/trusty_search_allowlist.py
+#   bash scripts/check_clean_workspace.sh   # exits 1
+#   git checkout -- src/claude_mpm/services/trusty_search_allowlist.py
+
+set -euo pipefail
+
+# git diff --name-only lists tracked files that differ from HEAD.
+# We include both working-tree changes (unstaged) and index changes (staged)
+# to catch any path by which a mutated file could end up in the workspace.
+dirty_files=$(git diff --name-only HEAD 2>/dev/null || true)
+staged_files=$(git diff --name-only --cached HEAD 2>/dev/null || true)
+
+combined=$(printf '%s\n%s' "$dirty_files" "$staged_files" \
+    | sort -u \
+    | grep -v '^[[:space:]]*$' \
+    || true)
+
+if [ -n "$combined" ]; then
+    # GitHub Actions annotation (no-op outside GHA)
+    echo "::error::DIRTY WORKSPACE DETECTED — possible mutation-test contamination (issue #887)"
+    echo ""
+    echo "ERROR: tracked source files are modified at job start — possible"
+    echo "       mutation-test contamination (issue #887)"
+    echo ""
+    echo "Modified tracked files:"
+    echo "$combined" | sed 's/^/  /'
+    echo ""
+    echo "This can happen when mutmut leaves a mutated file on disk after an"
+    echo "aborted run.  On PR #885 this caused a shifted-line TypeError at"
+    echo "import of trusty_search_allowlist.py."
+    echo ""
+    echo "Fix options:"
+    echo "  CI:    check whether a prior job left mutated files;"
+    echo "         run:  git checkout -- .  then re-trigger the job."
+    echo "  Local: run   git checkout -- .  to restore all tracked files."
+    echo "         If .mutmut-cache exists, a prior mutmut run is the likely cause."
+    exit 1
+fi
+
+echo "clean-workspace-check: OK — no tracked source files modified at job start."


### PR DESCRIPTION
Addresses #887 (mutated-source contamination theory from PR #885 CI).

## Investigation finding
CI does NOT run mutmut. `.github/workflows/` (test.yml, deepeval-tests.yml, guard-sensitive-paths.yml, release-wheels.yml) has no mutation step. mutmut config in setup.cfg + the `mutation-test` Makefile target are advisory/on-demand only (the target already self-restores via `git checkout HEAD --`), and `.mutmut-cache`/`mutants/` are already gitignored — a local mutmut run cannot commit a mutated file. The PR #885 `frozenset | NoneType` error with shifted line numbers was therefore most likely a transient stale-.pyc / xdist import edge case, not CI mutation contamination.

## Changes (defense-in-depth)
1. `scripts/check_clean_workspace.sh` — fail-fast guard: if any tracked file is dirty (working-tree or staged) it emits a GitHub Actions `::error::`, lists the files, prints remediation, and exits 1.
2. `.github/workflows/test.yml` — runs the guard as the first step after checkout (before deps/import) in the pytest job, with an explanatory header comment.
3. `Makefile` — documents the #887 finding on the `mutation-test` target.

Turns any silent tracked-source contamination into an obvious, early CI failure.

Closes #887