### PR TITLE
fix: rewrite Claude Code → Claude MPM footer in gh PR/issue bodies (hook backstop)

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -297,6 +297,13 @@ class ToolHandler:
             # If gh_footer_hook rewrote the command but ztk did not fire
             # (ztk absent, or ztk skipped compound/piped command), surface the
             # footer-fixed tool_input now.
+            #
+            # Invariant: _footer_rewrote is a complete hookSpecificOutput
+            # response (updatedInput already set).  We return it here
+            # regardless of ztk's hookSpecificOutput presence because ztk
+            # returned a no-op ({"continue": True}) — meaning ztk either
+            # chose not to rewrite or is not available.  The footer rewrite
+            # must still reach the harness so the corrected command is used.
             if _footer_rewrote is not None:
                 if _cb_warning_reason:
                     _hso = _footer_rewrote.get("hookSpecificOutput", {})

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -258,6 +258,26 @@ class ToolHandler:
                 if DEBUG:
                     _log(f"model_tier_hook failed (fail-open): {_e}")
         elif _tool_name_early == "Bash":
+            # gh_footer_hook runs BEFORE ztk so that if ztk wraps the command
+            # it wraps the already-corrected footer, not the old one.
+            # Track whether a footer rewrite occurred so we can return it when
+            # ztk does NOT fire (ztk passes through on compound/piped commands
+            # and when the ztk binary is absent).
+            _footer_rewrote: dict | None = None
+            try:
+                from claude_mpm.hooks.gh_footer_hook import build_gh_footer_response
+
+                _footer_response = build_gh_footer_response(event)
+                _footer_hso = _footer_response.get("hookSpecificOutput")
+                if isinstance(_footer_hso, dict):
+                    _updated_input = _footer_hso.get("updatedInput")
+                    if isinstance(_updated_input, dict):
+                        # Patch event in-place so ztk (below) sees fixed command.
+                        event["tool_input"] = _updated_input
+                        _footer_rewrote = _footer_response
+            except Exception as _e:
+                if DEBUG:
+                    _log(f"gh_footer_hook failed (fail-open): {_e}")
             try:
                 from claude_mpm.hooks.ztk_hook import build_ztk_response
 
@@ -274,6 +294,35 @@ class ToolHandler:
             except Exception as _e:
                 if DEBUG:
                     _log(f"ztk_hook failed (fail-open): {_e}")
+            # If gh_footer_hook rewrote the command but ztk did not fire
+            # (ztk absent, or ztk skipped compound/piped command), surface the
+            # footer-fixed tool_input now.
+            if _footer_rewrote is not None:
+                if _cb_warning_reason:
+                    _hso = _footer_rewrote.get("hookSpecificOutput", {})
+                    if isinstance(_hso, dict) and not _hso.get(
+                        "permissionDecisionReason"
+                    ):
+                        _hso["permissionDecisionReason"] = _cb_warning_reason
+                return _footer_rewrote
+        elif _tool_name_early.startswith("mcp__github__"):
+            # MCP GitHub tool calls (create_pull_request, create_issue, etc.)
+            # also need footer normalisation via gh_footer_hook.
+            try:
+                from claude_mpm.hooks.gh_footer_hook import build_gh_footer_response
+
+                _footer_response = build_gh_footer_response(event)
+                if _footer_response.get("hookSpecificOutput"):
+                    if _cb_warning_reason:
+                        _hso = _footer_response["hookSpecificOutput"]
+                        if isinstance(_hso, dict) and not _hso.get(
+                            "permissionDecisionReason"
+                        ):
+                            _hso["permissionDecisionReason"] = _cb_warning_reason
+                    return _footer_response
+            except Exception as _e:
+                if DEBUG:
+                    _log(f"gh_footer_hook (mcp) failed (fail-open): {_e}")
 
         # Enhanced debug logging for session correlation
         session_id = event.get("session_id", "")

--- a/src/claude_mpm/hooks/footer_constants.py
+++ b/src/claude_mpm/hooks/footer_constants.py
@@ -1,0 +1,39 @@
+"""Shared footer string constants for Claude Code → Claude MPM attribution rewriting.
+
+WHAT: Single source of truth for the old Claude Code footer patterns that need
+      replacing and the canonical Claude MPM footer that replaces them.
+WHY:  These strings are used in three distinct places — startup_migrations.py
+      (agent-file rewrite), gh_footer_hook.py (live PR/issue body rewrite), and
+      the PR template service.  Keeping them in one module prevents drift where a
+      URL changes in one place but not another.
+
+References
+----------
+LINK: none  (shared-constants helper, no governing spec yet)
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Old Claude Code footer patterns (both URL variants; neither has the emoji)
+# ---------------------------------------------------------------------------
+# The Claude Code CLI injects one of these two URL forms depending on version:
+#   - https://claude.ai/code   (older / canonical)
+#   - https://claude.com/claude-code  (newer alias)
+# Both must be matched to achieve full coverage.
+#
+# NOTE: Claude Code also prepends "🤖 " (robot emoji + space) in interactive
+# sessions, but the bare form (no emoji) appears in non-interactive / scripted
+# usage.  We therefore define both the bare strings (no emoji) — the match
+# logic in gh_footer_hook normalises by stripping the emoji prefix.
+CLAUDE_CODE_FOOTER_OLD = "Generated with [Claude Code](https://claude.ai/code)"
+CLAUDE_CODE_FOOTER_OLD_ALT = (
+    "Generated with [Claude Code](https://claude.com/claude-code)"
+)
+
+# ---------------------------------------------------------------------------
+# Canonical Claude MPM footer (with emoji)
+# ---------------------------------------------------------------------------
+MPM_FOOTER_CANONICAL = (
+    "🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)"
+)

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -123,12 +123,35 @@ _GH_BODY_CMD_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Regex to extract the value of --body / -b from a shell command string.
-# Handles both --body="..." and --body "..." forms (with single or double
-# quotes, or bare unquoted values without spaces).
-# NOTE: (?!-file) prevents --body-file from being matched as --body.
+# Regex to extract the --body / -b flag and its value from a shell command.
+#
+# Design notes
+# ------------
+# Group 1 (flag):  the flag token — ``--body`` or ``-b``.
+# Group 2 (sep):   separator between flag and value — ``=`` or one-or-more spaces.
+# Group 3 (quote): the opening quote character (``"`` or ``'``), or empty string
+#                  when the value is bare/unquoted.
+# Group 4 (dq):    double-quoted value (group 3 == ``"``).
+# Group 5 (sq):    single-quoted value (group 3 == ``'``).
+# Group 6 (bare):  bare unquoted value (group 3 == ``""``).
+#
+# Correctness constraints
+# -----------------------
+# * ``--body-file`` must NOT match as ``--body``:  the ``(?!-file)``
+#   look-ahead on ``--body`` prevents this.
+# * ``-b`` must only match as a standalone flag, NOT as a prefix of longer
+#   tokens such as ``-base`` or ``-branch``:
+#     - Requires a preceding word boundary (start-of-string or whitespace).
+#     - Requires the character after ``-b`` to be ``=``, whitespace, or
+#       end-of-string — i.e. ``(?=\s|=|$)``.
+# * Reconstruction (see _requote / rewrite_bash_command) rebuilds the flag
+#   text purely from the captured groups so it never relies on searching for
+#   the old value string inside the original flag text.
 _BODY_FLAG_RE = re.compile(
-    r"""(?:--body(?!-file)|-b(?!ody))\s*=?\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
+    r"""((?:--body(?!-file)|(?:(?:^|\s))-b(?=[\s=]|$)))"""  # group 1: flag token
+    r"""(\s*=\s*|\s+)"""  # group 2: separator
+    r"""("((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))""",  # groups 3-6: quoted or bare value
+    re.MULTILINE,
 )
 
 # Regex to extract the value of --body-file / -F.
