### PR TITLE
fix: audit and correct stale/inaccurate content in 6 bundled mpm-* skills

### DIFF
--- a/plugin/skills/mpm-monitor/SKILL.md
+++ b/plugin/skills/mpm-monitor/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-monitor
 description: Control monitoring server and dashboard
 user-invocable: true
-version: "1.0.0"
+version: "1.0.1"
 category: mpm-command
 tags: [mpm-command, system, pm-optional]
 ---
@@ -27,6 +27,6 @@ Manage Socket.IO monitoring server for real-time dashboard.
 - `--force`: Force kill to reclaim port
 - `--foreground`: Run in foreground (default: background)
 
-Dashboard: http://localhost:8766
+Dashboard: http://localhost:8765
 
 See docs/commands/monitor.md for details.

--- a/plugin/skills/mpm-session-management/SKILL.md
+++ b/plugin/skills/mpm-session-management/SKILL.md
@@ -10,92 +10,64 @@ alwaysApply: false
 **Applies To**: Project Manager Agent
 **Load Priority**: On-demand (context limit or session resume)
 
+> **Umbrella skill.** This skill covers the *concepts* of PM session lifecycle:
+> the auto-pause threshold system, git-based continuity, and how session
+> management fits the PM workflow. The concrete, user-invocable **procedures**
+> live in two dedicated skills — use them for the actual steps:
+> - **`mpm-session-pause`** — pause and persist current work state.
+> - **`mpm-session-resume`** — load context from a paused session.
+>
+> Do not duplicate their step-by-step instructions here; this skill points at
+> them.
+
 ## Purpose
 
-This skill provides session pause/resume capabilities for the PM when context limits are approaching or when resuming from a previous session. These protocols are only needed when hitting token limits or starting a session with existing pause state.
+This skill provides the conceptual model for PM session pause/resume when
+context limits are approaching or when resuming from a previous session. These
+protocols are only needed when hitting token limits or starting a session with
+existing pause state. For the operational steps, invoke `mpm-session-pause` /
+`mpm-session-resume`.
 
 ## When This Skill Is Loaded
 
-- Context usage reaches 70%+ thresholds
-- Session starts with `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
+- Context usage reaches 70%+ thresholds (informational warnings only)
 - Session starts with `.claude-mpm/sessions/LATEST-SESSION.txt`
 - User runs `/mpm-session-resume`
 
-## Auto-Pause System
+## Context Usage Monitoring
 
-The MPM framework automatically tracks context usage and pauses sessions when approaching limits:
+The MPM framework continuously tracks context usage and provides informational warnings as usage approaches limits. Context-usage auto-pause (which used to abort sessions at 90% usage) was disabled in commit da5166603 (PR #646) to preserve legitimate active work.
 
-### Threshold Levels
+### Threshold Levels and Warnings
 
 | Level | Usage | Behavior |
 |-------|-------|----------|
-| Caution | 70% | Warning displayed |
-| Warning | 85% | Stronger warning |
-| **Auto-Pause** | **90%** | **Session pause activated, actions recorded** |
-| Critical | 95% | Session nearly exhausted |
+| Caution | 70% | Informational warning: "Context usage at 70%. Consider wrapping up current work." |
+| Warning | 85% | Informational warning: "Context usage at 85%. Session nearing capacity." |
+| Auto-Pause Disabled | 90% | Informational warning: "Context usage at 90%. Consider wrapping up or running /compact (auto-pause is disabled)." |
+| Critical | 95% | Informational warning: "Context usage at 95%. Consider wrapping up or running /compact (auto-pause is disabled)." |
 
-### Auto-Pause Behavior (at 90%)
+Crossing these thresholds **only produces informational warnings**. No session pause is triggered, no ACTIVE-PAUSE.jsonl file is created. Sessions continue normally.
 
-When context usage reaches 90%:
+### Manual Session Pause
 
-1. Creates `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
-2. Records all subsequent actions (tool calls, responses) incrementally
-3. Displays warning to user about context limits
-4. On session end, finalizes to full session snapshot
+To save session state before context limits:
 
-The incremental recording ensures all work is captured even if the session hits hard limits.
+1. Use the **`/mpm-session-pause`** skill to explicitly create a session snapshot
+2. This captures git state, todos, task list, and accomplishments into `.claude-mpm/sessions/session-{timestamp}.*` files
+3. Sessions are stored in project-local `.claude-mpm/sessions/` directory (not synced across machines)
 
 ## Session Resume Protocol
 
-### At Session Start, PM Checks For
+> **Procedure.** The step-by-step resume flow now lives in **`mpm-session-resume`**.
+> Invoke that skill to load and display context from a paused session.
 
-**1. Active Incremental Pause**: `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
+When resuming work:
 
-If found:
-- Display warning with action count and context percentage
-- Options:
-  - **Continue**: Resume work from pause state
-  - **Finalize**: Run `/mpm-init pause --finalize` to create snapshot
-  - **Discard**: Start fresh (previous work still in git)
-
-**Example Response**:
-```
-⚠️ Active session pause detected
-
-Actions recorded: 47
-Context usage: ~92%
-
-Options:
-1. Continue working (actions will be recorded)
-2. Finalize pause: /mpm-init pause --finalize
-3. Discard pause: Delete .claude-mpm/sessions/ACTIVE-PAUSE.jsonl
-
-Would you like to continue from the paused session?
-```
-
-**2. Finalized Pause**: `.claude-mpm/sessions/LATEST-SESSION.txt`
-
-If found:
-- Display resume context with accomplishments and next steps
-- Load context from the session snapshot
-- Continue where previous session left off
-
-**Example Response**:
-```
-📋 Resuming from previous session
-
-Last session accomplished:
-- ✅ Implemented OAuth2 authentication (Engineer)
-- ✅ Deployed to staging (Vercel-ops)
-- ⏸️ QA verification in progress
-
-Next steps:
-- Complete QA verification of auth flow
-- Update documentation
-- Deploy to production
-
-Continue with QA verification?
-```
+1. Use **`/mpm-session-resume`** to load the most recent paused session
+2. The skill detects `.claude-mpm/sessions/LATEST-SESSION.txt` and loads the associated snapshot
+3. Session accomplishments, pending tasks, and git context are displayed
+4. PM can continue work with full prior context
 
 ## PM Response to Context Warnings
 
@@ -183,31 +155,32 @@ Context: Implementation complete, middleware updates in progress
 
 ## Session Files Structure
 
+Sessions are stored project-locally in `.claude-mpm/sessions/`:
+
 ```
 .claude-mpm/sessions/
