### PR TITLE
fix: exclude make/sam and build orchestrators from ztk wrapping (#904)

### DIFF
--- a/src/claude_mpm/hooks/ztk_hook.py
+++ b/src/claude_mpm/hooks/ztk_hook.py
@@ -46,6 +46,25 @@ _DISABLE_ENV_VAR = "CLAUDE_MPM_DISABLE_ZTK"
 _MPM_LOG_DIR = Path.home() / ".claude-mpm"
 _MPM_ZTK_LOG = _MPM_LOG_DIR / "ztk-savings.log"
 
+# Build/deploy orchestrators that spawn long subprocess chains with large
+# environments.  ztk's Zig proxy exits with code 2 on E2BIG / long-PATH
+# conditions (upstream issue against github.com/codejunkie99/ztk recommended).
+# Because orchestrators often print partial success ("Build Succeeded") before
+# a later stage fails, the exit-2 looks like success while downstream steps
+# silently never run.  We therefore skip ztk wrapping for these commands.
+_ORCHESTRATOR_EXCLUSIONS: frozenset[str] = frozenset(
+    {
+        "make",
+        "sam",
+        "rake",
+        "gradle",
+        "mvn",
+        "ant",
+        "cdk",
+        "terraform",
+    }
+)
+
 # ---------------------------------------------------------------------------
 # Functional verification cache + self-test
 # ---------------------------------------------------------------------------
@@ -717,6 +736,17 @@ def _build_ztk_response_impl(event: dict) -> dict:
     # any compound/piped command through UNCHANGED rather than wrap it.
     if "\n" in command or any(op in command for op in ("&&", "||", ";", "|")):
         _log_debug("command is compound/piped; passing through (avoids partial output)")
+        return {"continue": True}
+
+    # Exclusion: skip build/deploy orchestrators that spawn long subprocess chains
+    # with large environments.  See module-level _ORCHESTRATOR_EXCLUSIONS for
+    # the full list and rationale.
+    first_token = Path(stripped.split()[0]).name if stripped.split() else ""
+    if first_token in _ORCHESTRATOR_EXCLUSIONS:
+        _log_debug(
+            f"command first token {first_token!r} is a build/deploy orchestrator;"
+            " skipping ztk (avoids E2BIG/exit-2 on long PATH+argv chains)"
+        )
         return {"continue": True}
 
     # Graceful degradation: ztk must be resolvable

--- a/src/claude_mpm/hooks/ztk_hook.py
+++ b/src/claude_mpm/hooks/ztk_hook.py
@@ -58,12 +58,20 @@ _ORCHESTRATOR_EXCLUSIONS: frozenset[str] = frozenset(
         "sam",
         "rake",
         "gradle",
+        # gradlew is the Gradle wrapper script — spawns Gradle with the same
+        # large environment as `gradle` itself.
+        "gradlew",
         "mvn",
         "ant",
         "cdk",
         "terraform",
     }
 )
+
+# Transparent prefix commands that are skipped before extracting the effective
+# command basename for orchestrator exclusion.  Only these two well-known,
+# single-token prefixes are stripped — we do NOT recurse arbitrarily.
+_TRANSPARENT_PREFIXES: frozenset[str] = frozenset({"sudo", "time"})
 
 # ---------------------------------------------------------------------------
 # Functional verification cache + self-test
@@ -672,6 +680,40 @@ def _compute_currency(installed: str | None, required: str | None) -> str:
     return "current"
 
 
