### PR TITLE
fix: strip CLAUDE_CODE_CHILD_SESSION so /remote is available in MPM sessions (#905)

### DIFF
--- a/src/claude_mpm/core/headless_session.py
+++ b/src/claude_mpm/core/headless_session.py
@@ -488,6 +488,17 @@ class HeadlessSession:
         """Prepare the execution environment."""
         env = os.environ.copy()
 
+        # Remove Claude-specific variables inherited from a parent Claude session
+        # that would interfere with the spawned subprocess (e.g. CLAUDE_CODE_CHILD_SESSION
+        # hides the /remote slash command inside MPM-launched Claude sessions).
+        claude_vars_to_remove = [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "CLAUDECODE",
+        ]
+        for var in claude_vars_to_remove:
+            env.pop(var, None)
+
         # Apply env var defaults (propagates user's DISABLE_TELEMETRY preference)
         apply_subprocess_env_defaults(env)
 

--- a/src/claude_mpm/core/interactive_session.py
+++ b/src/claude_mpm/core/interactive_session.py
@@ -593,6 +593,7 @@ class InteractiveSession:
         # Remove Claude-specific variables that might interfere
         claude_vars_to_remove = [
             "CLAUDE_CODE_ENTRYPOINT",
+            "CLAUDE_CODE_CHILD_SESSION",
             "CLAUDECODE",
             "CLAUDE_CONFIG_DIR",
             "CLAUDE_MAX_PARALLEL_SUBAGENTS",

--- a/src/claude_mpm/core/oneshot_session.py
+++ b/src/claude_mpm/core/oneshot_session.py
@@ -366,6 +366,17 @@ class OneshotSession:
         """Prepare the execution environment."""
         env = os.environ.copy()
 
+        # Remove Claude-specific variables inherited from a parent Claude session
+        # that would interfere with the spawned subprocess (e.g. CLAUDE_CODE_CHILD_SESSION
+        # hides the /remote slash command inside MPM-launched Claude sessions).
+        claude_vars_to_remove = [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "CLAUDECODE",
+        ]
+        for var in claude_vars_to_remove:
+            env.pop(var, None)
+
         # Apply env var defaults (propagates user's DISABLE_TELEMETRY preference)
         apply_subprocess_env_defaults(env)
 

--- a/tests/cli/test_headless.py
+++ b/tests/cli/test_headless.py
@@ -502,6 +502,36 @@ class TestHeadlessIntegration:
 
         assert env.get("CI") == "true"
 
+    def test_environment_strips_child_session_var(self, mock_runner):
+        """CLAUDE_CODE_CHILD_SESSION must be absent from child env even when set.
+
+        Regression guard for issue #905: when MPM is itself launched inside a
+        Claude Code session the parent sets CLAUDE_CODE_CHILD_SESSION, which
+        propagates into the PM subprocess and hides the /remote slash command.
+        """
+        import os
+
+        mock_runner.claude_args = []
+
+        with patch.object(
+            HeadlessSession, "_get_working_directory", return_value=Path("/test")
+        ):
+            session = HeadlessSession(mock_runner)
+
+        with patch.dict(
+            os.environ,
+            {
+                "CLAUDE_CODE_CHILD_SESSION": "some-session-id",
+                "CLAUDE_CODE_ENTRYPOINT": "vscode",
+                "CLAUDECODE": "1",
+            },
+        ):
+            env = session._prepare_environment()
+
+        assert "CLAUDE_CODE_CHILD_SESSION" not in env
+        assert "CLAUDE_CODE_ENTRYPOINT" not in env
+        assert "CLAUDECODE" not in env
+
     def test_run_passes_through_custom_claude_args(self, mock_runner):
         """Custom claude_args should be passed to os.execvpe."""
         mock_runner.claude_args = ["--model", "opus"]

--- a/tests/core/test_interactive_session.py
+++ b/tests/core/test_interactive_session.py
@@ -606,6 +606,7 @@ class TestInteractiveSession:
         mock_env = {
             "PATH": "/usr/bin",
             "CLAUDE_CODE_ENTRYPOINT": "test",
+            "CLAUDE_CODE_CHILD_SESSION": "1",
             "CLAUDECODE": "test",
             "CLAUDE_CONFIG_DIR": "test",
             "CLAUDE_MAX_PARALLEL_SUBAGENTS": "test",
@@ -618,6 +619,7 @@ class TestInteractiveSession:
 
             # Should remove Claude-specific variables
             assert "CLAUDE_CODE_ENTRYPOINT" not in result
+            assert "CLAUDE_CODE_CHILD_SESSION" not in result
             assert "CLAUDECODE" not in result
             assert "CLAUDE_CONFIG_DIR" not in result
             assert "CLAUDE_MAX_PARALLEL_SUBAGENTS" not in result
@@ -626,6 +628,25 @@ class TestInteractiveSession:
             # Should keep other variables
             assert result["PATH"] == "/usr/bin"
             assert result["OTHER_VAR"] == "keep"
+
+    def test_prepare_environment_strips_child_session_var(self, interactive_session):
+        """CLAUDE_CODE_CHILD_SESSION must be absent from child env even when set.
+
+        Regression guard for issue #905: when MPM is itself launched inside a
+        Claude Code session the parent sets CLAUDE_CODE_CHILD_SESSION, which
+        propagates into the PM subprocess and hides the /remote slash command.
+        """
+        mock_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_CHILD_SESSION": "some-session-id",
+        }
+
+        with patch("os.environ.copy", return_value=mock_env):
+            result = interactive_session._prepare_environment()
+
+        assert "CLAUDE_CODE_CHILD_SESSION" not in result
+        # Sanity: unrelated vars survive
+        assert result["PATH"] == "/usr/bin"
 
     def test_change_to_user_directory_success(self, interactive_session, tmp_path):
         """Test changing to user directory successfully."""

--- a/tests/core/test_oneshot_session.py
+++ b/tests/core/test_oneshot_session.py
@@ -578,6 +578,29 @@ class TestOneshotSession:
                 "CLAUDE_MPM_IS_PM": "1",
             }
 
+    def test_prepare_environment_strips_child_session_var(self, oneshot_session):
+        """CLAUDE_CODE_CHILD_SESSION must be absent from child env even when set.
+
+        Regression guard for issue #905: when MPM is itself launched inside a
+        Claude Code session the parent sets CLAUDE_CODE_CHILD_SESSION, which
+        propagates into the PM subprocess and hides the /remote slash command.
+        """
+        mock_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_CHILD_SESSION": "some-session-id",
+            "CLAUDE_CODE_ENTRYPOINT": "vscode",
+            "CLAUDECODE": "1",
+        }
+
+        with patch("os.environ.copy", return_value=mock_env):
+            result = oneshot_session._prepare_environment()
+
+        assert "CLAUDE_CODE_CHILD_SESSION" not in result
+        assert "CLAUDE_CODE_ENTRYPOINT" not in result
+        assert "CLAUDECODE" not in result
+        # Unrelated vars survive
+        assert result["PATH"] == "/usr/bin"
+
     def test_prepare_environment_telemetry_opt_in(self, oneshot_session, monkeypatch):
         """When DISABLE_TELEMETRY=0 in shell, var must be absent from subprocess env.
 


### PR DESCRIPTION
## Summary

- **Root cause**: When MPM is launched inside a Claude Code session (e.g. as a subagent or via a nested invocation), the parent process sets `CLAUDE_CODE_CHILD_SESSION` in the environment. This variable propagated unchecked into all MPM-spawned subprocess environments (`InteractiveSession`, `OneshotSession`, `HeadlessSession`), causing the `/remote` slash command to be hidden inside those sessions.
- **Fix**: Add `CLAUDE_CODE_CHILD_SESSION` to the `claude_vars_to_remove` list in `InteractiveSession._prepare_environment()` (which already stripped related vars). Mirror the same removal block (covering `CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDECODE`) in `OneshotSession._prepare_environment()` and `HeadlessSession._prepare_environment()`, which previously did a bare `os.environ.copy()` with no CLAUDE_CODE_* filtering.
- MPM has zero internal reads of `CLAUDE_CODE_CHILD_SESSION`; stripping it is safe.

## Test plan

- [x] `test_prepare_environment_strips_child_session_var` added to `TestInteractiveSession`
- [x] `test_prepare_environment` in `TestInteractiveSession` extended to assert `CLAUDE_CODE_CHILD_SESSION` absent
- [x] `test_prepare_environment_strips_child_session_var` added to `TestOneshotSession`
- [x] `test_environment_strips_child_session_var` added to `TestHeadlessIntegration`
- [x] All 153 tests in the affected test files pass (`pytest tests/core/test_interactive_session.py tests/core/test_oneshot_session.py tests/cli/test_headless.py`)
- [x] `ruff format` and `ruff check --fix` pass with no violations

Closes #905

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)