-├── ACTIVE-PAUSE.jsonl      # Incremental actions during auto-pause
-├── LATEST-SESSION.txt      # Pointer to most recent finalized session
-├── session-*.json          # Machine-readable session snapshots
-├── session-*.yaml          # YAML format
-└── session-*.md            # Human-readable markdown
+├── LATEST-SESSION.txt       # Pointer to most recent paused session
+├── session-YYYYMMDD-HHMMSS.json   # Machine-readable session snapshots
+└── session-YYYYMMDD-HHMMSS.md     # Human-readable markdown summary
 ```
 
 ### File Purposes
 
-- **ACTIVE-PAUSE.jsonl**: Real-time action recording during auto-pause
 - **LATEST-SESSION.txt**: Points to most recent finalized session file
-- **session-*.json**: Complete session state (todos, context, agents used)
-- **session-*.yaml**: Same as JSON but YAML format
+- **session-*.json**: Complete session state (todos, git status, accomplishments, next steps)
 - **session-*.md**: Human-readable summary for quick review
+
+Sessions are created manually via `/mpm-session-pause` skill. The ACTIVE-PAUSE.jsonl file (used during auto-pause) is no longer created since auto-pause is disabled.
 
 ## Best Practices
 
 ### When Context Limits Approach
 
-1. **Don't panic**: Auto-pause system will capture your work
+1. **Monitor warnings**: When you see context warnings (70%+), begin wrapping up
 2. **Finish current phase**: Complete the delegation in progress
-3. **Update todos**: Ensure all todos reflect current state
-4. **Create handoff context**: Next PM session needs to understand state
+3. **Update todos**: Ensure all todos reflect current status
+4. **Create session snapshot**: Invoke `/mpm-session-pause` to save state for later resume
+5. **Create handoff context**: Document what's completed and what remains
 
 ### When Resuming Sessions
 
@@ -225,55 +198,12 @@ Context: Implementation complete, middleware updates in progress
 
 ## Common Scenarios
 
-### Scenario 1: Auto-Pause During Implementation
+Session pause/resume scenarios reduce to two procedures:
 
-```
-Context: 90% during Engineer delegation
+- **Approaching context limits / wrapping up** → Follow the "PM Response to Context Warnings" protocol above, then invoke **`/mpm-session-pause`** to create a session snapshot that persists your work state.
+- **Returning to work** → Invoke **`/mpm-session-resume`**, which loads the most recent paused session snapshot and displays prior accomplishments, pending tasks, and git context.
 
-PM Actions:
-1. Wait for Engineer to complete current file
-2. Track files immediately (git add + commit)
-3. Update todo with completion status
-4. Create summary of implementation state
-5. Session pauses, all recorded in ACTIVE-PAUSE.jsonl
-
-Next Session:
-1. PM detects ACTIVE-PAUSE.jsonl
-2. Continues from implementation state
-3. Proceeds to QA verification phase
-```
-
-### Scenario 2: Resume After Finalized Pause
-
-```
-Context: User returns to continue work
-
-PM Actions:
-1. Detects LATEST-SESSION.txt
-2. Loads session-{timestamp}.md for human summary
-3. Loads session-{timestamp}.json for full state
-4. Checks git log for verification
-5. Presents summary to user
-6. Continues workflow from next phase
-```
-
-### Scenario 3: Context Warning During Research
-
-```
-Context: 75% during Research agent investigation
-
-PM Actions:
-1. Allow Research to complete current investigation
-2. Don't start new research tasks
-3. Collect Research findings
-4. Document findings in session state
-5. Prepare for potential pause at 90%
-
-If 90% reached:
-1. Research findings already documented
-2. Implementation can start in next session
-3. Clear handoff context available
-```
+Keep delegations atomic and commit incrementally so either procedure resumes from a clean point.
 
 ## Integration with PM Workflow
 
@@ -286,11 +216,11 @@ User Request
     ↓
 Research (if needed)
     ↓
-[Monitor context usage]
+[Monitor context usage — watch for warnings]
     ↓
 Implementation
     ↓
-[Auto-pause if 90% reached]
+[Approaching limit? → /mpm-session-pause]
     ↓
 Deployment
     ↓
@@ -298,7 +228,7 @@ QA
     ↓
 Documentation
     ↓
-[Final session snapshot if paused]
+[Save session snapshot if context is high]
     ↓
 Report Results
 ```
@@ -313,6 +243,8 @@ Report Results
 
 ## Related Skills
 
+- `mpm-session-pause` - **Procedure**: pause and persist current work state
+- `mpm-session-resume` - **Procedure**: load context from a paused session
 - `mpm-git-file-tracking` - File tracking during pause/resume
 - `mpm-verification-protocols` - Verification state during pause
 - `mpm-delegation-patterns` - Resuming delegations mid-workflow

--- a/plugin/skills/mpm-session-pause/SKILL.md
+++ b/plugin/skills/mpm-session-pause/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-pause
 description: Pause session and save current work state for later resume
 user-invocable: true
-version: "1.5.0"
+version: "1.5.1"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 ---
@@ -17,9 +17,8 @@ When invoked, this skill:
 1. Captures current work state (todos, git status, context summary)
 2. Creates session files at `.claude-mpm/sessions/session-{timestamp}.*` (project-local)
 3. Updates `.claude-mpm/sessions/LATEST-SESSION.txt` pointer
-4. **Prunes stale git worktrees** under `<repo>/.claude/worktrees/` (see Worktree
-   Pruning section below)
-5. Shows user the session file path for later resume
+4. **Prunes stale git worktrees** under `<repo>/.claude/worktrees/` (see below)
+5. Shows the session file path for later resume
 
 ## Usage
 
@@ -76,7 +75,8 @@ A strict path-containment guard ensures deletion can never escape
 `.claude/worktrees/` — symlinks that resolve outside the directory are
 rejected and preserved.
 
-**Output** — after the session files are written, the pause command prints:
+**Output** — after the session files are written, the pause command prints a
+concise cleanup summary, e.g.:
 
 ```
 Worktree Cleanup:
@@ -88,8 +88,8 @@ Worktree Cleanup:
     /repo/.claude/worktrees/leftover-xyz: has uncommitted or untracked changes
 ```
 
-**Opt-out** — pass `--no-prune-worktrees` to the CLI to skip all cleanup (both
-registered pruning and orphan sweep):
+**Opt-out** — pass `--no-prune-worktrees` to skip all cleanup (both registered
+pruning and orphan sweep):
 
 ```bash
 claude-mpm session pause --no-prune-worktrees
@@ -97,7 +97,7 @@ claude-mpm session pause --no-prune-worktrees
 
 ## Implementation
 
-Run the console script directly:
+Run the console script directly — no interpreter resolution needed:
 
 ```bash
 # Basic pause (includes worktree pruning)
@@ -113,21 +113,40 @@ claude-mpm session pause --no-prune-worktrees
 claude-mpm session pause --export /tmp/session-backup.json
 ```
 
-Or invoke programmatically:
+If the user provided a message after `/mpm-session-pause`, pass it via `-m`:
 
-```python
-from pathlib import Path
-from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
-
-manager = SessionPauseManager(project_path=Path.cwd())
-
-# Default: pruning enabled
-session_id = manager.create_pause_session(
-    message="End of day",
-    prune_worktrees=True,   # set False to skip pruning
-)
-print(f"Session ID: {session_id}")
+```bash
+claude-mpm session pause -m "<user message here>"
 ```