+def _effective_command_basename(stripped: str) -> str:
+    """Return the effective command basename after skipping env-var assignments
+    and transparent prefix commands.
+
+    WHY: ``FOO=bar make deploy`` and ``sudo make install`` must be treated as
+    orchestrator commands the same way as bare ``make deploy``.  We skip:
+    1. Leading shell env-var assignment tokens (``NAME=value``).
+    2. Up to one transparent prefix from ``_TRANSPARENT_PREFIXES`` (``sudo``,
+       ``time``).
+
+    We do NOT recurse arbitrarily to avoid falsely excluding commands like
+    ``sudo sudo some-other-cmd`` — two prefixes are more likely a mistake than
+    an intended invocation pattern.
+
+    Returns the empty string when no command token remains (edge case: the
+    entire string is env assignments).
+    """
+    _ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+    tokens = stripped.split()
+    # Skip leading VAR=value tokens.
+    while tokens and _ENV_ASSIGN_RE.match(tokens[0]):
+        tokens = tokens[1:]
+
+    if not tokens:
+        return ""
+
+    # Skip at most one transparent prefix (sudo / time).
+    if tokens[0] in _TRANSPARENT_PREFIXES and len(tokens) > 1:
+        tokens = tokens[1:]
+
+    return Path(tokens[0]).name
+
+
 def build_ztk_response(event: dict) -> dict:
     """Build the ztk-rewrite response for a Bash tool call.
 
@@ -741,10 +783,12 @@ def _build_ztk_response_impl(event: dict) -> dict:
     # Exclusion: skip build/deploy orchestrators that spawn long subprocess chains
     # with large environments.  See module-level _ORCHESTRATOR_EXCLUSIONS for
     # the full list and rationale.
-    first_token = Path(stripped.split()[0]).name if stripped.split() else ""
-    if first_token in _ORCHESTRATOR_EXCLUSIONS:
+    # _effective_command_basename strips leading VAR=value assignments and a
+    # single transparent prefix (sudo / time) before comparing the basename.
+    effective_cmd = _effective_command_basename(stripped)
+    if effective_cmd in _ORCHESTRATOR_EXCLUSIONS:
         _log_debug(
-            f"command first token {first_token!r} is a build/deploy orchestrator;"
+            f"effective command {effective_cmd!r} is a build/deploy orchestrator;"
             " skipping ztk (avoids E2BIG/exit-2 on long PATH+argv chains)"
         )
         return {"continue": True}

--- a/tests/test_ztk_hook.py
+++ b/tests/test_ztk_hook.py
@@ -602,3 +602,58 @@ def test_resolve_ztk_no_auto_install_when_verify_false(tmp_path, monkeypatch):
 
     ztk_hook._resolve_ztk(verify=False)
     assert install_calls == []
+
+
+# ---------------------------------------------------------------------------
+# #904: build/deploy orchestrator exclusions (E2BIG / long-PATH guard)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Bare orchestrator names
+        "make deploy-agents",
+        "sam deploy",
+        "sam build",
+        "rake test",
+        "gradle build",
+        "mvn package",
+        "ant compile",
+        "cdk deploy",
+        "terraform apply",
+        # Full absolute paths normalise to the basename
+        "/usr/bin/make build",
+        "/usr/local/bin/sam deploy",
+        "/opt/homebrew/bin/make -j4",
+    ],
+)
+def test_orchestrator_commands_passthrough(tmp_path, monkeypatch, command):
+    """Build/deploy orchestrators must NOT be wrapped (passthrough).
+
+    Rationale: these tools exec subprocess chains with large environments;
+    ztk's Zig proxy exits code 2 on E2BIG / long-PATH conditions.
+    """
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event(command))
+    assert resp == {"continue": True}, (
+        f"orchestrator command was incorrectly rewritten: {command!r}"
+    )
+
+
+def test_non_orchestrator_still_wrapped(tmp_path, monkeypatch):
+    """A normal command (ls -la) is still wrapped even after the new guard."""
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event("ls -la"))
+    assert "hookSpecificOutput" in resp, "ls -la should be rewritten by ztk"
+
+
+def test_make_like_prefix_not_excluded(tmp_path, monkeypatch):
+    """A command whose name merely starts with 'make' (e.g. makeinfo) is NOT
+    excluded — the guard compares the full basename, not a prefix.
+    """
+    ztk = _working_ztk(tmp_path / "ztk")
+    _force_candidate(monkeypatch, ztk)
+    resp = ztk_hook.build_ztk_response(_bash_event("makeinfo --version"))
+    # makeinfo is not in _ORCHESTRATOR_EXCLUSIONS so it should be wrapped
+    assert "hookSpecificOutput" in resp, "makeinfo should not be excluded"

--- a/tests/test_ztk_hook.py
+++ b/tests/test_ztk_hook.py
@@ -624,6 +624,15 @@ def test_resolve_ztk_no_auto_install_when_verify_false(tmp_path, monkeypatch):
         "/usr/bin/make build",
         "/usr/local/bin/sam deploy",
         "/opt/homebrew/bin/make -j4",
+        # gradlew (Gradle wrapper) — same large-env risk as gradle
+        "./gradlew build",
+        "gradlew assemble",
+        # env-var prefix bypass (HIGH — #907 finding 1)
+        "FOO=bar make deploy",
+        "ENV=prod VAR=1 sam deploy",
+        # transparent prefix bypass (HIGH — #907 finding 2)
+        "sudo make install",
+        "time make build",
     ],
 )
 def test_orchestrator_commands_passthrough(tmp_path, monkeypatch, command):
@@ -631,6 +640,9 @@ def test_orchestrator_commands_passthrough(tmp_path, monkeypatch, command):
 
     Rationale: these tools exec subprocess chains with large environments;
     ztk's Zig proxy exits code 2 on E2BIG / long-PATH conditions.
+
+    Also covers: env-var assignment prefixes (FOO=bar make ...) and transparent
+    prefix commands (sudo / time) that were previously slipping through.
     """
     ztk = _working_ztk(tmp_path / "ztk")
     _force_candidate(monkeypatch, ztk)
