### PR TITLE
fix: implement WorktreeRemove cleanup in Python hook path (#912)

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/hook_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/hook_handler.py
@@ -514,6 +514,20 @@ class ClaudeHookHandler:
                 # unreachable but satisfies static analysis.
                 return
 
+            # WorktreeRemove: short-circuit BEFORE generic routing.
+            # Contract: stdout must be {"continue": true}; exit 0 always.
+            # The generic _route_event path invokes the passthrough handler
+            # which is observability-only and never runs git worktree remove,
+            # causing worktree directories to accumulate on disk (#912).
+            if hook_type == "WorktreeRemove":
+                # Disarm the SIGALRM timeout handler BEFORE any git I/O so
+                # that a slow removal can never trigger a double-emit.
+                _continue_sent = True
+                self._handle_worktree_remove(event)
+                # _handle_worktree_remove always calls sys.exit(); this line is
+                # unreachable but satisfies static analysis.
+                return
+
             # Route event to appropriate handler
             # Returns modified_input for PreToolUse, or decision dict for Stop hooks
             handler_result = self._route_event(event)
@@ -938,6 +952,94 @@ class ClaudeHookHandler:
         # ------------------------------------------------------------------
         _log(f"WorktreeCreate: all attempts failed for path '{worktree_path_str}'")
         sys.exit(1)
+
+    def _handle_worktree_remove(self, event: dict) -> None:
+        """Implement the WorktreeRemove hook contract for the Python entry point.
+
+        WHAT: Removes the git worktree at the path supplied by Claude Code,
+              prints ``{"continue": true}`` to stdout, and exits 0.
+        WHY: The generic ``_route_event`` path delegates to an observability-only
+             passthrough handler that returns ``None`` and never runs
+             ``git worktree remove``, so worktree directories accumulate on
+             disk after each isolated agent session ends (#912).  This method
+             mirrors ``claude-hook-fast.sh`` lines ~188-212 so the Python
+             binary and the bash script behave identically.
+
+        Contract (Claude Code spec):
+        - stdin JSON contains ``path`` (absolute path of the worktree to remove)
+          and ``cwd`` (repo root hint).
+        - Hook must run ``git worktree remove --force <path>`` and print
+          ``{"continue": true}`` to stdout.
+        - Exit 0 always — removal failures must not block Claude Code.
+        - Stdout must be exactly ``{"continue": true}`` (no extra bytes).
+
+        The dashboard socketio event is emitted best-effort BEFORE printing so
+        that no extra bytes leak onto stdout.
+
+        :spec: SPEC-HOOKS-03~1
+        """
+        path: str = event.get("path", event.get("worktree_path", ""))
+        cwd: str = event.get("cwd", "")
+
+        # ------------------------------------------------------------------
+        # Graceful no-op when path is absent
+        # ------------------------------------------------------------------
+        if not path:
+            _log("WorktreeRemove: no path field in event, skipping git removal")
+            print(json.dumps({"continue": True}), flush=True)
+            sys.exit(0)
+
+        # ------------------------------------------------------------------
+        # Resolve repo root (same logic as _handle_worktree_create)
+        # ------------------------------------------------------------------
+        repo_root: str = cwd or ""
+        if not repo_root:
+            try:
+                repo_root = subprocess.check_output(  # nosec B603 B607
+                    ["git", "rev-parse", "--show-toplevel"],
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                ).strip()
+            except Exception:
+                repo_root = str(Path.cwd())
+
+        try:
+            repo_root = str(Path(repo_root).resolve())
+        except Exception:
+            pass
+
+        # ------------------------------------------------------------------
+        # Emit dashboard event (best-effort, must happen BEFORE any stdout)
+        # ------------------------------------------------------------------
+        try:
+            self.event_handlers.handle_worktree_remove_fast(event)
+        except Exception as exc:
+            _log(f"WorktreeRemove: dashboard emit failed (non-fatal): {exc}")
+
+        # ------------------------------------------------------------------
+        # Run git worktree remove --force; failure is non-fatal (#912 spec)
+        # ------------------------------------------------------------------
+        try:
+            result = subprocess.run(  # nosec B603 B607
+                ["git", "-C", repo_root, "worktree", "remove", "--force", path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                _log(
+                    f"WorktreeRemove: git worktree remove exited {result.returncode} "
+                    f"for path '{path}': {result.stderr.strip()}"
+                )
+        except Exception as exc:
+            _log(f"WorktreeRemove: exception running git worktree remove: {exc}")
+
+        # ------------------------------------------------------------------
+        # Always signal continue — removal failures must not block Claude Code
+        # ------------------------------------------------------------------
+        print(json.dumps({"continue": True}), flush=True)
+        sys.exit(0)
 
     # Delegation methods for compatibility with event_handlers
     def _track_delegation(self, session_id: str, agent_type: str, request_data=None):

--- a/src/claude_mpm/hooks/claude_hooks/hook_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/hook_handler.py
@@ -1009,6 +1009,47 @@ class ClaudeHookHandler:
             pass
 
         # ------------------------------------------------------------------
+        # Path-containment guard: resolve path and verify it is inside the
+        # expected worktrees root before force-removing anything.
+        #
+        # WHY: ``git worktree remove --force`` is destructive.  A symlink or
+        # path-traversal payload in the ``path`` field could escape the
+        # worktrees directory and wipe arbitrary on-disk state.  We resolve
+        # both paths to their real, symlink-free absolute forms and reject
+        # any path that does not live inside the worktrees root.
+        #
+        # The expected root matches the convention used by _handle_worktree_create:
+        #   <parent_of_repo>/<repo-basename>-worktrees/
+        # If the incoming path lands outside that root we log the rejection
+        # and exit 0 with {"continue": true} — identical to the no-path case
+        # so that removal safety never blocks Claude Code.
+        # ------------------------------------------------------------------
+        repo_path = Path(repo_root)
+        worktrees_root = repo_path.parent / f"{repo_path.name}-worktrees"
+        try:
+            resolved_path = Path(path).resolve()
+            resolved_root = worktrees_root.resolve()
+        except Exception as exc:
+            _log(
+                f"WorktreeRemove: failed to resolve paths for containment check "
+                f"(path={path!r}, root={worktrees_root!r}): {exc} — skipping git removal"
+            )
+            print(json.dumps({"continue": True}), flush=True)
+            sys.exit(0)
+
+        path_is_contained = (
+            resolved_path == resolved_root or resolved_root in resolved_path.parents
+        )
+        if not path_is_contained:
+            _log(
+                f"WorktreeRemove: REJECTED — resolved path {resolved_path!r} is not "
+                f"contained within worktrees root {resolved_root!r}; "
+                f"skipping git worktree remove to prevent accidental data loss"
+            )
+            print(json.dumps({"continue": True}), flush=True)
+            sys.exit(0)
+
+        # ------------------------------------------------------------------
         # Emit dashboard event (best-effort, must happen BEFORE any stdout)
         # ------------------------------------------------------------------
         try:

--- a/tests/hooks/claude_hooks/test_worktree_remove.py
+++ b/tests/hooks/claude_hooks/test_worktree_remove.py
@@ -1,0 +1,393 @@
+"""Tests for the WorktreeRemove hook contract in the Python hook handler.
+
+Verifies that the Python ``claude-hook`` entry point correctly implements the
+Claude Code WorktreeRemove contract:
+- stdout is exactly ``{"continue": true}`` and exit code is 0
+- git worktree remove --force is invoked for the given path
+- worktree directory is absent after successful removal
+- exit 0 with {"continue": true} and NO git invocation when path is missing
+- removal failures (nonexistent path) still exit 0 with {"continue": true}
+
+Issue: #912
+"""
+
+import json
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(path: str = "", cwd: str = "") -> dict:
+    """Build a WorktreeRemove event dict as Claude Code sends it."""
+    return {
+        "hook_event_name": "WorktreeRemove",
+        "path": path,
+        "cwd": cwd,
+        "session_id": "test-session-remove-abc123",
+    }
+
+
+def _init_git_repo(path: Path) -> None:
+    """Create a minimal git repo so worktree commands work."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test User"],
+        check=True,
+        capture_output=True,
+    )
+    readme = path / "README.md"
+    readme.write_text("# test\n")
+    subprocess.run(
+        ["git", "-C", str(path), "add", "."], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _register_worktree(repo: Path, worktree_path: Path) -> None:
+    """Add a real git worktree at worktree_path branching off repo."""
+    branch = worktree_path.name
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            str(worktree_path),
+            "-b",
+            branch,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _invoke_handle_worktree_remove(event: dict) -> tuple[str, int]:
+    """Invoke _handle_worktree_remove and return (stdout_output, exit_code)."""
+    from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+    handler = ClaudeHookHandler()
+    captured_stdout = StringIO()
+    exit_code = -1
+
+    with patch("sys.stdout", captured_stdout):
+        with pytest.raises(SystemExit) as exc_info:
+            handler._handle_worktree_remove(event)
+        exit_code = exc_info.value.code if exc_info.value.code is not None else 0
+
+    return captured_stdout.getvalue().strip(), exit_code
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_git_repo(tmp_path: Path) -> Path:
+    """Temporary git repository for worktree removal tests."""
+    repo = tmp_path / "my-repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# (a) Successful removal: real repo + registered worktree
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWorktreeRemoveSuccess:
+    """Test _handle_worktree_remove with a real registered git worktree."""
+
+    def test_stdout_is_continue_json_on_success(self, tmp_git_repo: Path) -> None:
+        """(a) stdout must be exactly {"continue": true} on successful removal."""
+        worktree_path = tmp_git_repo.parent / "my-repo-worktrees" / "remove-agent"
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        _register_worktree(tmp_git_repo, worktree_path)
+        assert worktree_path.is_dir(), "worktree directory must exist before removal"
+
+        event = _make_event(path=str(worktree_path), cwd=str(tmp_git_repo))
+        stdout, exit_code = _invoke_handle_worktree_remove(event)
+
+        assert exit_code == 0, f"Expected exit 0, got {exit_code}"
+        parsed = json.loads(stdout)
+        assert parsed == {"continue": True}, f"Unexpected stdout: {stdout!r}"
+
+    def test_exit_code_zero_on_success(self, tmp_git_repo: Path) -> None:
+        """(a) exit code must be 0 on successful removal."""
+        worktree_path = tmp_git_repo.parent / "my-repo-worktrees" / "exit-zero-agent"
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        _register_worktree(tmp_git_repo, worktree_path)
+
+        event = _make_event(path=str(worktree_path), cwd=str(tmp_git_repo))
+        _stdout, exit_code = _invoke_handle_worktree_remove(event)
+
+        assert exit_code == 0
+
+    def test_worktree_directory_removed_after_call(self, tmp_git_repo: Path) -> None:
+        """(a) The worktree directory must not exist after successful removal."""
+        worktree_path = tmp_git_repo.parent / "my-repo-worktrees" / "dir-gone-agent"
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        _register_worktree(tmp_git_repo, worktree_path)
+        assert worktree_path.is_dir(), "precondition: worktree dir exists before test"
+
+        event = _make_event(path=str(worktree_path), cwd=str(tmp_git_repo))
+        _invoke_handle_worktree_remove(event)
+
+        assert not worktree_path.exists(), (
+            f"worktree directory still exists after removal: {worktree_path}"
+        )
+
+    def test_git_worktree_list_no_longer_shows_path(self, tmp_git_repo: Path) -> None:
+        """(a) git worktree list must no longer include the path after removal."""
+        worktree_path = tmp_git_repo.parent / "my-repo-worktrees" / "list-check-agent"
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        _register_worktree(tmp_git_repo, worktree_path)
+
+        event = _make_event(path=str(worktree_path), cwd=str(tmp_git_repo))
+        _invoke_handle_worktree_remove(event)
+
+        result = subprocess.run(
+            ["git", "-C", str(tmp_git_repo), "worktree", "list"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert str(worktree_path) not in result.stdout, (
+            f"git worktree list still shows removed path: {result.stdout}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Missing / empty path: no git invocation, graceful continue
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWorktreeRemoveMissingPath:
+    """Test _handle_worktree_remove when path field is absent or empty."""
+
+    def test_empty_path_stdout_is_continue_json(self, tmp_path: Path) -> None:
+        """(b) stdout must be {"continue": true} when path is empty."""
+        event = _make_event(path="", cwd=str(tmp_path))
+        stdout, exit_code = _invoke_handle_worktree_remove(event)
+
+        assert exit_code == 0, f"Expected exit 0, got {exit_code}"
+        parsed = json.loads(stdout)
+        assert parsed == {"continue": True}, f"Unexpected stdout: {stdout!r}"
+
+    def test_missing_path_field_no_git_invocation(self, tmp_path: Path) -> None:
+        """(b) No subprocess call must occur when path field is absent."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        # Build event without 'path' key at all
+        event = {
+            "hook_event_name": "WorktreeRemove",
+            "cwd": str(tmp_path),
+            "session_id": "no-path-session",
+        }
+        captured_stdout = StringIO()
+
+        with patch("subprocess.run") as mock_run:
+            with patch("sys.stdout", captured_stdout):
+                with pytest.raises(SystemExit) as exc_info:
+                    handler._handle_worktree_remove(event)
+
+            exit_code = exc_info.value.code if exc_info.value.code is not None else 0
+
+        # subprocess.run must NOT have been called (no path → no git)
+        for call in mock_run.call_args_list:
+            args = call.args[0] if call.args else call.kwargs.get("args", [])
+            assert "worktree" not in args, (
+                f"subprocess.run was called with git worktree args: {args}"
+            )
+
+        assert exit_code == 0
+        stdout = captured_stdout.getvalue().strip()
+        assert json.loads(stdout) == {"continue": True}
+
+    def test_empty_path_field_no_git_invocation(self, tmp_path: Path) -> None:
+        """(b) No git subprocess for worktree remove when path is empty string."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="", cwd=str(tmp_path))
+        captured_stdout = StringIO()
+
+        git_worktree_remove_called = []
+
+        original_run = subprocess.run
+
+        def tracking_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(cmd, list) and "worktree" in cmd and "remove" in cmd:
+                git_worktree_remove_called.append(cmd)
+            return original_run(cmd, *args, **kwargs)
+
+        with patch("subprocess.run", side_effect=tracking_run):
+            with patch("sys.stdout", captured_stdout):
+                with pytest.raises(SystemExit):
+                    handler._handle_worktree_remove(event)
+
+        assert len(git_worktree_remove_called) == 0, (
+            f"git worktree remove was called despite empty path: {git_worktree_remove_called}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (c) Removal failure: nonexistent path still exits 0 with {"continue": true}
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWorktreeRemoveFailure:
+    """Test that removal failures never block Claude Code."""
+
+    def test_nonexistent_path_exits_zero(self, tmp_git_repo: Path) -> None:
+        """(c) A nonexistent worktree path must still exit 0."""
+        nonexistent = str(tmp_git_repo.parent / "nonexistent-worktree-xyz")
+        event = _make_event(path=nonexistent, cwd=str(tmp_git_repo))
+        _stdout, exit_code = _invoke_handle_worktree_remove(event)
+        assert exit_code == 0, f"Expected exit 0 on removal failure, got {exit_code}"
+
+    def test_nonexistent_path_stdout_is_continue_json(self, tmp_git_repo: Path) -> None:
+        """(c) stdout must be {"continue": true} even when git removal fails."""
+        nonexistent = str(tmp_git_repo.parent / "nonexistent-worktree-abc")
+        event = _make_event(path=nonexistent, cwd=str(tmp_git_repo))
+        stdout, exit_code = _invoke_handle_worktree_remove(event)
+
+        assert exit_code == 0
+        parsed = json.loads(stdout)
+        assert parsed == {"continue": True}, f"Unexpected stdout: {stdout!r}"
+
+    def test_removal_failure_does_not_raise(self, tmp_git_repo: Path) -> None:
+        """(c) Removal failure must not propagate as an exception."""
+        nonexistent = str(tmp_git_repo.parent / "does-not-exist-worktree")
+        event = _make_event(path=nonexistent, cwd=str(tmp_git_repo))
+
+        # The only allowed exception is SystemExit(0); no other exception must leak.
+        with pytest.raises(SystemExit) as exc_info:
+            from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+            handler = ClaudeHookHandler()
+            captured_stdout = StringIO()
+            with patch("sys.stdout", captured_stdout):
+                handler._handle_worktree_remove(event)
+
+        assert exc_info.value.code == 0, (
+            f"Expected SystemExit(0) on failure, got SystemExit({exc_info.value.code})"
+        )
+
+    def test_subprocess_exception_does_not_propagate(self, tmp_git_repo: Path) -> None:
+        """(c) An OSError from subprocess.run must be caught and exit 0 still occurs."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="/some/path", cwd=str(tmp_git_repo))
+        captured_stdout = StringIO()
+
+        def raise_oserror(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(cmd, list) and "worktree" in cmd:
+                raise OSError("simulated git not found")
+            return MagicMock(returncode=0, stderr="")
+
+        with patch("subprocess.run", side_effect=raise_oserror):
+            with patch("sys.stdout", captured_stdout):
+                with pytest.raises(SystemExit) as exc_info:
+                    handler._handle_worktree_remove(event)
+
+        assert exc_info.value.code == 0
+        stdout = captured_stdout.getvalue().strip()
+        assert json.loads(stdout) == {"continue": True}
+
+
+# ---------------------------------------------------------------------------
+# Integration: handle() short-circuits WorktreeRemove correctly
+# ---------------------------------------------------------------------------
+
+
+class TestHandleIntegrationWorktreeRemove:
+    """Test that handle() routes WorktreeRemove through _handle_worktree_remove."""
+
+    def test_handle_calls_worktree_remove_method(self, tmp_git_repo: Path) -> None:
+        """handle() must call _handle_worktree_remove for WorktreeRemove events."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="/some/path", cwd=str(tmp_git_repo))
+        event_json = json.dumps(event)
+
+        called_with: list[dict] = []
+
+        def fake_handle_worktree_remove(evt: dict) -> None:
+            called_with.append(evt)
+            raise SystemExit(0)
+
+        handler._handle_worktree_remove = fake_handle_worktree_remove  # type: ignore[method-assign]
+
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.read.return_value = event_json
+            with patch("select.select", return_value=([mock_stdin], [], [])):
+                with pytest.raises(SystemExit):
+                    handler.handle()
+
+        assert len(called_with) == 1, (
+            "_handle_worktree_remove was not called exactly once"
+        )
+        assert called_with[0]["hook_event_name"] == "WorktreeRemove"
+
+    def test_handle_does_not_call_continue_execution_for_remove(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """handle() must NOT call _continue_execution for WorktreeRemove events."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="/some/path", cwd=str(tmp_git_repo))
+        event_json = json.dumps(event)
+
+        continue_called: list = []
+        original_continue = handler._continue_execution
+
+        def tracking_continue(*args, **kwargs):  # type: ignore[no-untyped-def]
+            continue_called.append((args, kwargs))
+            return original_continue(*args, **kwargs)
+
+        handler._continue_execution = tracking_continue  # type: ignore[method-assign]
+
+        # Replace _handle_worktree_remove to avoid real git I/O
+        def fake_handle_worktree_remove(evt: dict) -> None:
+            raise SystemExit(0)
+
+        handler._handle_worktree_remove = fake_handle_worktree_remove  # type: ignore[method-assign]
+
+        captured_stdout = StringIO()
+        with patch("sys.stdout", captured_stdout):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                mock_stdin.read.return_value = event_json
+                with patch("select.select", return_value=([mock_stdin], [], [])):
+                    with pytest.raises(SystemExit):
+                        handler.handle()
+
+        assert len(continue_called) == 0, (
+            f"_continue_execution was called {len(continue_called)} time(s) for "
+            f"WorktreeRemove — must not be called: {continue_called}"
+        )

--- a/tests/hooks/claude_hooks/test_worktree_remove.py
+++ b/tests/hooks/claude_hooks/test_worktree_remove.py
@@ -391,3 +391,203 @@ class TestHandleIntegrationWorktreeRemove:
             f"_continue_execution was called {len(continue_called)} time(s) for "
             f"WorktreeRemove — must not be called: {continue_called}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: SIGALRM timeout guard for WorktreeRemove
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeRemoveTimeoutGuard:
+    """Regression tests for the SIGALRM timeout + WorktreeRemove race condition.
+
+    Before the fix, if git worktree remove ran long and the 10-second SIGALRM
+    fired, timeout_handler would emit {"continue": true} to stdout because
+    _continue_sent was still False.
+
+    The fix sets _continue_sent = True immediately when WorktreeRemove is
+    detected, BEFORE any git I/O starts, so the timeout handler is disarmed.
+    """
+
+    def test_continue_sent_set_before_worktree_remove_runs(
+        self, tmp_path: Path
+    ) -> None:
+        """_continue_sent must be True before _handle_worktree_remove is entered.
+
+        Verify the observable consequence: even if _handle_worktree_remove raises
+        SystemExit(0) immediately (simulating an interrupted git operation),
+        _continue_execution must not have been called — the guard prevents
+        double-emit.
+        """
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="/some/worktree/path", cwd=str(tmp_path))
+        event_json = json.dumps(event)
+
+        continue_called: list = []
+        original_continue = handler._continue_execution
+
+        def tracking_continue(*args, **kwargs):  # type: ignore[no-untyped-def]
+            continue_called.append((args, kwargs))
+            return original_continue(*args, **kwargs)
+
+        handler._continue_execution = tracking_continue  # type: ignore[method-assign]
+
+        # Make _handle_worktree_remove raise SystemExit(0) immediately,
+        # as if SIGALRM interrupted it mid-git-operation.
+        def fake_handle_worktree_remove(evt: dict) -> None:
+            raise SystemExit(0)
+
+        handler._handle_worktree_remove = fake_handle_worktree_remove  # type: ignore[method-assign]
+
+        captured_stdout = StringIO()
+        with patch("sys.stdout", captured_stdout):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                mock_stdin.read.return_value = event_json
+                with patch("select.select", return_value=([mock_stdin], [], [])):
+                    with pytest.raises(SystemExit):
+                        handler.handle()
+
+        # _continue_execution must NOT have been called — the guard worked.
+        assert len(continue_called) == 0, (
+            f"_continue_execution was called {len(continue_called)} time(s); "
+            f"_continue_sent guard did not protect WorktreeRemove from the timeout handler"
+        )
+        stdout = captured_stdout.getvalue().strip()
+        assert '{"continue":' not in stdout, (
+            f"stdout contains bogus continue JSON — timeout guard failed: {stdout!r}"
+        )
+
+    def test_timeout_handler_cannot_emit_json_for_worktree_remove(
+        self, tmp_path: Path
+    ) -> None:
+        """Simulate SIGALRM firing during WorktreeRemove: stdout must not contain JSON.
+
+        Verify from the outside-in: when _handle_worktree_remove exits immediately,
+        the output on stdout must not contain {"continue": JSON emitted by the
+        fallback path (i.e. the _continue_sent = True guard prevents double-emit).
+        """
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        event = _make_event(path="/some/worktree/path", cwd=str(tmp_path))
+        event_json = json.dumps(event)
+
+        def fake_handle_worktree_remove(evt: dict) -> None:
+            raise SystemExit(0)
+
+        handler._handle_worktree_remove = fake_handle_worktree_remove  # type: ignore[method-assign]
+
+        captured_stdout = StringIO()
+        with patch("sys.stdout", captured_stdout):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                mock_stdin.read.return_value = event_json
+                with patch("select.select", return_value=([mock_stdin], [], [])):
+                    with pytest.raises(SystemExit):
+                        handler.handle()
+
+        stdout = captured_stdout.getvalue()
+        assert '{"continue": true}' not in stdout, (
+            f"Timeout guard failed: stdout contains bogus JSON: {stdout!r}"
+        )
+        assert '"continue"' not in stdout, (
+            f"Timeout guard failed: stdout contains JSON fragment: {stdout!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Path-containment guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeRemovePathContainmentGuard:
+    """Tests for the path-containment guard added to _handle_worktree_remove.
+
+    A WorktreeRemove event whose path is OUTSIDE the expected worktrees root
+    must be rejected: exit 0, {"continue": true}, NO git worktree remove call.
+    """
+
+    def test_path_outside_worktrees_root_exits_zero(self, tmp_git_repo: Path) -> None:
+        """A path outside <repo-parent>/<repo>-worktrees/ must exit 0."""
+        # Path outside the worktrees root — e.g. /tmp itself
+        outside_path = str(tmp_git_repo.parent / "some-other-directory" / "data")
+        event = _make_event(path=outside_path, cwd=str(tmp_git_repo))
+        _stdout, exit_code = _invoke_handle_worktree_remove(event)
+        assert exit_code == 0, f"Expected exit 0 for out-of-root path, got {exit_code}"
+
+    def test_path_outside_worktrees_root_stdout_is_continue_json(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """A path outside the worktrees root must still emit {"continue": true}."""
+        outside_path = str(tmp_git_repo.parent / "some-other-directory" / "data")
+        event = _make_event(path=outside_path, cwd=str(tmp_git_repo))
+        stdout, exit_code = _invoke_handle_worktree_remove(event)
+        assert exit_code == 0
+        parsed = json.loads(stdout)
+        assert parsed == {"continue": True}, f"Unexpected stdout: {stdout!r}"
+
+    def test_path_outside_worktrees_root_no_git_invocation(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """git worktree remove must NOT be called for a path outside the worktrees root."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        outside_path = str(tmp_git_repo.parent / "outside" / "escaped-path")
+        event = _make_event(path=outside_path, cwd=str(tmp_git_repo))
+
+        captured_stdout = StringIO()
+        git_remove_calls: list = []
+
+        original_run = subprocess.run
+
+        def tracking_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(cmd, list) and "worktree" in cmd and "remove" in cmd:
+                git_remove_calls.append(cmd)
+            return original_run(cmd, *args, **kwargs)
+
+        with patch("subprocess.run", side_effect=tracking_run):
+            with patch("sys.stdout", captured_stdout):
+                with pytest.raises(SystemExit):
+                    handler._handle_worktree_remove(event)
+
+        assert len(git_remove_calls) == 0, (
+            f"git worktree remove was called for an out-of-root path: {git_remove_calls}"
+        )
+
+    def test_path_inside_worktrees_root_allows_git_invocation(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """A path correctly inside the worktrees root must reach the git remove call."""
+        from src.claude_mpm.hooks.claude_hooks.hook_handler import ClaudeHookHandler
+
+        handler = ClaudeHookHandler()
+        # Path inside the expected worktrees root (may not exist — that's OK, removal
+        # failure is non-fatal and still exits 0)
+        inside_path = str(
+            tmp_git_repo.parent / f"{tmp_git_repo.name}-worktrees" / "test-agent"
+        )
+        event = _make_event(path=inside_path, cwd=str(tmp_git_repo))
+
+        captured_stdout = StringIO()
+        git_remove_calls: list = []
+
+        original_run = subprocess.run
+
+        def tracking_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(cmd, list) and "worktree" in cmd and "remove" in cmd:
+                git_remove_calls.append(cmd)
+            return original_run(cmd, *args, **kwargs)
+
+        with patch("subprocess.run", side_effect=tracking_run):
+            with patch("sys.stdout", captured_stdout):
+                with pytest.raises(SystemExit):
+                    handler._handle_worktree_remove(event)
+
+        assert len(git_remove_calls) == 1, (
+            f"Expected git worktree remove to be called once for a valid path, "
+            f"got {len(git_remove_calls)} calls"
+        )


### PR DESCRIPTION
## Summary

### Root Cause
The Python `claude-hook` entry point routed `WorktreeRemove` events to an observability-only passthrough handler (`handle_worktree_remove_fast`) that emits a Socket.IO dashboard event and returns `None` — **it never ran `git worktree remove`**. As a result, every worktree directory created by `isolation: "worktree"` was left on disk after the agent session ended.

The harness signal (`{"continue": true}`) was already correct for `WorktreeRemove`, so this was a silent resource-leak bug, not a harness-breaking one.

### The Fix (`src/claude_mpm/hooks/claude_hooks/hook_handler.py`)

Added a short-circuit in `handle()` immediately after the existing `WorktreeCreate` block:
- Sets `_continue_sent = True` first (disarms the SIGALRM race, same guard as `WorktreeCreate`)
- Calls `_handle_worktree_remove(event)` and returns — never falls through to `_route_event`

New method `_handle_worktree_remove()` mirrors `claude-hook-fast.sh` lines ~188–212:
- Extracts `path` from the event (with `worktree_path` as fallback)
- Resolves repo root from `cwd` (same helper logic as `_handle_worktree_create`)
- Graceful no-op with `{"continue": true}` when `path` is absent/empty
- Runs `git -C <repo_root> worktree remove --force <path>` (stderr captured, stdout suppressed)
- Removal failures are logged but **never block Claude Code** — exit 0 always
- Emits dashboard Socket.IO event best-effort before printing (no extra stdout bytes)
- Always prints `{"continue": true}` and `sys.exit(0)`

### Note
`WorktreeCreate` was already fixed by PR #909 (shipped in v6.5.72). This PR fixes the sibling event.

## Test plan

- [x] `(a)` stdout is `{"continue": true}` and exit 0 on successful removal (real temp git repo + real registered worktree, asserts dir is gone and `git worktree list` no longer shows path)
- [x] `(b)` exit 0 with `{"continue": true}` and NO git subprocess when path is empty/missing
- [x] `(c)` removal failure (nonexistent path, OSError) still exits 0 with `{"continue": true}` and does not raise
- [x] Integration: `handle()` short-circuits to `_handle_worktree_remove`, never calls `_continue_execution`
- [x] All 25 tests pass (`test_worktree_remove.py` + `test_worktree_create.py` — no WorktreeCreate regression)
- [x] `ruff format` + `ruff check` clean on both files

Closes #912

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)