+
+### If `claude-mpm session pause` fails
+
+If the command exits non-zero, capture the full error and show it verbatim —
+do **not** summarise with a generic "not importable" message:
+
+```bash
+claude-mpm session pause 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    echo ""
+    echo "ERROR: claude-mpm session pause failed (exit $rc)."
+    echo "Full error shown above."
+    echo ""
+    echo "Diagnostic steps:"
+    echo "  1. Verify claude-mpm is on PATH:  command -v claude-mpm"
+    echo "  2. Check the actual import error:  python3 -c 'import claude_mpm' 2>&1"
+    echo "  3. If a transitive dep fails (e.g. shadowed stdlib module), check"
+    echo "     sys.path[0] is not /tmp:  python3 -c 'import sys; print(sys.path[0])'"
+fi
+```
+
+> **Note on misleading ImportError messages (issue #781):** A bare
+> `except ImportError` can fire for transitive failures (e.g. a stray
+> `/tmp/bisect.py` shadowing stdlib `bisect`) unrelated to `claude_mpm`
+> itself. Always inspect the **actual** exception — `e.name` tells you
+> which module failed. If `e.name` does not start with `claude_mpm`, the
+> problem is a shadowed or missing transitive dependency, not a missing
+> `claude_mpm` installation.
 
 ## What Gets Saved
 
@@ -147,7 +166,6 @@ print(f"Session ID: {session_id}")
 **File Formats:**
 - `.md` - Human-readable markdown (for reading)
 - `.json` - Machine-readable (for tooling)
-- `.yaml` - Human-readable config (for editing)
 
 ## Session File Location
 
@@ -156,8 +174,7 @@ All session files are stored in the **project-local** directory:
 <project-root>/.claude-mpm/sessions/
 ├── LATEST-SESSION.txt          # Pointer to most recent session
 ├── session-YYYYMMDD-HHMMSS.md
-├── session-YYYYMMDD-HHMMSS.json
-└── session-YYYYMMDD-HHMMSS.yaml
+└── session-YYYYMMDD-HHMMSS.json
 ```
 
 This ensures sessions are scoped to the project that created them — pausing in
@@ -177,6 +194,11 @@ project A and opening project B will never load project A's session state.
 To resume this session:
 ```
 /mpm-session-resume
+```
+
+Or from the CLI:
+```bash
+claude-mpm session resume
 ```
 
 Or manually:
@@ -215,9 +237,9 @@ should not be committed. No git commit is created by the pause operation.
 
 ## Related Commands
 
-- `/mpm-session-resume` - Resume from most recent paused session
-- `/mpm-init resume` - Alternative resume command
-- See `docs/features/session-auto-resume.md` for auto-pause behavior
+- `/mpm-session-resume` — Resume from most recent paused session
+- `claude-mpm session resume` — CLI entry point for resume
+- `claude-mpm session pause --help` — Full CLI usage
 
 ## Notes
 
@@ -225,4 +247,4 @@ should not be committed. No git commit is created by the pause operation.
 - Add `.claude-mpm/sessions/` to `.gitignore`
 - No git commit is created — sessions live outside version control
 - LATEST-SESSION.txt always points to most recent session in the current project
-- Session format compatible with auto-pause feature (70% context trigger)
+- Session pause is manual-only; context-usage crossing thresholds (70%+) only prints informational warnings (auto-pause is disabled)

--- a/plugin/skills/mpm-session-resume/SKILL.md
+++ b/plugin/skills/mpm-session-resume/SKILL.md
@@ -153,8 +153,8 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 
 This skill is fundamentally different from Claude Code's native `claude --resume`/`--continue` and checkpoint-rewind (Esc-Esc / `/rewind`):
 
-- **Native `claude --resume`**: Replays the actual prior conversation transcript and tool-call history within the **same tool session**. State is ephemeral and lost when the tool exits.
-- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files. A **NEW conversation** in a new tool invocation loads the summary into context. Useful for resuming across multiple Claude Code sessions, long breaks, or context resets.
+- **Native `claude --resume`/`--continue`**: Replays the full raw conversation transcript (persisted to a JSONL file on disk) and continues the **exact same conversation thread**, typically scoped to the same working directory. This is not ephemeral — the transcript survives the tool exiting.
+- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a condensed textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files, loaded into a **brand-new conversation** rather than replaying the transcript. Useful for cross-project handoff, long-form work spanning many separate conversations, or a fresh context window with just the essential summary instead of the full raw history.
 
 ## Related Commands
 

--- a/plugin/skills/mpm-session-resume/SKILL.md
+++ b/plugin/skills/mpm-session-resume/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-resume
 description: Load context from paused session
 user-invocable: true
-version: "1.2.0"
+version: "1.4.2"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 ---
@@ -49,138 +49,63 @@ When invoked, this skill:
 
 ## Implementation
 
-**Execute the following Python code.  Parse the user's invocation arguments first,
-then dispatch to the appropriate code path.**
+Run the console script directly — no interpreter resolution needed:
 
-```python
-import sys
-from pathlib import Path
+```bash
+# Resume most recent session (lists if multiple exist)
+claude-mpm session resume
 
-try:
-    from claude_mpm.services.cli.session_resume_helper import SessionResumeHelper
-except ImportError:
-    print(
-        "ERROR: claude_mpm is not importable in the current Python environment.\n"
-        "If you installed via 'uv tool install claude-mpm', run:\n"
-        "  uv run python -c 'from claude_mpm.services.cli.session_resume_helper "
-        "import SessionResumeHelper'\n"
-        "Or invoke directly: claude-mpm session-resume\n"
-        "Alternatively, activate the virtual environment where claude-mpm is installed."
-    )
-    raise SystemExit(1)
+# Resume the 2nd most recent session
+claude-mpm session resume --select 2
 
-# --------------------------------------------------------------------------
-# Argument parsing
-# Invocation forms:
-#   /mpm-session-resume                    → list_mode=True if >1 session, else resume most recent
-#   /mpm-session-resume --select <value>   → select by index or partial ID
-#   /mpm-session-resume <session-id>       → exact session-id (backward-compatible)
-# --------------------------------------------------------------------------
+# Resume by partial session ID (date prefix)
+claude-mpm session resume --select 20240101
 
-# The skill receives user arguments via the 'args' variable set by the harness,
-# or you can parse from the invocation line.  Use whichever is available.
-# For safety, default to an empty list if 'args' is not defined.
-try:
-    raw_args = args  # type: ignore[name-defined]  # set by skill harness
-except NameError:
-    raw_args = []
+# Resume by exact session ID
+claude-mpm session resume session-20240101-143022
 
-select_value: str | None = None
-exact_session_id: str | None = None
-
-i = 0
-while i < len(raw_args):
-    token = str(raw_args[i])
-    if token == "--select" and i + 1 < len(raw_args):
-        select_value = str(raw_args[i + 1])
-        i += 2
-    elif not token.startswith("--"):
-        exact_session_id = token
-        i += 1
-    else:
-        i += 1
-
-# --------------------------------------------------------------------------
-# Create helper scoped to the current project.
-# --------------------------------------------------------------------------
-helper = SessionResumeHelper(project_path=Path.cwd())
-
-# --------------------------------------------------------------------------
-# Dispatch
-# --------------------------------------------------------------------------
-
-if select_value is not None:
-    # --select <index-or-partial-id>
-    session_data, error_msg = helper.resolve_session_by_selection(select_value)
-    if session_data is None:
-        print(error_msg)
-    else:
-        prompt_text = helper.format_resume_prompt(session_data)
-        print(prompt_text)
-        session_id = session_data.get("session_id", "unknown")
-        file_path = session_data.get("file_path")
-        print(f"Loaded session: {session_id}")
-        if file_path:
-            print(f"Source: {file_path}")
-
-elif exact_session_id is not None:
-    # Exact session ID supplied (backward-compatible form).
-    all_sessions = helper.list_all_sessions()
-    matched = [
-        s for s in all_sessions
-        if s.get("session_id") == exact_session_id
-    ]
-    if not matched:
-        print(f"No session found with ID: {exact_session_id}")
-        print("")
-        print(helper.format_session_list())
-    else:
-        session_data = matched[0]
-        prompt_text = helper.format_resume_prompt(session_data)
-        print(prompt_text)
-        file_path = session_data.get("file_path")
-        print(f"Loaded session: {exact_session_id}")
-        if file_path:
-            print(f"Source: {file_path}")
-
-else:
-    # No arguments — list when multiple sessions exist, else resume most recent.
-    session_count = helper.get_session_count()
-    if session_count == 0:
-        print("No paused sessions found for this project in .claude-mpm/sessions/")
-        print("")
-        print("To create a paused session, use: /mpm-session-pause")
-    elif session_count > 1:
-        # Show numbered list so the user can pick.
-        print(helper.format_session_list())
-        print("")
-        print("Resuming the most recent session automatically…")
-        session_data = helper.check_and_display_resume_prompt()
-        if session_data:
-            session_id = session_data.get("session_id", "unknown")
-            file_path = session_data.get("file_path")
-            print(f"Loaded session: {session_id}")
-            if file_path:
-                print(f"Source: {file_path}")
-    else:
-        # Only one session — resume it directly (existing behaviour).
-        session_data = helper.check_and_display_resume_prompt()
-        if session_data is None:
-            print("No paused sessions found for this project in .claude-mpm/sessions/")
-            print("")
-            print("To create a paused session, use: /mpm-session-pause")
-        else:
-            session_id = session_data.get("session_id", "unknown")
-            file_path = session_data.get("file_path")
-            print(f"")
-            print(f"Loaded session: {session_id}")
-            if file_path:
-                print(f"Source: {file_path}")
+# Resume from a specific project directory
+claude-mpm session resume --project-path /path/to/project
 ```
+
+> **Permission note (Bug #735):** Do **not** probe for sessions with
+> `ls .claude-mpm/sessions/ 2>/dev/null` — that swallows stderr, so a
+> permission-denied read looks identical to "no sessions" and resume wrongly
+> reports nothing to resume. The `claude-mpm session resume` command handles
+> this correctly via `check_session_dir_access()`.
+
+### If `claude-mpm session resume` fails
+
+If the command exits non-zero, capture the full error and show it verbatim —
+do **not** summarise with a generic "not importable" message:
+
+```bash
+claude-mpm session resume 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    echo ""
+    echo "ERROR: claude-mpm session resume failed (exit $rc)."
+    echo "Full error shown above."
+    echo ""
+    echo "Diagnostic steps:"
+    echo "  1. Verify claude-mpm is on PATH:  command -v claude-mpm"
+    echo "  2. Check the actual import error:  python3 -c 'import claude_mpm' 2>&1"
+    echo "  3. If a transitive dep fails (e.g. shadowed stdlib module), check"
+    echo "     sys.path[0] is not /tmp:  python3 -c 'import sys; print(sys.path[0])'"
+fi
+```
+
+> **Note on misleading ImportError messages (issue #781):** A bare
+> `except ImportError` can fire for transitive failures (e.g. a stray
+> `/tmp/bisect.py` shadowing stdlib `bisect`) unrelated to `claude_mpm`
+> itself. Always inspect the **actual** exception — `e.name` tells you
+> which module failed. If `e.name` does not start with `claude_mpm`, the
+> problem is a shadowed or missing transitive dependency, not a missing
+> `claude_mpm` installation.
 
 ## Session Storage Location
 
-**Session location:** project-local `.claude-mpm/sessions/session-*.md` (and `.json`/`.yaml`)
+**Session location:** project-local `.claude-mpm/sessions/session-*.md` (and `.json`)
 
 Sessions are stored relative to the project root so each project has its own
 isolated session history. Resume always validates that the session belongs to
@@ -192,8 +117,7 @@ The store contains:
 <project-root>/.claude-mpm/sessions/
 ├── LATEST-SESSION.txt                  # Pointer to most recent session
 ├── session-YYYYMMDD-HHMMSS.md          # Human-readable
-├── session-YYYYMMDD-HHMMSS.json        # Machine-readable (loaded by resume)
-└── session-YYYYMMDD-HHMMSS.yaml        # Config format
+└── session-YYYYMMDD-HHMMSS.json        # Machine-readable (loaded by resume)
 ```
 
 Resume reads the `.json` file (authoritative machine-readable format). The `.md` file is for humans; resume will not attempt to parse it as JSON.
@@ -222,13 +146,20 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 ## Notes
 
 - Reads existing sessions only. Does NOT create new files.
-- Auto-pause at 70% context creates sessions automatically; this skill reads them.
+- Session pause is manual-only via `/mpm-session-pause` skill; this skill loads them.
 - Session files are kept after resume (not auto-deleted) so you can resume multiple times.
-- To clear a session after resume, call `helper.clear_session(session_data)` explicitly.
+
+## Differentiating from Native Claude Code Resume
+
+This skill is fundamentally different from Claude Code's native `claude --resume`/`--continue` and checkpoint-rewind (Esc-Esc / `/rewind`):
+
+- **Native `claude --resume`**: Replays the actual prior conversation transcript and tool-call history within the **same tool session**. State is ephemeral and lost when the tool exits.
+- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files. A **NEW conversation** in a new tool invocation loads the summary into context. Useful for resuming across multiple Claude Code sessions, long breaks, or context resets.
 
 ## Related Commands
 
-- `/mpm-session-pause` - Pause current session and save state
-- `/mpm-init resume` - Alternative resume entry point
+- `/mpm-session-pause` — Pause current session and save state
+- `claude-mpm session pause` — CLI entry point for pause
+- `claude-mpm session resume --help` — Full CLI usage
 
 See `docs/features/session-auto-resume.md` for auto-pause behavior.

--- a/plugin/skills/mpm-session-resume/SKILL.md
+++ b/plugin/skills/mpm-session-resume/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-resume
 description: Load context from paused session
 user-invocable: true
-version: "1.4.2"
+version: "1.4.3"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 ---
@@ -162,4 +162,6 @@ This skill is fundamentally different from Claude Code's native `claude --resume
 - `claude-mpm session pause` — CLI entry point for pause
 - `claude-mpm session resume --help` — Full CLI usage
 
-See `docs/features/session-auto-resume.md` for auto-pause behavior.
+See the "Context Usage Monitoring" section of the `mpm-session-management` skill for
+how context-usage thresholds and warnings work (session pause is manual-only; there
+is no auto-pause).

--- a/plugin/skills/mpm/SKILL.md
+++ b/plugin/skills/mpm/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm
 description: Access Claude MPM functionality and manage multi-agent orchestration
 user-invocable: true
-version: "2.0.0"
+version: "2.0.1"
 category: mpm-command
 tags: [mpm-command, system, pm-required, framework]
 ---
@@ -32,43 +32,28 @@ Task(description="[what to do]", subagent_type="[agent-type]")
 
 ## Available Agents
 
-### Core Agents (always deployed)
+Claude MPM deploys a diverse set of specialized agents for different types of work. The canonical, always-current agent list is available via:
+- **`/agent-list` skill**: View all available agents
+- **Agent tool's available-agent-types**: Check which agents are active in your environment
+- **Delegation guide**: `src/claude_mpm/agents/AGENT_DELEGATION.md`
 
-| Agent | subagent_type | Role |
-|-------|---------------|------|
-| Engineer | `engineer` | Code implementation, refactoring, debugging |
-| Research | `Research` | Investigation, analysis, codebase exploration |
-| QA | `qa` | Testing, validation, quality assurance |
-| Documentation | `documentation` | Docs generation, API specs, guides |
-| Ops | `ops` | Deployment, infrastructure, operations |
-| Security | `security` | Vulnerability assessment, security review |
-| Ticketing | `ticketing` | Ticket tracking and workflow management |
+### Representative Agent Categories
 
-### Extended Agents (deployed per project)
+**Core Agents** (always deployed): `engineer`, `research`, `qa`, `documentation`, `ops`, `security`, `ticketing`
 
-| Agent | subagent_type | Role |
-|-------|---------------|------|
-| Version Control | `version-control` | Git operations, PR management, tagging |
-| Code Analyzer | `code-analyzer` | Codebase analysis, architecture review |
-| Code Review | `code-review` | PR review, semantic analysis |
-| Data Engineer | `data-engineer` | Database management, API integrations |
-| Product Owner | `product-owner` | Requirements, user stories, prioritization |
+**Extended Agents** (deployed per project): `version-control`, `data-engineer`, `product-owner`, `project-organizer`, `prompt-engineer`, `memory-manager`
 
-### Language-Specific Engineers
+**Language-Specific Engineers**: `python-engineer`, `typescript-engineer`, `javascript-engineer`, `golang-engineer`, `rust-engineer`, `java-engineer`, `ruby-engineer`, `php-engineer`, `dart-engineer`
 
-Deployed automatically based on project toolchain detection:
+**Framework Specialists**: `nextjs-engineer`, `react-engineer`, `svelte-engineer`, `tauri-engineer`, `phoenix-engineer`
 
-`python-engineer`, `typescript-engineer`, `javascript-engineer`, `golang-engineer`, `rust-engineer`, `java-engineer`, `ruby-engineer`, `php-engineer`, `dart-engineer`
+**Platform Operations**: `local-ops`, `vercel-ops`, `gcp-ops`, `aws-ops`, `digitalocean-ops`, `clerk-ops`
 
-**Framework specialists**: `nextjs-engineer`, `react-engineer`, `svelte-engineer`, `tauri-engineer`, `phoenix-engineer`
+**Quality & Testing**: `api-qa`, `web-qa`, `real-user`, `refactoring-engineer`
 
-### Platform Ops
+**Specialized**: `imagemagick`, `content`, `agentic-coder-optimizer`, `data-scientist`
 
-`local-ops` (local dev, PM2, Docker), `vercel-ops`, `gcp-ops`, `digitalocean-ops`, `clerk-ops`, `railway-ops`
-
-### Specialized Agents
-
-`api-qa`, `web-qa`, `code-review`, `code-analyzer`, `refactoring-engineer`, `prompt-engineer`, `content-agent`, `imagemagick`, `memory-manager`
+**Note**: The agent ecosystem evolves as features are added. Rather than listing every agent here (which would grow stale), use `/agent-list` or check your Agent tool's available-agent-types for the complete, current catalog.
 
 ## Skills System
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-monitor/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-monitor/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-monitor
 description: Control monitoring server and dashboard
 user-invocable: true
-version: "1.0.0"
+version: "1.0.1"
 category: mpm-command
 tags: [mpm-command, system, pm-optional]
 effort: low
@@ -28,6 +28,6 @@ Manage Socket.IO monitoring server for real-time dashboard.
 - `--force`: Force kill to reclaim port
 - `--foreground`: Run in foreground (default: background)
 
-Dashboard: http://localhost:8766
+Dashboard: http://localhost:8765
 
 See docs/commands/monitor.md for details.

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-management/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-management/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: "1.1.0"
+version: "1.1.1"
 effort: medium
 ---
 
@@ -29,49 +29,44 @@ existing pause state. For the operational steps, invoke `mpm-session-pause` /
 
 ## When This Skill Is Loaded
 
-- Context usage reaches 70%+ thresholds
-- Session starts with `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
+- Context usage reaches 70%+ thresholds (informational warnings only)
 - Session starts with `.claude-mpm/sessions/LATEST-SESSION.txt`
 - User runs `/mpm-session-resume`
 
-## Auto-Pause System
+## Context Usage Monitoring
 
-The MPM framework automatically tracks context usage and pauses sessions when approaching limits:
+The MPM framework continuously tracks context usage and provides informational warnings as usage approaches limits. Context-usage auto-pause (which used to abort sessions at 90% usage) was disabled in commit da5166603 (PR #646) to preserve legitimate active work.
 
-### Threshold Levels
+### Threshold Levels and Warnings
 
 | Level | Usage | Behavior |
 |-------|-------|----------|
-| Caution | 70% | Warning displayed |
-| Warning | 85% | Stronger warning |
-| **Auto-Pause** | **90%** | **Session pause activated, actions recorded** |
-| Critical | 95% | Session nearly exhausted |
+| Caution | 70% | Informational warning: "Context usage at 70%. Consider wrapping up current work." |
+| Warning | 85% | Informational warning: "Context usage at 85%. Session nearing capacity." |
+| Auto-Pause Disabled | 90% | Informational warning: "Context usage at 90%. Consider wrapping up or running /compact (auto-pause is disabled)." |
+| Critical | 95% | Informational warning: "Context usage at 95%. Consider wrapping up or running /compact (auto-pause is disabled)." |
 
-### Auto-Pause Behavior (at 90%)
+Crossing these thresholds **only produces informational warnings**. No session pause is triggered, no ACTIVE-PAUSE.jsonl file is created. Sessions continue normally.
 
-When context usage reaches 90%:
+### Manual Session Pause
 
-1. Creates `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
-2. Records all subsequent actions (tool calls, responses) incrementally
-3. Displays warning to user about context limits
-4. On session end, finalizes to full session snapshot
+To save session state before context limits:
 
-The incremental recording ensures all work is captured even if the session hits hard limits.
+1. Use the **`/mpm-session-pause`** skill to explicitly create a session snapshot
+2. This captures git state, todos, task list, and accomplishments into `.claude-mpm/sessions/session-{timestamp}.*` files
+3. Sessions are stored in project-local `.claude-mpm/sessions/` directory (not synced across machines)
 
 ## Session Resume Protocol
 
-> **Procedure moved.** The step-by-step resume flow (detecting
-> `ACTIVE-PAUSE.jsonl` vs. `LATEST-SESSION.txt`, the continue/finalize/discard
-> prompt, and loading the snapshot) now lives in **`mpm-session-resume`**.
-> Invoke that skill rather than duplicating its steps.
+> **Procedure.** The step-by-step resume flow now lives in **`mpm-session-resume`**.
+> Invoke that skill to load and display context from a paused session.
 
-At session start the PM checks for two states, both handled by
-`mpm-session-resume`:
+When resuming work:
 
-1. **Active incremental pause** — `.claude-mpm/sessions/ACTIVE-PAUSE.jsonl`
-   (auto-pause was triggered; continue, finalize, or discard).
-2. **Finalized pause** — `.claude-mpm/sessions/LATEST-SESSION.txt`
-   (a clean snapshot exists; load accomplishments + next steps).
+1. Use **`/mpm-session-resume`** to load the most recent paused session
+2. The skill detects `.claude-mpm/sessions/LATEST-SESSION.txt` and loads the associated snapshot
+3. Session accomplishments, pending tasks, and git context are displayed
+4. PM can continue work with full prior context
 
 ## PM Response to Context Warnings
 
@@ -159,31 +154,32 @@ Context: Implementation complete, middleware updates in progress
 
 ## Session Files Structure
 
+Sessions are stored project-locally in `.claude-mpm/sessions/`:
+
 ```
 .claude-mpm/sessions/
-├── ACTIVE-PAUSE.jsonl      # Incremental actions during auto-pause
-├── LATEST-SESSION.txt      # Pointer to most recent finalized session
-├── session-*.json          # Machine-readable session snapshots
-├── session-*.yaml          # YAML format
-└── session-*.md            # Human-readable markdown
+├── LATEST-SESSION.txt       # Pointer to most recent paused session
+├── session-YYYYMMDD-HHMMSS.json   # Machine-readable session snapshots
+└── session-YYYYMMDD-HHMMSS.md     # Human-readable markdown summary
 ```
 
 ### File Purposes
 
-- **ACTIVE-PAUSE.jsonl**: Real-time action recording during auto-pause
 - **LATEST-SESSION.txt**: Points to most recent finalized session file
-- **session-*.json**: Complete session state (todos, context, agents used)
-- **session-*.yaml**: Same as JSON but YAML format
+- **session-*.json**: Complete session state (todos, git status, accomplishments, next steps)
 - **session-*.md**: Human-readable summary for quick review
+
+Sessions are created manually via `/mpm-session-pause` skill. The ACTIVE-PAUSE.jsonl file (used during auto-pause) is no longer created since auto-pause is disabled.
 
 ## Best Practices
 
 ### When Context Limits Approach
 
-1. **Don't panic**: Auto-pause system will capture your work
+1. **Monitor warnings**: When you see context warnings (70%+), begin wrapping up
 2. **Finish current phase**: Complete the delegation in progress
-3. **Update todos**: Ensure all todos reflect current state
-4. **Create handoff context**: Next PM session needs to understand state
+3. **Update todos**: Ensure all todos reflect current status
+4. **Create session snapshot**: Invoke `/mpm-session-pause` to save state for later resume
+5. **Create handoff context**: Document what's completed and what remains
 
 ### When Resuming Sessions
 
@@ -201,17 +197,12 @@ Context: Implementation complete, middleware updates in progress
 
 ## Common Scenarios
 
-The recurring pause/resume scenarios (auto-pause mid-implementation, resuming
-after a finalized pause, context warning during research) all reduce to the
-same two procedures:
+Session pause/resume scenarios reduce to two procedures:
 
-- **Approaching a limit / wrapping up** → follow *PM Response to Context
-  Warnings* above, then invoke **`mpm-session-pause`** to persist state.
-- **Returning to work** → invoke **`mpm-session-resume`**, which detects the
-  pause state, loads the snapshot, and reconciles against git.
+- **Approaching context limits / wrapping up** → Follow the "PM Response to Context Warnings" protocol above, then invoke **`/mpm-session-pause`** to create a session snapshot that persists your work state.
+- **Returning to work** → Invoke **`/mpm-session-resume`**, which loads the most recent paused session snapshot and displays prior accomplishments, pending tasks, and git context.
 
-Keep delegations atomic and commit incrementally so either procedure resumes
-from a clean point.
+Keep delegations atomic and commit incrementally so either procedure resumes from a clean point.
 
 ## Integration with PM Workflow
 
@@ -224,11 +215,11 @@ User Request
     ↓
 Research (if needed)
     ↓
-[Monitor context usage]
+[Monitor context usage — watch for warnings]
     ↓
 Implementation
     ↓
-[Auto-pause if 90% reached]
+[Approaching limit? → /mpm-session-pause]
     ↓
 Deployment
     ↓
@@ -236,7 +227,7 @@ QA
     ↓
 Documentation
     ↓
-[Final session snapshot if paused]
+[Save session snapshot if context is high]
     ↓
 Report Results
 ```

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-pause/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-pause
 description: Pause session and save current work state for later resume
 user-invocable: true
-version: "1.5.0"
+version: "1.5.1"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 effort: medium
@@ -248,4 +248,4 @@ should not be committed. No git commit is created by the pause operation.
 - Add `.claude-mpm/sessions/` to `.gitignore`
 - No git commit is created — sessions live outside version control
 - LATEST-SESSION.txt always points to most recent session in the current project
-- Session format compatible with auto-pause feature (70% context trigger)
+- Session pause is manual-only; context-usage crossing thresholds (70%+) only prints informational warnings (auto-pause is disabled)

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-resume
 description: Load context from paused session
 user-invocable: true
-version: "1.4.1"
+version: "1.4.2"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 effort: medium
@@ -64,6 +64,9 @@ claude-mpm session resume --select 20240101
 
 # Resume by exact session ID
 claude-mpm session resume session-20240101-143022
+
+# Resume from a specific project directory
+claude-mpm session resume --project-path /path/to/project
 ```
 
 > **Permission note (Bug #735):** Do **not** probe for sessions with
@@ -144,8 +147,15 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 ## Notes
 
 - Reads existing sessions only. Does NOT create new files.
-- Auto-pause at 70% context creates sessions automatically; this skill reads them.
+- Session pause is manual-only via `/mpm-session-pause` skill; this skill loads them.
 - Session files are kept after resume (not auto-deleted) so you can resume multiple times.
+
+## Differentiating from Native Claude Code Resume
+
+This skill is fundamentally different from Claude Code's native `claude --resume`/`--continue` and checkpoint-rewind (Esc-Esc / `/rewind`):
+
+- **Native `claude --resume`**: Replays the actual prior conversation transcript and tool-call history within the **same tool session**. State is ephemeral and lost when the tool exits.
+- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files. A **NEW conversation** in a new tool invocation loads the summary into context. Useful for resuming across multiple Claude Code sessions, long breaks, or context resets.
 
 ## Related Commands
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm-session-resume
 description: Load context from paused session
 user-invocable: true
-version: "1.4.2"
+version: "1.4.3"
 category: mpm-command
 tags: [mpm-command, session, pm-recommended]
 effort: medium
@@ -163,4 +163,6 @@ This skill is fundamentally different from Claude Code's native `claude --resume
 - `claude-mpm session pause` — CLI entry point for pause
 - `claude-mpm session resume --help` — Full CLI usage
 
-See `docs/features/session-auto-resume.md` for auto-pause behavior.
+See the "Context Usage Monitoring" section of the `mpm-session-management` skill for
+how context-usage thresholds and warnings work (session pause is manual-only; there
+is no auto-pause).

--- a/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-session-resume/SKILL.md
@@ -154,8 +154,8 @@ This loads the session summary, accomplishments, next steps, git history, and pe
 
 This skill is fundamentally different from Claude Code's native `claude --resume`/`--continue` and checkpoint-rewind (Esc-Esc / `/rewind`):
 
-- **Native `claude --resume`**: Replays the actual prior conversation transcript and tool-call history within the **same tool session**. State is ephemeral and lost when the tool exits.
-- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files. A **NEW conversation** in a new tool invocation loads the summary into context. Useful for resuming across multiple Claude Code sessions, long breaks, or context resets.
+- **Native `claude --resume`/`--continue`**: Replays the full raw conversation transcript (persisted to a JSONL file on disk) and continues the **exact same conversation thread**, typically scoped to the same working directory. This is not ephemeral — the transcript survives the tool exiting.
+- **`/mpm-session-pause` + `/mpm-session-resume`**: Captures a condensed textual summary (git state, todos, task list, accomplishments) into `.claude-mpm/sessions/*.json` files, loaded into a **brand-new conversation** rather than replaying the transcript. Useful for cross-project handoff, long-form work spanning many separate conversations, or a fresh context window with just the essential summary instead of the full raw history.
 
 ## Related Commands
 

--- a/src/claude_mpm/skills/bundled/pm/mpm-workflow/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mpm-workflow
-version: "1.0.1"
+version: "1.0.2"
 description: Manage and customize MPM workflow configurations with local overrides
 when_to_use: workflow customization, phase configuration, verification gates, agent routing
 category: pm-configuration
@@ -35,7 +35,7 @@ Workflow Configuration Status:
   Source: project (.claude-mpm/WORKFLOW.md)
   Phases: 5
   Verification Gates: Enabled
-  Custom Overrides: Phase 2 (Code Analyzer) skipped
+  Custom Overrides: Phase 2 (Code Analysis) skipped
 ```
 
 ### `init`
@@ -77,8 +77,8 @@ Validating workflow configuration...
 **Output**: Requirements, constraints, success criteria
 **Template**: ...
 
-### Phase 2: Code Analyzer Review
-**Agent**: Code Analyzer
+### Phase 2: Code Analysis Review
+**Agent**: Code Analysis
 **Output**: APPROVED/NEEDS_IMPROVEMENT/BLOCKED
 **Decision**: ...
 
@@ -108,11 +108,11 @@ Validating workflow configuration...
 
 ## Customization Examples
 
-### Skip Code Analyzer for Trusted Projects
+### Skip Code Analysis for Trusted Projects
 
 ```markdown
-### Phase 2: Code Analyzer Review
-**Agent**: Code Analyzer
+### Phase 2: Code Analysis Review
+**Agent**: Code Analysis
 **Status**: OPTIONAL
 **Skip When**: Small fixes, documentation only
 ```

--- a/src/claude_mpm/skills/bundled/pm/mpm-workflow/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mpm-workflow
-version: "1.0.0"
+version: "1.0.1"
 description: Manage and customize MPM workflow configurations with local overrides
 when_to_use: workflow customization, phase configuration, verification gates, agent routing
 category: pm-configuration
@@ -22,11 +22,13 @@ Workflow files are loaded with the following priority (highest to lowest):
 2. **User-level**: `~/.claude-mpm/WORKFLOW.md` - User preferences across all projects
 3. **System default**: Built-in framework WORKFLOW.md
 
-## Commands
+## Actions
 
-### `/mpm-workflow status`
+These are skill-driven actions, not `claude-mpm workflow` CLI subcommands -- there is no such CLI surface. When this skill is invoked (e.g. via `/mpm-workflow status`), Claude itself reads, writes, or validates the WORKFLOW.md files directly, following the priority order above (project -> user -> system default).
 
-Show current workflow configuration and source:
+### `status`
+
+When invoked with `status`, Claude reports the current workflow configuration and its source. Example of what Claude reports back:
 
 ```
 Workflow Configuration Status:
@@ -36,30 +38,22 @@ Workflow Configuration Status:
   Custom Overrides: Phase 2 (Code Analyzer) skipped
 ```
 
-### `/mpm-workflow init`
+### `init`
 
-Initialize a local workflow configuration file:
+When invoked with `init`, Claude creates a local workflow configuration file:
 
-```bash
-# Creates .claude-mpm/WORKFLOW.md with defaults
-/mpm-workflow init
+- `/mpm-workflow init` -- Claude creates `.claude-mpm/WORKFLOW.md` with defaults
+- `/mpm-workflow init --minimal` -- Claude creates it with a minimal template
 
-# Creates with minimal template
-/mpm-workflow init --minimal
-```
+### `reset`
 
-### `/mpm-workflow reset`
+When invoked with `reset`, Claude removes the local override so the system default takes effect:
 
-Reset to default workflow configuration:
+- `/mpm-workflow reset` -- Claude removes the local override, falling back to the system default
 
-```bash
-# Removes local override, uses system default
-/mpm-workflow reset
-```
+### `validate`
 
-### `/mpm-workflow validate`
-
-Validate the current workflow configuration:
+When invoked with `validate`, Claude checks the current workflow configuration for completeness and reports findings. Example of what Claude reports back:
 
 ```
 Validating workflow configuration...
@@ -175,6 +169,4 @@ The workflow loader automatically injects workflow configuration into PM instruc
 
 ### Reset to defaults
 
-```bash
-/mpm-workflow reset
-```
+Invoke this skill with `/mpm-workflow reset` and Claude will remove the local override directly.

--- a/src/claude_mpm/skills/bundled/pm/mpm/SKILL.md
+++ b/src/claude_mpm/skills/bundled/pm/mpm/SKILL.md
@@ -2,7 +2,7 @@
 name: mpm
 description: Access Claude MPM functionality and manage multi-agent orchestration
 user-invocable: true
-version: "2.0.0"
+version: "2.0.1"
 category: mpm-command
 tags: [mpm-command, system, pm-required, framework]
 effort: medium
@@ -33,43 +33,28 @@ Task(description="[what to do]", subagent_type="[agent-type]")
 
 ## Available Agents
 
-### Core Agents (always deployed)
+Claude MPM deploys a diverse set of specialized agents for different types of work. The canonical, always-current agent list is available via:
+- **`/agent-list` skill**: View all available agents
+- **Agent tool's available-agent-types**: Check which agents are active in your environment
+- **Delegation guide**: `src/claude_mpm/agents/AGENT_DELEGATION.md`
 
-| Agent | subagent_type | Role |
-|-------|---------------|------|
-| Engineer | `engineer` | Code implementation, refactoring, debugging |
-| Research | `Research` | Investigation, analysis, codebase exploration |
-| QA | `qa` | Testing, validation, quality assurance |
-| Documentation | `documentation` | Docs generation, API specs, guides |
-| Ops | `ops` | Deployment, infrastructure, operations |
-| Security | `security` | Vulnerability assessment, security review |
-| Ticketing | `ticketing` | Ticket tracking and workflow management |
+### Representative Agent Categories
 
-### Extended Agents (deployed per project)
+**Core Agents** (always deployed): `engineer`, `research`, `qa`, `documentation`, `ops`, `security`, `ticketing`
 
-| Agent | subagent_type | Role |
-|-------|---------------|------|
-| Version Control | `version-control` | Git operations, PR management, tagging |
-| Code Analyzer | `code-analyzer` | Codebase analysis, architecture review |
-| Code Review | `code-review` | PR review, semantic analysis |
-| Data Engineer | `data-engineer` | Database management, API integrations |
-| Product Owner | `product-owner` | Requirements, user stories, prioritization |
+**Extended Agents** (deployed per project): `version-control`, `data-engineer`, `product-owner`, `project-organizer`, `prompt-engineer`, `memory-manager`
 
-### Language-Specific Engineers
+**Language-Specific Engineers**: `python-engineer`, `typescript-engineer`, `javascript-engineer`, `golang-engineer`, `rust-engineer`, `java-engineer`, `ruby-engineer`, `php-engineer`, `dart-engineer`
 
-Deployed automatically based on project toolchain detection:
+**Framework Specialists**: `nextjs-engineer`, `react-engineer`, `svelte-engineer`, `tauri-engineer`, `phoenix-engineer`
 
-`python-engineer`, `typescript-engineer`, `javascript-engineer`, `golang-engineer`, `rust-engineer`, `java-engineer`, `ruby-engineer`, `php-engineer`, `dart-engineer`
+**Platform Operations**: `local-ops`, `vercel-ops`, `gcp-ops`, `aws-ops`, `digitalocean-ops`, `clerk-ops`
 
-**Framework specialists**: `nextjs-engineer`, `react-engineer`, `svelte-engineer`, `tauri-engineer`, `phoenix-engineer`
+**Quality & Testing**: `api-qa`, `web-qa`, `real-user`, `refactoring-engineer`
 
-### Platform Ops
+**Specialized**: `imagemagick`, `content`, `agentic-coder-optimizer`, `data-scientist`
 
-`local-ops` (local dev, PM2, Docker), `vercel-ops`, `gcp-ops`, `digitalocean-ops`, `clerk-ops`, `railway-ops`
-
-### Specialized Agents
-
-`api-qa`, `web-qa`, `code-review`, `code-analyzer`, `refactoring-engineer`, `prompt-engineer`, `content-agent`, `imagemagick`, `memory-manager`
+**Note**: The agent ecosystem evolves as features are added. Rather than listing every agent here (which would grow stale), use `/agent-list` or check your Agent tool's available-agent-types for the complete, current catalog.
 
 ## Skills System
 


### PR DESCRIPTION
## Summary

Comprehensive accuracy-only fix pass covering 6 bundled PM skills that contained stale or factually incorrect content. All corrections independently verified against current source.

## Skills Fixed (1 file per commit, per CLAUDE.md convention)

### 1. mpm-session-pause, mpm-session-resume, mpm-session-management
- **Issue**: Incorrectly described "Auto-Pause System" (context-usage % triggered pause) as live/active
- **Reality**: Disabled in PR #646 (~4 weeks prior); auto-pause never fires, only prints warning
- **Fix**: Rewrote to accurately describe pause/resume as manual-only operations

### 2. mpm-session-resume (Additional)
- **Issue 1**: Missing documentation of `--project-path` flag
- **Issue 2**: Missing differentiation vs. native `claude --resume` (commonly confused)
- **Fix 1**: Added flag usage example
- **Fix 2**: Added clarification that native resume replays persisted transcript (not ephemeral)

### 3. mpm-monitor
- **Issue**: Dashboard port documented as 8766 (incorrect)
- **Reality**: Actual port is 8765 (verified in `cli/commands/monitor.py` and `daemon.py`)
- **Fix**: Corrected port reference

### 4. mpm (Hub Skill)
- **Issue**: Outdated agent catalog with fictional names (code-analyzer, code-review, railway-ops, content-agent)
- **Fix**: Replaced with verified current catalog; added dynamic pointer (`/agent-list`) to prevent future staleness

### 5. mpm-workflow
- **Issue**: Skill text implied `/mpm-workflow status|init|reset|validate` are real `claude-mpm workflow ...` CLI subcommands
- **Reality**: No such subparser exists
- **Fix**: Clarified these are skill-driven file-based actions, not CLI commands

### 6. plugin/skills/ Resync (Manual, One-Time)
- Resynced bundled→plugin copies for: `mpm-session-pause`, `mpm-session-resume`, `mpm-session-management`, `mpm-monitor`, mpm hub skill
- `mpm-workflow` has no plugin counterpart (correctly not created)
- **Process note**: No automated sync mechanism; this was manual one-time resync (separate process gap worth follow-up if desired)

## Verification

All content independently re-derived and verified against current source (not just agent claims):
- ✅ Auto-pause disablement verified (commit da5166603, auto_pause_handler.py docstring)
- ✅ Monitor port 8765 verified (monitor.py, daemon.py)
- ✅ Agent catalog names verified against available-agent-types
- ✅ mpm-workflow CLI subparser absence verified (no workflow subparser in codebase)
- ✅ Native resume behavior verified (persisted transcript replay, not ephemeral)

## Commits

13 commits, 13 files changed. See branch log for full detail.

## Next Steps

Per repo convention, after CI: `trusty-review` before squash-merge (handled separately, not in this PR).

---

Closes #914