@@ -142,18 +165,34 @@ def _is_gh_body_command(command: str) -> bool:
     return bool(_GH_BODY_CMD_RE.search(command))
 
 
-def _extract_body_inline(command: str) -> tuple[str, str] | None:
+def _extract_body_inline(
+    command: str,
+) -> tuple[str, re.Match] | None:  # type: ignore[type-arg]
     """Extract the inline body value from a ``--body``/``-b`` flag.
 
-    Returns ``(raw_value, flag_form)`` where *flag_form* is the matched
-    substring (used for replacement), or None if no inline body flag found.
+    Returns ``(decoded_value, match)`` where *decoded_value* is the unquoted
+    body string and *match* is the regex ``re.Match`` object (used for
+    precise, group-based reconstruction), or None if no inline body flag
+    was found.
+
+    The match groups are:
+      group(1)  — flag token (``--body`` or ``-b`` with surrounding whitespace)
+      group(2)  — separator (``=`` or spaces)
+      group(3)  — full quoted-or-bare value token including quotes
+      group(4)  — inner text when double-quoted (or None)
+      group(5)  — inner text when single-quoted (or None)
+      group(6)  — bare unquoted value (or None)
     """
     m = _BODY_FLAG_RE.search(command)
     if not m:
         return None
-    # One of the three capture groups will be set.
-    value = m.group(1) or m.group(2) or m.group(3) or ""
-    return value, m.group(0)
+    # Exactly one of groups 4, 5, 6 is set.
+    value = (
+        m.group(4)
+        if m.group(4) is not None
+        else (m.group(5) if m.group(5) is not None else (m.group(6) or ""))
+    )
+    return value, m
 
 
 def _extract_body_file(command: str) -> str | None:
@@ -164,14 +203,35 @@ def _extract_body_file(command: str) -> str | None:
     return m.group(1) or m.group(2) or m.group(3) or None
 
 
-def _requote(value: str, original_flag: str) -> str:
-    """Re-wrap *value* in the same quoting style as *original_flag*."""
-    if original_flag.endswith(f'"{value}"') or '="' in original_flag:
-        return f'"{value}"'
-    if original_flag.endswith(f"'{value}'") or "='" in original_flag:
-        return f"'{value}'"
-    # bare or --body= form — use double quotes if the value needs it
-    if " " in value or "\n" in value or '"' in value:
+def _requote(value: str, quote_char: str) -> str:
+    """Re-wrap *value* using the quoting style captured from the original flag.
+
+    *quote_char* is the opening quote character found in the original command
+    (``"`` for double-quoted, ``'`` for single-quoted, ``""`` for bare/unquoted).
+    This is read directly from the regex match group — it is never inferred by
+    searching the old value string inside the flag text, which avoids false
+    matches when the old body appears elsewhere in the command.
+
+    Rules:
+    - Double-quoted → keep double-quoted, escaping backslashes and embedded ``"``.
+    - Single-quoted → keep single-quoted (shell semantics: no escaping inside
+      single quotes, but we must ensure the value contains no literal ``'``; if
+      it does, fall back to double-quoting to avoid shell syntax breakage).
+    - Bare / unquoted → stay bare if safe (no spaces, newlines, or ``"``);
+      otherwise wrap in double quotes.
+    """
+    if quote_char == '"':
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if quote_char == "'":
+        if "'" not in value:
+            return f"'{value}'"
+        # Value contains a single quote — cannot stay single-quoted safely;
+        # fall back to double quotes with proper escaping.
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    # Bare / no quote char — add double quotes only if value requires them.
+    if " " in value or "\n" in value or '"' in value or "'" in value:
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     return value
@@ -180,9 +240,22 @@ def _requote(value: str, original_flag: str) -> str:
 def rewrite_bash_command(command: str) -> str | None:
     """Rewrite a Bash command string so any old footer in the body is canonical.
 
+    WHAT: Parses ``--body``/``-b`` (inline) and ``--body-file``/``-F`` (file)
+          flags from a ``gh pr/issue create/edit`` command, rewrites any old
+          Claude Code footer in the body to the MPM canonical footer, and
+          returns the modified command string.  For file-based bodies, the file
+          is rewritten in place and the command string is returned unchanged.
+    WHY:  This function is the single point where Bash-command bodies are
+          normalised; it must be robust against edge cases (empty values,
+          multi-line bodies, the old footer text appearing in other flags such
+          as ``--title``) so that the hook never corrupts legitimate commands.
+          Reconstruction uses regex match groups exclusively — never string
+          search on the old value — to avoid false matches.
+
     Returns the rewritten command string, or None if no rewrite was needed
     (already canonical, no footer found, or not a gh body command).
-    Fail-safe: any unexpected exception is caught; None is returned.
+    Fail-safe: any unexpected exception is caught; None is returned so the
+    original command is used unmodified.
     """
     try:
         if not _is_gh_body_command(command):
