### PR TITLE
fix: stop routing MPM agents to global ~/.claude/agents/ (#924 Fix A)

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/installer.py
+++ b/src/claude_mpm/hooks/claude_hooks/installer.py
@@ -676,9 +676,6 @@ main "$@"
             # Deploy user-level PM skills to ~/.claude/skills/
             self._deploy_user_level_skills()
 
-            # Deploy USER_LEVEL_AGENTS to ~/.claude/agents/
-            self._deploy_user_level_agents()
-
             # Clean up old deployed scripts if they exist
             self._cleanup_old_deployment()
 
@@ -724,40 +721,16 @@ main "$@"
             )
 
     def _deploy_user_level_agents(self) -> None:
-        """Deploy USER_LEVEL_AGENTS to ~/.claude/agents/ during hook installation.
+        """Deprecated: agents are now deployed to project-local scope.
 
-        These are the CORE engineering/PM/ops agents that should be shared across
-        all projects at the user level.  Deployment is non-blocking: errors are
-        logged as warnings but do not fail hook install.
+        .. deprecated::
+            Fix A for issue #924 removed user-level agent routing.  Agents are
+            deployed to project-local ``.claude/agents/`` by the normal
+            deployment flow, not pushed to ``~/.claude/agents/`` during hook
+            installation.  Retained as a no-op so any subclass override or
+            external caller does not break.
         """
-        try:
-            from claude_mpm.services.agents.deployment.agent_deployment import (
-                AgentDeploymentService,
-            )
-
-            deployer = AgentDeploymentService(working_directory=self.project_root)
-            # Deploy agents; USER_LEVEL_AGENTS will automatically be routed to
-            # ~/.claude/agents/ by the updated routing logic in deploy_agents().
-            results = deployer.deploy_agents(force_rebuild=False)
-
-            deployed_count = len(results.get("deployed", []))
-            updated_count = len(results.get("updated", []))
-            error_count = len(results.get("errors", []))
-
-            if deployed_count or updated_count:
-                self.logger.info(
-                    f"User-level agent deployment: deployed={deployed_count}, "
-                    f"updated={updated_count}"
-                )
-            if error_count:
-                self.logger.warning(
-                    f"User-level agent deployment had {error_count} errors: "
-                    f"{results.get('errors', [])}"
-                )
-        except Exception as exc:
-            self.logger.warning(
-                f"User-level agent deployment skipped (non-critical): {exc}"
-            )
+        self.logger.debug("_deploy_user_level_agents: no-op (agents now project-local)")
 
     def _cleanup_old_deployment(self) -> None:
         """Clean up old deployed hook scripts if they exist."""

--- a/src/claude_mpm/migrations/cleanup_overlap.py
+++ b/src/claude_mpm/migrations/cleanup_overlap.py
@@ -7,14 +7,16 @@ redundant "-agent" suffix (e.g. "research-agent" instead of "research") which
 should be cleaned up at the user level.
 
 WHAT THIS MODULE DOES:
-1. cleanup_agent_overlap: Archives project-level copies of USER_LEVEL_AGENTS
-   when the user-level copy already exists.
-2. cleanup_skill_overlap: Same for USER_LEVEL_SKILLS (directories, not files).
-3. cleanup_stale_agent_names: Archives user-level agents that have a redundant
-   "-agent" suffix when the correct (non-suffixed) name already exists.
+1. cleanup_agent_overlap: **No-op** since Fix A for #924 removed user-level
+   agent routing (agents are project-local everywhere now).
+2. cleanup_skill_overlap: Archives project-level copies of USER_LEVEL_SKILLS
+   (directories, not files) when the user-level copy already exists.  Skills are
+   a separate concern and remain user-level, so this is unchanged.
+3. cleanup_stale_agent_names: **No-op** since Fix A for #924; removal of stale
+   user-level agent copies is handled by the v6.5.81 migration instead.
 
-All operations are non-destructive: files are archived before removal, and a
-manifest is written to each archive directory documenting what happened.
+All skill operations are non-destructive: files are archived before removal, and
+a manifest is written to each archive directory documenting what happened.
 
 IDEMPOTENCY: Running this multiple times is safe -- if the archive already
 contains the file, the item is skipped.
@@ -112,7 +114,15 @@ def cleanup_agent_overlap(
 
     Returns:
         Dict with keys "archived", "skipped", "errors" (lists of agent names).
+
+    .. deprecated::
+        No-op since Fix A for #924 removed user-level agent routing.  Agents are
+        project-local everywhere now, so there is no user-level copy to
+        supersede a project copy; this function returns empty results without
+        touching any files.
     """
+    return {"archived": [], "skipped": [], "errors": []}
+
     user_level_agents = _get_user_level_agents()
     user_agents_base = Path.home() / ".claude" / "agents"
     project_agents_base = project_dir / ".claude" / "agents"
@@ -293,7 +303,15 @@ def cleanup_stale_agent_names(dry_run: bool = False) -> dict:
 
     Returns:
         Dict with keys "archived", "skipped", "errors" (lists of stale names).
+
+    .. deprecated::
+        No-op since Fix A for #924 removed user-level agent routing.  MPM no
+        longer maintains agents under ``~/.claude/agents/``, so there is nothing
+        to prune here; the removal of stale user-level copies is handled by the
+        v6.5.81 migration instead.
     """
+    return {"archived": [], "skipped": [], "errors": []}
+
     user_agents_base = Path.home() / ".claude" / "agents"
 
     date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")

--- a/src/claude_mpm/migrations/migrate_core_agents_to_user_level.py
+++ b/src/claude_mpm/migrations/migrate_core_agents_to_user_level.py
@@ -1,19 +1,12 @@
-"""Migration 6.2.0: Move CORE agents to user level, remove project-level duplicates.
+"""Migration 6.2.0 (historical no-op): Move CORE agents to user level.
 
-WHY: Agents in USER_LEVEL_AGENTS (CORE engineering specialists, PM, QA, ops, etc.)
-should live at ~/.claude/agents/ and be shared across all projects.
-Having copies in .claude/agents/ (project level) creates duplicates and confusion.
-
-WHAT THIS MIGRATION DOES:
-1. Iterates over every agent in USER_LEVEL_AGENTS.
-2. For each agent, verifies it exists at ~/.claude/agents/{agent}.md.
-3. Only if the user-level copy is confirmed present, removes the project-level
-   copy at .claude/agents/{agent}.md.
-4. Skips agents that are absent from user level (safe: never deletes blindly).
-5. Records the list of removed agents in the return value for reporting.
-
-IDEMPOTENCY: Running this migration multiple times is safe — if the project-level
-file no longer exists the migration simply skips it.
+.. deprecated::
+    Fix A for issue #924 removed user-level agent routing.  This migration
+    previously moved project-level copies of ``USER_LEVEL_AGENTS`` agents up to
+    the shared ``~/.claude/agents/``.  Since agents now deploy to project-local
+    scope only, the migration is a no-op: :func:`run_migration` returns ``True``
+    immediately so it never re-runs for users who had not executed it yet.  The
+    helper functions below are retained for reference but are unreachable.
 """
 
 import logging
@@ -146,13 +139,5 @@ def migrate_core_agents_to_user_level() -> bool:
 
 
 def run_migration() -> bool:
-    """Entry point called by the migration runner.
-
-    Returns:
-        True if migration completed without errors, False otherwise.
-    """
-    try:
-        return migrate_core_agents_to_user_level()
-    except Exception as exc:
-        logger.error("Unexpected error in migrate_core_agents_to_user_level: %s", exc)
-        return False
+    """No-op: user-level agent routing has been removed (see Fix A for #924)."""
+    return True

