### PR TITLE
docs: correct stale auto-pause claims in deprecated mpm-session-resume shim

### DIFF
--- a/src/claude_mpm/commands/mpm-session-resume.md
+++ b/src/claude_mpm/commands/mpm-session-resume.md
@@ -46,6 +46,11 @@ claude-mpm session resume session-20240101-143022
 
 **Token usage:** ~20-40k tokens (10-20% of context budget)
 
-**Note:** Reads existing sessions (created automatically at 70% context). Does NOT create new files.
+**Note:** Reads existing sessions only. Does NOT create new files. Sessions are
+created manually via `/mpm-session-pause`; context-usage auto-pause (the old
+"auto-pause at 70% context" behavior) is disabled and no longer writes an
+`ACTIVE-PAUSE.jsonl` artifact automatically — the 70%/90%/95% thresholds now emit
+informational warnings only.
 
-See docs/features/session-auto-resume.md for details.
+For details, see the `mpm-session-resume` / `mpm-session-pause` skills and the
+`mpm-session-management` skill (`src/claude_mpm/skills/bundled/pm/mpm-session-management/SKILL.md`).


### PR DESCRIPTION
## Summary

Corrects stale documentation in the deprecated `mpm-session-resume` command shim.

- Fixed outdated claim that sessions are "created automatically at 70% context" (feature was disabled in PR #646)
- Replaced dead link to `docs/features/session-auto-resume.md` with current pointer to maintained skills
- Now accurately describes context-usage warnings as informational only; sessions created manually via /mpm-session-pause

Mirrors fix from sibling PR #915 which addressed staleness in maintained skills but skipped this shim.

Closes #916