@@ -191,17 +264,32 @@ def rewrite_bash_command(command: str) -> str | None:
         # Try inline --body / -b first.
         extracted = _extract_body_inline(command)
         if extracted is not None:
-            body_value, flag_match = extracted
+            body_value, match = extracted
             new_body = rewrite_footer(body_value)
             if new_body == body_value:
                 return None  # already canonical or no footer
-            # Rebuild the flag with the new body value.
-            new_flag = flag_match[: flag_match.index(body_value)] + _requote(
-                new_body, flag_match
-            )
-            # If requote wrapped differently, reconstruct more carefully.
-            # Simple approach: replace the first occurrence of the old flag.
-            return command.replace(flag_match, new_flag, 1)
+
+            # Determine the quote char from the original flag's structure.
+            # group(3) is the full value token (with quotes); the first char
+            # of group(3) is the opening quote (``"`` or ``'``) or the first
+            # char of a bare value (no quote).
+            value_token = match.group(3) or ""
+            opening_char = value_token[:1] if value_token else ""
+            quote_char = opening_char if opening_char in ('"', "'") else ""
+
+            # Build the replacement text from match groups so the substitution
+            # is anchored to exactly this match position.  We preserve group(1)
+            # (the flag token, including any leading whitespace captured by the
+            # ``(?:^|\s)`` prefix in -b branches) and group(2) (separator).
+            flag_tok = match.group(1)  # e.g. " -b" or "--body"
+            sep_tok = match.group(2)  # e.g. "=" or " "
+            new_quoted = _requote(new_body, quote_char)
+            replacement = flag_tok + sep_tok + new_quoted
+
+            # re.sub with count=1 replaces the first (and only) match at the
+            # precise position found — never accidentally hits the old footer
+            # text that may appear elsewhere in the command (e.g. in --title).
+            return _BODY_FLAG_RE.sub(replacement, command, count=1)
 
         # Try --body-file / -F.
         file_path_str = _extract_body_file(command)

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -126,8 +126,9 @@ _GH_BODY_CMD_RE = re.compile(
 # Regex to extract the value of --body / -b from a shell command string.
 # Handles both --body="..." and --body "..." forms (with single or double
 # quotes, or bare unquoted values without spaces).
+# NOTE: (?!-file) prevents --body-file from being matched as --body.
 _BODY_FLAG_RE = re.compile(
-    r"""(?:--body|-b)\s*=?\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
+    r"""(?:--body(?!-file)|-b(?!ody))\s*=?\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
 )
 
 # Regex to extract the value of --body-file / -F.

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -1,0 +1,331 @@
+"""PreToolUse hook: rewrite Claude Code attribution footers to Claude MPM in GitHub PR/issue bodies.
+
+WHAT: Intercepts ``gh pr create``, ``gh pr edit``, ``gh issue create``, and
+      ``gh issue edit`` Bash commands (and their MCP equivalents) and normalises
+      any "Generated with [Claude Code]" footer in the body to the canonical
+      "🤖👥 Generated with [Claude MPM]" footer before the command is executed.
+WHY:  The version_control agent and other subagents default to the Claude Code
+      footer because they have no explicit footer directive.  Without a live
+      hook, vanilla Claude Code attribution leaks onto every PR and issue body
+      created by a claude-mpm session.
+
+Behaviour contract
+------------------
+- Intercepts: ``gh pr create``, ``gh pr edit``, ``gh issue create``,
+  ``gh issue edit`` Bash commands, plus MCP tool calls
+  ``mcp__github__create_pull_request`` and ``mcp__github__create_issue``.
+- Inline body (``--body``/``-b``): rewrites in the parsed argument value.
+- File body (``--body-file``/``-F``): reads the file, rewrites, writes back.
+- Idempotent: already-canonical MPM footer → no change, no spurious write.
+- Fail-safe: any parse error, I/O error, or unexpected exception → degrade
+  gracefully to ``{"continue": True}`` (NEVER blocks the gh command).
+- Only rewrites the single footer line; never touches other body content.
+
+References
+----------
+LINK: none
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from claude_mpm.hooks.footer_constants import (
+    CLAUDE_CODE_FOOTER_OLD,
+    CLAUDE_CODE_FOOTER_OLD_ALT,
+    MPM_FOOTER_CANONICAL,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Footer rewrite helpers
+# ---------------------------------------------------------------------------
+
+# All old-footer patterns we need to catch, ordered longest-first so the
+# regex engine matches greedily.  Each pattern is the bare text WITHOUT the
+# leading emoji/whitespace — we strip that with a prefix-aware regex below.
+_OLD_FOOTER_BARE = [
+    CLAUDE_CODE_FOOTER_OLD,
+    CLAUDE_CODE_FOOTER_OLD_ALT,
+]
+
+# Compiled pattern that matches either old footer, optionally preceded by
+# the Claude Code robot emoji and arbitrary surrounding whitespace.
+# Group 0 = the full match (emoji + text), stripped and replaced wholesale.
+_FOOTER_LINE_RE = re.compile(
+    r"[^\S\r\n]*(?:🤖[^\S\r\n]*)?"  # optional leading whitespace + robot emoji
+    r"(?:" + "|".join(re.escape(f) for f in _OLD_FOOTER_BARE) + r")"
+    r"[^\S\r\n]*",  # trailing whitespace on the line
+    re.MULTILINE,
+)
+
+
+def _needs_rewrite(body: str) -> bool:
+    """Return True if *body* contains any old Claude Code footer pattern."""
+    return bool(_FOOTER_LINE_RE.search(body))
+
+
+def _already_canonical(body: str) -> bool:
+    """Return True if *body* already contains the canonical MPM footer."""
+    return MPM_FOOTER_CANONICAL in body
+
+
+def rewrite_footer(body: str) -> str:
+    """Rewrite any old Claude Code footer line(s) to the canonical MPM footer.
+
+    WHAT: Pure string transformation — replaces the old footer line with
+          the canonical MPM footer.
+    WHY:  Keeping this as a pure function makes it trivially testable and
+          reusable outside the hook dispatch path.
+
+    Rules:
+    - If the body already contains the canonical MPM footer → return unchanged
+      (idempotent, even if an old footer is also present — avoids duplication).
+    - If the body contains one or more old-footer lines → replace with exactly
+      one canonical footer line (the last occurrence position is used for
+      replacement; all additional matches are removed).
+    - If neither → return unchanged.
+    """
+    if _already_canonical(body):
+        return body
+    if not _needs_rewrite(body):
+        return body
+
+    # Replace all old footer occurrences.  The first occurrence becomes the
+    # canonical footer; subsequent ones are removed.
+    first = True
+
+    def _replacer(m: re.Match) -> str:  # type: ignore[type-arg]
+        nonlocal first
+        if first:
+            first = False
+            return MPM_FOOTER_CANONICAL
+        return ""
+
+    # Collapse any double blank lines introduced by removing secondary matches.
+    return re.sub(r"\n{3,}", "\n\n", _FOOTER_LINE_RE.sub(_replacer, body))
+
+
+# ---------------------------------------------------------------------------
+# Bash command parsing helpers
+# ---------------------------------------------------------------------------
+
+# Regex that matches gh commands that operate on PR/issue bodies.
+# Deliberately matches across extra whitespace between tokens.
+_GH_BODY_CMD_RE = re.compile(
+    r"\bgh\s+"
+    r"(pr\s+(?:create|edit)|issue\s+(?:create|edit))"
+    r"\b",
+    re.IGNORECASE,
+)
+
+# Regex to extract the value of --body / -b from a shell command string.
+# Handles both --body="..." and --body "..." forms (with single or double
+# quotes, or bare unquoted values without spaces).
+_BODY_FLAG_RE = re.compile(
+    r"""(?:--body|-b)\s*=?\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
+)
+
+# Regex to extract the value of --body-file / -F.
+_BODY_FILE_FLAG_RE = re.compile(
+    r"""(?:--body-file|-F)\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
+)
+
+
+def _is_gh_body_command(command: str) -> bool:
+    """Return True if *command* is a gh pr/issue create/edit invocation."""
+    return bool(_GH_BODY_CMD_RE.search(command))
+
+
+def _extract_body_inline(command: str) -> tuple[str, str] | None:
+    """Extract the inline body value from a ``--body``/``-b`` flag.
+
+    Returns ``(raw_value, flag_form)`` where *flag_form* is the matched
+    substring (used for replacement), or None if no inline body flag found.
+    """
+    m = _BODY_FLAG_RE.search(command)
+    if not m:
+        return None
+    # One of the three capture groups will be set.
+    value = m.group(1) or m.group(2) or m.group(3) or ""
+    return value, m.group(0)
+
+
+def _extract_body_file(command: str) -> str | None:
+    """Extract the file path from a ``--body-file``/``-F`` flag, or None."""
+    m = _BODY_FILE_FLAG_RE.search(command)
+    if not m:
+        return None
+    return m.group(1) or m.group(2) or m.group(3) or None
+
+
+def _requote(value: str, original_flag: str) -> str:
+    """Re-wrap *value* in the same quoting style as *original_flag*."""
+    if original_flag.endswith(f'"{value}"') or '="' in original_flag:
+        return f'"{value}"'
+    if original_flag.endswith(f"'{value}'") or "='" in original_flag:
+        return f"'{value}'"
+    # bare or --body= form — use double quotes if the value needs it
+    if " " in value or "\n" in value or '"' in value:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def rewrite_bash_command(command: str) -> str | None:
+    """Rewrite a Bash command string so any old footer in the body is canonical.
+
+    Returns the rewritten command string, or None if no rewrite was needed
+    (already canonical, no footer found, or not a gh body command).
+    Fail-safe: any unexpected exception is caught; None is returned.
+    """
+    try:
+        if not _is_gh_body_command(command):
+            return None
+
+        # Try inline --body / -b first.
+        extracted = _extract_body_inline(command)
+        if extracted is not None:
+            body_value, flag_match = extracted
+            new_body = rewrite_footer(body_value)
+            if new_body == body_value:
+                return None  # already canonical or no footer
+            # Rebuild the flag with the new body value.
+            new_flag = flag_match[: flag_match.index(body_value)] + _requote(
+                new_body, flag_match
+            )
+            # If requote wrapped differently, reconstruct more carefully.
+            # Simple approach: replace the first occurrence of the old flag.
+            return command.replace(flag_match, new_flag, 1)
+
+        # Try --body-file / -F.
+        file_path_str = _extract_body_file(command)
+        if file_path_str is not None:
+            file_path = Path(file_path_str)
+            try:
+                original_body = file_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                logger.debug(
+                    "gh_footer_hook: cannot read body file %s: %s", file_path, exc
+                )
+                return None
+            new_body = rewrite_footer(original_body)
+            if new_body == original_body:
+                return None
+            try:
+                file_path.write_text(new_body, encoding="utf-8")
+            except OSError as exc:
+                logger.debug(
+                    "gh_footer_hook: cannot write body file %s: %s", file_path, exc
+                )
+                return None
+            # Command string itself is unchanged (file path is the same).
+            return command
+
+        return None  # no --body or --body-file flag found
+    except Exception as exc:
+        logger.debug("gh_footer_hook: rewrite_bash_command error (degrading): %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# MCP tool helpers
+# ---------------------------------------------------------------------------
+
+# MCP tool names that carry a PR/issue body field.
+_MCP_BODY_TOOLS = frozenset(
+    {
+        "mcp__github__create_pull_request",
+        "mcp__github__create_issue",
+        "mcp__github__update_pull_request",
+        "mcp__github__update_issue",
+    }
+)
+
+
+def rewrite_mcp_body(
+    tool_name: str, tool_input: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Rewrite the ``body`` field of a GitHub MCP tool call if needed.
+
+    Returns the updated *tool_input* dict with the body rewritten, or None if
+    no rewrite was needed or the tool is not a recognised body-carrying MCP
+    call.  Fail-safe: returns None on any error.
+    """
+    try:
+        if tool_name not in _MCP_BODY_TOOLS:
+            return None
+        body = tool_input.get("body")
+        if not isinstance(body, str):
+            return None
+        new_body = rewrite_footer(body)
+        if new_body == body:
+            return None
+        updated = dict(tool_input)
+        updated["body"] = new_body
+        return updated
+    except Exception as exc:
+        logger.debug("gh_footer_hook: rewrite_mcp_body error (degrading): %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Top-level hook entry point
+# ---------------------------------------------------------------------------
+
+
+def build_gh_footer_response(event: dict[str, Any]) -> dict[str, Any]:
+    """Build a PreToolUse hook response that normalises PR/issue body footers.
+
+    WHAT: Wraps rewrite_bash_command / rewrite_mcp_body and formats the result
+          as a Claude Code PreToolUse wire-format response dict.
+    WHY:  Single callable that the pretooluse_dispatcher and tool_handler can
+          both call without duplicating the response-envelope logic.
+
+    Returns:
+        ``{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+            "updatedInput": <modified tool_input>}}``  when a rewrite occurs.
+        ``{"continue": True}``  when no rewrite is needed.
+        ``{"continue": True}``  on any error (fail-safe).
+    """
+    try:
+        tool_name: str = event.get("tool_name", "")
+        tool_input: dict[str, Any] = event.get("tool_input", {}) or {}
+
+        if tool_name == "Bash":
+            command: str = tool_input.get("command", "")
+            if not isinstance(command, str) or not command.strip():
+                return {"continue": True}
+            new_command = rewrite_bash_command(command)
+            if new_command is None:
+                return {"continue": True}
+            updated_input = dict(tool_input)
+            updated_input["command"] = new_command
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "updatedInput": updated_input,
+                }
+            }
+
+        # MCP GitHub tool path
+        updated_input = rewrite_mcp_body(tool_name, tool_input)
+        if updated_input is None:
+            return {"continue": True}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "updatedInput": updated_input,
+            }
+        }
+    except Exception as exc:
+        logger.debug(
+            "gh_footer_hook: build_gh_footer_response error (degrading): %s", exc
+        )
+        return {"continue": True}

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -43,7 +43,12 @@ import json
 import sys
 from typing import Any
 
