### PR TITLE
fix: terminate stale MCP stdio servers on session pause

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/handlers/passthrough_handlers.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/passthrough_handlers.py
@@ -104,6 +104,16 @@ class PassthroughHandlers:
             f"Hook handler: Processing SessionStart - session: '{session_id}', pending_tasks: {session_start_data.get('pending_task_count', 0)}"
         )
 
+        # Capture live stdio MCP server PIDs for this session so `session pause`
+        # can terminate them cleanly (issue #927). Fail-open: the helper never
+        # raises, but wrap defensively so SessionStart handling is never blocked.
+        try:
+            from .session_start_mcp_handler import capture_session_mcp_pids
+
+            capture_session_mcp_pids(event)
+        except Exception as exc:  # nosec B110 - non-fatal MCP PID capture
+            _log(f"SessionStart MCP PID capture failed (non-fatal): {exc}")
+
         # Emit normalized event
         self.hook_handler._emit_socketio_event("", "session_start", session_start_data)
 

--- a/src/claude_mpm/hooks/claude_hooks/handlers/session_start_mcp_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/session_start_mcp_handler.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""SessionStart MCP-PID capture handler (issue #927).
+
+WHAT: On every Claude Code SessionStart event, discovers the live stdio-mode MCP
+server subprocesses Claude Code spawned for this project (trusty-memory,
+trusty-search, trusty-review, and any other stdio server declared in
+``.mcp.json``) and records their PIDs to
+``<project>/.claude-mpm/mcp-pids-<session_id>.json``.  ``claude-mpm session
+pause`` later reads those records to SIGTERM the stale servers cleanly.
+
+WHY: ``session pause`` runs as a standalone CLI invocation with no Claude Code
+hooks firing, and Claude Code owns the stdio MCP subprocesses.  Capturing the
+PIDs at session start is the only correlation point where the live servers and
+this session are both known, so pause can target exactly the right processes.
+
+CONVENTIONS: Mirrors ``stop_handler.py`` — fail-open (never raises to the hook
+dispatcher), with an always-on debug log so silent failures leave a paper trail.
+
+SESSION-ID CHOICE: We key the record file on the Claude Code ``session_id`` UUID
+from the SessionStart event (the natural per-session identifier available to
+hooks).  ``session pause`` has no way to correlate back to that UUID — it is a
+separate CLI process — so it globs ALL ``mcp-pids-*.json`` records for the
+project.  That is intentional and safe: pausing the project is a natural gate to
+reap every stdio MCP server spawned for it, and Claude Code simply respawns any
+still-active session's servers (picking up the current binary).
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Always-on debug log — same pattern as stop_handler._stop_debug so failures in
+# this fail-open handler remain visible without setting CLAUDE_MPM_HOOK_DEBUG.
+_MCP_DEBUG_LOG: Path = (
+    Path.home() / ".claude-mpm" / "logs" / "session-start-mcp-debug.log"
+)
+
+
+def _mcp_debug(message: str) -> None:
+    """Append *message* to the session-start MCP debug log, unconditionally."""
+    try:
+        _MCP_DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with _MCP_DEBUG_LOG.open("a") as fh:
+            fh.write(f"[{ts}] {message}\n")
+    except Exception:
+        pass  # Never raise from a debug helper.
+
+
+def capture_session_mcp_pids(event: dict) -> None:
+    """Capture stdio MCP server PIDs for a SessionStart *event*.
+
+    Fail-open: any error is logged to the debug file and swallowed so it can
+    never escape to the hook dispatcher.
+
+    Args:
+        event: The SessionStart hook event dict (uses ``session_id`` and
+            ``cwd``).
+    """
+    try:
+        session_id = event.get("session_id", "") or "unknown"
+        cwd = event.get("cwd", "") or str(Path.cwd())
+        project_dir = Path(cwd)
+
+        # Import lazily so the hook path stays cheap and self-contained.
+        from claude_mpm.services.cli.mcp_process_tracker import capture_session_pids
+
+        record_path = capture_session_pids(project_dir, session_id)
+        if record_path is None:
+            _mcp_debug(
+                f"capture_session_mcp_pids: no stdio MCP processes recorded "
+                f"(session={session_id!r} cwd={cwd!r})"
+            )
+        else:
+            _mcp_debug(
+                f"capture_session_mcp_pids: wrote {record_path} "
+                f"(session={session_id!r})"
+            )
+    except Exception as exc:  # nosec B110 - fail-open by design
+        _mcp_debug(f"capture_session_mcp_pids FAILED (fail-open): {exc}")

--- a/src/claude_mpm/services/cli/mcp_process_tracker.py
+++ b/src/claude_mpm/services/cli/mcp_process_tracker.py
@@ -1,0 +1,414 @@
+"""MCP stdio-server process tracking for session lifecycle cleanup (issue #927).
+
+WHAT: Discovers the stdio-mode MCP server subprocesses that Claude Code spawns
+for a session (``trusty-memory serve --stdio``, ``trusty-search serve --index
+<name>``, ``trusty-review serve --stdio``, and any other stdio server declared
+in ``.mcp.json``) and records their PIDs + live command lines so
+``claude-mpm session pause`` can terminate them cleanly later.
+
+WHY: ``claude-mpm session pause`` is a standalone CLI invocation — no Claude
+Code Stop/SessionEnd hooks fire during it, and Claude Code owns the stdio MCP
+subprocesses as its own children.  Without explicit PID tracking those servers
+are never terminated on pause and accumulate indefinitely, each pinned to
+whatever binary version was current when the session started (some observed
+running for weeks).
+
+SAFETY (critical):
+- We ONLY ever record/terminate processes whose live command line matches a
+  stdio-server invocation declared in the project's ``.mcp.json``.  Matching is
+  by full command-line signature (command basename + configured args), never by
+  process name alone.
+- The shared trusty-search HTTP daemon (``trusty-search start --foreground
+  --port 7878``) and the trusty-memory HTTP daemon (``trusty-memory serve
+  --foreground``) use DIFFERENT invocations and are therefore never matched.
+  As belt-and-suspenders we additionally exclude any candidate whose command
+  line contains ``--foreground`` or ``--port 7878``.
+- stdio invocations (e.g. ``trusty-memory serve --stdio``) are identical across
+  every project/session, so discovery additionally scopes to processes spawned
+  by THIS session's ``claude`` process via PPID ancestry — capturing another
+  concurrent session's identically-invoked server would let one project's pause
+  kill it.
+- Every function here is fail-open: missing ``pgrep``, malformed ``.mcp.json``,
+  or subprocess errors return empty/None rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - used only for pgrep/ps process discovery
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Command-line markers that identify the SHARED, long-lived HTTP daemons which
+# must NEVER be terminated by session cleanup.  Any candidate whose live cmdline
+# contains one of these is skipped regardless of signature match.
+_DAEMON_EXCLUSION_MARKERS = ("--foreground", "--port 7878")
+
+# Prefix for the per-session PID record files written under
+# ``<project>/.claude-mpm/``.
+_PID_FILE_PREFIX = "mcp-pids-"
+
+
+def _mcp_config_path(project_dir: Path) -> Path:
+    """Return the path to the project's ``.mcp.json`` file."""
+    return project_dir / ".mcp.json"
+
+
+def _pid_dir(project_dir: Path) -> Path:
+    """Return the ``.claude-mpm`` directory where PID records are stored."""
+    return project_dir / ".claude-mpm"
+
+
+def load_stdio_server_signatures(project_dir: Path) -> list[str]:
+    """Load command-line signatures for every stdio MCP server in ``.mcp.json``.
+
+    WHAT: Parses ``<project_dir>/.mcp.json`` and, for each server that runs in
+    stdio mode, builds a signature string of the form
+    ``"<command-basename> <arg1> <arg2> ..."`` (e.g.
+    ``"trusty-search serve --index tm-claude-mpm-01"``).  A server is treated as
+    stdio when its ``type`` is ``"stdio"``, or when ``type`` is absent but it
+    declares a ``command`` and no ``url`` (http/sse servers declare a ``url``).
+
+    WHY: The signature is the precise gate used to distinguish the short-lived
+    stdio MCP children (which we clean up) from the shared HTTP daemons and any
+    other process — a live process must contain this exact signature substring
+    to be considered a match.
+
+    Args:
+        project_dir: Project root containing ``.mcp.json``.
+
+    Returns:
+        List of signature strings.  Empty if the file is missing/unreadable or
+        no stdio servers are declared.
+    """
+    config_path = _mcp_config_path(project_dir)
+    try:
+        raw = config_path.read_text()
+    except OSError:
+        return []
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        return []
+
+    signatures: list[str] = []
+    for server in servers.values():
+        if not isinstance(server, dict):
+            continue
+        server_type = server.get("type")
+        # Skip explicit non-stdio transports.
+        if server_type in ("http", "sse") or "url" in server:
+            continue
+        # Accept "stdio" or an untyped server that declares a command.
+        command = server.get("command")
+        if not command or not isinstance(command, str):
+            continue
+        if server_type not in (None, "stdio"):
+            continue
+
+        args = server.get("args") or []
+        if not isinstance(args, list):
+            args = []
+        tokens = [Path(command).name, *[str(a) for a in args]]
+        signatures.append(" ".join(tokens))
+
+    return signatures
+
+
+def _pgrep_pids(pattern: str) -> list[int]:
+    """Return PIDs of processes whose full command line matches *pattern*.
+
+    Uses ``pgrep -f <pattern>`` which is portable across Linux and macOS/BSD
+    (both emit one PID per line).  We deliberately do NOT rely on ``pgrep -a``
+    to print command lines — BSD/macOS ``pgrep`` ignores ``-a`` and prints only
+    PIDs — instead the caller re-reads each PID's live command line via
+    :func:`get_process_cmdline` and filters on it.
+
+    Exit code 1 (no matches) and a missing ``pgrep`` binary are both treated as
+    "no results" rather than errors (fail-open).
+    """
+    if shutil.which("pgrep") is None:
+        return []
+    try:
+        result = subprocess.run(  # nosec B603, B607 - fixed argv, no shell
+            ["pgrep", "-f", pattern],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode not in (0, 1):
+        return []
+    pids: list[int] = []
+    for token in result.stdout.split():
+        try:
+            pids.append(int(token))
+        except ValueError:
+            continue
+    return pids
+
+
+def _is_excluded(cmdline: str) -> bool:
+    """True if *cmdline* looks like a shared HTTP daemon that must be preserved."""
+    return any(marker in cmdline for marker in _DAEMON_EXCLUSION_MARKERS)
+
+
+def _build_ppid_map() -> dict[int, int]:
+    """Return a ``{pid: ppid}`` map of every process, or {} on failure.
+
+    Uses ``ps -eo pid=,ppid=`` which is portable across Linux and macOS/BSD.
+    """
+    if shutil.which("ps") is None:
+        return {}
+    try:
+        result = subprocess.run(  # nosec B603, B607 - fixed argv, no shell
+            ["ps", "-eo", "pid=,ppid="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    ppid_map: dict[int, int] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        try:
+            ppid_map[int(parts[0])] = int(parts[1])
+        except ValueError:
+            continue
+    return ppid_map
+
+
+def _ancestor_pids(pid: int, ppid_map: dict[int, int]) -> set[int]:
+    """Return the set of ancestor PIDs of *pid* (parent, grandparent, ...).
+
+    Walks the ``ppid_map`` chain with a cycle/iteration guard.  The universal
+    roots 0 and 1 are intentionally EXCLUDED: detached daemons (started with
+    ``start_new_session=True``) reparent to init/launchd (ppid 1), so treating
+    pid 1 as an "ancestor" would wrongly claim ownership of the shared daemons.
+    """
+    ancestors: set[int] = set()
+    current = pid
+    for _ in range(64):  # generous depth cap; guards against cycles
+        parent = ppid_map.get(current)
+        if parent is None or parent in (0, 1) or parent in ancestors:
+            break
+        ancestors.add(parent)
+        current = parent
+    return ancestors
+
+
+def _session_owned_pids(candidate_pids: set[int]) -> set[int] | None:
+    """Return the subset of *candidate_pids* spawned by THIS Claude Code session.
+
+    WHAT: Builds a process table and computes the ancestry of the current
+    process (the SessionStart hook runs as a descendant of the session's
+    ``claude`` process).  A candidate MCP server belongs to this session iff its
+    PARENT is one of our ancestors — the session's ``claude`` process is both
+    the direct parent of the stdio MCP servers it spawned AND an ancestor of
+    this hook.
+
+    WHY: stdio invocations like ``trusty-memory serve --stdio`` are IDENTICAL
+    across every project/session (the palace is selected via an env var, not the
+    command line), so a signature match alone would capture other live sessions'
+    servers and pausing one project would kill them.  PPID-ancestry scoping
+    restricts capture to exactly this session's children.
+
+    Returns:
+        The owned subset, or ``None`` if session ownership cannot be determined
+        (process table unavailable or no usable ancestry) — the caller then
+        falls back to signature-only matching.
+    """
+    ppid_map = _build_ppid_map()
+    if not ppid_map:
+        return None
+    ancestors = _ancestor_pids(os.getpid(), ppid_map)
+    if not ancestors:
+        return None
+    return {pid for pid in candidate_pids if ppid_map.get(pid) in ancestors}
+
+
+def discover_stdio_mcp_processes(project_dir: Path) -> list[dict[str, Any]]:
+    """Discover live stdio MCP server processes for THIS session.
+
+    WHAT: Loads stdio server signatures from ``.mcp.json`` and, for each, uses
+    ``pgrep -f`` on the command basename to find candidate PIDs, then re-reads
+    each PID's live command line (via ``ps``) and keeps only those whose command
+    line contains the full signature substring and does NOT look like a shared
+    HTTP daemon.  Finally, when session ownership can be determined, restricts
+    the result to processes spawned by this session's ``claude`` process (see
+    :func:`_session_owned_pids`).
+
+    WHY: This is the discovery half of the #927 fix — it produces the exact set
+    of PIDs (with their live command lines) that session pause is later allowed
+    to terminate.  Re-reading the cmdline per PID (rather than trusting
+    ``pgrep -a``) is required for macOS/BSD portability, where ``pgrep`` prints
+    only PIDs.  PPID scoping prevents capturing other concurrent sessions'
+    identically-invoked stdio servers.
+
+    Args:
+        project_dir: Project root containing ``.mcp.json``.
+
+    Returns:
+        List of dicts, each with keys ``pid`` (int), ``cmdline`` (str, the live
+        command line), and ``signature`` (str, the matched ``.mcp.json``
+        signature).  Deduplicated by PID.  Empty on any failure.
+    """
+    signatures = load_stdio_server_signatures(project_dir)
+    if not signatures:
+        return []
+
+    self_pid = os.getpid()
+    seen_pids: set[int] = set()
+    processes: list[dict[str, Any]] = []
+
+    for signature in signatures:
+        # Use the first token (command basename) as the pgrep pattern, then
+        # confirm the match against the PID's live command line in Python — this
+        # avoids treating regex metacharacters in the signature as patterns and
+        # behaves identically on Linux and macOS.
+        basename = signature.split(" ", 1)[0]
+        for pid in _pgrep_pids(basename):
+            if pid in seen_pids or pid == self_pid or pid <= 0:
+                continue
+            cmdline = get_process_cmdline(pid)
+            if cmdline is None:
+                continue
+            if signature not in cmdline:
+                continue
+            if _is_excluded(cmdline):
+                continue
+            seen_pids.add(pid)
+            processes.append({"pid": pid, "cmdline": cmdline, "signature": signature})
+
+    # Restrict to this session's own children when ownership is determinable.
+    owned = _session_owned_pids(seen_pids)
+    if owned is not None:
+        processes = [p for p in processes if p["pid"] in owned]
+
+    return processes
+
+
+def write_pid_file(
+    project_dir: Path, session_id: str, processes: list[dict[str, Any]]
+) -> Path | None:
+    """Write discovered *processes* to ``.claude-mpm/mcp-pids-<session_id>.json``.
+
+    Creates ``.claude-mpm/`` if needed.  Returns the written path, or None on
+    failure (fail-open).  A record is always written when there are processes;
+    with an empty *processes* list this is a no-op returning None so we do not
+    litter empty files.
+    """
+    if not processes:
+        return None
+
+    safe_session = _sanitize_session_id(session_id)
+    pid_dir = _pid_dir(project_dir)
+    try:
+        pid_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    record = {
+        "session_id": session_id,
+        "project_dir": str(project_dir),
+        "captured_at": datetime.now(UTC).isoformat(),
+        "processes": processes,
+    }
+    target = pid_dir / f"{_PID_FILE_PREFIX}{safe_session}.json"
+    try:
+        target.write_text(json.dumps(record, indent=2))
+    except OSError:
+        return None
+    return target
+
+
+def _sanitize_session_id(session_id: str) -> str:
+    """Return a filesystem-safe token derived from *session_id*.
+
+    Keeps alphanumerics, dashes and underscores; replaces everything else with
+    ``-``.  Falls back to ``"unknown"`` for an empty id.
+    """
+    if not session_id:
+        return "unknown"
+    return "".join(c if (c.isalnum() or c in "-_") else "-" for c in session_id)
+
+
+def capture_session_pids(project_dir: Path, session_id: str) -> Path | None:
+    """Discover stdio MCP processes and persist them for *session_id*.
+
+    Convenience wrapper combining :func:`discover_stdio_mcp_processes` and
+    :func:`write_pid_file`.  Returns the written record path or None.
+    """
+    processes = discover_stdio_mcp_processes(project_dir)
+    return write_pid_file(project_dir, session_id, processes)
+
+
+def iter_pid_files(project_dir: Path) -> list[Path]:
+    """Return all ``mcp-pids-*.json`` record files under ``.claude-mpm/``."""
+    pid_dir = _pid_dir(project_dir)
+    if not pid_dir.is_dir():
+        return []
+    try:
+        return sorted(pid_dir.glob(f"{_PID_FILE_PREFIX}*.json"))
+    except OSError:
+        return []
+
+
+def process_is_alive(pid: int) -> bool:
+    """Return True if a process with *pid* currently exists.
+
+    Uses ``os.kill(pid, 0)`` which sends no signal but performs the existence +
+    permission check.  Returns False for a missing process and True for a
+    process we lack permission to signal (EPERM means it exists).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def get_process_cmdline(pid: int) -> str | None:
+    """Return the live command line for *pid*, or None if unavailable.
+
+    Uses ``ps -p <pid> -o command=`` which works on both macOS/BSD and Linux.
+    Returns None if the process is gone, ``ps`` is missing, or the call fails.
+    """
+    if pid <= 0 or shutil.which("ps") is None:
+        return None
+    try:
+        result = subprocess.run(  # nosec B603, B607 - fixed argv, no shell
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    cmdline = result.stdout.strip()
+    return cmdline or None

--- a/src/claude_mpm/services/cli/session_pause_manager.py
+++ b/src/claude_mpm/services/cli/session_pause_manager.py
@@ -34,7 +34,9 @@ DESIGN DECISIONS:
 """
 
 import json
+import os
 import shutil
+import signal
 import subprocess  # nosec B404 - required for git operations
 from datetime import UTC, datetime
 from pathlib import Path
@@ -151,8 +153,139 @@ class SessionPauseManager:
             except Exception as exc:  # nosec B110 - intentional non-fatal wrapper
                 logger.warning("Worktree pruning failed (non-fatal): %s", exc)
 
+        # Terminate tracked stdio MCP servers spawned by Claude Code for this
+        # project (issue #927).  Failures are non-fatal — pause must never fail
+        # because of MCP cleanup — mirroring the worktree-prune wrapper above.
+        try:
+            term_summary = self._terminate_mcp_servers()
+            logger.info(
+                "MCP server cleanup: terminated=%d skipped=%d files=%d",
+                term_summary["terminated"],
+                term_summary["skipped"],
+                term_summary["files_processed"],
+            )
+            state["mcp_termination_summary"] = term_summary
+        except Exception as exc:  # nosec B110 - intentional non-fatal wrapper
+            logger.warning("MCP server cleanup failed (non-fatal): %s", exc)
+
         logger.info(f"Pause session created: {session_id}")
         return session_id
+
+    # ------------------------------------------------------------------
+    # MCP stdio-server cleanup (issue #927)
+    # ------------------------------------------------------------------
+
+    def _terminate_mcp_servers(self) -> dict[str, Any]:
+        """Terminate stdio MCP servers recorded for this project at pause time.
+
+        WHAT: Reads every ``.claude-mpm/mcp-pids-*.json`` record written by the
+        SessionStart hook for this project.  For each recorded process it
+        (1) verifies the PID is still alive, (2) re-reads the live command line
+        and confirms the recorded signature is still present (guards against a
+        recycled PID now belonging to an unrelated process), and only then
+        (3) sends ``SIGTERM``.  Consumed record files are deleted afterwards so
+        stale entries do not accumulate.
+
+        WHY: ``session pause`` is a standalone CLI invocation with no Claude
+        Code hooks; the stdio MCP subprocesses are Claude Code's children and
+        are otherwise never reaped, piling up over time (issue #927).  Only
+        PIDs explicitly recorded for this project are ever signaled, and only
+        after the live cmdline is re-validated — we never kill by process name.
+        SIGTERM (not SIGKILL) lets these cooperating stdio servers exit cleanly;
+        Claude Code is free to respawn any it still needs on the current binary.
+
+        Returns:
+            Summary dict with keys ``terminated`` (int), ``skipped`` (int),
+            ``files_processed`` (int), and ``processes`` (list of per-process
+            decision records).
+        """
+        from claude_mpm.services.cli import mcp_process_tracker as tracker
+
+        summary: dict[str, Any] = {
+            "terminated": 0,
+            "skipped": 0,
+            "files_processed": 0,
+            "processes": [],
+        }
+
+        pid_files = tracker.iter_pid_files(self.project_path)
+        for pid_file in pid_files:
+            summary["files_processed"] += 1
+            try:
+                record = json.loads(pid_file.read_text())
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                logger.warning(
+                    "MCP cleanup: could not read %s (non-fatal): %s", pid_file, exc
+                )
+                # Remove unreadable/corrupt record so it does not accumulate.
+                self._delete_pid_file(pid_file)
+                continue
+
+            for entry in record.get("processes", []):
+                decision = self._terminate_one_mcp_process(entry, tracker)
+                summary["processes"].append(decision)
+                if decision["action"] == "terminated":
+                    summary["terminated"] += 1
+                else:
+                    summary["skipped"] += 1
+
+            # The record has been consumed — clean it up regardless of outcome.
+            self._delete_pid_file(pid_file)
+
+        return summary
+
+    def _terminate_one_mcp_process(
+        self, entry: dict[str, Any], tracker: Any
+    ) -> dict[str, Any]:
+        """Validate and SIGTERM a single recorded MCP process entry.
+
+        Returns a decision record with ``pid``, ``action``
+        (``"terminated"`` | ``"skipped"``), and ``reason``.
+        """
+        pid = entry.get("pid")
+        signature = entry.get("signature") or entry.get("cmdline") or ""
+
+        if not isinstance(pid, int) or pid <= 0:
+            return {"pid": pid, "action": "skipped", "reason": "invalid pid"}
+
+        # Rule 1: process must still be alive.
+        if not tracker.process_is_alive(pid):
+            return {"pid": pid, "action": "skipped", "reason": "process not running"}
+
+        # Rule 2: live cmdline must still match the recorded signature — this is
+        # the recycled-PID guard.  If the PID now belongs to an unrelated
+        # process, the signature will not be present and we must NOT signal it.
+        live_cmdline = tracker.get_process_cmdline(pid)
+        if live_cmdline is None:
+            return {
+                "pid": pid,
+                "action": "skipped",
+                "reason": "could not read live cmdline",
+            }
+        if signature and signature not in live_cmdline:
+            return {
+                "pid": pid,
+                "action": "skipped",
+                "reason": "live cmdline no longer matches (recycled pid)",
+            }
+
+        # Rule 3: SIGTERM only — cooperating stdio servers exit cleanly.
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return {"pid": pid, "action": "skipped", "reason": "process exited"}
+        except OSError as exc:
+            return {"pid": pid, "action": "skipped", "reason": f"kill failed: {exc}"}
+
+        logger.info("MCP cleanup: sent SIGTERM to pid %d (%s)", pid, signature)
+        return {"pid": pid, "action": "terminated", "reason": "SIGTERM sent"}
+
+    def _delete_pid_file(self, pid_file: Path) -> None:
+        """Delete a consumed MCP PID record file (non-fatal on error)."""
+        try:
+            pid_file.unlink()
+        except OSError as exc:
+            logger.debug("MCP cleanup: could not remove %s: %s", pid_file, exc)
 
     # ------------------------------------------------------------------
     # Worktree pruning

--- a/tests/test_mcp_process_tracker.py
+++ b/tests/test_mcp_process_tracker.py
@@ -1,0 +1,338 @@
+"""Tests for MCP stdio-server process tracking (issue #927).
+
+WHAT: Exercises signature parsing from ``.mcp.json``, live-process discovery
+via a mocked ``pgrep``, and the PID-record writer in
+``claude_mpm.services.cli.mcp_process_tracker``.
+
+WHY: Discovery is safety-critical — it must record only the short-lived stdio
+MCP children and never the shared HTTP daemons.  These tests mock the process
+table so the distinction is validated deterministically.
+
+    uv run pytest -p no:xdist tests/test_mcp_process_tracker.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - used at runtime in signatures
+
+import pytest  # noqa: TC002 - used at runtime as fixture type annotation
+
+from claude_mpm.services.cli import mcp_process_tracker as tracker
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+# A realistic .mcp.json: two stdio servers plus one HTTP server (url-based).
+_MCP_JSON = {
+    "mcpServers": {
+        "trusty-memory": {
+            "command": "trusty-memory",
+            "args": ["serve", "--stdio"],
+            "type": "stdio",
+        },
+        "trusty-search": {
+            "command": "trusty-search",
+            "args": ["serve", "--index", "tm-claude-mpm-01"],
+            "type": "stdio",
+        },
+        "some-http": {
+            "type": "http",
+            "url": "https://example.com/mcp",
+        },
+    }
+}
+
+
+def _write_mcp_json(project_dir: Path, data: dict) -> None:
+    (project_dir / ".mcp.json").write_text(json.dumps(data))
+
+
+def _install_fake_proc_table(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    """Wire the ``pgrep``/``ps`` seam to a fake process table.
+
+    *lines* are ``"<pid> <cmdline>"`` strings.  ``_pgrep_pids`` returns the PIDs
+    whose cmdline contains the search pattern (mimicking ``pgrep -f``), and
+    ``get_process_cmdline`` maps a PID back to its cmdline (mimicking ``ps``).
+    PPID-ancestry scoping is disabled (``_session_owned_pids`` -> None) so these
+    fixtures exercise the signature/exclusion logic in isolation; ownership
+    scoping has its own dedicated tests.
+    """
+    table: dict[int, str] = {}
+    for line in lines:
+        pid_str, cmdline = line.split(" ", 1)
+        table[int(pid_str)] = cmdline
+
+    def _fake_pgrep_pids(pattern: str) -> list[int]:
+        return [pid for pid, cmd in table.items() if pattern in cmd]
+
+    def _fake_cmdline(pid: int) -> str | None:
+        return table.get(pid)
+
+    monkeypatch.setattr(tracker, "_pgrep_pids", _fake_pgrep_pids)
+    monkeypatch.setattr(tracker, "get_process_cmdline", _fake_cmdline)
+    monkeypatch.setattr(tracker, "_session_owned_pids", lambda _pids: None)
+
+
+# ---------------------------------------------------------------------------
+# Signature parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_signatures_extracts_stdio_only(tmp_path: Path) -> None:
+    _write_mcp_json(tmp_path, _MCP_JSON)
+    sigs = tracker.load_stdio_server_signatures(tmp_path)
+    assert "trusty-memory serve --stdio" in sigs
+    assert "trusty-search serve --index tm-claude-mpm-01" in sigs
+    # HTTP (url-based) server is excluded.
+    assert all("example.com" not in s for s in sigs)
+    assert len(sigs) == 2
+
+
+def test_load_signatures_uses_command_basename(tmp_path: Path) -> None:
+    _write_mcp_json(
+        tmp_path,
+        {
+            "mcpServers": {
+                "m": {
+                    "command": "/Users/x/.cargo/bin/trusty-memory",
+                    "args": ["serve", "--stdio"],
+                    "type": "stdio",
+                }
+            }
+        },
+    )
+    sigs = tracker.load_stdio_server_signatures(tmp_path)
+    assert sigs == ["trusty-memory serve --stdio"]
+
+
+def test_load_signatures_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert tracker.load_stdio_server_signatures(tmp_path) == []
+
+
+def test_load_signatures_malformed_json_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text("{not json")
+    assert tracker.load_stdio_server_signatures(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Discovery — the core safety behavior
+# ---------------------------------------------------------------------------
+
+
+def test_discover_matches_stdio_and_excludes_http_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_mcp_json(tmp_path, _MCP_JSON)
+
+    lines = [
+        # stdio children — should be matched.
+        "1001 trusty-memory serve --stdio",
+        "1002 trusty-search serve --index tm-claude-mpm-01",
+        # shared HTTP daemons — must NEVER match.
+        "2001 trusty-memory serve --foreground",
+        "2002 /Users/x/.cargo/bin/trusty-search start --foreground --no-auto-discover --port 7878",
+        # unrelated process sharing a name fragment but not the signature.
+        "3001 trusty-search reindex --index other",
+    ]
+    _install_fake_proc_table(monkeypatch, lines)
+
+    procs = tracker.discover_stdio_mcp_processes(tmp_path)
+    pids = {p["pid"] for p in procs}
+
+    assert pids == {1001, 1002}
+    # HTTP daemons and unrelated processes excluded.
+    assert 2001 not in pids
+    assert 2002 not in pids
+    assert 3001 not in pids
+
+
+def test_discover_records_live_cmdline_and_signature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_mcp_json(tmp_path, _MCP_JSON)
+    lines = ["1001 trusty-memory serve --stdio"]
+    _install_fake_proc_table(monkeypatch, lines)
+
+    procs = tracker.discover_stdio_mcp_processes(tmp_path)
+    assert len(procs) == 1
+    assert procs[0]["pid"] == 1001
+    assert procs[0]["cmdline"] == "trusty-memory serve --stdio"
+    assert procs[0]["signature"] == "trusty-memory serve --stdio"
+
+
+def test_discover_deduplicates_pids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_mcp_json(tmp_path, _MCP_JSON)
+    # Same PID matched by two signature searches — should appear once. The PID's
+    # cmdline contains both command names so both basename searches surface it.
+    monkeypatch.setattr(tracker, "_pgrep_pids", lambda _pattern: [1001, 1001])
+    monkeypatch.setattr(
+        tracker,
+        "get_process_cmdline",
+        lambda _pid: (
+            "trusty-memory serve --stdio trusty-search serve --index tm-claude-mpm-01"
+        ),
+    )
+    monkeypatch.setattr(tracker, "_session_owned_pids", lambda _pids: None)
+
+    procs = tracker.discover_stdio_mcp_processes(tmp_path)
+    assert len(procs) == 1
+
+
+# ---------------------------------------------------------------------------
+# PPID-ancestry session scoping
+# ---------------------------------------------------------------------------
+
+
+def test_ancestor_pids_excludes_init_roots() -> None:
+    # 500 -> 400 -> 300 -> 1 (init).  pid 1 and 0 must NOT be ancestors.
+    ppid_map = {500: 400, 400: 300, 300: 1, 1: 0}
+    ancestors = tracker._ancestor_pids(500, ppid_map)
+    assert ancestors == {400, 300}
+    assert 1 not in ancestors
+    assert 0 not in ancestors
+
+
+def test_ancestor_pids_handles_cycle() -> None:
+    ppid_map = {10: 20, 20: 10}  # pathological cycle
+    # The guard must TERMINATE (no infinite loop) and return a bounded set.
+    ancestors = tracker._ancestor_pids(10, ppid_map)
+    assert ancestors == {10, 20}
+
+
+def test_session_owned_pids_scopes_to_our_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Our hook is pid 900, whose ancestor claude is 800.
+    # 111 is a sibling session's server (parent 700 — not our ancestor).
+    ppid_map = {
+        900: 800,  # us -> claude(800)
+        800: 1,  # claude -> init
+        100: 800,  # our MCP server (child of our claude)
+        111: 700,  # other session's MCP server (child of other claude)
+        700: 1,
+    }
+    monkeypatch.setattr(tracker, "_build_ppid_map", lambda: ppid_map)
+    monkeypatch.setattr(tracker.os, "getpid", lambda: 900)
+
+    owned = tracker._session_owned_pids({100, 111})
+    assert owned == {100}
+
+
+def test_session_owned_pids_none_when_table_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tracker, "_build_ppid_map", dict)
+    assert tracker._session_owned_pids({1, 2, 3}) is None
+
+
+def test_discover_scopes_out_other_session_processes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_mcp_json(tmp_path, _MCP_JSON)
+    # Two sessions run an identical `trusty-memory serve --stdio`; only 100 is
+    # a child of our session.
+    table = {100: "trusty-memory serve --stdio", 111: "trusty-memory serve --stdio"}
+    monkeypatch.setattr(
+        tracker,
+        "_pgrep_pids",
+        lambda pattern: [p for p, c in table.items() if pattern in c],
+    )
+    monkeypatch.setattr(tracker, "get_process_cmdline", table.get)
+    # Ownership: only 100 is our child.
+    monkeypatch.setattr(tracker, "_session_owned_pids", lambda pids: {100} & pids)
+
+    procs = tracker.discover_stdio_mcp_processes(tmp_path)
+    assert {p["pid"] for p in procs} == {100}
+
+
+def test_discover_no_signatures_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No .mcp.json → no signatures → no discovery, pgrep never consulted.
+    called = {"hit": False}
+
+    def _boom(_pattern: str) -> list[int]:
+        called["hit"] = True
+        return []
+
+    monkeypatch.setattr(tracker, "_pgrep_pids", _boom)
+    assert tracker.discover_stdio_mcp_processes(tmp_path) == []
+    assert called["hit"] is False
+
+
+def test_pgrep_pids_handles_missing_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tracker.shutil, "which", lambda _name: None)
+    # Must never raise even though pgrep is "missing".
+    assert tracker._pgrep_pids("trusty-memory") == []
+
+
+# ---------------------------------------------------------------------------
+# PID-record writer
+# ---------------------------------------------------------------------------
+
+
+def test_write_pid_file_creates_record(tmp_path: Path) -> None:
+    procs = [
+        {"pid": 1001, "cmdline": "trusty-memory serve --stdio", "signature": "sig"}
+    ]
+    path = tracker.write_pid_file(tmp_path, "abc-123", procs)
+    assert path is not None
+    assert path.name == "mcp-pids-abc-123.json"
+
+    record = json.loads(path.read_text())
+    assert record["session_id"] == "abc-123"
+    assert record["processes"][0]["pid"] == 1001
+    assert "captured_at" in record
+
+
+def test_write_pid_file_empty_processes_is_noop(tmp_path: Path) -> None:
+    assert tracker.write_pid_file(tmp_path, "abc", []) is None
+    assert (
+        list((tmp_path / ".claude-mpm").glob("*.json")) == []
+        or not (tmp_path / ".claude-mpm").exists()
+    )
+
+
+def test_write_pid_file_sanitizes_session_id(tmp_path: Path) -> None:
+    procs = [{"pid": 1, "cmdline": "x", "signature": "x"}]
+    path = tracker.write_pid_file(tmp_path, "weird/../id", procs)
+    assert path is not None
+    # No path separators leak into the filename.
+    assert "/" not in path.name
+    assert path.parent == tmp_path / ".claude-mpm"
+
+
+def test_iter_pid_files_finds_records(tmp_path: Path) -> None:
+    procs = [{"pid": 1, "cmdline": "x", "signature": "x"}]
+    tracker.write_pid_file(tmp_path, "s1", procs)
+    tracker.write_pid_file(tmp_path, "s2", procs)
+    files = tracker.iter_pid_files(tmp_path)
+    assert len(files) == 2
+    assert all(f.name.startswith("mcp-pids-") for f in files)
+
+
+def test_iter_pid_files_missing_dir(tmp_path: Path) -> None:
+    assert tracker.iter_pid_files(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# process_is_alive / get_process_cmdline against the current process
+# ---------------------------------------------------------------------------
+
+
+def test_process_is_alive_true_for_self() -> None:
+    import os
+
+    assert tracker.process_is_alive(os.getpid()) is True
+
+
+def test_process_is_alive_false_for_bad_pid() -> None:
+    assert tracker.process_is_alive(-1) is False
+    # A very high PID is almost certainly not in use.
+    assert tracker.process_is_alive(2_000_000_000) is False

--- a/tests/test_session_pause_mcp_cleanup.py
+++ b/tests/test_session_pause_mcp_cleanup.py
@@ -1,0 +1,250 @@
+"""Tests for stdio-MCP cleanup in SessionPauseManager (issue #927).
+
+WHAT: Exercises ``SessionPauseManager._terminate_mcp_servers()`` and its
+integration into ``create_pause_session()`` — recorded PIDs are SIGTERM'd only
+when the live command line still matches, recycled PIDs are skipped, failures
+never propagate, and pause always succeeds.
+
+WHY: Killing the wrong process (a recycled PID, or the shared HTTP daemon) is a
+correctness/safety hazard.  These tests mock the process table + signal path so
+the validation gates are verified deterministically.
+
+    uv run pytest -p no:xdist tests/test_session_pause_mcp_cleanup.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+from pathlib import Path  # noqa: TC003 - used at runtime in signatures
+
+import pytest  # noqa: TC002 - used at runtime as fixture type annotation
+
+from claude_mpm.services.cli import mcp_process_tracker as tracker
+from claude_mpm.services.cli.session_pause_manager import SessionPauseManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_pid_record(
+    project_dir: Path, session_id: str, processes: list[dict]
+) -> Path:
+    """Write an mcp-pids record file directly (bypassing discovery)."""
+    pid_dir = project_dir / ".claude-mpm"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    path = pid_dir / f"mcp-pids-{session_id}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "project_dir": str(project_dir),
+                "captured_at": "2026-01-01T00:00:00+00:00",
+                "processes": processes,
+            }
+        )
+    )
+    return path
+
+
+class _KillRecorder:
+    """Captures os.kill(pid, sig) calls in place of the real signal."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int]] = []
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+
+
+# ---------------------------------------------------------------------------
+# Termination gates
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_signals_matching_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pid_record(
+        tmp_path,
+        "s1",
+        [
+            {
+                "pid": 4242,
+                "cmdline": "trusty-memory serve --stdio",
+                "signature": "trusty-memory serve --stdio",
+            }
+        ],
+    )
+
+    monkeypatch.setattr(tracker, "process_is_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        tracker, "get_process_cmdline", lambda _pid: "trusty-memory serve --stdio"
+    )
+    killer = _KillRecorder()
+    monkeypatch.setattr(os, "kill", killer)
+
+    mgr = SessionPauseManager(project_path=tmp_path)
+    summary = mgr._terminate_mcp_servers()
+
+    assert summary["terminated"] == 1
+    assert summary["skipped"] == 0
+    # Exactly one SIGTERM (never SIGKILL) to the recorded PID.
+    assert killer.calls == [(4242, signal.SIGTERM)]
+    # Record file consumed.
+    assert tracker.iter_pid_files(tmp_path) == []
+
+
+def test_terminate_uses_sigterm_not_sigkill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pid_record(
+        tmp_path,
+        "s1",
+        [
+            {
+                "pid": 55,
+                "cmdline": "trusty-memory serve --stdio",
+                "signature": "trusty-memory serve --stdio",
+            }
+        ],
+    )
+    monkeypatch.setattr(tracker, "process_is_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        tracker, "get_process_cmdline", lambda _pid: "trusty-memory serve --stdio"
+    )
+    killer = _KillRecorder()
+    monkeypatch.setattr(os, "kill", killer)
+
+    SessionPauseManager(project_path=tmp_path)._terminate_mcp_servers()
+
+    assert all(sig == signal.SIGTERM for _pid, sig in killer.calls)
+    assert all(sig != signal.SIGKILL for _pid, sig in killer.calls)
+
+
+def test_terminate_skips_recycled_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pid_record(
+        tmp_path,
+        "s1",
+        [
+            {
+                "pid": 4242,
+                "cmdline": "trusty-memory serve --stdio",
+                "signature": "trusty-memory serve --stdio",
+            }
+        ],
+    )
+
+    monkeypatch.setattr(tracker, "process_is_alive", lambda _pid: True)
+    # PID is alive but now belongs to something unrelated (recycled).
+    monkeypatch.setattr(
+        tracker, "get_process_cmdline", lambda _pid: "/usr/bin/python somethingelse"
+    )
+    killer = _KillRecorder()
+    monkeypatch.setattr(os, "kill", killer)
+
+    summary = SessionPauseManager(project_path=tmp_path)._terminate_mcp_servers()
+
+    assert summary["terminated"] == 0
+    assert summary["skipped"] == 1
+    # Critically: no signal sent to the recycled PID.
+    assert killer.calls == []
+
+
+def test_terminate_skips_dead_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pid_record(
+        tmp_path,
+        "s1",
+        [
+            {
+                "pid": 999,
+                "cmdline": "trusty-memory serve --stdio",
+                "signature": "trusty-memory serve --stdio",
+            }
+        ],
+    )
+    monkeypatch.setattr(tracker, "process_is_alive", lambda _pid: False)
+    killer = _KillRecorder()
+    monkeypatch.setattr(os, "kill", killer)
+
+    summary = SessionPauseManager(project_path=tmp_path)._terminate_mcp_servers()
+
+    assert summary["terminated"] == 0
+    assert summary["skipped"] == 1
+    assert killer.calls == []
+
+
+def test_terminate_no_records_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    killer = _KillRecorder()
+    monkeypatch.setattr(os, "kill", killer)
+    summary = SessionPauseManager(project_path=tmp_path)._terminate_mcp_servers()
+    assert summary == {
+        "terminated": 0,
+        "skipped": 0,
+        "files_processed": 0,
+        "processes": [],
+    }
+    assert killer.calls == []
+
+
+def test_terminate_removes_corrupt_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pid_dir = tmp_path / ".claude-mpm"
+    pid_dir.mkdir(parents=True)
+    bad = pid_dir / "mcp-pids-bad.json"
+    bad.write_text("{not valid json")
+
+    summary = SessionPauseManager(project_path=tmp_path)._terminate_mcp_servers()
+    assert summary["files_processed"] == 1
+    # Corrupt record cleaned up so it does not accumulate.
+    assert not bad.exists()
+
+
+# ---------------------------------------------------------------------------
+# Integration: pause must succeed even if MCP cleanup blows up
+# ---------------------------------------------------------------------------
+
+
+def test_create_pause_session_survives_mcp_cleanup_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mgr = SessionPauseManager(project_path=tmp_path)
+
+    def _boom() -> dict:
+        raise RuntimeError("simulated MCP cleanup failure")
+
+    monkeypatch.setattr(mgr, "_terminate_mcp_servers", _boom)
+
+    # prune_worktrees=False keeps the test hermetic (no git needed).
+    session_id = mgr.create_pause_session(message="test", prune_worktrees=False)
+
+    assert session_id.startswith("session-")
+    # Session artifacts were still written despite the cleanup blowing up.
+    assert (mgr.pause_dir / f"{session_id}.json").exists()
+    assert (mgr.pause_dir / f"{session_id}.md").exists()
+
+
+def test_create_pause_session_invokes_mcp_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mgr = SessionPauseManager(project_path=tmp_path)
+
+    called = {"hit": False}
+
+    def _fake() -> dict:
+        called["hit"] = True
+        return {"terminated": 0, "skipped": 0, "files_processed": 0, "processes": []}
+
+    monkeypatch.setattr(mgr, "_terminate_mcp_servers", _fake)
+
+    mgr.create_pause_session(message="test", prune_worktrees=False)
+    assert called["hit"] is True


### PR DESCRIPTION
## Summary

`claude-mpm session pause` did not terminate the MCP stdio server processes launched for a session. Each pause left those processes running, and over repeated pause/resume cycles they accumulated as stale orphans.

## Fix (two parts)

1. **PID capture at session start** — a new SessionStart handler (`session_start_mcp_handler.py`) records the PIDs of MCP stdio servers launched for the session, using a shared discovery module (`mcp_process_tracker.py`). It's wired into the existing `PassthroughHandlers` SessionStart path defensively (try/except), so a capture failure never blocks normal SessionStart processing.
2. **Cleanup at pause time** — `session_pause_manager.py` gains `_terminate_mcp_servers()`, called from `create_pause_session()`, which SIGTERMs the MCP stdio processes recorded for that session.

## Safety findings from implementation

- **macOS `pgrep -a` incompatibility**: macOS's `pgrep` doesn't support `-a`, unlike Linux. Process discovery uses `pgrep -f` plus a `ps` lookup for full command-line matching instead, so behavior is consistent across platforms.
- **PPID-ancestry scoping**: stdio MCP invocations are byte-identical across concurrent sessions (same command line), so command-line matching alone can't distinguish which session owns which process. Discovery/cleanup is scoped by process ancestry (walking PPIDs) so a pause in one session can't terminate another concurrent session's MCP processes.

## Test evidence

Verified directly (not just quoted from the implementation notes):

```
uv run pytest tests/test_mcp_process_tracker.py tests/test_session_pause_mcp_cleanup.py -v
============================== 29 passed in 0.31s ==============================

uv run pytest tests/test_session_pause_prune_worktrees.py tests/test_session_command.py -v
======================== 68 passed, 1 warning in 5.32s =========================
```

- 29 new tests (21 for `mcp_process_tracker`, 8 for the pause-time cleanup) — all passing.
- 68 existing regression tests across the related session-pause and session-command suites — all passing, no failures introduced.

Closes #927