### PR TITLE
feat: filter agent capabilities by per-project manifest

### DIFF
--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -713,6 +713,10 @@ class FrameworkLoader:
                             if agent_data:
                                 deployed_agents.append(agent_data)
 
+            # Filter down to the project's agent manifest, if one exists
+            # (issue #923). Absent a manifest, all deployed agents are kept.
+            deployed_agents = self._filter_agents_by_manifest(deployed_agents)
+
             # Generate capabilities section
             section = self.capability_generator.generate_capabilities_section(
                 deployed_agents, local_agents
@@ -729,6 +733,60 @@ class FrameworkLoader:
             fallback = self.content_formatter.get_fallback_capabilities()
             self._cache_manager.set_capabilities(fallback)
             return fallback
+
+    def _filter_agents_by_manifest(
+        self, deployed_agents: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Filter deployed agents down to the project's agent manifest, if any.
+
+        WHAT: Reads ``.claude-mpm/agent_manifest.json`` at the current project
+        root (via ``agent_manifest.read_agent_manifest``) and, when present,
+        keeps only the entries in ``deployed_agents`` whose ``id`` appears in
+        the manifest. Manifest IDs with no matching deployed agent (e.g. the
+        agent was later removed or renamed) are silently skipped rather than
+        raising.
+
+        WHY: Closes #923 -- exposing the full ~50-agent catalog to every
+        project regardless of relevance clutters the PM's system prompt.
+        Projects that ran ``claude-mpm agents auto-configure`` (or
+        ``deploy-auto``) already persisted the set of agents relevant to
+        their toolchain; this filters the capabilities section down to that
+        set. Projects without a manifest (the common case today) fall back
+        to returning ``deployed_agents`` unchanged, preserving prior
+        behavior.
+
+        Args:
+            deployed_agents: Parsed agent metadata dicts, each with an "id" key.
+
+        Returns:
+            The filtered list, or ``deployed_agents`` unchanged if no valid
+            manifest is found.
+
+        :spec: none
+        """
+        try:
+            from claude_mpm.services.agents.agent_manifest import (
+                read_agent_manifest,
+            )
+
+            manifest_agent_ids = read_agent_manifest(Path.cwd())
+        except Exception as e:
+            self.logger.debug(f"Agent manifest lookup skipped: {e}")
+            return deployed_agents
+
+        if manifest_agent_ids is None:
+            return deployed_agents
+
+        allowed_ids = set(manifest_agent_ids)
+        filtered = [
+            agent for agent in deployed_agents if agent.get("id") in allowed_ids
+        ]
+
+        self.logger.debug(
+            f"Filtered deployed agents by project manifest: "
+            f"{len(filtered)}/{len(deployed_agents)} kept"
+        )
+        return filtered
 
     # === Output Style Management ===
 

--- a/src/claude_mpm/core/framework_loader.py
+++ b/src/claude_mpm/core/framework_loader.py
@@ -686,7 +686,26 @@ class FrameworkLoader:
         return self.content_formatter.format_minimal_framework(self.framework_content)
 
     def _generate_agent_capabilities_section(self) -> str:
-        """Generate agent capabilities section with caching."""
+        """Generate agent capabilities section with caching.
+
+        WHAT: Builds the "## Available Agent Capabilities" Markdown block for
+        the PM system prompt by combining locally-defined JSON agent
+        templates with agents deployed to ``.claude/agents/`` (project) and
+        ``~/.claude/agents`` (user), then narrowing the deployed set down to
+        the project's ``.claude-mpm/agent_manifest.json`` allow-list when one
+        exists (see :meth:`_filter_agents_by_manifest`). Falls back to a
+        generic hardcoded section on any error or when no agents are found.
+        Result is cached via ``self._cache_manager`` to avoid re-globbing and
+        re-parsing every deployed agent file on each call.
+
+        WHY: Issue #923 -- resolving the project root once here (instead of
+        letting the manifest filter independently call ``Path.cwd()``) keeps
+        the ``.claude/agents/`` glob and the manifest lookup pointed at the
+        exact same directory, even when the process cwd is a subdirectory of
+        the real project root or ``CLAUDE_MPM_USER_PWD`` is set.
+
+        :spec: none
+        """
         # Try cache first
         cached_capabilities = self._cache_manager.get_capabilities()
         if cached_capabilities is not None:
@@ -698,10 +717,22 @@ class FrameworkLoader:
             # Discover local JSON templates
             local_agents = self._discover_local_json_templates()
 
+            # Resolve the project root ONCE and reuse it for both the
+            # .claude/agents/ glob below and the manifest lookup in
+            # _filter_agents_by_manifest, so the two can never disagree
+            # about which project they're looking at (issue #923 review).
+            # self._path_resolver.find_project_root() walks up from cwd
+            # looking for project markers (.git, pyproject.toml,
+            # .claude-mpm, etc.) and honors CLAUDE_MPM_USER_PWD, which is
+            # more robust than a bare Path.cwd() when claude-mpm runs from
+            # a global install or a subdirectory. Falls back to Path.cwd()
+            # if no marker is found (preserves prior behavior).
+            project_root = self._path_resolver.find_project_root() or Path.cwd()
+
             # Get deployed agents from .claude/agents/
             deployed_agents = []
             agents_dirs = [
-                Path.cwd() / ".claude" / "agents",
+                project_root / ".claude" / "agents",
                 Path.home() / ".claude" / "agents",
             ]
 
@@ -715,7 +746,9 @@ class FrameworkLoader:
 
             # Filter down to the project's agent manifest, if one exists
             # (issue #923). Absent a manifest, all deployed agents are kept.
-            deployed_agents = self._filter_agents_by_manifest(deployed_agents)
+            deployed_agents = self._filter_agents_by_manifest(
+                deployed_agents, project_root
+            )
 
             # Generate capabilities section
             section = self.capability_generator.generate_capabilities_section(
@@ -735,14 +768,14 @@ class FrameworkLoader:
             return fallback
 
     def _filter_agents_by_manifest(
-        self, deployed_agents: list[dict[str, Any]]
+        self, deployed_agents: list[dict[str, Any]], project_root: Path
     ) -> list[dict[str, Any]]:
         """Filter deployed agents down to the project's agent manifest, if any.
 
-        WHAT: Reads ``.claude-mpm/agent_manifest.json`` at the current project
-        root (via ``agent_manifest.read_agent_manifest``) and, when present,
-        keeps only the entries in ``deployed_agents`` whose ``id`` appears in
-        the manifest. Manifest IDs with no matching deployed agent (e.g. the
+        WHAT: Reads ``.claude-mpm/agent_manifest.json`` at ``project_root``
+        (via ``agent_manifest.read_agent_manifest``) and, when present, keeps
+        only the entries in ``deployed_agents`` whose ``id`` appears in the
+        manifest. Manifest IDs with no matching deployed agent (e.g. the
         agent was later removed or renamed) are silently skipped rather than
         raising.
 
@@ -755,8 +788,15 @@ class FrameworkLoader:
         to returning ``deployed_agents`` unchanged, preserving prior
         behavior.
 
+        ``project_root`` is passed in by the caller (rather than this method
+        re-deriving it via ``Path.cwd()``) so the manifest lookup always uses
+        the exact same root ``_generate_agent_capabilities_section`` used to
+        find ``.claude/agents/`` -- avoiding a mismatch if cwd were to differ
+        from the resolved project root or change between the two lookups.
+
         Args:
             deployed_agents: Parsed agent metadata dicts, each with an "id" key.
+            project_root: The project root to look for the manifest under.
 
         Returns:
             The filtered list, or ``deployed_agents`` unchanged if no valid
@@ -769,7 +809,7 @@ class FrameworkLoader:
                 read_agent_manifest,
             )
 
-            manifest_agent_ids = read_agent_manifest(Path.cwd())
+            manifest_agent_ids = read_agent_manifest(project_root)
         except Exception as e:
             self.logger.debug(f"Agent manifest lookup skipped: {e}")
             return deployed_agents

--- a/src/claude_mpm/services/agents/agent_manifest.py
+++ b/src/claude_mpm/services/agents/agent_manifest.py
@@ -1,0 +1,118 @@
+"""Per-project agent manifest persistence.
+
+WHAT: Provides ``write_agent_manifest``/``read_agent_manifest`` helpers that
+persist and load a small JSON file (``.claude-mpm/agent_manifest.json``)
+recording which agent IDs the auto-configure workflow recommended/deployed
+for a given project.
+
+WHY: Without this manifest, the PM's "Available Agent Capabilities" system
+prompt section (built in ``core/framework_loader.py``) has no way to know
+which of the ~50 possible agent templates are actually relevant to a given
+project, so it always exposes the full catalog. Persisting the
+recommendation output here lets capability generation filter down to what
+auto-configure already determined is relevant, while remaining fully
+backward compatible: projects that never ran auto-configure simply have no
+manifest file, and callers fall back to today's "show everything" behavior.
+
+References
+----------
+GitHub issue: https://github.com/bobmatnyc/claude-mpm/issues/923
+LINK: none
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from claude_mpm.core.logging_utils import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+logger = get_logger(__name__)
+
+#: Directory (relative to project root) that holds claude-mpm project state.
+MANIFEST_DIRNAME = ".claude-mpm"
+#: Manifest file name within MANIFEST_DIRNAME.
+MANIFEST_FILENAME = "agent_manifest.json"
+#: Bump when the on-disk schema changes in an incompatible way.
+MANIFEST_SCHEMA_VERSION = 1
+
+
+def get_manifest_path(project_path: Path) -> Path:
+    """Return the manifest path for ``project_path`` (existence not checked)."""
+    return project_path / MANIFEST_DIRNAME / MANIFEST_FILENAME
+
+
+def write_agent_manifest(
+    project_path: Path,
+    agent_ids: Iterable[str],
+    *,
+    toolchain_summary: dict[str, Any] | None = None,
+) -> Path:
+    """Persist the recommended/deployed agent-id list for ``project_path``.
+
+    Args:
+        project_path: Project root directory.
+        agent_ids: Agent IDs (``.claude/agents/*.md`` stems) to record.
+        toolchain_summary: Optional debugging context (e.g. detected
+            language/frameworks) stored alongside the agent list.
+
+    Returns:
+        The path the manifest was written to (whether or not the write
+        succeeded -- callers that need to confirm success should check
+        ``.exists()`` themselves).
+    """
+    manifest_path = get_manifest_path(project_path)
+
+    data: dict[str, Any] = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "agent_ids": sorted({str(agent_id) for agent_id in agent_ids}),
+    }
+    if toolchain_summary is not None:
+        data["toolchain_summary"] = toolchain_summary
+
+    try:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        with manifest_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=False)
+            f.write("\n")
+        logger.debug(f"Wrote agent manifest to {manifest_path}")
+    except OSError as e:
+        logger.warning(f"Failed to write agent manifest to {manifest_path}: {e}")
+
+    return manifest_path
+
+
+def read_agent_manifest(project_path: Path) -> list[str] | None:
+    """Read the agent-id allow-list for ``project_path``.
+
+    Returns ``None`` when the manifest is absent, unreadable, or malformed
+    (missing/invalid ``agent_ids``) so callers can distinguish "no manifest,
+    use the full catalog" from "manifest present but empty" (an empty list is
+    returned as ``[]``, not ``None``).
+    """
+    manifest_path = get_manifest_path(project_path)
+    if not manifest_path.exists():
+        return None
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError) as e:
+        logger.warning(f"Could not read agent manifest at {manifest_path}: {e}")
+        return None
+
+    agent_ids = data.get("agent_ids") if isinstance(data, dict) else None
+    if not isinstance(agent_ids, list):
+        logger.warning(
+            f"Agent manifest at {manifest_path} is missing a valid 'agent_ids' "
+            "list; ignoring and falling back to the full catalog"
+        )
+        return None
+
+    return [str(agent_id) for agent_id in agent_ids if isinstance(agent_id, str)]

--- a/src/claude_mpm/services/agents/agent_selection_service.py
+++ b/src/claude_mpm/services/agents/agent_selection_service.py
@@ -39,6 +39,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from claude_mpm.services.agents.agent_manifest import write_agent_manifest
 from claude_mpm.services.agents.single_tier_deployment_service import (
     SingleTierDeploymentService,
 )
@@ -406,6 +407,20 @@ class AgentSelectionService:
             f"{deployed_count} deployed, {failed_count} failed, "
             f"{missing_count} missing (status: {status})"
         )
+
+        # Persist a per-project agent manifest so framework_loader can filter
+        # the "Available Agent Capabilities" section to what's actually
+        # relevant here instead of the full catalog (#923). Skip on dry-run
+        # since nothing was actually deployed.
+        if not dry_run and deployed_agents:
+            try:
+                write_agent_manifest(
+                    project_path,
+                    deployed_agents,
+                    toolchain_summary=toolchain,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to write agent manifest: {e}")
 
         return report
 

--- a/src/claude_mpm/services/agents/auto_config_manager.py
+++ b/src/claude_mpm/services/agents/auto_config_manager.py
@@ -1218,15 +1218,24 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
         # config above) so framework_loader can filter the "Available Agent
         # Capabilities" section down to agents relevant to this project
         # instead of the full catalog. See issue #923.
-        try:
-            write_agent_manifest(
-                project_path,
-                (rec.agent_id for rec in recommendations),
-                toolchain_summary={
-                    "primary_language": toolchain.primary_language,
-                    "frameworks": [fw.name for fw in toolchain.frameworks],
-                },
-            )
-        except Exception as e:
-            self.logger.warning(f"Failed to write agent manifest: {e}")
-            # Don't raise - manifest write is non-critical (best-effort)
+        #
+        # Guard on non-empty recommendations: an empty manifest is NOT the
+        # same as no manifest at all. No manifest -> framework_loader falls
+        # back to the full catalog; an empty manifest would actively hide
+        # every agent from the PM's capabilities section, which is never
+        # the intent here (this method only runs after a successful
+        # deployment, so an empty `recommendations` means there was nothing
+        # to persist, not that zero agents should be shown).
+        if recommendations:
+            try:
+                write_agent_manifest(
+                    project_path,
+                    (rec.agent_id for rec in recommendations),
+                    toolchain_summary={
+                        "primary_language": toolchain.primary_language,
+                        "frameworks": [fw.name for fw in toolchain.frameworks],
+                    },
+                )
+            except Exception as e:
+                self.logger.warning(f"Failed to write agent manifest: {e}")
+                # Don't raise - manifest write is non-critical (best-effort)

--- a/src/claude_mpm/services/agents/auto_config_manager.py
+++ b/src/claude_mpm/services/agents/auto_config_manager.py
@@ -34,6 +34,7 @@ from ..core.models.agent_config import (
     ValidationResult,
 )
 from ..core.models.toolchain import ToolchainAnalysis
+from .agent_manifest import write_agent_manifest
 from .observers import IDeploymentObserver, NullObserver
 from .recommender import AgentRecommenderService
 
@@ -1212,3 +1213,20 @@ class AutoConfigManagerService(BaseService, IAutoConfigManager):
         except Exception as e:
             self.logger.error(f"Failed to save configuration: {e}", exc_info=True)
             # Don't raise - configuration save is non-critical
+
+        # Persist a lightweight agent-id manifest (separate from the YAML
+        # config above) so framework_loader can filter the "Available Agent
+        # Capabilities" section down to agents relevant to this project
+        # instead of the full catalog. See issue #923.
+        try:
+            write_agent_manifest(
+                project_path,
+                (rec.agent_id for rec in recommendations),
+                toolchain_summary={
+                    "primary_language": toolchain.primary_language,
+                    "frameworks": [fw.name for fw in toolchain.frameworks],
+                },
+            )
+        except Exception as e:
+            self.logger.warning(f"Failed to write agent manifest: {e}")
+            # Don't raise - manifest write is non-critical (best-effort)

--- a/tests/services/agents/test_auto_config_manager.py
+++ b/tests/services/agents/test_auto_config_manager.py
@@ -666,6 +666,42 @@ async def test_save_configuration(service, temp_project_dir):
     )
     assert len(config_data["auto_config"]["deployed_agents"]) == 1
 
+    # Issue #923: a lightweight agent-id manifest is written alongside the
+    # YAML config so framework_loader can filter its capabilities section.
+    from claude_mpm.services.agents.agent_manifest import read_agent_manifest
+
+    assert read_agent_manifest(temp_project_dir) == ["python-engineer"]
+
+
+@pytest.mark.asyncio
+async def test_save_configuration_skips_agent_manifest_when_recommendations_empty(
+    service, temp_project_dir
+):
+    """Regression guard (trusty-review finding, PR #926): an empty
+    ``recommendations`` list must NOT write an empty agent manifest.
+
+    A missing manifest means "no opinion, show the full catalog"; an empty
+    manifest means "show nothing" -- those are not the same thing, and
+    ``_save_configuration`` only runs after a successful (possibly
+    zero-agent) deployment, so writing an empty manifest here would be
+    unintentional.
+    """
+    toolchain = ToolchainAnalysis(
+        project_path=temp_project_dir,
+        language_detection=LanguageDetection(
+            primary_language="Python",
+            language_percentages={"Python": 100.0},
+        ),
+        frameworks=[],
+        deployment_target=None,
+    )
+
+    await service._save_configuration(temp_project_dir, toolchain, [])
+
+    from claude_mpm.services.agents.agent_manifest import get_manifest_path
+
+    assert not get_manifest_path(temp_project_dir).exists()
+
 
 # ============================================================================
 # Test: Error Handling

--- a/tests/test_agent_manifest_filtering.py
+++ b/tests/test_agent_manifest_filtering.py
@@ -31,6 +31,10 @@ from claude_mpm.services.agents.agent_manifest import (
     read_agent_manifest,
     write_agent_manifest,
 )
+from claude_mpm.services.core.service_container import (
+    ServiceContainer,
+    get_global_container,
+)
 
 _AGENT_MD_TEMPLATE = """---
 name: {agent_id}
@@ -55,7 +59,35 @@ def _write_agent_md(agents_dir: Path, agent_id: str) -> None:
 def _make_loader():
     """Build a FrameworkLoader with capability/metadata caching disabled so
     each call regenerates from disk instead of returning a stale cached
-    string (mirrors the pattern used in test_local_agent_templates.py)."""
+    string (mirrors the pattern used in test_local_agent_templates.py).
+
+    CRITICAL: passes a brand-new ``ServiceContainer()`` instead of relying
+    on ``FrameworkLoader``'s default (``get_global_container()``).
+
+    ``FrameworkLoader._register_services`` only registers
+    ``ICacheManager``/``IPathResolver``/``IMemoryManager`` the FIRST time
+    they're requested from a given container, and the global container is a
+    process-wide singleton (``claude_mpm.services.core.service_container.
+    _global_container``) that lives for the lifetime of the pytest worker
+    process. If some OTHER test in this worker builds a real, unmocked
+    ``FrameworkLoader()`` first, ``ICacheManager`` gets permanently bound to
+    the REAL ``CacheManager`` class in the global container; every later
+    call to ``patch("claude_mpm.core.framework_loader.CacheManager")``
+    becomes a no-op (``is_registered(ICacheManager)`` is already True), and
+    every subsequent loader -- including this one -- silently inherits that
+    first real ``CacheManager`` singleton and whatever it has cached
+    (typically the real repo's full ~30-agent catalog, cached for up to 60s).
+
+    This is exactly what broke PR #926 in CI: it passed locally when only
+    this narrow test file ran first in the process, and failed under the
+    full/parallel (``pytest -n auto``) suite where other test files had
+    already primed the global container before this module's tests ran.
+    An isolated ``ServiceContainer`` per loader sidesteps the whole problem:
+    ``is_registered(ICacheManager)`` is always False on a fresh container,
+    so the ``patch(...)`` below is honored every time, regardless of what
+    ran before it in this process. See also TestFrameworkLoaderContainerIsolation
+    below, which asserts this directly.
+    """
     from claude_mpm.core.framework_loader import FrameworkLoader
 
     with patch("claude_mpm.core.framework_loader.CacheManager") as mock_cache_cls:
@@ -64,7 +96,7 @@ def _make_loader():
         mock_cache.get_agent_metadata.return_value = None
         mock_cache_cls.return_value = mock_cache
         mock_cache_cls.__name__ = "CacheManager"  # avoid MagicMock repr leaking
-        return FrameworkLoader()
+        return FrameworkLoader(service_container=ServiceContainer())
 
 
 @pytest.fixture
@@ -256,6 +288,114 @@ class TestProjectRootResolution:
         result = loader._filter_agents_by_manifest(deployed, real_project)
 
         assert result == [{"id": "engineer"}]
+
+
+class TestFrameworkLoaderContainerIsolation:
+    """Regression guard for a CI-only failure on PR #926.
+
+    WHAT: Asserts that ``_make_loader()`` (this module's test helper) gives
+    every loader an isolated ``ServiceContainer`` instead of the
+    process-global one, and that two loaders built via ``_make_loader()``
+    never end up sharing the same ``ICacheManager`` instance.
+
+    WHY: ``ServiceContainer`` registers ``ICacheManager``/``IPathResolver``/
+    ``IMemoryManager`` as SINGLETONs the first time they're resolved, and
+    ``get_global_container()`` is a module-level singleton that lives for
+    the whole pytest worker process. Under ``pytest -n auto`` (this repo's
+    CI/`make test` mode), some OTHER test file in the same worker may build
+    a real, unmocked ``FrameworkLoader()`` before this module's tests run.
+    If ``_make_loader()`` ever goes back to using the default/global
+    container, ``patch("claude_mpm.core.framework_loader.CacheManager")``
+    becomes a silent no-op for every loader after that first real one, and
+    every capabilities lookup in this file starts returning whatever the
+    real ``CacheManager`` singleton has cached -- in practice, the real
+    repo's full agent catalog. This exact failure mode is what broke CI on
+    PR #926: narrow local runs passed (nothing had primed the global
+    container yet), the full parallel suite failed (something already had).
+
+    These tests fail loudly if that isolation is ever accidentally removed.
+    """
+
+    def test_make_loader_does_not_use_the_global_container(self, isolated_project):
+        loader = _make_loader()
+
+        assert loader.container is not get_global_container(), (
+            "_make_loader() must construct FrameworkLoader with its own "
+            "ServiceContainer(), not the process-global one -- otherwise "
+            "the CacheManager patch above can be silently bypassed by "
+            "whatever registered ICacheManager first in this process "
+            "(see PR #926 CI failure: real repo's agent catalog leaking "
+            "into these tests)."
+        )
+
+    def test_two_loaders_do_not_share_a_cache_manager_instance(self, isolated_project):
+        loader_a = _make_loader()
+        loader_b = _make_loader()
+
+        assert loader_a._cache_manager is not loader_b._cache_manager, (
+            "Each _make_loader() call must get its own mocked CacheManager "
+            "instance. Two loaders sharing one means the global container's "
+            "SINGLETON caching is leaking across loaders -- exactly the "
+            "mechanism that let the real repo's cached capabilities string "
+            "leak into this module's tests in CI."
+        )
+
+    def test_capabilities_correct_even_when_a_real_loader_ran_first_in_process(
+        self, tmp_path, monkeypatch
+    ):
+        """Directly reproduces the CI failure mode.
+
+        Ordering matters here and mirrors what actually happened in CI: a
+        real, unmocked ``FrameworkLoader`` (as any other test file in the
+        full suite might build) runs FIRST -- while cwd is still wherever
+        the test process started, e.g. the real repo root -- and its real
+        ``CacheManager`` caches the real repo's capabilities string on the
+        process-global container's singleton. THEN this test's isolated
+        fixture project is created and chdir'd into. A properly-isolated
+        ``_make_loader()`` call must see this test's own fixture agent (via
+        the "Test agent engineer" description unique to ``_write_agent_md``),
+        not whatever the real loader cached beforehand -- the cache doesn't
+        care about cwd, so if the two loaders shared a ``CacheManager``, the
+        stale real string would win regardless of any project-root fix.
+        """
+        import claude_mpm.services.core.service_container as service_container_module
+        from claude_mpm.core.framework_loader import FrameworkLoader
+
+        # Reset the global container around this test only, so priming it
+        # here can't leak into unrelated tests that happen to run after
+        # this one in the same worker.
+        monkeypatch.setattr(service_container_module, "_global_container", None)
+
+        # Simulate "some other test built a real FrameworkLoader first" by
+        # constructing one against the (now-fresh) global container BEFORE
+        # this test's own project directory/chdir exist, and priming its
+        # capabilities cache.
+        real_loader = FrameworkLoader()
+        real_loader._generate_agent_capabilities_section()
+
+        # Now set up this test's isolated fixture project and chdir into it.
+        project_dir = tmp_path / "project"
+        fake_home = tmp_path / "fake_home"
+        project_dir.mkdir()
+        fake_home.mkdir()
+        monkeypatch.chdir(project_dir)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.delenv("CLAUDE_MPM_USER_PWD", raising=False)
+
+        agents_dir = project_dir / ".claude" / "agents"
+        _write_agent_md(agents_dir, "engineer")
+        write_agent_manifest(project_dir, ["engineer"])
+
+        # A properly-isolated loader must be unaffected by the cache primed
+        # above -- it must see THIS test's fixture agent, not the real
+        # repo's cached catalog.
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "Test agent engineer" in capabilities, (
+            "capabilities must reflect THIS test's fixture agent, not a "
+            "stale capabilities string cached by an earlier, unmocked "
+            "FrameworkLoader sharing the process-global container"
+        )
 
 
 class TestAgentManifestReadWrite:

--- a/tests/test_agent_manifest_filtering.py
+++ b/tests/test_agent_manifest_filtering.py
@@ -72,7 +72,14 @@ def isolated_project(tmp_path, monkeypatch):
     """Chdir into an isolated project directory and neutralize
     ``Path.home()`` so the real ``~/.claude/agents`` catalog on the
     developer/CI machine can't leak into assertions about the project's
-    deployed-agent set."""
+    deployed-agent set.
+
+    Also clears ``CLAUDE_MPM_USER_PWD``: when set (e.g. this very repo's dev
+    environment), ``PathResolver._get_working_dir()``/``find_project_root()``
+    prefer it over ``Path.cwd()``, which would otherwise silently point
+    project-root resolution back at the real repo instead of ``project_dir``
+    and break every test in this module.
+    """
     project_dir = tmp_path / "project"
     fake_home = tmp_path / "fake_home"
     project_dir.mkdir()
@@ -80,6 +87,7 @@ def isolated_project(tmp_path, monkeypatch):
 
     monkeypatch.chdir(project_dir)
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.delenv("CLAUDE_MPM_USER_PWD", raising=False)
 
     return project_dir
 
@@ -159,7 +167,7 @@ class TestFilterAgentsByManifestUnit:
         loader = _make_loader()
         deployed = [{"id": "engineer"}, {"id": "qa"}]
 
-        result = loader._filter_agents_by_manifest(deployed)
+        result = loader._filter_agents_by_manifest(deployed, isolated_project)
 
         assert result == deployed
 
@@ -168,7 +176,7 @@ class TestFilterAgentsByManifestUnit:
         loader = _make_loader()
         deployed = [{"id": "engineer"}, {"id": "qa"}]
 
-        result = loader._filter_agents_by_manifest(deployed)
+        result = loader._filter_agents_by_manifest(deployed, isolated_project)
 
         assert result == [{"id": "engineer"}]
 
@@ -187,9 +195,67 @@ class TestFilterAgentsByManifestUnit:
         loader = _make_loader()
         deployed = [{"id": "engineer"}, {"id": "qa"}]
 
-        result = loader._filter_agents_by_manifest(deployed)
+        result = loader._filter_agents_by_manifest(deployed, isolated_project)
 
         assert result == deployed
+
+
+class TestProjectRootResolution:
+    """Regression coverage: the manifest lookup must use the resolved
+    project root threaded in by ``_generate_agent_capabilities_section``,
+    not an independently-derived ``Path.cwd()``, so the two can't silently
+    disagree about which project they're looking at."""
+
+    def test_manifest_and_agents_found_from_a_subdirectory(self, tmp_path, monkeypatch):
+        """cwd inside a nested subdirectory of the project must still
+        resolve to the real project root (via a ``.git`` marker), so both
+        the deployed-agent glob and the manifest lookup find the right
+        files -- even though a bare ``Path.cwd()`` would look in
+        ``nested_cwd/.claude/agents`` (nonexistent) instead."""
+        project_dir = tmp_path / "project"
+        fake_home = tmp_path / "fake_home"
+        nested_cwd = project_dir / "subdir" / "nested"
+        project_dir.mkdir()
+        fake_home.mkdir()
+        nested_cwd.mkdir(parents=True)
+        (project_dir / ".git").mkdir()  # project-root marker for find_project_root
+
+        agents_dir = project_dir / ".claude" / "agents"
+        _write_agent_md(agents_dir, "engineer")
+        _write_agent_md(agents_dir, "python-engineer")
+        write_agent_manifest(project_dir, ["engineer"])
+
+        monkeypatch.chdir(nested_cwd)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.delenv("CLAUDE_MPM_USER_PWD", raising=False)
+
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "`engineer`" in capabilities
+        assert "`python-engineer`" not in capabilities
+
+    def test_filter_uses_passed_project_root_not_cwd(self, tmp_path, monkeypatch):
+        """_filter_agents_by_manifest must read the manifest from the
+        explicitly-passed project_root, not from Path.cwd()."""
+        real_project = tmp_path / "real_project"
+        elsewhere_cwd = tmp_path / "elsewhere"
+        real_project.mkdir()
+        elsewhere_cwd.mkdir()
+
+        write_agent_manifest(real_project, ["engineer"])
+
+        # cwd points somewhere else entirely -- a manifest lookup that
+        # incorrectly used Path.cwd() would find no manifest here and fail
+        # open (return the unfiltered list) instead of filtering.
+        monkeypatch.chdir(elsewhere_cwd)
+        monkeypatch.delenv("CLAUDE_MPM_USER_PWD", raising=False)
+
+        loader = _make_loader()
+        deployed = [{"id": "engineer"}, {"id": "qa"}]
+
+        result = loader._filter_agents_by_manifest(deployed, real_project)
+
+        assert result == [{"id": "engineer"}]
 
 
 class TestAgentManifestReadWrite:

--- a/tests/test_agent_manifest_filtering.py
+++ b/tests/test_agent_manifest_filtering.py
@@ -1,0 +1,264 @@
+"""Tests for per-project agent manifest filtering (issue #923).
+
+WHAT: Verifies that ``FrameworkLoader._generate_agent_capabilities_section``
+filters the deployed-agent catalog by ``.claude-mpm/agent_manifest.json``
+when the manifest is present, falls back to today's full-catalog behavior
+when it is absent, and tolerates manifest entries that reference agent IDs
+no longer present on disk. Also covers the ``agent_manifest`` module's
+write/read round trip in isolation.
+
+WHY: Issue #923 -- the PM's "Available Agent Capabilities" system prompt
+section previously exposed every ``.claude/agents/*.md`` file regardless of
+project relevance (~50 agents in practice). This module pins the filtering
+behavior added to ``framework_loader.py`` and the manifest persistence
+helpers in ``agent_manifest.py`` so both remain backward compatible for
+projects that never ran auto-configure.
+
+References
+----------
+GitHub issue: https://github.com/bobmatnyc/claude-mpm/issues/923
+LINK: none
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_mpm.services.agents.agent_manifest import (
+    get_manifest_path,
+    read_agent_manifest,
+    write_agent_manifest,
+)
+
+_AGENT_MD_TEMPLATE = """---
+name: {agent_id}
+description: Test agent {agent_id}
+model: sonnet
+---
+
+# {agent_id}
+
+Test agent instructions.
+"""
+
+
+def _write_agent_md(agents_dir: Path, agent_id: str) -> None:
+    """Write a minimal deployable agent .md file with YAML frontmatter."""
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{agent_id}.md").write_text(
+        _AGENT_MD_TEMPLATE.format(agent_id=agent_id), encoding="utf-8"
+    )
+
+
+def _make_loader():
+    """Build a FrameworkLoader with capability/metadata caching disabled so
+    each call regenerates from disk instead of returning a stale cached
+    string (mirrors the pattern used in test_local_agent_templates.py)."""
+    from claude_mpm.core.framework_loader import FrameworkLoader
+
+    with patch("claude_mpm.core.framework_loader.CacheManager") as mock_cache_cls:
+        mock_cache = MagicMock()
+        mock_cache.get_capabilities.return_value = None
+        mock_cache.get_agent_metadata.return_value = None
+        mock_cache_cls.return_value = mock_cache
+        mock_cache_cls.__name__ = "CacheManager"  # avoid MagicMock repr leaking
+        return FrameworkLoader()
+
+
+@pytest.fixture
+def isolated_project(tmp_path, monkeypatch):
+    """Chdir into an isolated project directory and neutralize
+    ``Path.home()`` so the real ``~/.claude/agents`` catalog on the
+    developer/CI machine can't leak into assertions about the project's
+    deployed-agent set."""
+    project_dir = tmp_path / "project"
+    fake_home = tmp_path / "fake_home"
+    project_dir.mkdir()
+    fake_home.mkdir()
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    return project_dir
+
+
+class TestCapabilitiesManifestFiltering:
+    """FrameworkLoader._generate_agent_capabilities_section manifest behavior."""
+
+    def test_manifest_present_filters_to_listed_agents(self, isolated_project):
+        """A manifest listing a subset of deployed agents narrows the
+        capabilities section to just that subset."""
+        agents_dir = isolated_project / ".claude" / "agents"
+        _write_agent_md(agents_dir, "engineer")
+        _write_agent_md(agents_dir, "python-engineer")
+        _write_agent_md(agents_dir, "rust-engineer")
+
+        write_agent_manifest(isolated_project, ["engineer", "python-engineer"])
+
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "`engineer`" in capabilities
+        assert "`python-engineer`" in capabilities
+        assert "`rust-engineer`" not in capabilities
+
+    def test_manifest_absent_keeps_full_catalog(self, isolated_project):
+        """Regression guard: with no manifest file, every deployed agent
+        still appears (today's pre-#923 behavior, unchanged)."""
+        agents_dir = isolated_project / ".claude" / "agents"
+        _write_agent_md(agents_dir, "engineer")
+        _write_agent_md(agents_dir, "python-engineer")
+        _write_agent_md(agents_dir, "rust-engineer")
+
+        manifest_path = get_manifest_path(isolated_project)
+        assert not manifest_path.exists()
+
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "`engineer`" in capabilities
+        assert "`python-engineer`" in capabilities
+        assert "`rust-engineer`" in capabilities
+
+    def test_manifest_referencing_missing_agent_id_does_not_crash(
+        self, isolated_project
+    ):
+        """A stale manifest entry for an agent ID that no longer exists on
+        disk must be skipped gracefully, not raise."""
+        agents_dir = isolated_project / ".claude" / "agents"
+        _write_agent_md(agents_dir, "engineer")
+
+        write_agent_manifest(isolated_project, ["engineer", "long-retired-agent-xyz"])
+
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "`engineer`" in capabilities
+        assert "long-retired-agent-xyz" not in capabilities
+
+    def test_empty_manifest_yields_no_agents_but_does_not_crash(self, isolated_project):
+        """An empty (but present) manifest filters every project-specific
+        agent out. ``generate_capabilities_section`` treats an empty
+        deployed-agent list the same as "no agents found" and returns its
+        generic fallback text -- this must not crash, and must not include
+        the project-specific agent that the manifest filtered out."""
+        agents_dir = isolated_project / ".claude" / "agents"
+        _write_agent_md(agents_dir, "python-engineer")
+
+        write_agent_manifest(isolated_project, [])
+
+        capabilities = _make_loader()._generate_agent_capabilities_section()
+
+        assert "Available Agent Capabilities" in capabilities
+        assert "`python-engineer`" not in capabilities
+
+
+class TestFilterAgentsByManifestUnit:
+    """Direct unit tests for FrameworkLoader._filter_agents_by_manifest."""
+
+    def test_returns_unchanged_list_without_manifest(self, isolated_project):
+        loader = _make_loader()
+        deployed = [{"id": "engineer"}, {"id": "qa"}]
+
+        result = loader._filter_agents_by_manifest(deployed)
+
+        assert result == deployed
+
+    def test_filters_by_manifest_ids(self, isolated_project):
+        write_agent_manifest(isolated_project, ["engineer"])
+        loader = _make_loader()
+        deployed = [{"id": "engineer"}, {"id": "qa"}]
+
+        result = loader._filter_agents_by_manifest(deployed)
+
+        assert result == [{"id": "engineer"}]
+
+    def test_manifest_read_error_falls_back_to_full_list(
+        self, isolated_project, monkeypatch
+    ):
+        """If reading the manifest raises for any reason, filtering must
+        fail open (return the unfiltered list) rather than propagate."""
+        import claude_mpm.services.agents.agent_manifest as agent_manifest_module
+
+        def _boom(_project_path):
+            raise RuntimeError("simulated read failure")
+
+        monkeypatch.setattr(agent_manifest_module, "read_agent_manifest", _boom)
+
+        loader = _make_loader()
+        deployed = [{"id": "engineer"}, {"id": "qa"}]
+
+        result = loader._filter_agents_by_manifest(deployed)
+
+        assert result == deployed
+
+
+class TestAgentManifestReadWrite:
+    """Unit tests for the agent_manifest module in isolation (no FrameworkLoader)."""
+
+    def test_read_returns_none_when_absent(self, tmp_path):
+        assert read_agent_manifest(tmp_path) is None
+
+    def test_write_then_read_round_trip_dedupes_and_sorts(self, tmp_path):
+        write_agent_manifest(tmp_path, ["qa", "engineer", "engineer"])
+
+        agent_ids = read_agent_manifest(tmp_path)
+
+        assert agent_ids == ["engineer", "qa"]
+
+    def test_write_creates_manifest_file_at_expected_path(self, tmp_path):
+        write_agent_manifest(tmp_path, ["engineer"])
+
+        expected = tmp_path / ".claude-mpm" / "agent_manifest.json"
+        assert expected.exists()
+
+        data = json.loads(expected.read_text(encoding="utf-8"))
+        assert data["agent_ids"] == ["engineer"]
+        assert "generated_at" in data
+        assert "schema_version" in data
+
+    def test_write_persists_toolchain_summary(self, tmp_path):
+        write_agent_manifest(
+            tmp_path,
+            ["python-engineer"],
+            toolchain_summary={"primary_language": "python"},
+        )
+
+        data = json.loads(get_manifest_path(tmp_path).read_text(encoding="utf-8"))
+        assert data["toolchain_summary"] == {"primary_language": "python"}
+
+    def test_read_returns_none_on_malformed_json(self, tmp_path):
+        manifest_dir = tmp_path / ".claude-mpm"
+        manifest_dir.mkdir()
+        (manifest_dir / "agent_manifest.json").write_text(
+            "{not valid json", encoding="utf-8"
+        )
+
+        assert read_agent_manifest(tmp_path) is None
+
+    def test_read_returns_none_when_agent_ids_key_missing(self, tmp_path):
+        manifest_dir = tmp_path / ".claude-mpm"
+        manifest_dir.mkdir()
+        (manifest_dir / "agent_manifest.json").write_text(
+            json.dumps({"schema_version": 1}), encoding="utf-8"
+        )
+
+        assert read_agent_manifest(tmp_path) is None
+
+    def test_read_returns_none_when_agent_ids_not_a_list(self, tmp_path):
+        manifest_dir = tmp_path / ".claude-mpm"
+        manifest_dir.mkdir()
+        (manifest_dir / "agent_manifest.json").write_text(
+            json.dumps({"agent_ids": "engineer"}), encoding="utf-8"
+        )
+
+        assert read_agent_manifest(tmp_path) is None
+
+    def test_read_ignores_non_string_entries(self, tmp_path):
+        manifest_dir = tmp_path / ".claude-mpm"
+        manifest_dir.mkdir()
+        (manifest_dir / "agent_manifest.json").write_text(
+            json.dumps({"agent_ids": ["engineer", 42, None, "qa"]}),
+            encoding="utf-8",
+        )
+
+        assert read_agent_manifest(tmp_path) == ["engineer", "qa"]


### PR DESCRIPTION
## Summary

Adds per-project agent manifest persistence to filter the agent capabilities list by project-specific configuration. After successful `agents auto-configure` or `agents deploy-auto` CLI deployments, a manifest is written to `.claude-mpm/agent_manifest.json` that explicitly lists which agents are active for that project.

## Implementation

- New `src/claude_mpm/services/agents/agent_manifest.py` with `write_agent_manifest`/`read_agent_manifest` helpers
- The manifest is written automatically after successful deployments via `agents auto-configure` (auto_config_manager.py) and `agents deploy-auto` (agent_selection_service.py)
- `framework_loader.py` gained `_filter_agents_by_manifest`, wired into `_generate_agent_capabilities_section`
- When a manifest exists, the capabilities list is filtered to manifest-listed agent IDs; falls back to full-catalog behavior when absent (fully backward compatible)
- Gracefully skips filtering if the manifest references a missing agent ID

## Testing

- 179 tests pass across all touched modules
- Plus a 37-passed/3-skipped framework_loader sweep
- Code passes ruff linter checks

Closes #923