-from claude_mpm.hooks import context_circuit_breaker, model_tier_hook, ztk_hook
+from claude_mpm.hooks import (
+    context_circuit_breaker,
+    gh_footer_hook,
+    model_tier_hook,
+    ztk_hook,
+)
 
 
 def _passthrough() -> dict[str, Any]:
@@ -140,8 +145,27 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
             response = model_tier_hook.build_model_tier_response(event)
             return _merge_warning_into_response(response, warning_reason)
         if tool_name == "Bash":
+            # gh_footer_hook runs first so the footer is fixed before ztk
+            # wraps the command.  If ztk does not fire (absent binary or
+            # compound command), the footer-fixed response is returned directly.
+            _footer_rewrite: dict | None = None
+            _footer_resp = gh_footer_hook.build_gh_footer_response(event)
+            if _footer_resp.get("hookSpecificOutput"):
+                _updated = _footer_resp["hookSpecificOutput"].get("updatedInput")
+                if isinstance(_updated, dict):
+                    event["tool_input"] = _updated  # let ztk see the fixed cmd
+                    _footer_rewrite = _footer_resp
             response = ztk_hook.build_ztk_response(event)
-            return _merge_warning_into_response(response, warning_reason)
+            if response.get("hookSpecificOutput"):
+                return _merge_warning_into_response(response, warning_reason)
+            if _footer_rewrite is not None:
+                return _merge_warning_into_response(_footer_rewrite, warning_reason)
+            return _merge_warning_into_response(_passthrough(), warning_reason)
+        if tool_name.startswith("mcp__github__"):
+            # MCP GitHub body normalisation (create_pull_request, create_issue…).
+            _mcp_resp = gh_footer_hook.build_gh_footer_response(event)
+            if _mcp_resp.get("hookSpecificOutput"):
+                return _merge_warning_into_response(_mcp_resp, warning_reason)
 
         base = _passthrough()
         return _merge_warning_into_response(base, warning_reason)

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -109,6 +109,19 @@ def _merge_warning_into_response(
 def dispatch(event: dict[str, Any]) -> dict[str, Any]:
     """Evaluate all PreToolUse / PermissionRequest concerns for one event.
 
+    WHAT: Reads a single hook event and routes it through the full
+          PreToolUse concern stack in order — PermissionRequest routing,
+          context circuit breaker, model-tier injection (Agent), gh-footer
+          normalisation + ztk rewrite (Bash), and MCP GitHub body
+          normalisation — then returns exactly one wire-format response
+          dict ready for JSON serialisation.
+    WHY:  Consolidating four previously separate Python subprocess hooks
+          into one importable function eliminates the subprocess-spawn
+          latency that accumulated on every tool call.  The strict
+          processing order (circuit-breaker first, gh_footer before ztk,
+          fail-open on any exception) is the invariant that makes this
+          dispatcher safe to use across all tool types.
+
     Returns a single wire-format response dict ready to be JSON-serialized.
     Never raises: any failure falls back to pass-through.
     """

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -1,0 +1,416 @@
+"""Tests for the gh_footer_hook PreToolUse hook.
+
+Covers:
+- rewrite_footer: old-footer variants → canonical; idempotent; body-unchanged cases.
+- rewrite_bash_command: extracts body from --body/--body=/--body "..."/-b/--body-file/-F;
+  ignores unrelated gh commands; no-op when footer is already canonical.
+- rewrite_mcp_body: MCP tool body field normalisation.
+- build_gh_footer_response: wire-format response for Bash and MCP tools.
+- Graceful degradation: malformed / empty input does not raise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_mpm.hooks.footer_constants import (
+    CLAUDE_CODE_FOOTER_OLD,
+    CLAUDE_CODE_FOOTER_OLD_ALT,
+    MPM_FOOTER_CANONICAL,
+)
+from claude_mpm.hooks.gh_footer_hook import (
+    _is_gh_body_command,
+    build_gh_footer_response,
+    rewrite_bash_command,
+    rewrite_footer,
+    rewrite_mcp_body,
+)
+
+# ---------------------------------------------------------------------------
+# rewrite_footer — pure string transformation
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteFooter:
+    """Tests for the pure rewrite_footer helper."""
+
+    def test_old_footer_claude_ai_url_no_emoji(self):
+        body = f"Some content\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+
+    def test_old_footer_claude_com_url_no_emoji(self):
+        body = f"Some content\n\n{CLAUDE_CODE_FOOTER_OLD_ALT}"
+        result = rewrite_footer(body)
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD_ALT not in result
+
+    def test_old_footer_with_robot_emoji(self):
+        body = f"Some content\n\n🤖 {CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert MPM_FOOTER_CANONICAL in result
+        # emoji + old string should be replaced by canonical
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+
+    def test_old_footer_alt_with_robot_emoji(self):
+        body = f"Some content\n\n🤖 {CLAUDE_CODE_FOOTER_OLD_ALT}"
+        result = rewrite_footer(body)
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD_ALT not in result
+
+    def test_idempotent_when_already_canonical(self):
+        body = f"Some content\n\n{MPM_FOOTER_CANONICAL}"
+        result = rewrite_footer(body)
+        assert result == body
+
+    def test_idempotent_canonical_with_old_footer_also_present(self):
+        # If canonical is already there, do not add another copy even if old
+        # footer is also somehow present.
+        body = f"Some content\n\n{MPM_FOOTER_CANONICAL}\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert result == body  # leave unchanged when canonical already present
+        assert result.count(MPM_FOOTER_CANONICAL) == 1
+
+    def test_no_footer_body_unchanged(self):
+        body = "## Summary\n\nSome PR body without any footer."
+        result = rewrite_footer(body)
+        assert result == body
+
+    def test_empty_body_unchanged(self):
+        assert rewrite_footer("") == ""
+
+    def test_body_text_around_footer_preserved(self):
+        body = (
+            "## Summary\n\nThis is the PR description.\n\n"
+            f"🤖 {CLAUDE_CODE_FOOTER_OLD}\n"
+        )
+        result = rewrite_footer(body)
+        assert "## Summary" in result
+        assert "This is the PR description." in result
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_duplicate_old_footers_collapsed_to_one(self):
+        body = f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}\n\n{CLAUDE_CODE_FOOTER_OLD_ALT}"
+        result = rewrite_footer(body)
+        assert result.count(MPM_FOOTER_CANONICAL) == 1
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+        assert CLAUDE_CODE_FOOTER_OLD_ALT not in result
+
+    def test_multiline_body_footer_at_end(self):
+        body = (
+            "Line 1\nLine 2\nLine 3\n\n"
+            "🤖 Generated with [Claude Code](https://claude.ai/code)"
+        )
+        result = rewrite_footer(body)
+        assert "Line 1" in result
+        assert "Line 2" in result
+        assert MPM_FOOTER_CANONICAL in result
+
+
+# ---------------------------------------------------------------------------
+# _is_gh_body_command
+# ---------------------------------------------------------------------------
+
+
+class TestIsGhBodyCommand:
+    def test_pr_create(self):
+        assert _is_gh_body_command("gh pr create --title T --body B")
+
+    def test_pr_edit(self):
+        assert _is_gh_body_command("gh pr edit 42 --body B")
+
+    def test_issue_create(self):
+        assert _is_gh_body_command("gh issue create --title T --body B")
+
+    def test_issue_edit(self):
+        assert _is_gh_body_command("gh issue edit 7 --body B")
+
+    def test_extra_whitespace_between_tokens(self):
+        assert _is_gh_body_command("gh   pr   create --body B")
+
+    def test_uppercase_ignored(self):
+        # Case-insensitive match
+        assert _is_gh_body_command("GH PR CREATE --body B")
+
+    def test_unrelated_pr_view(self):
+        assert not _is_gh_body_command("gh pr view 42")
+
+    def test_unrelated_repo_clone(self):
+        assert not _is_gh_body_command("gh repo clone org/repo")
+
+    def test_unrelated_pr_list(self):
+        assert not _is_gh_body_command("gh pr list")
+
+    def test_unrelated_issue_list(self):
+        assert not _is_gh_body_command("gh issue list")
+
+    def test_not_a_gh_command(self):
+        assert not _is_gh_body_command("git push origin main")
+
+    def test_empty_command(self):
+        assert not _is_gh_body_command("")
+
+
+# ---------------------------------------------------------------------------
+# rewrite_bash_command — command string parsing + rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteBashCommand:
+    """Tests for rewrite_bash_command with various flag forms."""
+
+    def _make_cmd(self, body: str, flag: str = "--body") -> str:
+        return f'gh pr create --title "My PR" {flag} "{body}"'
+
+    def test_body_flag_double_quotes(self):
+        cmd = f'gh pr create --title "PR" --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+
+    def test_body_flag_with_equals(self):
+        cmd = f'gh pr create --body="{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_short_flag_b(self):
+        cmd = f'gh issue create -b "{CLAUDE_CODE_FOOTER_OLD_ALT}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_already_canonical_returns_none(self):
+        cmd = f'gh pr create --body "{MPM_FOOTER_CANONICAL}"'
+        assert rewrite_bash_command(cmd) is None
+
+    def test_no_footer_returns_none(self):
+        cmd = 'gh pr create --body "No footer here"'
+        assert rewrite_bash_command(cmd) is None
+
+    def test_unrelated_command_returns_none(self):
+        assert rewrite_bash_command("git push origin main") is None
+
+    def test_pr_view_returns_none(self):
+        assert rewrite_bash_command("gh pr view 42") is None
+
+    def test_body_file_flag(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}")
+        cmd = f"gh pr create --body-file {body_file}"
+        result = rewrite_bash_command(cmd)
+        # Command string is unchanged (same file path)
+        assert result == cmd
+        # But file content was rewritten
+        new_content = body_file.read_text()
+        assert MPM_FOOTER_CANONICAL in new_content
+        assert CLAUDE_CODE_FOOTER_OLD not in new_content
+
+    def test_body_file_short_flag(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"{CLAUDE_CODE_FOOTER_OLD_ALT}")
+        cmd = f"gh issue create -F {body_file}"
+        result = rewrite_bash_command(cmd)
+        assert result == cmd
+        assert MPM_FOOTER_CANONICAL in body_file.read_text()
+
+    def test_body_file_already_canonical_returns_none(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"Content\n\n{MPM_FOOTER_CANONICAL}")
+        cmd = f"gh pr create --body-file {body_file}"
+        assert rewrite_bash_command(cmd) is None
+
+    def test_body_file_missing_returns_none(self):
+        cmd = "gh pr create --body-file /nonexistent/path/body.md"
+        result = rewrite_bash_command(cmd)
+        assert result is None  # graceful degradation
+
+    def test_empty_command_returns_none(self):
+        assert rewrite_bash_command("") is None
+
+    def test_env_var_prefix_before_gh(self):
+        # Commands like: GITHUB_TOKEN=xxx gh pr create ...
+        cmd = f'GITHUB_TOKEN=xxx gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_exception_in_rewrite_returns_none(self, monkeypatch):
+        """Graceful degradation when rewrite_footer raises unexpectedly."""
+        from claude_mpm.hooks import gh_footer_hook
+
+        monkeypatch.setattr(
+            gh_footer_hook,
+            "rewrite_footer",
+            lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        cmd = f'gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        # Should not raise; should return None
+        result = rewrite_bash_command(cmd)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# rewrite_mcp_body — MCP tool body field normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteMcpBody:
+    def test_create_pull_request_old_footer(self):
+        tool_input = {"title": "My PR", "body": f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}"}
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result["body"]
+        assert CLAUDE_CODE_FOOTER_OLD not in result["body"]
+
+    def test_create_issue_old_footer_alt(self):
+        tool_input = {"title": "Issue", "body": f"Desc\n\n{CLAUDE_CODE_FOOTER_OLD_ALT}"}
+        result = rewrite_mcp_body("mcp__github__create_issue", tool_input)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result["body"]
+
+    def test_already_canonical_returns_none(self):
+        tool_input = {"body": f"{MPM_FOOTER_CANONICAL}"}
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is None
+
+    def test_no_footer_returns_none(self):
+        tool_input = {"body": "Just a description"}
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is None
+
+    def test_non_github_tool_returns_none(self):
+        tool_input = {"body": f"{CLAUDE_CODE_FOOTER_OLD}"}
+        result = rewrite_mcp_body("mcp__gitlab__create_pr", tool_input)
+        assert result is None
+
+    def test_no_body_field_returns_none(self):
+        tool_input = {"title": "No body"}
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is None
+
+    def test_non_string_body_returns_none(self):
+        tool_input = {"body": None}
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is None
+
+    def test_update_pull_request(self):
+        tool_input = {"body": f"Update content\n\n{CLAUDE_CODE_FOOTER_OLD}"}
+        result = rewrite_mcp_body("mcp__github__update_pull_request", tool_input)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result["body"]
+
+    def test_other_fields_preserved(self):
+        tool_input = {
+            "title": "My PR",
+            "base": "main",
+            "head": "feat/foo",
+            "body": f"Description\n\n{CLAUDE_CODE_FOOTER_OLD}",
+        }
+        result = rewrite_mcp_body("mcp__github__create_pull_request", tool_input)
+        assert result is not None
+        assert result["title"] == "My PR"
+        assert result["base"] == "main"
+        assert result["head"] == "feat/foo"
+
+
+# ---------------------------------------------------------------------------
+# build_gh_footer_response — wire-format integration
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGhFooterResponse:
+    def _bash_event(self, command: str) -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+
+    def _mcp_event(self, tool_name: str, body: str) -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {"title": "T", "body": body},
+        }
+
+    def test_bash_returns_updated_input_when_rewritten(self):
+        cmd = f'gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        response = build_gh_footer_response(self._bash_event(cmd))
+        assert "hookSpecificOutput" in response
+        hso = response["hookSpecificOutput"]
+        assert "updatedInput" in hso
+        assert MPM_FOOTER_CANONICAL in hso["updatedInput"]["command"]
+
+    def test_bash_returns_continue_when_no_rewrite_needed(self):
+        cmd = 'gh pr create --body "No footer"'
+        response = build_gh_footer_response(self._bash_event(cmd))
+        assert response == {"continue": True}
+
+    def test_bash_unrelated_command_returns_continue(self):
+        response = build_gh_footer_response(self._bash_event("git push origin main"))
+        assert response == {"continue": True}
+
+    def test_mcp_returns_updated_input_when_rewritten(self):
+        event = self._mcp_event(
+            "mcp__github__create_pull_request",
+            f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}",
+        )
+        response = build_gh_footer_response(event)
+        assert "hookSpecificOutput" in response
+        hso = response["hookSpecificOutput"]
+        assert MPM_FOOTER_CANONICAL in hso["updatedInput"]["body"]
+
+    def test_mcp_returns_continue_when_no_footer(self):
+        event = self._mcp_event("mcp__github__create_issue", "Just a description")
+        response = build_gh_footer_response(event)
+        assert response == {"continue": True}
+
+    def test_unrecognised_tool_returns_continue(self):
+        event = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "foo.py", "content": CLAUDE_CODE_FOOTER_OLD},
+        }
+        response = build_gh_footer_response(event)
+        assert response == {"continue": True}
+
+    def test_empty_event_returns_continue(self):
+        response = build_gh_footer_response({})
+        assert response == {"continue": True}
+
+    def test_malformed_event_returns_continue(self):
+        response = build_gh_footer_response({"tool_name": None, "tool_input": None})
+        assert response == {"continue": True}
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — no raise on bad inputs
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    def test_rewrite_footer_non_string_input(self):
+        # Should not raise even if called with weird types; treat gracefully
+        # (In practice the type hint says str, but be defensive.)
+        result = rewrite_footer("")
+        assert result == ""
+
+    def test_rewrite_bash_command_none_like_input(self):
+        assert rewrite_bash_command("") is None
+
+    def test_build_response_no_tool_name(self):
+        assert build_gh_footer_response({}) == {"continue": True}
+
+    def test_build_response_none_tool_input(self):
+        response = build_gh_footer_response({"tool_name": "Bash", "tool_input": None})
+        assert response == {"continue": True}
+
+    def test_build_response_bash_empty_command(self):
+        event = {"tool_name": "Bash", "tool_input": {"command": ""}}
+        assert build_gh_footer_response(event) == {"continue": True}
+
+    def test_build_response_bash_whitespace_command(self):
+        event = {"tool_name": "Bash", "tool_input": {"command": "   "}}
+        assert build_gh_footer_response(event) == {"continue": True}

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -253,6 +253,85 @@ class TestRewriteBashCommand:
 
 
 # ---------------------------------------------------------------------------
+# FIX 3 regression tests: quoting preservation, multi-line body, title safety
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteBashCommandFix3:
+    """Regression tests added for trusty-review correctness findings."""
+
+    def test_multiline_body_roundtrip(self):
+        """Multi-line body with embedded newlines rewrites footer and stays well-formed."""
+        body = f"## Summary\n\nLine one\nLine two\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        # Embed newlines literally inside a double-quoted shell argument.
+        cmd = f'gh pr create --title "My PR" --body "{body}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None, "Expected a rewrite for multi-line body"
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+        # The --title token must still be intact.
+        assert '--title "My PR"' in result
+
+    def test_old_footer_in_title_does_not_get_rewritten(self):
+        """Regression (finding a): old footer text in --title must not be touched."""
+        title_with_footer = f"PR about {CLAUDE_CODE_FOOTER_OLD}"
+        body_with_footer = f"Description\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        cmd = f'gh pr create --title "{title_with_footer}" --body "{body_with_footer}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None, "Expected body to be rewritten"
+        # The canonical footer must appear (body was rewritten).
+        assert MPM_FOOTER_CANONICAL in result
+        # The title must be unchanged: the old footer text is still inside it.
+        assert f'--title "{title_with_footer}"' in result
+
+    def test_short_b_flag_standalone_parses(self):
+        """Standalone -b flag is matched; parses and rewrites correctly."""
+        cmd = f'gh issue create -b "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_dash_base_like_token_not_misrewritten(self):
+        """Regression (finding c): -base-like tokens are not treated as -b body flag."""
+        # A command with -base main (not a real gh flag; purely tests the
+        # standalone-flag boundary assertion for -b).
+        cmd = f'gh pr create -base main --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        # The body should still get rewritten (via --body); -base is untouched.
+        assert result is not None
+        assert "-base main" in result
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_body_equals_form_preserves_double_quotes(self):
+        """--body= form with double quotes keeps double-quote style after rewrite."""
+        cmd = f'gh pr create --body="{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        # Result must contain the MPM footer wrapped in double quotes.
+        assert f'"{MPM_FOOTER_CANONICAL}"' in result
+
+    def test_body_space_form_preserves_double_quotes(self):
+        """--body "..." (space separator) keeps double-quote style after rewrite."""
+        cmd = f'gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert f'"{MPM_FOOTER_CANONICAL}"' in result
+
+    def test_single_quoted_body_preserves_single_quotes(self):
+        """Single-quoted body stays single-quoted after rewrite (finding b)."""
+        cmd = f"gh pr create --body '{CLAUDE_CODE_FOOTER_OLD}'"
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert f"'{MPM_FOOTER_CANONICAL}'" in result
+
+    def test_idempotent_multiline_body_no_double_rewrite(self):
+        """Idempotency: a body that already has the MPM footer returns None."""
+        body = f"## Summary\n\n{MPM_FOOTER_CANONICAL}"
+        cmd = f'gh pr create --body "{body}"'
+        assert rewrite_bash_command(cmd) is None
+
+
+# ---------------------------------------------------------------------------
 # rewrite_mcp_body — MCP tool body field normalisation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
Vanilla claude-mpm leaked the default `🤖 Generated with [Claude Code]` footer onto PRs created in managed projects (observed on bobmatnyc/trusty-tools#1547). Root cause: the `version_control` agent had no footer directive, so the model's built-in Claude Code footer slipped through when it composed PR bodies.

## Fix (deterministic backstop)
Adds a claude-mpm PreToolUse hook that intercepts `gh pr create|edit` and `gh issue create|edit` and rewrites any Claude Code attribution footer to the canonical `🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)` in the body — handling `--body`, `--body=`, `-b`, and `--body-file`/`-F`. Idempotent, fail-safe (degrades to leaving the command unchanged on any parse ambiguity — never blocks or crashes the gh command). Commit-message attribution is unchanged (already handled by commit_cost_tracker + setup-git-hooks.sh).

- New shared `footer_constants` module (single source of truth for old/canonical footer strings, reused from the existing migration constants).
- New `gh_footer_hook` wired into both the tool_handler and standalone PreToolUse dispatch paths.
- 416 lines of tests covering footer-variant rewrites, idempotency, body-flag parsing (`--body`/`-b`/`--body-file`/`-F`), ignoring unrelated gh commands, and graceful degradation.

## Companion
Pairs with bobmatnyc/claude-mpm-agents#36, which adds the explicit footer directive to the `version_control` agent (mirroring the ticketing agent). Instruction + deterministic hook = belt and suspenders.

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)