### PR TITLE
fix: add WWL doc-comment to _terminate_one_mcp_process (unblock CI)

### DIFF
--- a/src/claude_mpm/services/cli/session_pause_manager.py
+++ b/src/claude_mpm/services/cli/session_pause_manager.py
@@ -239,6 +239,25 @@ class SessionPauseManager:
     ) -> dict[str, Any]:
         """Validate and SIGTERM a single recorded MCP process entry.
 
+        WHAT: Given one recorded MCP stdio process entry, runs three
+        sequential safety checks — the PID is a valid positive int, the
+        process is still alive, and its live cmdline still contains the
+        recorded signature — before sending SIGTERM. Each check returns
+        early with a "skipped" decision on failure; a successful SIGTERM
+        (or a benign ``ProcessLookupError``/``OSError`` while sending it)
+        produces the final decision record.
+
+        WHY: A recorded PID can go stale between session start and pause:
+        the process may have already exited, or — on most OSes — the PID
+        may have been recycled by an unrelated process. Blindly signalling
+        the recorded PID risks killing a wrong, unrelated process, so the
+        cmdline-signature comparison acts as a recycled-PID guard. SIGTERM
+        (never SIGKILL) is used so a cooperating stdio server can shut down
+        cleanly. The branching needed for these guards pushes this method
+        over the LOC/CC thresholds; the branches are all safety checks and
+        splitting them into more helpers would not simplify the control
+        flow, so the complexity is intentional and documented here instead.
+
         Returns a decision record with ``pid``, ``action``
         (``"terminated"`` | ``"skipped"``), and ``reason``.
         """


### PR DESCRIPTION
## Summary
- CI on `main` is failing `tests/test_wwl_granularity.py::TestWWLBaseline::test_no_new_violations_in_baseline_mode` for every open PR, because the WWL ratchet check has no way to distinguish this failure from a real new violation.
- Root cause: #928 added `SessionPauseManager._terminate_one_mcp_process` in `src/claude_mpm/services/cli/session_pause_manager.py`. That method exceeds the WWL granularity thresholds (LOC=45, CC=11) but was merged without the required `WHAT:`/`WHY:` doc-comment, and it isn't present in the WWL baseline (`docs/specs/.wwl-baseline.json`) either.
- This PR adds the missing `WHAT:`/`WHY:` doc-comment to the method instead of regenerating the baseline — it documents the three sequential safety checks (valid PID, process still alive, live-cmdline signature match) and explains why the branching/complexity is warranted (guards against signalling a recycled PID).

## Test plan
- [x] `uv run pytest tests/test_wwl_granularity.py -p no:xdist` → `60 passed`
- [x] `uv run ruff check src/claude_mpm/services/cli/session_pause_manager.py` → `All checks passed!`

Unblocks CI for all open PRs, including #932.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)