### PR TITLE
fix: gh_footer_hook advisory hardening follow-ups (#891)

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -238,6 +238,20 @@ class ToolHandler:
         # actual work to do (model injection or ztk rewrite).
         # When a circuit-breaker warning is pending we attach it to the
         # response before returning so it is not silently dropped.
+
+        # Single import guard for build_gh_footer_response — used in both the
+        # Bash and mcp__github__ branches below.  If the module is unavailable
+        # (e.g. partially installed environment) both branches degrade gracefully
+        # via the None sentinel rather than raising ImportError at call sites.
+        _build_gh_footer_response = None
+        try:
+            from claude_mpm.hooks.gh_footer_hook import (
+                build_gh_footer_response as _build_gh_footer_response,
+            )
+        except Exception as _e:
+            if DEBUG:
+                _log(f"gh_footer_hook import failed (fail-open): {_e}")
+
         _tool_name_early = event.get("tool_name", "")
         if _tool_name_early == "Agent":
             try:
@@ -264,24 +278,25 @@ class ToolHandler:
             # ztk does NOT fire (ztk passes through on compound/piped commands
             # and when the ztk binary is absent).
             _footer_rewrote: dict | None = None
+            _ztk_event = event  # default: ztk sees the original event
             try:
-                from claude_mpm.hooks.gh_footer_hook import build_gh_footer_response
-
-                _footer_response = build_gh_footer_response(event)
-                _footer_hso = _footer_response.get("hookSpecificOutput")
-                if isinstance(_footer_hso, dict):
-                    _updated_input = _footer_hso.get("updatedInput")
-                    if isinstance(_updated_input, dict):
-                        # Patch event in-place so ztk (below) sees fixed command.
-                        event["tool_input"] = _updated_input
-                        _footer_rewrote = _footer_response
+                if _build_gh_footer_response is not None:
+                    _footer_response = _build_gh_footer_response(event)
+                    _footer_hso = _footer_response.get("hookSpecificOutput")
+                    if isinstance(_footer_hso, dict):
+                        _updated_input = _footer_hso.get("updatedInput")
+                        if isinstance(_updated_input, dict):
+                            # Use a shallow copy so ztk sees the footer-fixed
+                            # command without mutating the caller's event in-place.
+                            _ztk_event = {**event, "tool_input": _updated_input}
+                            _footer_rewrote = _footer_response
             except Exception as _e:
                 if DEBUG:
                     _log(f"gh_footer_hook failed (fail-open): {_e}")
             try:
                 from claude_mpm.hooks.ztk_hook import build_ztk_response
 
-                _ztk_response = build_ztk_response(event)
+                _ztk_response = build_ztk_response(_ztk_event)
                 if _ztk_response.get("hookSpecificOutput"):
                     # ztk rewrote the command; return the modified tool_input.
                     if _cb_warning_reason:
@@ -316,17 +331,16 @@ class ToolHandler:
             # MCP GitHub tool calls (create_pull_request, create_issue, etc.)
             # also need footer normalisation via gh_footer_hook.
             try:
-                from claude_mpm.hooks.gh_footer_hook import build_gh_footer_response
-
-                _footer_response = build_gh_footer_response(event)
-                if _footer_response.get("hookSpecificOutput"):
-                    if _cb_warning_reason:
-                        _hso = _footer_response["hookSpecificOutput"]
-                        if isinstance(_hso, dict) and not _hso.get(
-                            "permissionDecisionReason"
-                        ):
-                            _hso["permissionDecisionReason"] = _cb_warning_reason
-                    return _footer_response
+                if _build_gh_footer_response is not None:
+                    _footer_response = _build_gh_footer_response(event)
+                    if _footer_response.get("hookSpecificOutput"):
+                        if _cb_warning_reason:
+                            _hso = _footer_response["hookSpecificOutput"]
+                            if isinstance(_hso, dict) and not _hso.get(
+                                "permissionDecisionReason"
+                            ):
+                                _hso["permissionDecisionReason"] = _cb_warning_reason
+                        return _footer_response
             except Exception as _e:
                 if DEBUG:
                     _log(f"gh_footer_hook (mcp) failed (fail-open): {_e}")

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -339,6 +339,10 @@ class ToolHandler:
                             if isinstance(_hso, dict) and not _hso.get(
                                 "permissionDecisionReason"
                             ):
+                                # Safe: _footer_response is a fresh local dict
+                                # returned by build_gh_footer_response — not the
+                                # caller's event dict — so in-place mutation here
+                                # does not affect the caller.
                                 _hso["permissionDecisionReason"] = _cb_warning_reason
                         return _footer_response
             except Exception as _e:

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -148,6 +148,19 @@ _GH_BODY_CMD_RE = re.compile(
 # * Reconstruction (see _requote / rewrite_bash_command) rebuilds the flag
 #   text purely from the captured groups so it never relies on searching for
 #   the old value string inside the original flag text.
+#
+# Why not shlex.split (item 3 evaluation)
+# ----------------------------------------
+# shlex.split correctly tokenises the shell command but loses byte-position
+# information, making it impossible to perform a targeted substitution back
+# into the original string without re-quoting and reconstructing the entire
+# command from scratch — which risks losing formatting, multi-line literals,
+# and heredoc constructs that the regex approach preserves.  For the one
+# realistic failure mode (``--body`` text appearing in *another* flag's
+# value), the existing ``count=1`` constraint already prevents accidental
+# re-matching after the first substitution.  A shlex-based path would be
+# safer in pathological edge cases but would regress on the quoting
+# round-trip tests (``TestRewriteBashCommandFix3``).  Tradeoff accepted.
 _BODY_FLAG_RE = re.compile(
     r"""((?:--body(?!-file)|(?:(?:^|\s))-b(?=[\s=]|$)))"""  # group 1: flag token
     r"""(\s*=\s*|\s+)"""  # group 2: separator

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -321,20 +321,31 @@ def rewrite_bash_command(command: str) -> str | None:
                 return None
             try:
                 # Write atomically: write to a temp file in the same directory
-                # (guarantees same filesystem so os.replace is atomic), then
+                # (guarantees same filesystem so Path.replace is atomic), then
                 # rename over the target.  Path.write_text is not atomic —
                 # a crash mid-write would corrupt the body file.
+                #
+                # Leak-safety: tmp_path is tracked from the moment the file is
+                # created.  A try/finally ensures the temp file is unlinked on
+                # any failure path (write error or rename error), so orphaned
+                # temp files cannot accumulate.
                 dir_path = file_path.parent
-                with tempfile.NamedTemporaryFile(
-                    mode="w",
-                    encoding="utf-8",
-                    dir=dir_path,
-                    delete=False,
-                    suffix=".tmp",
-                ) as tmp:
-                    tmp_path = tmp.name
-                    tmp.write(new_body)
-                Path(tmp_path).replace(file_path)
+                tmp_path: str | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        mode="w",
+                        encoding="utf-8",
+                        dir=dir_path,
+                        delete=False,
+                        suffix=".tmp",
+                    ) as tmp:
+                        tmp_path = tmp.name
+                        tmp.write(new_body)
+                    Path(tmp_path).replace(file_path)
+                    tmp_path = None  # rename succeeded; nothing to clean up
+                finally:
+                    if tmp_path is not None:
+                        Path(tmp_path).unlink(missing_ok=True)
             except OSError as exc:
                 logger.debug(
                     "gh_footer_hook: cannot write body file %s: %s", file_path, exc

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -86,8 +87,8 @@ def rewrite_footer(body: str) -> str:
     - If the body already contains the canonical MPM footer → return unchanged
       (idempotent, even if an old footer is also present — avoids duplication).
     - If the body contains one or more old-footer lines → replace with exactly
-      one canonical footer line (the last occurrence position is used for
-      replacement; all additional matches are removed).
+      one canonical footer line (the first occurrence is rewritten to the
+      canonical footer; all subsequent matches are removed).
     - If neither → return unchanged.
     """
     if _already_canonical(body):
@@ -306,7 +307,21 @@ def rewrite_bash_command(command: str) -> str | None:
             if new_body == original_body:
                 return None
             try:
-                file_path.write_text(new_body, encoding="utf-8")
+                # Write atomically: write to a temp file in the same directory
+                # (guarantees same filesystem so os.replace is atomic), then
+                # rename over the target.  Path.write_text is not atomic —
+                # a crash mid-write would corrupt the body file.
+                dir_path = file_path.parent
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    encoding="utf-8",
+                    dir=dir_path,
+                    delete=False,
+                    suffix=".tmp",
+                ) as tmp:
+                    tmp_path = tmp.name
+                    tmp.write(new_body)
+                Path(tmp_path).replace(file_path)
             except OSError as exc:
                 logger.debug(
                     "gh_footer_hook: cannot write body file %s: %s", file_path, exc

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -163,12 +163,15 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
             # compound command), the footer-fixed response is returned directly.
             _footer_rewrite: dict | None = None
             _footer_resp = gh_footer_hook.build_gh_footer_response(event)
+            ztk_event = event  # default: ztk sees the original event
             if _footer_resp.get("hookSpecificOutput"):
                 _updated = _footer_resp["hookSpecificOutput"].get("updatedInput")
                 if isinstance(_updated, dict):
-                    event["tool_input"] = _updated  # let ztk see the fixed cmd
+                    # Use a shallow copy so ztk sees the footer-fixed command
+                    # without mutating the caller's event dict in-place.
+                    ztk_event = {**event, "tool_input": _updated}
                     _footer_rewrite = _footer_resp
-            response = ztk_hook.build_ztk_response(event)
+            response = ztk_hook.build_ztk_response(ztk_event)
             if response.get("hookSpecificOutput"):
                 return _merge_warning_into_response(response, warning_reason)
             if _footer_rewrite is not None:

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -493,3 +493,88 @@ class TestGracefulDegradation:
     def test_build_response_bash_whitespace_command(self):
         event = {"tool_name": "Bash", "tool_input": {"command": "   "}}
         assert build_gh_footer_response(event) == {"continue": True}
+
+
+# ---------------------------------------------------------------------------
+# _cb_warning_reason injection on the MCP (mcp__github__) branch
+# ---------------------------------------------------------------------------
+
+
+class TestCbWarningReasonMcpBranch:
+    """Verify that the circuit-breaker warning reason propagates through the
+    dispatcher when both the MCP footer rewrite fires AND the breaker has
+    emitted an allow-with-warning.
+
+    This exercises the ``pretooluse_dispatcher.dispatch()`` path:
+        mcp__github__ tool → build_gh_footer_response → rewrite fires
+        → _merge_warning_into_response injects the stashed warning reason.
+    """
+
+    def _mcp_event_with_old_footer(
+        self, tool_name: str = "mcp__github__create_pull_request"
+    ) -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {
+                "title": "My PR",
+                "body": f"Description\n\n{CLAUDE_CODE_FOOTER_OLD}",
+            },
+        }
+
+    def test_warning_reason_injected_on_mcp_footer_rewrite(self, monkeypatch):
+        """When context breaker fires allow+warning AND MCP footer is rewritten,
+        the permissionDecisionReason must appear in the returned response."""
+        from claude_mpm.hooks import context_circuit_breaker, pretooluse_dispatcher
+
+        warning_msg = "Context at 97% — consider compacting"
+
+        monkeypatch.setattr(
+            context_circuit_breaker,
+            "evaluate",
+            lambda _event: {
+                "permissionDecision": "allow",
+                "permissionDecisionReason": warning_msg,
+            },
+        )
+
+        event = self._mcp_event_with_old_footer()
+        response = pretooluse_dispatcher.dispatch(event)
+
+        # Footer was rewritten — hookSpecificOutput must be present.
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, "Expected hookSpecificOutput when footer was rewritten"
+
+        # The rewritten body must contain the canonical MPM footer.
+        updated_input = hso.get("updatedInput", {})
+        assert MPM_FOOTER_CANONICAL in updated_input.get("body", ""), (
+            "Expected MPM canonical footer in rewritten MCP body"
+        )
+
+        # The circuit-breaker warning reason must have been injected.
+        assert hso.get("permissionDecisionReason") == warning_msg, (
+            f"Expected warning reason '{warning_msg}' in hookSpecificOutput, "
+            f"got: {hso.get('permissionDecisionReason')!r}"
+        )
+
+    def test_no_warning_when_breaker_silent(self, monkeypatch):
+        """When the circuit breaker does not fire, permissionDecisionReason is
+        absent even when the MCP footer is rewritten."""
+        from claude_mpm.hooks import context_circuit_breaker, pretooluse_dispatcher
+
+        monkeypatch.setattr(
+            context_circuit_breaker,
+            "evaluate",
+            lambda _event: {},
+        )
+
+        event = self._mcp_event_with_old_footer()
+        response = pretooluse_dispatcher.dispatch(event)
+
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, "Expected hookSpecificOutput when footer was rewritten"
+        assert MPM_FOOTER_CANONICAL in hso.get("updatedInput", {}).get("body", "")
+        # No warning reason should be present when breaker was silent.
+        assert not hso.get("permissionDecisionReason"), (
+            "Expected no permissionDecisionReason when circuit breaker was silent"
+        )

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -578,3 +578,106 @@ class TestCbWarningReasonMcpBranch:
         assert not hso.get("permissionDecisionReason"), (
             "Expected no permissionDecisionReason when circuit breaker was silent"
         )
+
+
+# ---------------------------------------------------------------------------
+# _cb_warning_reason injection via ToolHandler.handle_pre_tool_fast (MCP branch)
+# ---------------------------------------------------------------------------
+
+
+class TestCbWarningReasonToolHandlerMcpBranch:
+    """Verify that the circuit-breaker warning reason propagates through
+    ToolHandler.handle_pre_tool_fast() on the mcp__github__ branch.
+
+    tool_handler.py has an independent reimplementation of the same MCP
+    _cb_warning_reason injection logic (~L334-343).  These tests drive that
+    path directly, independent of pretooluse_dispatcher.
+    """
+
+    def _make_tool_handler(self):
+        """Build a minimal ToolHandler with mocked dependencies."""
+        from unittest.mock import MagicMock
+
+        from claude_mpm.hooks.claude_hooks.handlers.base import BaseEventHandler
+        from claude_mpm.hooks.claude_hooks.handlers.tool_handler import ToolHandler
+
+        mock_hh = MagicMock()
+        mock_hh._emit_socketio_event = MagicMock(return_value=None)
+        mock_hh._get_delegation_agent_type = MagicMock(return_value="unknown")
+
+        base = MagicMock(spec=BaseEventHandler)
+        base.hook_handler = mock_hh
+        base._get_git_branch = MagicMock(return_value="main")
+        base.log_manager = None
+
+        return ToolHandler(base)
+
+    def _mcp_event(self, tool_name: str = "mcp__github__create_pull_request") -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {
+                "title": "My PR",
+                "body": f"Description\n\n{CLAUDE_CODE_FOOTER_OLD}",
+            },
+            "session_id": "test-session",
+            "cwd": "/tmp",
+        }
+
+    def test_warning_reason_injected_via_tool_handler_mcp(self, monkeypatch):
+        """When context breaker fires allow+warning AND MCP footer is rewritten,
+        ToolHandler.handle_pre_tool_fast must inject permissionDecisionReason."""
+        from claude_mpm.hooks import context_circuit_breaker
+
+        warning_msg = "Context at 96% — consider compacting"
+
+        monkeypatch.setattr(
+            context_circuit_breaker,
+            "evaluate",
+            lambda _event: {
+                "permissionDecision": "allow",
+                "permissionDecisionReason": warning_msg,
+            },
+        )
+
+        handler = self._make_tool_handler()
+        response = handler.handle_pre_tool_fast(self._mcp_event())
+
+        assert response is not None, "Expected a response dict, not None"
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, "Expected hookSpecificOutput when footer was rewritten"
+
+        # Body must have been rewritten to canonical footer.
+        updated_input = hso.get("updatedInput", {})
+        assert MPM_FOOTER_CANONICAL in updated_input.get("body", ""), (
+            "Expected MPM canonical footer in rewritten MCP body"
+        )
+
+        # Warning reason must have been injected.
+        assert hso.get("permissionDecisionReason") == warning_msg, (
+            f"Expected warning reason in hookSpecificOutput, "
+            f"got: {hso.get('permissionDecisionReason')!r}"
+        )
+
+    def test_no_warning_when_breaker_silent_tool_handler(self, monkeypatch):
+        """When the circuit breaker does not fire, no permissionDecisionReason
+        is present in the MCP footer-rewrite response from ToolHandler."""
+        from claude_mpm.hooks import context_circuit_breaker
+
+        monkeypatch.setattr(
+            context_circuit_breaker,
+            "evaluate",
+            lambda _event: {},
+        )
+
+        handler = self._make_tool_handler()
+        response = handler.handle_pre_tool_fast(self._mcp_event())
+
+        assert response is not None, "Expected a response dict, not None"
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, "Expected hookSpecificOutput when footer was rewritten"
+        assert MPM_FOOTER_CANONICAL in hso.get("updatedInput", {}).get("body", "")
+        # No warning reason when breaker was silent.
+        assert not hso.get("permissionDecisionReason"), (
+            "Expected no permissionDecisionReason when circuit breaker was silent"
+        )


### PR DESCRIPTION
## Summary
This PR addresses 6 hardening items to improve robustness and stability of the `gh_footer_hook` module and related event-dispatching code:

1. **Atomic body-file write** — prevents partial writes and I/O race conditions during file operations
2. **Avoid in-place event mutation in dispatcher** — eliminates unintended side effects when processing tool events
3. **Avoid event mutation in tool_handler** — maintains immutability of event data passed through hooks
4. **Hoist gh_footer import** — deduplicates module loading in tool_handler
5. **Shlex tradeoff documentation** — explains rationale for the `_BODY_FLAG_RE` pattern over `shlex.split`
6. **Rewrite_footer docstring fix** — corrects function documentation
7. **MCP _cb_warning_reason test coverage** — extends test suite for injection path validation

## Tests
- **70 tests** pass in `test_gh_footer_hook.py`
- **279 tests** pass across `tests/hooks/`
- Code style: `ruff` clean, no format issues

Closes #891

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)