@@ -646,14 +658,26 @@ def test_non_orchestrator_still_wrapped(tmp_path, monkeypatch):
     _force_candidate(monkeypatch, ztk)
     resp = ztk_hook.build_ztk_response(_bash_event("ls -la"))
     assert "hookSpecificOutput" in resp, "ls -la should be rewritten by ztk"
+    # The rewritten command must begin with the resolved ztk binary path.
+    rewritten = resp["hookSpecificOutput"]["updatedInput"]["command"]
+    assert rewritten.startswith(str(ztk)), (
+        f"expected rewritten command to start with ztk path {ztk!r}, got {rewritten!r}"
+    )
 
 
 def test_make_like_prefix_not_excluded(tmp_path, monkeypatch):
-    """A command whose name merely starts with 'make' (e.g. makeinfo) is NOT
-    excluded — the guard compares the full basename, not a prefix.
+    """Commands whose names merely start with 'make' or 'ant' are NOT excluded —
+    the guard compares the full basename, not a prefix.
     """
     ztk = _working_ztk(tmp_path / "ztk")
     _force_candidate(monkeypatch, ztk)
-    resp = ztk_hook.build_ztk_response(_bash_event("makeinfo --version"))
-    # makeinfo is not in _ORCHESTRATOR_EXCLUSIONS so it should be wrapped
-    assert "hookSpecificOutput" in resp, "makeinfo should not be excluded"
+
+    for cmd in ("makeinfo --version", "antlr MyGrammar.g4"):
+        resp = ztk_hook.build_ztk_response(_bash_event(cmd))
+        assert "hookSpecificOutput" in resp, (
+            f"{cmd!r} should not be excluded (full-basename match only)"
+        )
+        rewritten = resp["hookSpecificOutput"]["updatedInput"]["command"]
+        assert rewritten.startswith(str(ztk)), (
+            f"expected rewritten command to start with ztk path; got {rewritten!r}"
+        )


### PR DESCRIPTION
## Summary

- Adds a module-level `_ORCHESTRATOR_EXCLUSIONS` frozenset (`make`, `sam`, `rake`, `gradle`, `mvn`, `ant`, `cdk`, `terraform`) to `src/claude_mpm/hooks/ztk_hook.py`.
- In `_build_ztk_response_impl`, extract the first token of every Bash command with `Path(token).name` so full paths like `/usr/bin/make` normalise to `make`; if that basename is in the exclusion set, return passthrough (`{"continue": True}`) before ztk is invoked.
- Adds 14 new parametrised tests in `tests/test_ztk_hook.py` covering all excluded tools, absolute-path variants, a non-excluded similar name (`makeinfo`), and a sanity-check that ordinary commands (`ls -la`) are still wrapped.

## Root cause

The ztk PreToolUse hook rewrites every Bash command to `ztk run <cmd>`.
When `make deploy-agents` runs, `make` exec-chains into `sam build` then
`sam deploy`.  `sam` is invoked with a long PATH and argv that can exceed
`ARG_MAX`; ztk's Zig proxy exits with **code 2** on this `E2BIG` condition.
Because `sam build` prints `"Build Succeeded"` before `sam deploy` is
reached, the overall exit looks like success — while `sam deploy` silently
never runs.

## Fix

Skip ztk wrapping entirely for commands whose first token is a
build/deploy orchestrator.  The exclusion sits after the existing
`-c`/`-e` and compound-operator guards and matches the same
`_log_debug` / `{"continue": True}` style used throughout the function.

## Note on upstream

An issue against **github.com/codejunkie99/ztk** for the `E2BIG` /
long-PATH exit-code-2 behaviour is recommended so that the root cause can
be fixed in the proxy itself.  This PR applies a defensive client-side
guard in the meantime.

## Test plan

- [x] `uv run pytest tests/test_ztk_hook.py` — 56 passed, 0 failed
- [x] `uv run ruff format . && uv run ruff check --fix .` — clean

Closes #904