### PR TITLE
docs: require incremental commits for long-running background builds

### DIFF
--- a/src/claude_mpm/agents/PM_INSTRUCTIONS.md
+++ b/src/claude_mpm/agents/PM_INSTRUCTIONS.md
@@ -345,6 +345,8 @@ Use `run_in_background: true` for fire-and-forget parallel work.
 
 For the canonical step-by-step worktree workflow see `WORKFLOW.md` → "Worktree Workflow (default)" and "Worktree-Based Branch Workflow (CRITICAL)".
 
+**Long-running background builds:** When delegating a long-running or `run_in_background: true` file-modifying agent, the PM MUST instruct that agent to commit each self-contained layer incrementally (using `wip:` or conventional commit prefixes) as work lands, rather than deferring all commits to the end. Uncommitted work in an isolated worktree evaporates if the session pauses, ends, or the agent is killed before it commits — the ephemeral worktree is torn down and loose files are lost permanently. Committed objects, by contrast, survive as dangling commits recoverable via `git fsck`. Incremental commits ensure progress is durable in git's object database; squash polishing can happen at PR time.
+
 **Worktree isolation constraints:**
 - **Never** use `isolation: "worktree"` for ops/restart/deployment tasks — these are stateless, not file-modification tasks.
 - `isolation: "worktree"` requires a git repository. If the project has no `.git` directory, do NOT pass `isolation: "worktree"` to any agent call (it will throw "not in a git repository" and fail immediately).

--- a/src/claude_mpm/agents/WORKFLOW.md
+++ b/src/claude_mpm/agents/WORKFLOW.md
@@ -81,11 +81,14 @@ Feature/fix work uses git worktrees; the PRIMARY checkout stays on the default b
    ```
    Only run after confirming squash-merge has landed on main. If the worktree has untracked files, inspect with `git -C .claude/worktrees/issue-<N>-<slug> status` first; commit or stash anything you want to keep, then retry removal (or use `--force` only if files are disposable).
 
+6. **Long-running / background builds MUST commit incrementally** — A background or long-running agent (especially `run_in_background: true` in an isolated worktree) must make a WIP commit as each self-contained layer/component lands, NOT one all-or-nothing commit at the end. Uncommitted work in an ephemeral isolated worktree exists only as loose files on disk; if the session ends, pauses, or the agent is killed, the worktree is torn down and any uncommitted files are lost permanently (committed objects, by contrast, survive as dangling commits recoverable via `git fsck`). Commit early, commit often — each layer gets its own `wip:` or conventional commit so progress is durable in git's object database. Squash into clean conventional commits at PR time.
+
 ### Rationale
 - **Eliminates checkout contention**: No competing branch switches in the primary tree
 - **Enables safe parallelism**: Multiple agents work on separate issues without file-system conflicts
 - **Consistent with isolation patterns**: Aligns with the `isolation: "worktree"` pattern on Agent tool calls
 - **Keeps stable HEAD**: Primary tree always points to `main` for reliable reference pulls and deployments
+- **Durable progress**: Incremental commits survive session end; uncommitted worktree files do not
 
 ## Mandatory 5-Phase Sequence
 


### PR DESCRIPTION
## Summary

Adds guidance to PM agents about critical requirement for incremental commits in long-running background worktree-isolated operations.

When agents run in ephemeral worktrees (via `isolation: worktree`), uncommitted work is permanently lost if the session ends before a final commit. This PR documents the pattern: each significant layer of work must be committed incrementally within the worktree, not just at the end.

## Changes

- **PM_INSTRUCTIONS.md**: Note on committing incrementally for long-running background tasks
- **WORKFLOW.md**: Detailed guidance with code example showing commit pattern

## Related

This prevents data loss in long-running agent operations and teaches agents to treat worktree-isolated work as requiring checkpoint commits between phases.