### PR TITLE
fix(deployment): stop re-creating project-level duplicates for USER_LEVEL_AGENTS

### DIFF
--- a/src/claude_mpm/services/agents/deployment/async_agent_deployment.py
+++ b/src/claude_mpm/services/agents/deployment/async_agent_deployment.py
@@ -31,6 +31,9 @@ import aiofiles
 from claude_mpm.config.paths import paths
 from claude_mpm.core.config import Config
 from claude_mpm.core.logger import get_logger
+from claude_mpm.services.agents.deployment.user_level_routing import (
+    skip_project_level_user_agent,
+)
 
 from .base_agent_locator import BaseAgentLocator
 
@@ -405,6 +408,16 @@ class AsyncAgentDeploymentService:
             """Deploy a single agent asynchronously."""
             try:
                 agent_name = agent.get("_agent_name", "unknown")
+
+                # Never write CORE (USER_LEVEL_AGENTS) agents into a project-level
+                # .claude/agents/ directory; self-heal any stale project copy.
+                if skip_project_level_user_agent(agent_name, agents_dir, self.logger):
+                    self.logger.debug(
+                        f"Skipped user-level CORE agent for project target: "
+                        f"{agent_name}"
+                    )
+                    return None
+
                 target_file = agents_dir / f"{agent_name}.md"
 
                 # Build markdown content in thread pool (CPU-bound)

--- a/src/claude_mpm/services/agents/deployment/local_template_deployment.py
+++ b/src/claude_mpm/services/agents/deployment/local_template_deployment.py
@@ -11,6 +11,9 @@ from typing import Any
 import yaml
 
 from claude_mpm.core.logging_config import get_logger
