### PR TITLE
feat: enforce agent deprecated: true at the tool-dispatch layer

### DIFF
--- a/docs/specs/hooks.md
+++ b/docs/specs/hooks.md
@@ -697,6 +697,22 @@ the harness can surface the warning to the user while still proceeding.
 
 - **Inputs:** A `PreToolUse` event dict where `tool_name == "Agent"`.
 
+- **Deprecated-agent guard (issue #922):** Checked first, unconditionally — even
+  when `tool_input` already has a `"model"` field, and regardless of the version
+  gate below. `_scan_deprecated_agents(cwd)` scans every `.md` file in
+  `<cwd>/.claude/agents/` via `MetadataProcessor.parse_agent_metadata` (the same
+  parsing path used elsewhere for agent frontmatter) and builds a set of
+  normalized identifiers for every agent with `deprecated: true`. Each deprecated
+  agent is registered under three identifier forms — filename stem, parsed `id`
+  (the `name:` field, or the stem when absent), and an explicit `agent_id:` field
+  when present — each normalized via `normalize_agent_id()`, so a `subagent_type`
+  matches regardless of which of this repo's two agent-identity schemes the
+  caller used. If `tool_input["subagent_type"]` matches, returns a `deny`
+  decision immediately with `permissionDecisionReason` set to the agent's own
+  `description:` frontmatter text (falling back to a generic message if the
+  description is missing or is the `MetadataProcessor` placeholder
+  `"Specialized agent"`). Result is cached per-`cwd` at module level.
+
 - **Precondition:** Only injects a model if the `tool_input` dict does not already
   contain a `"model"` field. If a model is already specified, returns immediately with
   no modification.
@@ -740,12 +756,28 @@ without modifying code. The `CLAUDE_MPM_SUB_AGENT` injection is the mechanism th
 enables `claude-hook-fast.sh` to skip recursive hook processing for sub-agent
 invocations.
 
+Prior to #922, an agent's `deprecated: true` frontmatter field was parsed into
+`agent_data` but nothing downstream ever read it — the only enforcement was a
+hand-written "[DEPRECATED]" sentence in `AGENT_DELEGATION.md`, which depended on
+every agent author remembering to write it and did nothing to stop an actual
+dispatch. Enforcing the guard inside `build_model_tier_response` (rather than
+adding a new hook registration) means every existing PreToolUse call site —
+`ToolHandler.handle_pre_tool_fast` and `pretooluse_dispatcher.dispatch`, both of
+which already call this function for `Agent` tool calls — gets the guard for
+free. Registering three identifier forms per deprecated agent addresses a prior
+audit finding that this repo uses two different agent-identity schemes
+(name-based in `capability_generator.py` vs. filename-stem-based
+`normalize_agent_id()` in `unified_agent_registry.py`), so the guard cannot be
+bypassed simply by passing a differently-shaped `subagent_type` string.
+
 ### Implementing Modules
 
 | Module path | Qualname | Role |
 |-------------|----------|------|
-| `src/claude_mpm/hooks/model_tier_hook.py` | `build_model_tier_response` | PreToolUse model injection |
+| `src/claude_mpm/hooks/model_tier_hook.py` | `build_model_tier_response` | PreToolUse model injection + deprecated-agent guard |
 | `src/claude_mpm/hooks/model_tier_hook.py` | `build_permission_request_response` | PermissionRequest routing |
+| `src/claude_mpm/hooks/model_tier_hook.py` | `_scan_deprecated_agents` | Builds normalized deprecated-agent identifier map (issue #922) |
+| `src/claude_mpm/hooks/model_tier_hook.py` | `_deprecated_agent_response` | Renders the PreToolUse deny envelope for a matched deprecated agent |
 
 ---
 

--- a/src/claude_mpm/hooks/model_tier_hook.py
+++ b/src/claude_mpm/hooks/model_tier_hook.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python3
 """PreToolUse + PermissionRequest hook dispatcher.
 
+WHAT: Injects model tiers into Agent tool calls, blocks dispatch of agents
+whose frontmatter declares ``deprecated: true``, and renders PermissionRequest
+allow/deny decisions.
+WHY: Claude Code ignores agent frontmatter ``model:`` fields (upstream issue
+anthropics/claude-code#44385) and previously enforced deprecation only via a
+hand-written prose sentence in ``AGENT_DELEGATION.md`` -- nothing stopped an
+actual dispatch of a deprecated agent (issue #922). Centralizing both concerns
+in the same PreToolUse entrypoint means every existing call site
+(``ToolHandler.handle_pre_tool_fast`` and ``pretooluse_dispatcher.dispatch``)
+gets the deprecation guard for free, without adding new hook registrations.
+
 This module is referenced from ``.claude/settings.json`` for two distinct
 events:
 
-* ``PreToolUse`` (matcher ``Agent``) — injects a default model into Agent
-  tool calls because Claude Code ignores agent frontmatter ``model:`` fields
-  (upstream issue anthropics/claude-code#44385).
+* ``PreToolUse`` (matcher ``Agent``) — blocks dispatch of ``deprecated: true``
+  agents (issue #922) and injects a default model into Agent tool calls
+  because Claude Code ignores agent frontmatter ``model:`` fields (upstream
+  issue anthropics/claude-code#44385).
 * ``PermissionRequest`` (matcher ``*``) — runs the policy engine in
   :mod:`claude_mpm.hooks.permission_policy` and emits a real allow/deny
   decision instead of the previous unconditional approve (issue #421).
@@ -23,6 +35,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 from claude_mpm.hooks import permission_policy
 from claude_mpm.utils.agent_filters import normalize_agent_id
@@ -200,6 +213,161 @@ def _read_model_from_config(agent_name: str, cwd: str) -> str | None:
     return _resolve_tier_alias(value)
 
 
+# Module-level cache mapping cwd -> {normalized identifier: description} for
+# agents whose frontmatter declares ``deprecated: true``. Keyed by cwd (rather
+# than a single flat value like ``_AGENT_MODEL_CONFIG``) so tests and
+# multi-project sessions that vary ``cwd`` within one process do not read
+# stale results from a different project's ``.claude/agents/`` directory.
+_DEPRECATED_AGENTS_CACHE: dict[str, dict[str, str]] = {}
+
+# Mirrors the literal placeholder ``MetadataProcessor.parse_agent_metadata``
+# fills into ``agent_data["description"]`` before frontmatter is merged in
+# (see ``core/framework/processors/metadata_processor.py``). Frontmatter that
+# omits ``description:`` entirely leaves this placeholder in place, which is
+# indistinguishable from a "real" description by content alone -- so we treat
+# an exact match against this sentinel as "no real description" and fall back
+# to a generic reason rather than denying with an unhelpful, uninformative
+# message.
+_DEFAULT_AGENT_DESCRIPTION = "Specialized agent"
+
+
+def _scan_deprecated_agents(cwd: str) -> dict[str, str]:
+    """Build a map of normalized agent identifiers to their description text.
+
+    WHAT: Scans every ``.md`` file in ``<cwd>/.claude/agents/``, parses each
+    one's frontmatter via ``MetadataProcessor.parse_agent_metadata``, and
+    returns a dict of normalized identifier -> deny-reason text for every
+    agent whose frontmatter sets ``deprecated: true``.
+    WHY: A boolean ``deprecated: true`` field existed in agent frontmatter
+    but nothing downstream ever enforced it -- the only prior guard was a
+    hand-written prose sentence in ``AGENT_DELEGATION.md`` (issue #922).
+    Scanning live frontmatter here (rather than hardcoding agent names) means
+    the guard tracks whatever agent authors actually mark deprecated, and
+    registering three identifier forms per agent covers this repo's two
+    divergent agent-identity schemes without guessing which one a given
+    caller's ``subagent_type`` uses.
+
+    Scans every ``.md`` file in ``<cwd>/.claude/agents/`` -- the same deployed
+    agent directory ``_read_model_from_frontmatter`` already reads from, and
+    the directory Claude Code actually resolves ``subagent_type`` against at
+    runtime -- for frontmatter with ``deprecated: true``. Parsing goes through
+    :meth:`MetadataProcessor.parse_agent_metadata`, the single parsing path
+    already used to turn agent frontmatter into ``agent_data`` (see
+    ``core/framework/processors/metadata_processor.py``), so this function
+    never hardcodes a list of deprecated agent names or re-implements
+    frontmatter extraction.
+
+    A prior audit found this repo uses two different agent-identity schemes
+    (name-based in ``capability_generator.py`` vs. filename-stem-based
+    ``normalize_agent_id()`` in ``unified_agent_registry.py``). To match
+    defensively regardless of which scheme a caller's ``subagent_type`` uses,
+    every deprecated agent is registered under all of: its filename stem, its
+    parsed ``id`` (the frontmatter ``name:`` field, or the stem when absent),
+    and an explicit frontmatter ``agent_id:`` field when present -- each
+    normalized via :func:`normalize_agent_id` so comparisons are
+    case-insensitive and separator-insensitive (e.g. "ops", "Ops", "Ops Agent"
+    all resolve to the same key).
+
+    Result is cached per-cwd at module level for the lifetime of the hook
+    process. Never raises: a missing directory, unreadable file, or malformed
+    frontmatter is skipped rather than propagated, so a single bad agent file
+    cannot block dispatch of every other agent.
+
+    :spec: SPEC-HOOKS-12~1
+    """
+    if cwd in _DEPRECATED_AGENTS_CACHE:
+        return _DEPRECATED_AGENTS_CACHE[cwd]
+
+    result: dict[str, str] = {}
+    if cwd:
+        agents_dir = Path(cwd) / ".claude" / "agents"
+        if agents_dir.is_dir():
+            try:
+                from claude_mpm.core.framework.processors.metadata_processor import (
+                    MetadataProcessor,
+                )
+
+                processor: Any = MetadataProcessor()
+            except Exception:
+                processor = None
+
+            if processor is not None:
+                for agent_file in sorted(agents_dir.glob("*.md")):
+                    agent_data = processor.parse_agent_metadata(agent_file)
+                    if not agent_data or not agent_data.get("deprecated"):
+                        continue
+
+                    # Prefer the agent's own description text (agent authors
+                    # already write replacement guidance there, e.g. the
+                    # "[DEPRECATED] Use platform-specific ops agents..." text
+                    # on ops.md). A missing/placeholder description must
+                    # never be treated as "not deprecated" though: blocking
+                    # dispatch is the safe failure mode for anything
+                    # explicitly flagged ``deprecated: true``, so we fall
+                    # back to a generic reason instead of skipping the agent.
+                    description = agent_data.get("description")
+                    has_real_description = (
+                        isinstance(description, str)
+                        and bool(description.strip())
+                        and description.strip() != _DEFAULT_AGENT_DESCRIPTION
+                    )
+                    reason = (
+                        description.strip()
+                        if has_real_description
+                        else (
+                            f"Agent '{agent_file.stem}' is marked "
+                            "deprecated: true in its frontmatter."
+                        )
+                    )
+
+                    keys = {
+                        normalize_agent_id(agent_file.stem),
+                        normalize_agent_id(str(agent_data.get("id", ""))),
+                    }
+                    agent_id_field = agent_data.get("agent_id")
+                    if isinstance(agent_id_field, str) and agent_id_field.strip():
+                        keys.add(normalize_agent_id(agent_id_field))
+
+                    for key in keys:
+                        if key:
+                            result[key] = reason
+
+    _DEPRECATED_AGENTS_CACHE[cwd] = result
+    return result
+
+
+def _deprecated_agent_response(agent_type: str, cwd: str) -> dict | None:
+    """Return a PreToolUse deny envelope if ``agent_type`` is deprecated.
+
+    Surfaces the deprecated agent's own ``description:`` frontmatter text
+    (which agent authors already write with replacement guidance, e.g.
+    "[DEPRECATED] Use platform-specific ops agents...") as the deny reason,
+    rather than inventing a new message format -- so the enforcement message
+    stays in sync with whatever agent authors write (issue #922).
+
+    Returns ``None`` (no opinion) when ``agent_type`` is empty or does not
+    match any deprecated agent, so the caller can fall through to normal
+    model-tier resolution.
+
+    :spec: SPEC-HOOKS-12~1
+    """
+    normalized = normalize_agent_id(agent_type)
+    if not normalized:
+        return None
+
+    description = _scan_deprecated_agents(cwd).get(normalized)
+    if description is None:
+        return None
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": description,
+        }
+    }
+
+
 def _read_model_from_frontmatter(agent_name: str, cwd: str) -> str | None:
     """Try to read model: from agent .md frontmatter."""
     agents_dir = Path(cwd) / ".claude" / "agents"
@@ -243,7 +411,7 @@ def _handle_permission_request(event: dict) -> None:
 
 
 def build_model_tier_response(event: dict) -> dict:
-    """Resolve and inject the model tier for an Agent tool call.
+    """Block deprecated agents, else resolve and inject the model tier.
 
     Returns the full ``hookSpecificOutput``-wrapped payload dict, or
     ``{"continue": True}`` when the event is not an Agent call, already has a
@@ -252,6 +420,16 @@ def build_model_tier_response(event: dict) -> dict:
 
     Exposed as an importable function so ``pretooluse_dispatcher`` can call it
     directly without spawning a subprocess.
+
+    Deprecated-agent guard (issue #922)
+    ------------------------------------
+    Checked first, unconditionally -- even when the caller already set an
+    explicit ``model`` in ``tool_input``, and regardless of the version gate
+    below. The goal is to block dispatch of the agent entirely, not just its
+    model-tier routing, so this check cannot be bypassed by pre-setting
+    ``model`` and it does not depend on ``updatedInput`` support (a plain
+    ``permissionDecision: "deny"`` works on every supported Claude Code
+    version). See :func:`_deprecated_agent_response`.
 
     Model injection is version-gated
     ---------------------------------
@@ -273,17 +451,24 @@ def build_model_tier_response(event: dict) -> dict:
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 
+    if tool_name != "Agent":
+        return {"continue": True}
+
+    agent_type = tool_input.get("subagent_type", "")
+    cwd = event.get("cwd", "")
+
+    deprecated_response = _deprecated_agent_response(agent_type, cwd)
+    if deprecated_response is not None:
+        return deprecated_response
+
     # Only intercept Agent tool calls that don't already have a model
-    if tool_name != "Agent" or "model" in tool_input:
+    if "model" in tool_input:
         return {"continue": True}
 
     # Version gate: skip injection when PreToolUse input modification is
     # unsupported (pre-v2.0.30).  Fail open so Claude Code is never blocked.
     if not _check_pretool_modify_supported():
         return {"continue": True}
-
-    agent_type = tool_input.get("subagent_type", "")
-    cwd = event.get("cwd", "")
 
     # Resolution priority (highest -> lowest):
     #   1. Explicit ``model`` in the Agent tool call (handled above).

--- a/tests/hooks/test_deprecated_agent_guard.py
+++ b/tests/hooks/test_deprecated_agent_guard.py
@@ -1,0 +1,307 @@
+"""Unit tests for the deprecated-agent PreToolUse guard (issue #922).
+
+Covers:
+
+* Dispatching a ``deprecated: true`` agent is blocked and the deny reason
+  surfaces the agent's own ``description:`` frontmatter text.
+* Dispatching a non-deprecated agent is unaffected (falls through to normal
+  model-tier resolution).
+* Matching is case-insensitive and works against all three agent-identity
+  forms this repo uses: filename stem, ``name:`` frontmatter field, and an
+  explicit ``agent_id:`` frontmatter field.
+* A missing ``.claude/agents/`` directory (or missing ``cwd``) fails open.
+* A deprecated agent with no real description text still gets a fallback
+  deny reason rather than silently bypassing the guard.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make src importable when tests are run directly without an installed package.
+_SRC = Path(__file__).resolve().parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from claude_mpm.hooks import model_tier_hook
+
+OPS_FRONTMATTER = """---
+model: haiku
+name: Ops
+description: "[DEPRECATED] Use platform-specific ops agents (Local Ops, Vercel Ops, GCP Ops, AWS Ops, DigitalOcean Ops)"
+deprecated: true
+agent_id: ops
+agent_type: ops
+---
+
+# Ops Agent
+
+Body content is irrelevant to metadata parsing.
+"""
+
+ENGINEER_FRONTMATTER = """---
+model: sonnet
+name: Engineer
+description: "General-purpose engineering agent."
+agent_id: engineer
+agent_type: engineer
+---
+
+# Engineer Agent
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecated_agents_cache():
+    """Ensure each test starts with a clean per-cwd cache and model config.
+
+    ``_DEPRECATED_AGENTS_CACHE`` is keyed by cwd, so distinct tmp_path
+    fixtures across tests do not collide -- but we still clear it to keep
+    tests fully independent of execution order/module state.
+
+    ``_AGENT_MODEL_CONFIG`` is forced to an empty dict (rather than left as
+    ``None``, which would trigger a real load) so tests never pick up the
+    developer machine's actual ``~/.claude-mpm/config/configuration.yaml``
+    (which may set per-agent model overrides, e.g. ``engineer: opus``) --
+    these tests only care about the deprecation guard and the
+    frontmatter-based model fallback, not real user config.
+    """
+    model_tier_hook._DEPRECATED_AGENTS_CACHE.clear()
+    model_tier_hook._AGENT_MODEL_CONFIG = {}
+    yield
+    model_tier_hook._DEPRECATED_AGENTS_CACHE.clear()
+    model_tier_hook._AGENT_MODEL_CONFIG = None
+
+
+def _write_agent(agents_dir: Path, filename: str, content: str) -> None:
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / filename).write_text(content, encoding="utf-8")
+
+
+def _agent_event(subagent_type: str, cwd: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Agent",
+        "tool_input": {"subagent_type": subagent_type},
+        "cwd": cwd,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) Deprecated agent dispatch is blocked with the expected message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_deprecated_agent_dispatch_is_denied(tmp_path: Path) -> None:
+    """Dispatching a deprecated agent by its filename stem must be denied."""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "ops.md", OPS_FRONTMATTER)
+
+    response = model_tier_hook.build_model_tier_response(
+        _agent_event("ops", str(tmp_path))
+    )
+
+    spec = response["hookSpecificOutput"]
+    assert spec["hookEventName"] == "PreToolUse"
+    assert spec["permissionDecision"] == "deny"
+    assert spec["permissionDecisionReason"] == (
+        "[DEPRECATED] Use platform-specific ops agents "
+        "(Local Ops, Vercel Ops, GCP Ops, AWS Ops, DigitalOcean Ops)"
+    )
+
+
+@pytest.mark.unit
+def test_deprecated_agent_denied_even_with_explicit_model(tmp_path: Path) -> None:
+    """Pre-setting ``model`` in tool_input must not bypass the deprecation guard."""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "ops.md", OPS_FRONTMATTER)
+
+    event = _agent_event("ops", str(tmp_path))
+    event["tool_input"]["model"] = "opus"
+
+    response = model_tier_hook.build_model_tier_response(event)
+
+    spec = response["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# (b) Non-deprecated agent dispatch is unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_deprecated_agent_falls_through_to_model_injection(
+    tmp_path: Path,
+) -> None:
+    """A non-deprecated agent must not be denied; normal tier logic still runs."""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "ops.md", OPS_FRONTMATTER)
+    _write_agent(agents_dir, "engineer.md", ENGINEER_FRONTMATTER)
+
+    model_tier_hook._pretool_modify_supported = True
+    try:
+        response = model_tier_hook.build_model_tier_response(
+            _agent_event("engineer", str(tmp_path))
+        )
+    finally:
+        model_tier_hook._pretool_modify_supported = None
+
+    spec = response["hookSpecificOutput"]
+    assert spec.get("permissionDecision") != "deny"
+    assert "updatedInput" in spec
+    assert spec["updatedInput"]["model"] == "sonnet"
+
+
+@pytest.mark.unit
+def test_missing_agents_directory_fails_open(tmp_path: Path) -> None:
+    """No ``.claude/agents/`` directory at all must not crash or deny."""
+    model_tier_hook._pretool_modify_supported = True
+    try:
+        response = model_tier_hook.build_model_tier_response(
+            _agent_event("engineer", str(tmp_path))
+        )
+    finally:
+        model_tier_hook._pretool_modify_supported = None
+
+    spec = response["hookSpecificOutput"]
+    assert spec.get("permissionDecision") != "deny"
+
+
+# ---------------------------------------------------------------------------
+# (c) Case-insensitive matching against both identity schemes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subagent_type",
+    [
+        "ops",
+        "Ops",
+        "OPS",
+        "Ops Agent",
+        "ops-agent",
+    ],
+)
+def test_case_insensitive_match_against_filename_stem_and_name_field(
+    tmp_path: Path, subagent_type: str
+) -> None:
+    """Both filename-stem ("ops") and name-field ("Ops") schemes must match.
+
+    ``normalize_agent_id`` strips an ``-agent`` suffix and lowercases/
+    dashes the input, so "Ops Agent" / "ops-agent" normalize to the same
+    key as the filename stem "ops" and the frontmatter ``name: Ops`` field.
+    """
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "ops.md", OPS_FRONTMATTER)
+
+    response = model_tier_hook.build_model_tier_response(
+        _agent_event(subagent_type, str(tmp_path))
+    )
+
+    spec = response["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "deny", (
+        f"Expected deny for subagent_type={subagent_type!r}"
+    )
+
+
+@pytest.mark.unit
+def test_case_insensitive_match_against_explicit_agent_id_field(
+    tmp_path: Path,
+) -> None:
+    """A deprecated agent whose ``name:`` differs from its ``agent_id:`` must
+    still be matched via the explicit ``agent_id:`` frontmatter field.
+    """
+    frontmatter = """---
+name: Local Operations
+description: "[DEPRECATED] Use platform-specific ops agents instead."
+deprecated: true
+agent_id: local-ops-agent
+---
+"""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "local-operations.md", frontmatter)
+
+    response = model_tier_hook.build_model_tier_response(
+        _agent_event("Local-Ops-Agent", str(tmp_path))
+    )
+
+    spec = response["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "deny"
+    assert "DEPRECATED" in spec["permissionDecisionReason"]
+
+
+@pytest.mark.unit
+def test_deprecated_false_is_not_blocked(tmp_path: Path) -> None:
+    """An agent with ``deprecated: false`` (or absent) must never be denied."""
+    frontmatter = """---
+name: Fresh Agent
+description: "A perfectly supported agent."
+deprecated: false
+agent_id: fresh
+---
+"""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "fresh.md", frontmatter)
+
+    model_tier_hook._pretool_modify_supported = True
+    try:
+        response = model_tier_hook.build_model_tier_response(
+            _agent_event("fresh", str(tmp_path))
+        )
+    finally:
+        model_tier_hook._pretool_modify_supported = None
+
+    spec = response["hookSpecificOutput"]
+    assert spec.get("permissionDecision") != "deny"
+
+
+@pytest.mark.unit
+def test_deprecated_agent_without_description_still_blocked_with_fallback_reason(
+    tmp_path: Path,
+) -> None:
+    """A deprecated agent lacking real description text must still be denied.
+
+    ``deprecated: true`` is the authoritative signal; a missing/placeholder
+    description must never be treated as "not deprecated" (that would let a
+    malformed agent file silently bypass the guard). A generic fallback
+    reason referencing the agent is used instead of inventing content.
+    """
+    frontmatter = """---
+name: Broken
+deprecated: true
+agent_id: broken
+---
+"""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "broken.md", frontmatter)
+
+    response = model_tier_hook.build_model_tier_response(
+        _agent_event("broken", str(tmp_path))
+    )
+
+    spec = response["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "deny"
+    assert "broken" in spec["permissionDecisionReason"]
+    assert "deprecated" in spec["permissionDecisionReason"]
+
+
+@pytest.mark.unit
+def test_scan_deprecated_agents_is_cached_per_cwd(tmp_path: Path) -> None:
+    """Repeated calls with the same cwd must reuse the cached scan result."""
+    agents_dir = tmp_path / ".claude" / "agents"
+    _write_agent(agents_dir, "ops.md", OPS_FRONTMATTER)
+
+    first = model_tier_hook._scan_deprecated_agents(str(tmp_path))
+    # Mutate the directory after the first scan; a cached second call must
+    # not pick up the new file (proves caching, not just idempotent scanning).
+    _write_agent(agents_dir, "engineer.md", ENGINEER_FRONTMATTER)
+    second = model_tier_hook._scan_deprecated_agents(str(tmp_path))
+
+    assert first == second
+    assert "ops" in first


### PR DESCRIPTION
## Summary

Adds runtime enforcement of the `deprecated: true` agent flag at the tool-dispatch layer. When a deprecated agent is dispatched via the Agent tool, a PreToolUse hook now blocks the dispatch and returns a user-facing error that surfaces the agent's own `description:` field.

## Implementation

- The guard lives inside the existing `build_model_tier_response` in `src/claude_mpm/hooks/model_tier_hook.py`
- No new hook registration was needed — both existing PreToolUse call sites already invoke this function for Agent tool calls
- Deprecated agents are discovered by scanning `.claude/agents/*.md` frontmatter live via `MetadataProcessor.parse_agent_metadata` (no hardcoded list)
- Each deprecated agent is matched against three normalized identifiers (filename stem, `name:`, `agent_id:`) to handle both identity schemes in this codebase
- The deny message surfaces the agent's own `description:` field for clarity

## Testing

- 46 tests pass (13 new + 33 pre-existing)
- Full `tests/hooks/` suite passes (396 passed, 23 unrelated skips)
- Code passes ruff linter checks

Closes #922