--- a/src/claude_mpm/migrations/registry.py
+++ b/src/claude_mpm/migrations/registry.py
@@ -277,6 +277,13 @@ def _run_skill_cleanup_migration() -> bool:
     return run_migration()
 
 
+def _run_remove_user_level_agents() -> bool:
+    """Remove stale MPM-owned agents from ~/.claude/agents/ (issue #924, Fix A)."""
+    from .v6_5_81_remove_user_level_agents import run_migration
+
+    return run_migration()
+
+
 # Registry of all migrations, ordered by version
 MIGRATIONS: list[Migration] = [
     Migration(
@@ -469,6 +476,12 @@ MIGRATIONS: list[Migration] = [
         version="6.5.80",
         description="Rename mcp-collision skills and patch SKILL.md name fields",
         run=_run_skill_cleanup_migration,
+    ),
+    Migration(
+        id="v6_5_81_remove_user_level_agents",
+        version="6.5.81",
+        description="Remove stale MPM-owned agents from ~/.claude/agents/ (issue #924, Fix A)",
+        run=_run_remove_user_level_agents,
     ),
 ]
 

--- a/src/claude_mpm/migrations/v6_5_81_remove_user_level_agents.py
+++ b/src/claude_mpm/migrations/v6_5_81_remove_user_level_agents.py
@@ -1,10 +1,15 @@
 """Migration v6.5.81: Remove MPM-owned agents from ~/.claude/agents/.
 
-With Fix A for issue #924, all MPM agents now deploy to project-local
-.claude/agents/ instead of the shared ~/.claude/agents/. This migration
-self-heals existing installs by removing the stale user-level copies.
+WHAT: One-time self-heal migration that removes claude-mpm-owned agent files
+from the shared user-level ~/.claude/agents/ directory.
 
-An agent file is considered MPM-owned if its YAML frontmatter contains any of:
+WHY: With Fix A for issue #924, MPM agents now deploy to project-local
+.claude/agents/ instead of the shared ~/.claude/agents/. This migration
+cleans up stale user-level copies left by prior releases so they no longer
+appear in non-MPM Claude Code sessions on the same machine.
+
+Detection: An agent file is considered MPM-owned if its YAML frontmatter
+contains any of:
   - author: claude-mpm
   - category: claude-mpm
   - source: external

--- a/src/claude_mpm/migrations/v6_5_81_remove_user_level_agents.py
+++ b/src/claude_mpm/migrations/v6_5_81_remove_user_level_agents.py
@@ -1,0 +1,61 @@
+"""Migration v6.5.81: Remove MPM-owned agents from ~/.claude/agents/.
+
+With Fix A for issue #924, all MPM agents now deploy to project-local
+.claude/agents/ instead of the shared ~/.claude/agents/. This migration
+self-heals existing installs by removing the stale user-level copies.
+
+An agent file is considered MPM-owned if its YAML frontmatter contains any of:
+  - author: claude-mpm
+  - category: claude-mpm
+  - source: external
+  - agent_type: claude-mpm
+"""
+
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_MPM_MARKERS = re.compile(
+    r"^(author|category|source|agent_type):\s*(claude-mpm|external)\s*$",
+    re.MULTILINE,
+)
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+
+def _is_mpm_owned(path: Path) -> bool:
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+        fm_match = _FRONTMATTER_RE.match(content)
+        if not fm_match:
+            return False
+        return bool(_MPM_MARKERS.search(fm_match.group(1)))
+    except OSError:
+        return False
+
+
+def run_migration() -> bool:
+    """Remove MPM-owned agent files from ~/.claude/agents/."""
+    user_agents_dir = Path.home() / ".claude" / "agents"
+    if not user_agents_dir.is_dir():
+        logger.info("v6_5_81: ~/.claude/agents/ not found, nothing to clean up")
+        return True
+
+    removed = []
+    errors = []
+    for md_file in user_agents_dir.glob("*.md"):
+        if _is_mpm_owned(md_file):
+            try:
+                md_file.unlink()
+                removed.append(md_file.name)
+                logger.info(f"v6_5_81: removed user-level agent {md_file.name}")
+            except OSError as exc:
+                errors.append(str(exc))
+                logger.warning(f"v6_5_81: could not remove {md_file}: {exc}")
+
+    logger.info(
+        f"v6_5_81: removed {len(removed)} user-level MPM agents"
+        f"{', errors: ' + str(len(errors)) if errors else ''}"
+    )
+    return not errors

--- a/src/claude_mpm/services/agents/deployment/agent_deployment.py
+++ b/src/claude_mpm/services/agents/deployment/agent_deployment.py
@@ -410,11 +410,9 @@ class AgentDeploymentService(ConfigServiceBase, AgentDeploymentInterface):
             source_tier = self.base_agent_locator.determine_source_tier(
                 self.templates_dir
             )
-            user_agents_dir_preview = Path.home() / ".claude" / "agents"
             self.logger.info(
                 f"Building and deploying {source_tier} agents: "
-                f"CORE agents → {user_agents_dir_preview}, "
-                f"project agents → {agents_dir}"
+                f"all agents → {agents_dir}"
             )
 
             # Note: System instructions are now loaded directly by SimpleClaudeRunner
@@ -463,12 +461,6 @@ class AgentDeploymentService(ConfigServiceBase, AgentDeploymentInterface):
                 results["total"] = len(template_files)
                 agent_sources = {}
 
-            # Determine user-level agents directory for CORE agents.
-            # USER_LEVEL_AGENTS are deployed to ~/.claude/agents/ so they are
-            # shared across all projects.  All other agents go to the project-
-            # level agents_dir (already resolved above).
-            user_agents_dir = Path.home() / ".claude" / "agents"
-
             # Deploy each agent template
             for template_file in template_files:
                 template_file_path = (
@@ -491,17 +483,11 @@ class AgentDeploymentService(ConfigServiceBase, AgentDeploymentInterface):
                 # but then all get skipped due to redundant version checks.
                 skip_version_check = use_multi_source and not force_rebuild
 
-                # Route agent to correct deployment target:
-                # - USER_LEVEL_AGENTS → ~/.claude/agents/ (shared across projects)
-                # - all others       → <project>/.claude/agents/ (project-specific)
-                from claude_mpm.utils.agent_filters import normalize_agent_id
-
-                normalized_name = normalize_agent_id(agent_name)
-                if normalized_name in USER_LEVEL_AGENTS:
-                    deploy_target = user_agents_dir
-                    deploy_target.mkdir(parents=True, exist_ok=True)
-                else:
-                    deploy_target = agents_dir
+                # All agents deploy to the project-local .claude/agents/
+                # directory (Fix A for #924).  User-level routing to
+                # ~/.claude/agents/ has been removed because it caused MPM
+                # agents to appear in ALL Claude Code sessions on the machine.
+                deploy_target = agents_dir
 
                 self.single_agent_deployer.deploy_single_agent(
                     template_file=template_file_path,

--- a/src/claude_mpm/services/agents/deployment/user_level_routing.py
+++ b/src/claude_mpm/services/agents/deployment/user_level_routing.py
@@ -1,4 +1,12 @@
-"""Deprecated user-level agent routing helpers (legacy).
+"""User-level agent routing predicates (deprecated).
+
+WHAT: Predicates and guards that previously routed CORE MPM agents to the
+shared ~/.claude/agents/ directory instead of the project-local one.
+
+WHY: This module is now deprecated. With Fix A for issue #924, all agents
+deploy to project-local scope. skip_project_level_user_agent() is a no-op
+that always returns False. The predicates are retained for backward
+compatibility with any code that imports them.
 
 .. deprecated::
     Fix A for issue #924 removed user-level agent routing.  All agents now

--- a/src/claude_mpm/services/agents/deployment/user_level_routing.py
+++ b/src/claude_mpm/services/agents/deployment/user_level_routing.py
@@ -1,17 +1,17 @@
-"""Project-level deployment guard for USER_LEVEL_AGENTS (CORE agents).
+"""Deprecated user-level agent routing helpers (legacy).
 
-WHAT: Single chokepoint predicate that stops CORE agents (members of
-``USER_LEVEL_AGENTS``) from being written into a project's ``.claude/agents/``
-directory, and self-heals by pruning any stale project-level duplicate left
-over from an earlier routing bug.
+.. deprecated::
+    Fix A for issue #924 removed user-level agent routing.  All agents now
+    deploy to project-local ``.claude/agents/``.  This module is retained only
+    because migration and cleanup code still imports the predicate helpers
+    below; :func:`skip_project_level_user_agent` is now a no-op that always
+    returns ``False``.
 
-WHY: Several deployment code paths write agent files, but historically only the
-canonical :meth:`AgentDeploymentService.deploy_agents` applied USER_LEVEL_AGENTS
-routing.  The other paths silently re-created project-level copies of CORE
-agents, which shadow the shared ``~/.claude/agents/`` copies (project always
-wins over user in resolution order) and bloat every session's context with
-duplicate definitions that will never be selected.  Centralising the decision
-here guarantees every write path behaves identically.
+Historically this module was the single chokepoint that stopped CORE agents
+(members of ``USER_LEVEL_AGENTS``) from being written into a project's
+``.claude/agents/`` directory and pruned stale project-level duplicates so the
+shared ``~/.claude/agents/`` copies would win resolution.  That behaviour is
+gone; agents are project-local everywhere now.
 
 References
 ----------
@@ -23,7 +23,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from claude_mpm.services.agents.deployment_utils import normalize_deployment_filename
 from claude_mpm.utils.agent_filters import normalize_agent_id
 
 _logger = logging.getLogger(__name__)
@@ -44,17 +43,31 @@ def _user_level_agents() -> frozenset[str]:
 
 
 def is_user_level_agent(agent_name: str) -> bool:
-    """Return True when *agent_name* is a CORE agent that belongs at user level."""
+    """Return True when *agent_name* is a CORE agent that belongs at user level.
+
+    .. deprecated::
+        User-level agent routing was removed by Fix A for #924; this helper is
+        retained only because migration/cleanup code still imports it.
+    """
     return normalize_agent_id(agent_name) in _user_level_agents()
 
 
 def user_level_agents_dir() -> Path:
-    """Return the shared user-level agents directory (``~/.claude/agents``)."""
+    """Return the shared user-level agents directory (``~/.claude/agents``).
+
+    .. deprecated::
+        Legacy helper retained for migration/cleanup code; agents no longer
+        deploy here (Fix A for #924).
+    """
     return Path.home() / ".claude" / "agents"
 
 
 def is_user_level_agents_dir(target_dir: Path) -> bool:
-    """Return True when *target_dir* is the shared ``~/.claude/agents`` directory."""
+    """Return True when *target_dir* is the shared ``~/.claude/agents`` directory.
+
+    .. deprecated::
+        Legacy helper retained for migration/cleanup code (Fix A for #924).
+    """
     try:
         return Path(target_dir).resolve() == user_level_agents_dir().resolve()
     except OSError:
@@ -66,49 +79,15 @@ def skip_project_level_user_agent(
     target_dir: Path,
     logger: logging.Logger | None = None,
 ) -> bool:
-    """Guard a project-level write of a CORE agent and self-heal stale copies.
+    """Deprecated no-op guard; always returns ``False``.
 
-    WHAT: Returns ``True`` when *agent_name* is a ``USER_LEVEL_AGENTS`` member and
-    *target_dir* is a project-level ``.claude/agents/`` directory (i.e. NOT the
-    shared ``~/.claude/agents``); in that case any stale project-level file for
-    the agent is deleted before returning so callers skip the write.  Returns
-    ``False`` for non-CORE agents and for writes targeting the shared user-level
-    directory, which are always allowed.
+    .. deprecated::
+        User-level agent routing was removed by Fix A for #924.  This guard
+        previously blocked CORE agents (``USER_LEVEL_AGENTS`` members) from being
+        written into a project's ``.claude/agents/`` directory and pruned stale
+        project-level duplicates.  All agents now deploy to project-local scope,
+        so the guard never skips anything and always returns ``False``.
 
-    WHY: CORE agents must live only at ``~/.claude/agents``.  Every deployment
-    path calls this before writing so no path can re-introduce a project-level
-    duplicate, and existing leftovers are cleaned up automatically on next deploy.
-    The shared ``~/.claude/agents`` directory is never modified here.
-
-    :spec: SPEC-AGENTS-10~1
+        The signature is preserved so existing call sites continue to work.
     """
-    if not is_user_level_agent(agent_name):
-        return False
-
-    target_dir = Path(target_dir)
-    if is_user_level_agents_dir(target_dir):
-        return False
-
-    log = logger or _logger
-
-    # Self-heal: prune leftover project-level duplicate(s).  Cover the normalized
-    # dash-based filename plus the raw stem so historical variants are removed.
-    candidates = {
-        normalize_deployment_filename(f"{agent_name}.md"),
-        f"{normalize_agent_id(agent_name)}.md",
-        f"{agent_name}.md",
-    }
-    for filename in candidates:
-        stale = target_dir / filename
-        try:
-            if stale.is_file():
-                stale.unlink()
-                log.info(
-                    "Removed stale project-level CORE agent %s (belongs at %s)",
-                    stale,
-                    user_level_agents_dir(),
-                )
-        except OSError as exc:  # pragma: no cover - defensive
-            log.debug("Could not remove stale project agent %s: %s", stale, exc)
-
-    return True
+    return False

--- a/tests/migrations/test_cleanup_overlap.py
+++ b/tests/migrations/test_cleanup_overlap.py
@@ -1,6 +1,10 @@
 """Tests for the startup overlap cleanup system.
 
 Tests use tmp_path and monkeypatch to avoid touching real ~/.claude/ directories.
+
+Fix A for issue #924 removed user-level agent routing: ``cleanup_agent_overlap``
+and ``cleanup_stale_agent_names`` are now no-ops (they return empty results and
+touch no files).  Skill overlap cleanup is a separate concern and remains active.
 """
 
 import json
@@ -54,20 +58,22 @@ def fake_project(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# Agent overlap tests
+# Agent overlap tests (now a no-op)
 # ---------------------------------------------------------------------------
 
 
-class TestCleanupAgentOverlap:
-    """Tests for cleanup_agent_overlap."""
+class TestCleanupAgentOverlapIsNoOp:
+    """cleanup_agent_overlap is a no-op after Fix A for #924."""
 
-    def test_archives_duplicates(self, fake_home: Path, fake_project: Path):
-        """When both user and project copies exist, project copy is archived."""
+    def test_does_not_archive_duplicates(self, fake_home: Path, fake_project: Path):
+        """Even when both user and project copies exist, nothing is archived."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
 
         user_claude = fake_home / ".claude"
         _setup_agent_file(user_claude, "pm", content="# user pm")
-        _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
+        project_file = _setup_agent_file(
+            fake_project / ".claude", "pm", content="# project pm"
+        )
 
         with patch(
             "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
@@ -75,42 +81,30 @@ class TestCleanupAgentOverlap:
         ):
             result = cleanup_agent_overlap(fake_project)
 
-        assert "pm" in result["archived"]
-        # Project file removed
-        assert not (fake_project / ".claude" / "agents" / "pm.md").exists()
-        # Archived copy exists
-        archived_files = list(
-            (fake_project / ".claude" / "agents" / "archived").rglob("pm.md")
-        )
-        assert len(archived_files) == 1
+        assert result == {"archived": [], "skipped": [], "errors": []}
+        # Project file left intact — no archiving.
+        assert project_file.exists()
+        assert not (fake_project / ".claude" / "agents" / "archived").exists()
 
     @pytest.mark.usefixtures("fake_home")
-    def test_skips_non_duplicates(self, fake_project: Path):
-        """Agent only at project level should NOT be archived (no user copy)."""
+    def test_returns_empty_result(self, fake_project: Path):
+        """The no-op returns empty result lists regardless of inputs."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
 
-        # Only project copy, no user copy
         _setup_agent_file(fake_project / ".claude", "pm", content="# project pm")
 
-        with patch(
-            "claude_mpm.migrations.cleanup_overlap._get_user_level_agents",
-            return_value=frozenset({"pm"}),
-        ):
-            result = cleanup_agent_overlap(fake_project)
+        result = cleanup_agent_overlap(fake_project)
 
-        assert "pm" in result["skipped"]
-        assert result["archived"] == []
-        # Project file still there
-        assert (fake_project / ".claude" / "agents" / "pm.md").exists()
+        assert result == {"archived": [], "skipped": [], "errors": []}
 
 
 # ---------------------------------------------------------------------------
-# Skill overlap tests
+# Skill overlap tests (unchanged behavior)
 # ---------------------------------------------------------------------------
 
 
 class TestCleanupSkillOverlap:
-    """Tests for cleanup_skill_overlap."""
+    """Tests for cleanup_skill_overlap (still active)."""
 
     def test_archives_duplicates(self, fake_home: Path, fake_project: Path):
         """When both user and project copies exist, project copy is archived."""
@@ -137,54 +131,40 @@ class TestCleanupSkillOverlap:
 
 
 # ---------------------------------------------------------------------------
-# Stale agent names tests
+# Stale agent names tests (now a no-op)
 # ---------------------------------------------------------------------------
 
 
-class TestCleanupStaleAgentNames:
-    """Tests for cleanup_stale_agent_names."""
+class TestCleanupStaleAgentNamesIsNoOp:
+    """cleanup_stale_agent_names is a no-op after Fix A for #924."""
 
-    def test_archives_stale_suffix(self, fake_home: Path):
-        """Stale '-agent' suffixed file gets archived when correct name exists."""
+    def test_does_not_archive_stale_suffix(self, fake_home: Path):
+        """A stale '-agent' suffixed file is left untouched."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
 
         user_claude = fake_home / ".claude"
-        _setup_agent_file(user_claude, "research-agent", content="# stale")
+        stale_file = _setup_agent_file(user_claude, "research-agent", content="# stale")
         _setup_agent_file(user_claude, "research", content="# correct")
 
         result = cleanup_stale_agent_names()
 
-        assert "research-agent" in result["archived"]
-        # Stale file removed
-        assert not (user_claude / "agents" / "research-agent.md").exists()
-        # Correct file untouched
+        assert result == {"archived": [], "skipped": [], "errors": []}
+        # Both files remain — nothing archived.
+        assert stale_file.exists()
         assert (user_claude / "agents" / "research.md").exists()
-
-    def test_skips_when_no_correct_replacement(self, fake_home: Path):
-        """Stale file should NOT be archived if the correct name is missing."""
-        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
-
-        user_claude = fake_home / ".claude"
-        _setup_agent_file(user_claude, "research-agent", content="# stale")
-        # No "research.md" exists
-
-        result = cleanup_stale_agent_names()
-
-        assert "research-agent" in result["skipped"]
-        # Stale file still there
-        assert (user_claude / "agents" / "research-agent.md").exists()
+        assert not (user_claude / "agents" / "archived").exists()
 
 
 # ---------------------------------------------------------------------------
-# Dry-run tests
+# Dry-run tests (no-op functions ignore dry_run and archive nothing)
 # ---------------------------------------------------------------------------
 
 
 class TestDryRun:
-    """Tests for dry_run=True mode."""
+    """Tests for dry_run=True mode against the no-op agent functions."""
 
     def test_does_not_modify_agents(self, fake_home: Path, fake_project: Path):
-        """dry_run=True leaves all files in place."""
+        """dry_run=True on the no-op still leaves all files in place."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
 
         user_claude = fake_home / ".claude"
@@ -199,13 +179,12 @@ class TestDryRun:
         ):
             result = cleanup_agent_overlap(fake_project, dry_run=True)
 
-        assert "pm" in result["archived"]  # Reported as would-archive
-        assert project_file.exists()  # But file still there
-        # No archive directory created
+        assert result["archived"] == []
+        assert project_file.exists()
         assert not (fake_project / ".claude" / "agents" / "archived").exists()
 
     def test_does_not_modify_stale_agents(self, fake_home: Path):
-        """dry_run=True leaves stale agent files in place."""
+        """dry_run=True on the no-op leaves stale agent files in place."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
 
         user_claude = fake_home / ".claude"
@@ -214,7 +193,7 @@ class TestDryRun:
 
         result = cleanup_stale_agent_names(dry_run=True)
 
-        assert "research-agent" in result["archived"]
+        assert result["archived"] == []
         assert stale_file.exists()
 
 
@@ -227,7 +206,7 @@ class TestIdempotency:
     """Tests that running cleanup twice does not error or double-archive."""
 
     def test_second_run_agent_overlap(self, fake_home: Path, fake_project: Path):
-        """Running agent overlap cleanup twice doesn't error."""
+        """Running agent overlap cleanup twice doesn't error (no-op)."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
 
         user_claude = fake_home / ".claude"
@@ -241,13 +220,11 @@ class TestIdempotency:
             result1 = cleanup_agent_overlap(fake_project)
             result2 = cleanup_agent_overlap(fake_project)
 
-        assert "pm" in result1["archived"]
-        # Second run: project file gone, so it's skipped
-        assert "pm" in result2["skipped"]
-        assert result2["errors"] == []
+        assert result1 == {"archived": [], "skipped": [], "errors": []}
+        assert result2 == {"archived": [], "skipped": [], "errors": []}
 
     def test_second_run_stale_agents(self, fake_home: Path):
-        """Running stale cleanup twice doesn't error."""
+        """Running stale cleanup twice doesn't error (no-op)."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
 
         user_claude = fake_home / ".claude"
@@ -257,9 +234,8 @@ class TestIdempotency:
         result1 = cleanup_stale_agent_names()
         result2 = cleanup_stale_agent_names()
 
-        assert "research-agent" in result1["archived"]
-        assert "research-agent" in result2["skipped"]
-        assert result2["errors"] == []
+        assert result1 == {"archived": [], "skipped": [], "errors": []}
+        assert result2 == {"archived": [], "skipped": [], "errors": []}
 
 
 # ---------------------------------------------------------------------------
@@ -268,12 +244,15 @@ class TestIdempotency:
 
 
 class TestManifest:
-    """Tests for _cleanup_manifest.json creation."""
+    """The no-op agent/stale functions never write a manifest.
 
-    def test_manifest_written_for_agent_overlap(
+    Skill overlap still writes a manifest, so that path is covered here.
+    """
+
+    def test_no_manifest_written_for_agent_overlap(
         self, fake_home: Path, fake_project: Path
     ):
-        """Verify _cleanup_manifest.json exists and has correct structure."""
+        """No _cleanup_manifest.json is created by the no-op agent cleanup."""
         from claude_mpm.migrations.cleanup_overlap import cleanup_agent_overlap
 
         user_claude = fake_home / ".claude"
@@ -286,9 +265,29 @@ class TestManifest:
         ):
             cleanup_agent_overlap(fake_project)
 
-        # Find manifest
         manifests = list(
-            (fake_project / ".claude" / "agents" / "archived").rglob(
+            (fake_project / ".claude" / "agents").rglob("_cleanup_manifest.json")
+        )
+        assert manifests == []
+
+    def test_manifest_written_for_skill_overlap(
+        self, fake_home: Path, fake_project: Path
+    ):
+        """Skill overlap cleanup still writes a manifest with correct structure."""
+        from claude_mpm.migrations.cleanup_overlap import cleanup_skill_overlap
+
+        user_claude = fake_home / ".claude"
+        _setup_skill_dir(user_claude, "mpm-help")
+        _setup_skill_dir(fake_project / ".claude", "mpm-help")
+
+        with patch(
+            "claude_mpm.migrations.cleanup_overlap._get_user_level_skills",
+            return_value=frozenset({"mpm-help"}),
+        ):
+            cleanup_skill_overlap(fake_project)
+
+        manifests = list(
+            (fake_project / ".claude" / "skills" / "archived").rglob(
                 "_cleanup_manifest.json"
             )
         )
@@ -296,31 +295,8 @@ class TestManifest:
 
         manifest = json.loads(manifests[0].read_text())
         assert "cleanup_date" in manifest
-        assert "reason" in manifest
-        assert "source_level" in manifest
         assert manifest["source_level"] == "project"
-        assert "superseded_by" in manifest
-        assert "archived_files" in manifest
-        assert "pm.md" in manifest["archived_files"]
-
-    def test_manifest_written_for_stale_agents(self, fake_home: Path):
-        """Verify manifest is written when stale agents are archived."""
-        from claude_mpm.migrations.cleanup_overlap import cleanup_stale_agent_names
-
-        user_claude = fake_home / ".claude"
-        _setup_agent_file(user_claude, "research-agent")
-        _setup_agent_file(user_claude, "research")
-
-        cleanup_stale_agent_names()
-
-        manifests = list(
-            (user_claude / "agents" / "archived").rglob("_cleanup_manifest.json")
-        )
-        assert len(manifests) == 1
-
-        manifest = json.loads(manifests[0].read_text())
-        assert manifest["source_level"] == "user"
-        assert "research-agent.md" in manifest["archived_files"]
+        assert "mpm-help" in manifest["archived_files"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migrations/__init__.py
+++ b/tests/unit/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for claude_mpm.migrations."""

--- a/tests/unit/migrations/test_remove_user_level_agents.py
+++ b/tests/unit/migrations/test_remove_user_level_agents.py
@@ -1,0 +1,110 @@
+"""Tests for the v6.5.81 remove-user-level-agents migration (issue #924, Fix A).
+
+The migration removes MPM-owned agent files from the shared ``~/.claude/agents/``
+directory, identifying them by frontmatter markers.  Non-MPM agent files must be
+left untouched, and a missing directory is a successful no-op.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_mpm.migrations.v6_5_81_remove_user_level_agents import run_migration
+
+
+@pytest.fixture()
+def fake_home():
+    """Yield a temporary directory to stand in for ``Path.home()``."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+def _write_agent(agents_dir: Path, name: str, frontmatter: str) -> Path:
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / f"{name}.md"
+    path.write_text(f"---\n{frontmatter}\n---\n\n# {name}\n", encoding="utf-8")
+    return path
+
+
+def test_removes_mpm_owned_agent(fake_home):
+    """An agent whose frontmatter marks it MPM-owned is removed."""
+    agents_dir = fake_home / ".claude" / "agents"
+    mpm_agent = _write_agent(
+        agents_dir, "engineer", "name: engineer\nauthor: claude-mpm"
+    )
+    assert mpm_agent.exists()
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+    assert not mpm_agent.exists(), "MPM-owned agent must be removed"
+
+
+def test_removes_external_source_agent(fake_home):
+    """The ``source: external`` marker also identifies an MPM-owned agent."""
+    agents_dir = fake_home / ".claude" / "agents"
+    external_agent = _write_agent(
+        agents_dir, "research", "name: research\nsource: external"
+    )
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+    assert not external_agent.exists()
+
+
+def test_skips_non_mpm_agent(fake_home):
+    """An agent without MPM markers is left untouched."""
+    agents_dir = fake_home / ".claude" / "agents"
+    user_agent = _write_agent(
+        agents_dir, "my-custom-agent", "name: my-custom-agent\nauthor: alice"
+    )
+    assert user_agent.exists()
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+    assert user_agent.exists(), "Non-MPM agent must be preserved"
+
+
+def test_skips_agent_without_frontmatter(fake_home):
+    """A file with no YAML frontmatter is not considered MPM-owned."""
+    agents_dir = fake_home / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    plain = agents_dir / "notes.md"
+    plain.write_text("# just some notes\n", encoding="utf-8")
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+    assert plain.exists()
+
+
+def test_handles_missing_dir(fake_home):
+    """A missing ~/.claude/agents/ directory is a successful no-op."""
+    assert not (fake_home / ".claude" / "agents").exists()
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+
+
+def test_mixed_dir_removes_only_mpm(fake_home):
+    """Only MPM-owned files are removed; user files remain."""
+    agents_dir = fake_home / ".claude" / "agents"
+    mpm_agent = _write_agent(agents_dir, "qa", "name: qa\ncategory: claude-mpm")
+    user_agent = _write_agent(agents_dir, "custom", "name: custom\nauthor: bob")
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = run_migration()
+
+    assert result is True
+    assert not mpm_agent.exists()
+    assert user_agent.exists()

--- a/tests/unit/services/agents/test_user_level_agents_split.py
+++ b/tests/unit/services/agents/test_user_level_agents_split.py
@@ -1,19 +1,23 @@
-"""Tests verifying USER_LEVEL_AGENTS split: CORE agents go to ~/.claude/agents/,
-project-specific agents go to <project>/.claude/agents/.
+"""Tests verifying project-local agent routing after Fix A for issue #924.
 
-Issue #412: Split core agents into user-level vs project-level storage.
+User-level agent routing has been removed: ALL agents (CORE and project-specific)
+now deploy to ``<project>/.claude/agents/`` instead of ``~/.claude/agents/``.  The
+``USER_LEVEL_AGENTS`` frozenset is retained (migration/cleanup code still imports
+it) but no longer influences deployment targets.
+
+Historical context: Issue #412 originally split core agents into user-level
+storage; #924 reverted that split.
 """
 
-import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 
 class TestUserLevelAgentsConstant:
-    """Verify the USER_LEVEL_AGENTS frozenset is correctly defined."""
+    """Verify the USER_LEVEL_AGENTS frozenset is still defined (retained for migrations)."""
 
     def test_user_level_agents_is_frozenset(self):
         """USER_LEVEL_AGENTS must be a frozenset for immutability."""
@@ -89,7 +93,7 @@ class TestUserLevelAgentsConstant:
 
 
 class TestDeployAgentsRouting:
-    """Verify deploy_agents() routes agents to correct directories."""
+    """Verify deploy_agents() routes ALL agents to project-local .claude/agents/."""
 
     def _make_template_file(self, tmp_dir: Path, agent_name: str) -> Path:
         """Create a minimal agent template .md file."""
@@ -110,91 +114,66 @@ class TestDeployAgentsRouting:
             fake_project.mkdir()
             yield fake_home, fake_project
 
-    def test_user_level_agent_deployed_to_home_claude_agents(self, temp_dirs):
-        """An agent in USER_LEVEL_AGENTS must be deployed to ~/.claude/agents/."""
-        from claude_mpm.services.agents.deployment.agent_deployment import (
-            USER_LEVEL_AGENTS,
+    def test_core_agent_deployed_to_project_agents(self, temp_dirs):
+        """A CORE (USER_LEVEL_AGENTS) agent must now deploy to project-local dir."""
+        from claude_mpm.services.agents.deployment.user_level_routing import (
+            skip_project_level_user_agent,
         )
 
         fake_home, fake_project = temp_dirs
-        # Pick any member of USER_LEVEL_AGENTS
-        sample_agent = next(iter(sorted(USER_LEVEL_AGENTS)))
-
-        user_agents_dir = fake_home / ".claude" / "agents"
         project_agents_dir = fake_project / ".claude" / "agents"
 
-        # Simulate what deploy_agents does: route based on USER_LEVEL_AGENTS
-        from claude_mpm.utils.agent_filters import normalize_agent_id
+        core_agent = "engineer"
 
-        normalized = normalize_agent_id(sample_agent)
-        if normalized in USER_LEVEL_AGENTS:
-            deploy_target = user_agents_dir
-        else:
-            deploy_target = project_agents_dir
-
-        assert deploy_target == user_agents_dir, (
-            f"Agent '{sample_agent}' (normalized: '{normalized}') should deploy to "
-            f"user-level {user_agents_dir} but routing chose {deploy_target}"
-        )
+        # The routing guard is now a no-op, so CORE agents are never skipped for
+        # a project-level target and therefore deploy to project-local scope.
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert (
+                skip_project_level_user_agent(core_agent, project_agents_dir) is False
+            )
 
     def test_non_user_level_agent_deployed_to_project_agents(self, temp_dirs):
-        """An agent NOT in USER_LEVEL_AGENTS must deploy to project-level .claude/agents/."""
-        from claude_mpm.services.agents.deployment.agent_deployment import (
-            USER_LEVEL_AGENTS,
+        """A project-specific agent still deploys to project-level .claude/agents/."""
+        from claude_mpm.services.agents.deployment.user_level_routing import (
+            skip_project_level_user_agent,
         )
 
         fake_home, fake_project = temp_dirs
-        # Use a clearly project-specific name
+        project_agents_dir = fake_project / ".claude" / "agents"
+
         project_only_agent = "my-custom-project-agent-xyz"
 
-        user_agents_dir = fake_home / ".claude" / "agents"
-        project_agents_dir = fake_project / ".claude" / "agents"
+        with patch("pathlib.Path.home", return_value=fake_home):
+            assert (
+                skip_project_level_user_agent(project_only_agent, project_agents_dir)
+                is False
+            )
 
-        assert project_only_agent not in USER_LEVEL_AGENTS
-
-        from claude_mpm.utils.agent_filters import normalize_agent_id
-
-        normalized = normalize_agent_id(project_only_agent)
-        if normalized in USER_LEVEL_AGENTS:
-            deploy_target = user_agents_dir
-        else:
-            deploy_target = project_agents_dir
-
-        assert deploy_target == project_agents_dir, (
-            f"Agent '{project_only_agent}' should deploy to project-level "
-            f"{project_agents_dir} but routing chose {deploy_target}"
-        )
-
-    def test_all_user_level_agents_route_to_home(self, temp_dirs):
-        """Every member of USER_LEVEL_AGENTS must route to ~/.claude/agents/."""
+    def test_all_user_level_agents_route_to_project(self, temp_dirs):
+        """Every member of USER_LEVEL_AGENTS must route to project-local scope."""
         from claude_mpm.services.agents.deployment.agent_deployment import (
             USER_LEVEL_AGENTS,
         )
+        from claude_mpm.services.agents.deployment.user_level_routing import (
+            skip_project_level_user_agent,
+        )
 
         fake_home, fake_project = temp_dirs
-        user_agents_dir = fake_home / ".claude" / "agents"
         project_agents_dir = fake_project / ".claude" / "agents"
 
-        from claude_mpm.utils.agent_filters import normalize_agent_id
+        skipped = []
+        with patch("pathlib.Path.home", return_value=fake_home):
+            for agent_name in USER_LEVEL_AGENTS:
+                if skip_project_level_user_agent(agent_name, project_agents_dir):
+                    skipped.append(agent_name)
 
-        wrong_targets = []
-        for agent_name in USER_LEVEL_AGENTS:
-            normalized = normalize_agent_id(agent_name)
-            if normalized in USER_LEVEL_AGENTS:
-                deploy_target = user_agents_dir
-            else:
-                deploy_target = project_agents_dir
-
-            if deploy_target != user_agents_dir:
-                wrong_targets.append(agent_name)
-
-        assert not wrong_targets, (
-            f"These USER_LEVEL_AGENTS did not route to user level: {wrong_targets}"
+        assert not skipped, (
+            f"These agents were wrongly skipped for project-level deploy: {skipped}"
         )
 
 
-class TestMigrationCoreAgentsToUserLevel:
-    """Verify the 6.2.0 migration removes project-level duplicates safely."""
+class TestMigrationCoreAgentsToUserLevelIsNoOp:
+    """Verify the 6.2.0 migration is now a no-op (Fix A for #924)."""
 
     @pytest.fixture()
     def temp_dirs(self):
@@ -215,81 +194,18 @@ class TestMigrationCoreAgentsToUserLevel:
         )
         return path
 
-    def test_migration_removes_project_copy_when_user_copy_exists(self, temp_dirs):
-        """Migration removes project-level file when user-level copy is confirmed."""
+    def test_run_migration_returns_true(self):
+        """run_migration() is a no-op that always succeeds."""
         from claude_mpm.migrations.migrate_core_agents_to_user_level import (
-            migrate_core_agents_to_user_level,
-        )
-        from claude_mpm.services.agents.deployment.agent_deployment import (
-            USER_LEVEL_AGENTS,
+            run_migration,
         )
 
-        fake_home, fake_project = temp_dirs
-        # Pick a USER_LEVEL_AGENTS member
-        agent = next(iter(sorted(USER_LEVEL_AGENTS)))
+        assert run_migration() is True
 
-        user_agents_dir = fake_home / ".claude" / "agents"
-        project_agents_dir = fake_project / ".claude" / "agents"
-
-        # Both copies exist initially
-        self._write_agent(user_agents_dir, agent)
-        project_file = self._write_agent(project_agents_dir, agent)
-
-        assert project_file.exists()
-
-        # Run migration with patched home and cwd pointing to fake_project
-        with (
-            patch("pathlib.Path.home", return_value=fake_home),
-            patch(
-                "claude_mpm.migrations.migrate_core_agents_to_user_level._find_project_roots",
-                return_value=[fake_project],
-            ),
-        ):
-            success = migrate_core_agents_to_user_level()
-
-        assert success, "Migration should succeed"
-        assert not project_file.exists(), (
-            f"Project-level {agent}.md should be removed after migration"
-        )
-        # User-level copy must be preserved
-        assert (user_agents_dir / f"{agent}.md").exists(), (
-            f"User-level {agent}.md must be preserved after migration"
-        )
-
-    def test_migration_skips_removal_when_no_user_copy(self, temp_dirs):
-        """Migration does NOT remove project copy when user-level copy is absent."""
+    def test_run_migration_does_not_touch_project_files(self, temp_dirs):
+        """The no-op migration must not remove any project-level agent file."""
         from claude_mpm.migrations.migrate_core_agents_to_user_level import (
-            migrate_core_agents_to_user_level,
-        )
-        from claude_mpm.services.agents.deployment.agent_deployment import (
-            USER_LEVEL_AGENTS,
-        )
-
-        fake_home, fake_project = temp_dirs
-        agent = next(iter(sorted(USER_LEVEL_AGENTS)))
-
-        project_agents_dir = fake_project / ".claude" / "agents"
-        project_file = self._write_agent(project_agents_dir, agent)
-        # No user-level copy
-
-        with (
-            patch("pathlib.Path.home", return_value=fake_home),
-            patch(
-                "claude_mpm.migrations.migrate_core_agents_to_user_level._find_project_roots",
-                return_value=[fake_project],
-            ),
-        ):
-            success = migrate_core_agents_to_user_level()
-
-        assert success, "Migration should succeed even when user copy is absent"
-        assert project_file.exists(), (
-            "Project-level file must NOT be removed when user-level copy is missing"
-        )
-
-    def test_migration_is_idempotent(self, temp_dirs):
-        """Running migration twice is safe — second run is a no-op."""
-        from claude_mpm.migrations.migrate_core_agents_to_user_level import (
-            migrate_core_agents_to_user_level,
+            run_migration,
         )
         from claude_mpm.services.agents.deployment.agent_deployment import (
             USER_LEVEL_AGENTS,
@@ -300,57 +216,20 @@ class TestMigrationCoreAgentsToUserLevel:
 
         user_agents_dir = fake_home / ".claude" / "agents"
         project_agents_dir = fake_project / ".claude" / "agents"
-
         self._write_agent(user_agents_dir, agent)
-        self._write_agent(project_agents_dir, agent)
+        project_file = self._write_agent(project_agents_dir, agent)
 
-        with (
-            patch("pathlib.Path.home", return_value=fake_home),
-            patch(
-                "claude_mpm.migrations.migrate_core_agents_to_user_level._find_project_roots",
-                return_value=[fake_project],
-            ),
-        ):
-            success1 = migrate_core_agents_to_user_level()
-            # Run again — project file is already gone
-            success2 = migrate_core_agents_to_user_level()
+        with patch("pathlib.Path.home", return_value=fake_home):
+            success = run_migration()
 
-        assert success1
-        assert success2, "Second migration run must succeed (idempotent)"
-
-    def test_migration_skips_non_user_level_project_agents(self, temp_dirs):
-        """Migration must not touch project-specific agents not in USER_LEVEL_AGENTS."""
-        from claude_mpm.migrations.migrate_core_agents_to_user_level import (
-            migrate_core_agents_to_user_level,
-        )
-        from claude_mpm.services.agents.deployment.agent_deployment import (
-            USER_LEVEL_AGENTS,
-        )
-
-        fake_home, fake_project = temp_dirs
-        project_agents_dir = fake_project / ".claude" / "agents"
-
-        custom_agent = "my-project-specific-agent"
-        assert custom_agent not in USER_LEVEL_AGENTS
-        project_file = self._write_agent(project_agents_dir, custom_agent)
-
-        with (
-            patch("pathlib.Path.home", return_value=fake_home),
-            patch(
-                "claude_mpm.migrations.migrate_core_agents_to_user_level._find_project_roots",
-                return_value=[fake_project],
-            ),
-        ):
-            success = migrate_core_agents_to_user_level()
-
-        assert success
+        assert success is True
         assert project_file.exists(), (
-            "Project-specific agent must NOT be touched by the migration"
+            "No-op migration must not remove the project-level agent file"
         )
 
 
 class TestMigrationRegistry:
-    """Verify 6.2.0 migration is registered in the migration registry."""
+    """Verify 6.2.0 migration is still registered (now a no-op)."""
 
     def test_migration_registered(self):
         """6.2.0_core_agents_to_user_level must be in the migration registry."""

--- a/tests/unit/services/agents/test_user_level_routing_guard.py
+++ b/tests/unit/services/agents/test_user_level_routing_guard.py
@@ -1,12 +1,13 @@
-"""Tests for the project-level deployment guard for USER_LEVEL_AGENTS.
+"""Tests for the deprecated project-level deployment guard.
 
-These tests verify that no deployment code path writes a CORE
-(``USER_LEVEL_AGENTS``) agent into a project's ``.claude/agents/`` directory,
-and that a stale project-level copy left over from the earlier routing bug is
-cleaned up automatically on the next deploy.
+Fix A for issue #924 removed user-level agent routing.  All agents now deploy to
+project-local ``.claude/agents/``.  :func:`skip_project_level_user_agent` is now
+a no-op that always returns ``False`` and never prunes anything, and every
+deployment path writes CORE (``USER_LEVEL_AGENTS``) agents into the project-level
+directory just like any other agent.
 
-The shared user-level directory (``~/.claude/agents``) must never be modified by
-the guard.
+The predicate helpers (:func:`is_user_level_agent`, :func:`is_user_level_agents_dir`)
+are retained for migration/cleanup code and are still exercised here.
 """
 
 import tempfile
@@ -40,7 +41,7 @@ def temp_dirs():
 
 
 class TestGuardPredicates:
-    """Basic predicate behavior."""
+    """Basic predicate behavior (retained legacy helpers)."""
 
     def test_core_agent_recognized(self):
         assert is_user_level_agent(CORE_AGENT) is True
@@ -58,17 +59,19 @@ class TestGuardPredicates:
             assert is_user_level_agents_dir(project_agents_dir) is False
 
 
-class TestProjectLevelGuard:
-    """skip_project_level_user_agent decision + self-heal behavior."""
+class TestDeprecatedGuardIsNoOp:
+    """skip_project_level_user_agent() always returns False (Fix A for #924)."""
 
-    def test_core_agent_skipped_for_project_target(self, temp_dirs):
-        """A CORE agent must be skipped when the target is project-level."""
+    def test_core_agent_not_skipped_for_project_target(self, temp_dirs):
+        """A CORE agent is no longer skipped for a project-level target."""
         fake_home, project_agents_dir, _ = temp_dirs
         with patch("pathlib.Path.home", return_value=fake_home):
-            assert skip_project_level_user_agent(CORE_AGENT, project_agents_dir) is True
+            assert (
+                skip_project_level_user_agent(CORE_AGENT, project_agents_dir) is False
+            )
 
     def test_project_agent_not_skipped(self, temp_dirs):
-        """A non-CORE agent must NOT be skipped (it belongs at project level)."""
+        """A non-CORE agent is not skipped either."""
         fake_home, project_agents_dir, _ = temp_dirs
         with patch("pathlib.Path.home", return_value=fake_home):
             assert (
@@ -76,24 +79,24 @@ class TestProjectLevelGuard:
                 is False
             )
 
-    def test_core_agent_allowed_for_user_level_target(self, temp_dirs):
-        """Writing a CORE agent to the shared user-level dir is allowed."""
+    def test_core_agent_not_skipped_for_user_level_target(self, temp_dirs):
+        """Always False, regardless of whether the target is the user-level dir."""
         fake_home, _, user_agents_dir = temp_dirs
         with patch("pathlib.Path.home", return_value=fake_home):
             assert skip_project_level_user_agent(CORE_AGENT, user_agents_dir) is False
 
-    def test_stale_project_copy_is_pruned(self, temp_dirs):
-        """A leftover project-level CORE agent file is removed on next deploy."""
+    def test_stale_project_copy_is_not_pruned(self, temp_dirs):
+        """The self-heal pruning was removed: a project-level file is left intact."""
         fake_home, project_agents_dir, _ = temp_dirs
-        stale = project_agents_dir / f"{CORE_AGENT}.md"
-        stale.write_text("---\nname: engineer\n---\n\n# stale duplicate\n")
-        assert stale.exists()
+        existing = project_agents_dir / f"{CORE_AGENT}.md"
+        existing.write_text("---\nname: engineer\n---\n\n# project copy\n")
+        assert existing.exists()
 
         with patch("pathlib.Path.home", return_value=fake_home):
             skipped = skip_project_level_user_agent(CORE_AGENT, project_agents_dir)
 
-        assert skipped is True
-        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
+        assert skipped is False
+        assert existing.exists(), "Guard must no longer prune project-level files"
 
     def test_user_level_copy_never_touched(self, temp_dirs):
         """The shared ~/.claude/agents copy must never be removed by the guard."""
@@ -107,90 +110,15 @@ class TestProjectLevelGuard:
         assert user_copy.exists(), "User-level copy must be preserved"
 
 
-class TestDeploymentPathsHonorGuard:
-    """Every write path must skip CORE agents for project targets."""
+class TestDeploymentPathsDeployCoreAgents:
+    """Every write path now deploys CORE agents to the project-level directory."""
 
     def _template(self, tmp_dir: Path, name: str) -> Path:
         template = tmp_dir / f"{name}.md"
         template.write_text(f"---\nname: {name}\nversion: 1.0.0\n---\n\n# {name}\n")
         return template
 
-    def test_single_agent_deployer_skips_core_agent(self, temp_dirs):
-        """SingleAgentDeployer.deploy_single_agent skips + prunes CORE agents."""
-        from claude_mpm.services.agents.deployment.single_agent_deployer import (
-            SingleAgentDeployer,
-        )
-
-        fake_home, project_agents_dir, _ = temp_dirs
-        template_dir = project_agents_dir.parent
-        template_file = self._template(template_dir, CORE_AGENT)
-
-        # Seed a stale project-level duplicate to prove self-heal.
-        stale = project_agents_dir / f"{CORE_AGENT}.md"
-        stale.write_text("stale")
-
-        deployer = SingleAgentDeployer(
-            template_builder=None, version_manager=None, results_manager=None
-        )
-        results = {
-            "deployed": [],
-            "updated": [],
-            "migrated": [],
-            "skipped": [],
-            "errors": [],
-        }
-
-        with patch("pathlib.Path.home", return_value=fake_home):
-            deployer.deploy_single_agent(
-                template_file=template_file,
-                agents_dir=project_agents_dir,
-                base_agent_data={},
-                base_agent_version=(1, 0, 0),
-                force_rebuild=True,
-                deployment_mode="project",
-                results=results,
-            )
-
-        assert CORE_AGENT in results["skipped"]
-        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
-        assert not (project_agents_dir / f"{CORE_AGENT}.md").exists()
-
-    def test_deploy_agent_returns_none_on_skip(self, temp_dirs):
-        """SingleAgentDeployer.deploy_agent returns None (not True) on skip.
-
-        Why: Regression guard for #919 — a bare ``True`` on a skipped CORE agent
-        was indistinguishable from a real deployment and inflated success counts.
-        The skip path must return ``None`` so callers can tell them apart.
-        Test: Deploy a CORE agent to a project-level dir and assert the return is
-        exactly ``None`` (not ``True``), and that no file is written.
-        """
-        from claude_mpm.services.agents.deployment.single_agent_deployer import (
-            SingleAgentDeployer,
-        )
-
-        fake_home, project_agents_dir, _ = temp_dirs
-        template_dir = project_agents_dir.parent
-        template_file = self._template(template_dir, CORE_AGENT)
-
-        deployer = SingleAgentDeployer(
-            template_builder=None, version_manager=None, results_manager=None
-        )
-
-        with patch("pathlib.Path.home", return_value=fake_home):
-            result = deployer.deploy_agent(
-                agent_name=CORE_AGENT,
-                templates_dir=template_dir,
-                target_dir=project_agents_dir,
-                base_agent_path=template_dir / "BASE_AGENT.md",
-                force_rebuild=True,
-                working_directory=template_dir,
-            )
-
-        assert result is None, "Skip must return None, not True (see #919)"
-        assert not (project_agents_dir / f"{CORE_AGENT}.md").exists()
-
-    def test_agent_processor_skips_core_agent(self, temp_dirs):
-        """AgentProcessor.process_agent skips + prunes CORE agents."""
+    def _deploy_via_processor(self, temp_dirs, agent_name: str):
         from claude_mpm.services.agents.deployment.processors import (
             AgentDeploymentContext,
             AgentProcessor,
@@ -198,10 +126,7 @@ class TestDeploymentPathsHonorGuard:
 
         fake_home, project_agents_dir, _ = temp_dirs
         template_dir = project_agents_dir.parent
-        template_file = self._template(template_dir, CORE_AGENT)
-
-        stale = project_agents_dir / f"{CORE_AGENT}.md"
-        stale.write_text("stale")
+        template_file = self._template(template_dir, agent_name)
 
         context = AgentDeploymentContext.from_template_file(
             template_file=template_file,
@@ -212,38 +137,10 @@ class TestDeploymentPathsHonorGuard:
             deployment_mode="project",
             source_info="system",
         )
-        processor = AgentProcessor(template_builder=None, version_manager=None)
-
-        with patch("pathlib.Path.home", return_value=fake_home):
-            result = processor.process_agent(context)
-
-        assert result.status.value == "skipped"
-        assert not stale.exists(), "Stale project-level CORE agent must be pruned"
-
-    def test_project_agent_still_deploys_via_single_deployer(self, temp_dirs):
-        """A non-CORE agent is still written to the project-level directory."""
-        from claude_mpm.services.agents.deployment.processors import (
-            AgentDeploymentContext,
-            AgentProcessor,
-        )
-
-        fake_home, project_agents_dir, _ = temp_dirs
-        template_dir = project_agents_dir.parent
-        template_file = self._template(template_dir, PROJECT_AGENT)
-
-        context = AgentDeploymentContext.from_template_file(
-            template_file=template_file,
-            agents_dir=project_agents_dir,
-            base_agent_data={},
-            base_agent_version=(1, 0, 0),
-            force_rebuild=True,
-            deployment_mode="project",
-            source_info="project",
-        )
 
         class _StubBuilder:
             def build_agent_markdown(self, *args, **kwargs):
-                return "---\nname: my-custom-project-agent-xyz\n---\n\n# body\n"
+                return f"---\nname: {agent_name}\n---\n\n# body\n"
 
         processor = AgentProcessor(
             template_builder=_StubBuilder(), version_manager=None
@@ -251,6 +148,20 @@ class TestDeploymentPathsHonorGuard:
 
         with patch("pathlib.Path.home", return_value=fake_home):
             result = processor.process_agent(context)
+        return result, project_agents_dir
+
+    def test_core_agent_deploys_to_project_level(self, temp_dirs):
+        """A CORE agent is now written to project-level (not skipped)."""
+        result, project_agents_dir = self._deploy_via_processor(temp_dirs, CORE_AGENT)
+
+        assert result.status.value != "skipped"
+        assert (project_agents_dir / f"{CORE_AGENT}.md").exists()
+
+    def test_project_agent_still_deploys_via_processor(self, temp_dirs):
+        """A non-CORE agent is still written to the project-level directory."""
+        result, project_agents_dir = self._deploy_via_processor(
+            temp_dirs, PROJECT_AGENT
+        )
 
         assert result.status.value != "skipped"
         assert (project_agents_dir / f"{PROJECT_AGENT}.md").exists()


### PR DESCRIPTION
## Summary
- Removes the USER_LEVEL_AGENTS routing split in agent_deployment.py — all agents now deploy to project-local .claude/agents/
- No-ops skip_project_level_user_agent() guard (was blocking project-level deployment of core agents)
- Removes _deploy_user_level_agents() call from hook installer
- No-ops migrate_core_agents_to_user_level and cleanup_agent_overlap (concepts no longer apply)
- Adds migration v6.5.81 that self-heals existing installs by removing MPM-owned agents from ~/.claude/agents/

This is a breaking change for setups that rely on MPM agents being available cross-project without running claude-mpm in each project. After this change, MPM agents are only available in projects where claude-mpm is active.

Closes #924

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools