### PR TITLE
fix: guard release-check against double version bumps (#896)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -882,6 +882,15 @@ release-check: ## Check if environment is ready for release
 	else \
 		echo "$(GREEN)✓ On main branch$(NC)"; \
 	fi
+	@LAST_MSG=$$(git log -1 --format="%s"); \
+	if echo "$$LAST_MSG" | grep -qE "^bump:"; then \
+		echo "$(RED)✗ HEAD is already a bump commit: $$LAST_MSG$(NC)"; \
+		echo "$(YELLOW)  A prior release likely bumped but did not finish.$(NC)"; \
+		echo "$(YELLOW)  To finish it:  make release-build-current && make release-publish$(NC)"; \
+		echo "$(YELLOW)  Do NOT re-run make release-patch — it would double-bump.$(NC)"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✓ HEAD is not a bump commit$(NC)"
 	@echo "$(GREEN)✓ Release prerequisites check passed$(NC)"
 
 # Run tests before release

--- a/src/claude_mpm/templates/claude/commands/release.md
+++ b/src/claude_mpm/templates/claude/commands/release.md
@@ -32,4 +32,16 @@ Steps to follow:
 
 If $ARGUMENTS is empty or not one of patch/minor/major, ask the user which type they want before proceeding.
 
+**Recovery if release fails mid-build**: If `make release-$ARGUMENTS` fails *after*
+the version bump (i.e. during the build or publish step), do **NOT** re-run
+`make release-$ARGUMENTS` — it would bump the version a second time (double-bump).
+Instead, finish the in-progress release without bumping again:
+
+```
+make release-build-current && make release-publish
+```
+
+`release-check` now aborts if HEAD is already a `bump:` commit, which catches this
+case automatically.
+
 **CRITICAL**: Never manually edit version files or call `./scripts/publish_to_pypi.sh` directly. Always use the Makefile targets.


### PR DESCRIPTION
## Summary

Adds a guard at the end of the `release-check` Makefile recipe that aborts if HEAD is already a `bump:` commit, preventing a second `make release-patch` from double-bumping. This addresses the root cause of the 6.5.61→6.5.62→6.5.63 incident where operators ran release commands twice, resulting in consecutive version bumps without corresponding code changes.

The guard covers `release-patch`, `release-minor`, and `release-major` since they all depend on `release-check`.

## How it works

- After `release-check` completes, a conditional check examines the most recent commit message
- If HEAD is a `bump:` commit (indicating a version was already incremented), the Makefile exits with an error and logs guidance
- Non-bump commits proceed normally

## Recovery path for mid-build failures

If a release build fails partway through and needs recovery:
```bash
make release-build-current  # Resume from the current release state
make release-publish        # Publish the built release
```

This recovery path is also documented in `/release` command help (`src/claude_mpm/templates/claude/commands/release.md`).

## Verification

- Makefile syntax validated: `make -n release-check` parses without errors
- Grep logic simulation confirms: bump commit → abort, non-bump commit → proceed

Closes #896

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)