+from claude_mpm.services.agents.deployment.user_level_routing import (
+    skip_project_level_user_agent,
+)
 from claude_mpm.services.agents.local_template_manager import (
     LocalAgentTemplate,
     LocalAgentTemplateManager,
@@ -110,6 +113,14 @@ class LocalTemplateDeploymentService:
         Returns:
             'deployed', 'updated', or 'skipped'
         """
+        # Never write CORE (USER_LEVEL_AGENTS) agents into a project-level
+        # .claude/agents/ directory; self-heal any stale project copy.
+        if skip_project_level_user_agent(template.agent_id, self.target_dir, logger):
+            logger.debug(
+                f"Skipped user-level CORE agent for project target: {template.agent_id}"
+            )
+            return "skipped"
+
         target_file = self.target_dir / f"{template.agent_id}.md"
 
         # Check if needs update

--- a/src/claude_mpm/services/agents/deployment/processors/agent_processor.py
+++ b/src/claude_mpm/services/agents/deployment/processors/agent_processor.py
@@ -4,6 +4,9 @@ import time
 
 from claude_mpm.core.exceptions import AgentDeploymentError
 from claude_mpm.core.logger import get_logger
+from claude_mpm.services.agents.deployment.user_level_routing import (
+    skip_project_level_user_agent,
+)
 
 from .agent_deployment_context import AgentDeploymentContext
 from .agent_deployment_result import AgentDeploymentResult
@@ -40,6 +43,22 @@ class AgentProcessor:
 
         try:
             self.logger.debug(f"Processing agent: {context.agent_name}")
+
+            # Never write CORE (USER_LEVEL_AGENTS) agents into a project-level
+            # .claude/agents/ directory; self-heal any stale project copy.
+            if skip_project_level_user_agent(
+                context.agent_name, context.target_file.parent, self.logger
+            ):
+                self.logger.debug(
+                    f"Skipped user-level CORE agent for project target: "
+                    f"{context.agent_name}"
+                )
+                return AgentDeploymentResult.skipped(
+                    context.agent_name,
+                    context.template_file,
+                    context.target_file,
+                    reason="CORE agent belongs at user level (~/.claude/agents)",
+                )
 
             # Check if agent needs update
             needs_update, is_migration, reason = self._check_update_status(context)

--- a/src/claude_mpm/services/agents/deployment/single_agent_deployer.py
+++ b/src/claude_mpm/services/agents/deployment/single_agent_deployer.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Any
 
 from claude_mpm.core.exceptions import AgentDeploymentError
+from claude_mpm.services.agents.deployment.user_level_routing import (
+    skip_project_level_user_agent,
+)
 from claude_mpm.services.agents.deployment_utils import (
     get_underscore_variant_filename,
     normalize_deployment_filename,
@@ -70,6 +73,16 @@ class SingleAgentDeployer:
             agent_start_time = time.time()
 
             agent_name = template_file.stem
+
+            # Never write CORE (USER_LEVEL_AGENTS) agents into a project-level
+            # .claude/agents/ directory; self-heal any stale project copy.
+            if skip_project_level_user_agent(agent_name, agents_dir, self.logger):
+                results["skipped"].append(agent_name)
+                self.logger.debug(
+                    f"Skipped user-level CORE agent for project target: {agent_name}"
+                )
+                return
+
             normalized_filename = normalize_deployment_filename(f"{agent_name}.md")
             target_file = agents_dir / normalized_filename
 
@@ -222,6 +235,14 @@ class SingleAgentDeployer:
                     f"Agent template not found in any source: {agent_name}"
                 )
                 return False
+
+            # Never write CORE (USER_LEVEL_AGENTS) agents into a project-level
+            # .claude/agents/ directory; self-heal any stale project copy.
+            if skip_project_level_user_agent(agent_name, target_dir, self.logger):
+                self.logger.debug(
+                    f"Skipped user-level CORE agent for project target: {agent_name}"
+                )
+                return True
 
             # Ensure target directory exists
             target_dir.mkdir(parents=True, exist_ok=True)

--- a/src/claude_mpm/services/agents/deployment/user_level_routing.py
+++ b/src/claude_mpm/services/agents/deployment/user_level_routing.py
@@ -1,0 +1,114 @@
+"""Project-level deployment guard for USER_LEVEL_AGENTS (CORE agents).
+
+WHAT: Single chokepoint predicate that stops CORE agents (members of
+``USER_LEVEL_AGENTS``) from being written into a project's ``.claude/agents/``
+directory, and self-heals by pruning any stale project-level duplicate left
+over from an earlier routing bug.
+
+WHY: Several deployment code paths write agent files, but historically only the
+canonical :meth:`AgentDeploymentService.deploy_agents` applied USER_LEVEL_AGENTS
+routing.  The other paths silently re-created project-level copies of CORE
+agents, which shadow the shared ``~/.claude/agents/`` copies (project always
+wins over user in resolution order) and bloat every session's context with
+duplicate definitions that will never be selected.  Centralising the decision
+here guarantees every write path behaves identically.
+
+References
+----------
+SPEC-AGENTS-10~1 : docs/specs/agents.md#SPEC-AGENTS-10~1
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from claude_mpm.services.agents.deployment_utils import normalize_deployment_filename
+from claude_mpm.utils.agent_filters import normalize_agent_id
+
+_logger = logging.getLogger(__name__)
+
+
+def _user_level_agents() -> frozenset[str]:
+    """Return USER_LEVEL_AGENTS, imported lazily to avoid a circular import.
+
+    WHAT: Fetches the canonical CORE-agent name set from ``agent_deployment``.
+    WHY: ``agent_deployment`` imports many deployment sub-modules at load time,
+    so importing it at module scope here would create an import cycle.
+    """
+    from claude_mpm.services.agents.deployment.agent_deployment import (
+        USER_LEVEL_AGENTS,
+    )
+
+    return USER_LEVEL_AGENTS
+
+
+def is_user_level_agent(agent_name: str) -> bool:
+    """Return True when *agent_name* is a CORE agent that belongs at user level."""
+    return normalize_agent_id(agent_name) in _user_level_agents()
+
+
+def user_level_agents_dir() -> Path:
+    """Return the shared user-level agents directory (``~/.claude/agents``)."""
+    return Path.home() / ".claude" / "agents"
+
+
+def is_user_level_agents_dir(target_dir: Path) -> bool:
+    """Return True when *target_dir* is the shared ``~/.claude/agents`` directory."""
+    try:
+        return Path(target_dir).resolve() == user_level_agents_dir().resolve()
+    except OSError:
+        return False
+
+
+def skip_project_level_user_agent(
+    agent_name: str,
+    target_dir: Path,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Guard a project-level write of a CORE agent and self-heal stale copies.
+
+    WHAT: Returns ``True`` when *agent_name* is a ``USER_LEVEL_AGENTS`` member and
+    *target_dir* is a project-level ``.claude/agents/`` directory (i.e. NOT the
+    shared ``~/.claude/agents``); in that case any stale project-level file for
+    the agent is deleted before returning so callers skip the write.  Returns
+    ``False`` for non-CORE agents and for writes targeting the shared user-level
+    directory, which are always allowed.
+
+    WHY: CORE agents must live only at ``~/.claude/agents``.  Every deployment
+    path calls this before writing so no path can re-introduce a project-level
+    duplicate, and existing leftovers are cleaned up automatically on next deploy.
+    The shared ``~/.claude/agents`` directory is never modified here.
+
+    :spec: SPEC-AGENTS-10~1
+    """
+    if not is_user_level_agent(agent_name):
+        return False
+
+    target_dir = Path(target_dir)
+    if is_user_level_agents_dir(target_dir):
+        return False
+
+    log = logger or _logger
+
+    # Self-heal: prune leftover project-level duplicate(s).  Cover the normalized
+    # dash-based filename plus the raw stem so historical variants are removed.
+    candidates = {
+        normalize_deployment_filename(f"{agent_name}.md"),
+        f"{normalize_agent_id(agent_name)}.md",
+        f"{agent_name}.md",
+    }
+    for filename in candidates:
+        stale = target_dir / filename
+        try:
+            if stale.is_file():
+                stale.unlink()
+                log.info(
+                    "Removed stale project-level CORE agent %s (belongs at %s)",
+                    stale,
+                    user_level_agents_dir(),
+                )
+        except OSError as exc:  # pragma: no cover - defensive
+            log.debug("Could not remove stale project agent %s: %s", stale, exc)
+
+    return True

--- a/tests/unit/services/agents/test_user_level_routing_guard.py
+++ b/tests/unit/services/agents/test_user_level_routing_guard.py
@@ -1,0 +1,222 @@
+"""Tests for the project-level deployment guard for USER_LEVEL_AGENTS.
+
+These tests verify that no deployment code path writes a CORE
+(``USER_LEVEL_AGENTS``) agent into a project's ``.claude/agents/`` directory,
+and that a stale project-level copy left over from the earlier routing bug is
+cleaned up automatically on the next deploy.
+
+The shared user-level directory (``~/.claude/agents``) must never be modified by
+the guard.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_mpm.services.agents.deployment.agent_deployment import USER_LEVEL_AGENTS
+from claude_mpm.services.agents.deployment.user_level_routing import (
+    is_user_level_agent,
+    is_user_level_agents_dir,
+    skip_project_level_user_agent,
+)
+
+CORE_AGENT = "engineer"  # A stable member of USER_LEVEL_AGENTS.
+PROJECT_AGENT = "my-custom-project-agent-xyz"
+
+
+@pytest.fixture()
+def temp_dirs():
+    """Yield (fake_home, project_agents_dir, user_agents_dir)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        fake_home = base / "home"
+        project_agents_dir = base / "project" / ".claude" / "agents"
+        user_agents_dir = fake_home / ".claude" / "agents"
+        project_agents_dir.mkdir(parents=True)
+        user_agents_dir.mkdir(parents=True)
+        yield fake_home, project_agents_dir, user_agents_dir
+
+
+class TestGuardPredicates:
+    """Basic predicate behavior."""
+
+    def test_core_agent_recognized(self):
+        assert is_user_level_agent(CORE_AGENT) is True
+        # Title-case / .md variants normalize to the same CORE name.
+        assert is_user_level_agent("Engineer.md") is True
+
+    def test_project_agent_not_core(self):
+        assert PROJECT_AGENT not in USER_LEVEL_AGENTS
+        assert is_user_level_agent(PROJECT_AGENT) is False
+
+    def test_user_level_dir_detection(self, temp_dirs):
+        fake_home, project_agents_dir, user_agents_dir = temp_dirs
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert is_user_level_agents_dir(user_agents_dir) is True
+            assert is_user_level_agents_dir(project_agents_dir) is False
+
+
+class TestProjectLevelGuard:
+    """skip_project_level_user_agent decision + self-heal behavior."""
+
+    def test_core_agent_skipped_for_project_target(self, temp_dirs):
+        """A CORE agent must be skipped when the target is project-level."""
+        fake_home, project_agents_dir, _ = temp_dirs
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert skip_project_level_user_agent(CORE_AGENT, project_agents_dir) is True
+
+    def test_project_agent_not_skipped(self, temp_dirs):
+        """A non-CORE agent must NOT be skipped (it belongs at project level)."""
+        fake_home, project_agents_dir, _ = temp_dirs
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert (
+                skip_project_level_user_agent(PROJECT_AGENT, project_agents_dir)
+                is False
+            )
+
+    def test_core_agent_allowed_for_user_level_target(self, temp_dirs):
+        """Writing a CORE agent to the shared user-level dir is allowed."""
+        fake_home, _, user_agents_dir = temp_dirs
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert skip_project_level_user_agent(CORE_AGENT, user_agents_dir) is False
+
+    def test_stale_project_copy_is_pruned(self, temp_dirs):
+        """A leftover project-level CORE agent file is removed on next deploy."""
+        fake_home, project_agents_dir, _ = temp_dirs
+        stale = project_agents_dir / f"{CORE_AGENT}.md"
+        stale.write_text("---\nname: engineer\n---\n\n# stale duplicate\n")
+        assert stale.exists()
+
+        with patch("pathlib.Path.home", return_value=fake_home):
+            skipped = skip_project_level_user_agent(CORE_AGENT, project_agents_dir)
+
+        assert skipped is True
+        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
+
+    def test_user_level_copy_never_touched(self, temp_dirs):
+        """The shared ~/.claude/agents copy must never be removed by the guard."""
+        fake_home, project_agents_dir, user_agents_dir = temp_dirs
+        user_copy = user_agents_dir / f"{CORE_AGENT}.md"
+        user_copy.write_text("---\nname: engineer\n---\n\n# user copy\n")
+
+        with patch("pathlib.Path.home", return_value=fake_home):
+            skip_project_level_user_agent(CORE_AGENT, project_agents_dir)
+
+        assert user_copy.exists(), "User-level copy must be preserved"
+
+
+class TestDeploymentPathsHonorGuard:
+    """Every write path must skip CORE agents for project targets."""
+
+    def _template(self, tmp_dir: Path, name: str) -> Path:
+        template = tmp_dir / f"{name}.md"
+        template.write_text(f"---\nname: {name}\nversion: 1.0.0\n---\n\n# {name}\n")
+        return template
+
+    def test_single_agent_deployer_skips_core_agent(self, temp_dirs):
+        """SingleAgentDeployer.deploy_single_agent skips + prunes CORE agents."""
+        from claude_mpm.services.agents.deployment.single_agent_deployer import (
+            SingleAgentDeployer,
+        )
+
+        fake_home, project_agents_dir, _ = temp_dirs
+        template_dir = project_agents_dir.parent
+        template_file = self._template(template_dir, CORE_AGENT)
+
+        # Seed a stale project-level duplicate to prove self-heal.
+        stale = project_agents_dir / f"{CORE_AGENT}.md"
+        stale.write_text("stale")
+
+        deployer = SingleAgentDeployer(
+            template_builder=None, version_manager=None, results_manager=None
+        )
+        results = {
+            "deployed": [],
+            "updated": [],
+            "migrated": [],
+            "skipped": [],
+            "errors": [],
+        }
+
+        with patch("pathlib.Path.home", return_value=fake_home):
+            deployer.deploy_single_agent(
+                template_file=template_file,
+                agents_dir=project_agents_dir,
+                base_agent_data={},
+                base_agent_version=(1, 0, 0),
+                force_rebuild=True,
+                deployment_mode="project",
+                results=results,
+            )
+
+        assert CORE_AGENT in results["skipped"]
+        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
+        assert not (project_agents_dir / f"{CORE_AGENT}.md").exists()
+
+    def test_agent_processor_skips_core_agent(self, temp_dirs):
+        """AgentProcessor.process_agent skips + prunes CORE agents."""
+        from claude_mpm.services.agents.deployment.processors import (
+            AgentDeploymentContext,
+            AgentProcessor,
+        )
+
+        fake_home, project_agents_dir, _ = temp_dirs
+        template_dir = project_agents_dir.parent
+        template_file = self._template(template_dir, CORE_AGENT)
+
+        stale = project_agents_dir / f"{CORE_AGENT}.md"
+        stale.write_text("stale")
+
+        context = AgentDeploymentContext.from_template_file(
+            template_file=template_file,
+            agents_dir=project_agents_dir,
+            base_agent_data={},
+            base_agent_version=(1, 0, 0),
+            force_rebuild=True,
+            deployment_mode="project",
+            source_info="system",
+        )
+        processor = AgentProcessor(template_builder=None, version_manager=None)
+
+        with patch("pathlib.Path.home", return_value=fake_home):
+            result = processor.process_agent(context)
+
+        assert result.status.value == "skipped"
+        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
+
+    def test_project_agent_still_deploys_via_single_deployer(self, temp_dirs):
+        """A non-CORE agent is still written to the project-level directory."""
+        from claude_mpm.services.agents.deployment.processors import (
+            AgentDeploymentContext,
+            AgentProcessor,
+        )
+
+        fake_home, project_agents_dir, _ = temp_dirs
+        template_dir = project_agents_dir.parent
+        template_file = self._template(template_dir, PROJECT_AGENT)
+
+        context = AgentDeploymentContext.from_template_file(
+            template_file=template_file,
+            agents_dir=project_agents_dir,
+            base_agent_data={},
+            base_agent_version=(1, 0, 0),
+            force_rebuild=True,
+            deployment_mode="project",
+            source_info="project",
+        )
+
+        class _StubBuilder:
+            def build_agent_markdown(self, *args, **kwargs):
+                return "---\nname: my-custom-project-agent-xyz\n---\n\n# body\n"
+
+        processor = AgentProcessor(
+            template_builder=_StubBuilder(), version_manager=None
+        )
+
+        with patch("pathlib.Path.home", return_value=fake_home):
+            result = processor.process_agent(context)
+
+        assert result.status.value != "skipped"
+        assert (project_agents_dir / f"{PROJECT_AGENT}.md").exists()


### PR DESCRIPTION
Closes #917

## Summary

Multiple agent deployment code paths (pipeline AgentProcessor, AsyncAgentDeploymentService, SingleAgentDeployer, LocalTemplateDeploymentService) lacked the USER_LEVEL_AGENTS routing guard that only the canonical AgentDeploymentService had. This caused project-level `.claude/agents/{name}.md` duplicates to silently regenerate after the 6.2.0/6.2.1 migrations already cleaned them up.

## Solution

Added a shared chokepoint guard (`user_level_routing.py`) used by every write path, with self-healing cleanup of stale project-level duplicates. Scoped strictly to git-ignored `.claude/agents/`; does not touch `~/.claude/agents/` or `~/.claude-mpm/agents/`.

## Test Coverage

Six commits with conventional prefixes, one file per commit. All 281 tests pass + self-heal regression test.