### PR TITLE
fix(hooks): stop gh_footer_hook mutating agent body files; fix footer duplication, add opt-out (#937)

### DIFF
--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -318,10 +318,19 @@ class ToolHandler:
                             _hso["permissionDecisionReason"] = _cb_warning_reason
                     # ztk's response replaces the footer hook's, so carry the
                     # body-file advisory across or it would be dropped.
+                    # ztk may itself set additionalContext; APPEND rather than
+                    # overwrite-or-skip so neither message is lost.  (Skipping
+                    # when ztk claimed the field silently dropped the advisory,
+                    # which is the exact failure this block exists to prevent.)
                     if _footer_advisory:
                         _hso = _ztk_response["hookSpecificOutput"]
-                        if isinstance(_hso, dict) and not _hso.get("additionalContext"):
-                            _hso["additionalContext"] = _footer_advisory
+                        if isinstance(_hso, dict):
+                            _existing = _hso.get("additionalContext")
+                            _hso["additionalContext"] = (
+                                f"{_existing}\n\n{_footer_advisory}"
+                                if _existing
+                                else _footer_advisory
+                            )
                     return _ztk_response
             except Exception as _e:
                 if DEBUG:

--- a/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
+++ b/src/claude_mpm/hooks/claude_hooks/handlers/tool_handler.py
@@ -278,6 +278,12 @@ class ToolHandler:
             # ztk does NOT fire (ztk passes through on compound/piped commands
             # and when the ztk binary is absent).
             _footer_rewrote: dict | None = None
+            # gh_footer_hook may instead return an advisory (additionalContext)
+            # with NO updatedInput — that happens on the --body-file path,
+            # where the hook is deliberately read-only and asks the agent to
+            # fix the file itself.  Track it separately so the advice survives
+            # even when ztk rewrites the command and returns its own response.
+            _footer_advisory: str | None = None
             _ztk_event = event  # default: ztk sees the original event
             try:
                 if _build_gh_footer_response is not None:
@@ -290,6 +296,11 @@ class ToolHandler:
                             # command without mutating the caller's event in-place.
                             _ztk_event = {**event, "tool_input": _updated_input}
                             _footer_rewrote = _footer_response
+                        _advisory = _footer_hso.get("additionalContext")
+                        if isinstance(_advisory, str) and _advisory:
+                            _footer_advisory = _advisory
+                            if _footer_rewrote is None:
+                                _footer_rewrote = _footer_response
             except Exception as _e:
                 if DEBUG:
                     _log(f"gh_footer_hook failed (fail-open): {_e}")
@@ -305,20 +316,27 @@ class ToolHandler:
                             "permissionDecisionReason"
                         ):
                             _hso["permissionDecisionReason"] = _cb_warning_reason
+                    # ztk's response replaces the footer hook's, so carry the
+                    # body-file advisory across or it would be dropped.
+                    if _footer_advisory:
+                        _hso = _ztk_response["hookSpecificOutput"]
+                        if isinstance(_hso, dict) and not _hso.get("additionalContext"):
+                            _hso["additionalContext"] = _footer_advisory
                     return _ztk_response
             except Exception as _e:
                 if DEBUG:
                     _log(f"ztk_hook failed (fail-open): {_e}")
-            # If gh_footer_hook rewrote the command but ztk did not fire
-            # (ztk absent, or ztk skipped compound/piped command), surface the
-            # footer-fixed tool_input now.
+            # If gh_footer_hook produced anything (a rewritten command or a
+            # body-file advisory) but ztk did not fire (ztk absent, or ztk
+            # skipped a compound/piped command), surface it now.
             #
             # Invariant: _footer_rewrote is a complete hookSpecificOutput
-            # response (updatedInput already set).  We return it here
-            # regardless of ztk's hookSpecificOutput presence because ztk
-            # returned a no-op ({"continue": True}) — meaning ztk either
-            # chose not to rewrite or is not available.  The footer rewrite
-            # must still reach the harness so the corrected command is used.
+            # response (updatedInput and/or additionalContext already set).
+            # We return it here regardless of ztk's hookSpecificOutput presence
+            # because ztk returned a no-op ({"continue": True}) — meaning ztk
+            # either chose not to rewrite or is not available.  The footer
+            # rewrite must still reach the harness so the corrected command is
+            # used.
             if _footer_rewrote is not None:
                 if _cb_warning_reason:
                     _hso = _footer_rewrote.get("hookSpecificOutput", {})

--- a/src/claude_mpm/hooks/gh_footer_hook.py
+++ b/src/claude_mpm/hooks/gh_footer_hook.py
@@ -15,8 +15,13 @@ Behaviour contract
   ``gh issue edit`` Bash commands, plus MCP tool calls
   ``mcp__github__create_pull_request`` and ``mcp__github__create_issue``.
 - Inline body (``--body``/``-b``): rewrites in the parsed argument value.
-- File body (``--body-file``/``-F``): reads the file, rewrites, writes back.
-- Idempotent: already-canonical MPM footer → no change, no spurious write.
+- File body (``--body-file``/``-F``): **read-only**.  The hook NEVER writes to
+  a caller-owned file; it emits an ``additionalContext`` advisory naming the
+  file and the canonical footer so the agent can fix it with its own
+  Edit/Write tools (which keeps the harness' file bookkeeping consistent).
+- Idempotent: already-canonical MPM footer → no change, no advisory.
+- Opt-out: ``{"gh_footer_hook": {"disabled": true}}`` in the settings cascade,
+  or the ``CLAUDE_MPM_DISABLE_GH_FOOTER`` environment variable.
 - Fail-safe: any parse error, I/O error, or unexpected exception → degrade
   gracefully to ``{"continue": True}`` (NEVER blocks the gh command).
 - Only rewrites the single footer line; never touches other body content.
@@ -28,9 +33,10 @@ LINK: none
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import re
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +47,76 @@ from claude_mpm.hooks.footer_constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Opt-out switch (mirrors context_circuit_breaker's settings cascade)
+# ---------------------------------------------------------------------------
+
+# Environment variable name for the disable switch (secondary).
+_DISABLE_ENV_VAR = "CLAUDE_MPM_DISABLE_GH_FOOTER"
+
+# Config key path inside .claude/settings.json (primary).
+# JSON path: {"gh_footer_hook": {"disabled": true}}
+_CONFIG_KEY = "gh_footer_hook"
+_CONFIG_DISABLED_FIELD = "disabled"
+
+# Values accepted as "truthy" for both the env var and the settings field.
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _settings_candidates(cwd: str) -> list[Path]:
+    """Return ordered list of settings files to check (highest-priority first)."""
+    candidates: list[Path] = []
+    if cwd:
+        candidates.extend(
+            [
+                Path(cwd) / ".claude" / "settings.local.json",
+                Path(cwd) / ".claude" / "settings.json",
+            ]
+        )
+    candidates.append(Path.home() / ".claude" / "settings.json")
+    return candidates
+
+
+def _is_disabled(cwd: str) -> bool:
+    """Return True if the gh footer hook has been explicitly disabled.
+
+    WHAT: Resolves the opt-out switch by consulting the
+          ``CLAUDE_MPM_DISABLE_GH_FOOTER`` env var followed by the
+          ``gh_footer_hook.disabled`` field in the standard settings cascade
+          (.claude/settings.local.json → .claude/settings.json →
+          ~/.claude/settings.json).
+    WHY:  gh_footer_hook silently rewrites agent-authored PR/issue bodies.
+          Every other hook in the live PreToolUse chain has an off-switch;
+          without one, a project that legitimately wants Claude Code
+          attribution has no way to keep it.
+
+    Checks, in order:
+    1. ``CLAUDE_MPM_DISABLE_GH_FOOTER`` env var (any truthy value).
+    2. ``gh_footer_hook.disabled`` in .claude/settings.local.json.
+    3. ``gh_footer_hook.disabled`` in .claude/settings.json.
+    4. ``gh_footer_hook.disabled`` in ~/.claude/settings.json.
+    """
+    env_val = os.environ.get(_DISABLE_ENV_VAR, "").strip().lower()
+    if env_val in _TRUTHY:
+        return True
+
+    for settings_path in _settings_candidates(cwd):
+        try:
+            if not settings_path.is_file():
+                continue
+            with settings_path.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            hook_config = data.get(_CONFIG_KEY)
+            if isinstance(hook_config, dict):
+                disabled_val = hook_config.get(_CONFIG_DISABLED_FIELD, False)
+                if disabled_val is True or str(disabled_val).lower() in _TRUTHY:
+                    return True
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+
+    return False
+
 
 # ---------------------------------------------------------------------------
 # Footer rewrite helpers
@@ -54,11 +130,41 @@ _OLD_FOOTER_BARE = [
     CLAUDE_CODE_FOOTER_OLD_ALT,
 ]
 
-# Compiled pattern that matches either old footer, optionally preceded by
-# the Claude Code robot emoji and arbitrary surrounding whitespace.
-# Group 0 = the full match (emoji + text), stripped and replaced wholesale.
+# Attribution emoji that may decorate a footer.  ``🤖`` is what Claude Code
+# emits; ``👥`` appears in the MPM canonical footer and therefore shows up in
+# half-migrated bodies (e.g. someone hand-edited the emoji but not the text).
+_ATTRIBUTION_EMOJI = "🤖👥"
+
+# A "run" of attribution emoji: one or more of them in any order/repetition,
+# with optional horizontal whitespace between/after them.  ``[^\S\r\n]``
+# deliberately excludes newlines so a run can never span a line break.
+_EMOJI_RUN = r"(?:[" + _ATTRIBUTION_EMOJI + r"][^\S\r\n]*)+"
+
+# Compiled pattern that matches either old footer together with any stale
+# attribution emoji attached to it.
+#
+# Two — and ONLY two — emoji placements are consumed:
+#   (a) an emoji run immediately preceding the footer text on the SAME line
+#       (``🤖👥 Generated with ...``, ``👥 Generated with ...``);
+#   (b) a whole preceding line whose entire non-newline content is an emoji
+#       run (``🤖\nGenerated with ...``, ``🤖👥\nGenerated with ...``).
+#
+# Why the shape is this narrow
+# ----------------------------
+# The previous pattern only consumed a bare adjacent ``🤖``.  Anything else —
+# ``👥``, ``🤖👥``, or an emoji on the preceding line — was left behind, so the
+# canonical replacement (which starts with ``🤖👥``) produced a DUPLICATED
+# prefix such as ``🤖👥🤖👥 Generated with [Claude MPM](...)``.
+#
+# The obvious "just strip across the preceding line break" fix is WRONG: a body
+# containing prose such as ``🤖 indicates an automated build step\nGenerated
+# with [Claude Code](...)`` would lose the entire sentence.  Requiring the
+# preceding line to consist *solely* of an emoji run (anchored with ``^`` under
+# re.MULTILINE and terminated by ``\r?\n``) keeps that prose intact.
 _FOOTER_LINE_RE = re.compile(
-    r"[^\S\r\n]*(?:🤖[^\S\r\n]*)?"  # optional leading whitespace + robot emoji
+    r"(?:^[^\S\r\n]*" + _EMOJI_RUN + r"\r?\n)?"  # (b) emoji-only preceding line
+    r"[^\S\r\n]*"  # leading whitespace on the footer line
+    r"(?:" + _EMOJI_RUN + r")?"  # (a) same-line emoji run
     r"(?:" + "|".join(re.escape(f) for f in _OLD_FOOTER_BARE) + r")"
     r"[^\S\r\n]*",  # trailing whitespace on the line
     re.MULTILINE,
@@ -161,6 +267,17 @@ _GH_BODY_CMD_RE = re.compile(
 # re-matching after the first substitution.  A shlex-based path would be
 # safer in pathological edge cases but would regress on the quoting
 # round-trip tests (``TestRewriteBashCommandFix3``).  Tradeoff accepted.
+#
+# Flag-form coverage (fix 3B)
+# ---------------------------
+# ``--body VALUE``, ``--body=VALUE``, ``-b VALUE`` and ``-b=VALUE`` are all
+# matched via the ``(\s*=\s*|\s+)`` separator group.
+#
+# The GLUED short form ``-bVALUE`` is deliberately NOT supported.  ``gh pr
+# create`` accepts single-dash long-ish tokens in the wild (e.g. a user typing
+# ``-base main``), and allowing a glued ``-b`` would parse ``-base`` as
+# ``-b`` + ``ase`` and corrupt the command.  The false-positive risk outweighs
+# the coverage gain, so ``-b`` keeps its ``(?=[\s=]|$)`` boundary assertion.
 _BODY_FLAG_RE = re.compile(
     r"""((?:--body(?!-file)|(?:(?:^|\s))-b(?=[\s=]|$)))"""  # group 1: flag token
     r"""(\s*=\s*|\s+)"""  # group 2: separator
@@ -169,9 +286,30 @@ _BODY_FLAG_RE = re.compile(
 )
 
 # Regex to extract the value of --body-file / -F.
+#
+# Flag-form coverage (fix 3B)
+# ---------------------------
+# Previously this required ``\s+`` between the flag and its value, so
+# ``--body-file=path``, ``-F=path`` and ``-Fpath`` bypassed the hook entirely
+# even though ``gh`` (pflag) accepts all three.  The separator is now
+# ``(?:\s*=\s*|\s+)`` for the long form and ``(?:\s*=\s*|\s*)`` for ``-F``,
+# the trailing ``\s*`` branch covering the glued ``-Fpath`` spelling.
+#
+# Unlike ``-b`` (see above) the glued ``-F`` form is safe to support: ``gh``
+# has no other single-dash flag beginning with ``F``, so ``-Fxxx`` is
+# unambiguous.  The leading ``(?:^|\s)`` keeps ``-F`` from matching inside a
+# longer token such as ``--body-file``.
 _BODY_FILE_FLAG_RE = re.compile(
-    r"""(?:--body-file|-F)\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
+    r"""(?:^|\s)"""
+    r"""(?:--body-file(?:\s*=\s*|\s+)|-F(?:\s*=\s*|\s*))"""
+    r"""(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))"""
 )
+
+# ``--body-file -`` / ``-F -`` means "read the body from stdin".  There is no
+# file on disk to inspect, and treating it as a path is actively dangerous:
+# ``Path('-')`` resolves to a real file named ``-`` if one happens to exist in
+# the working directory.  Recognised and skipped explicitly, before any read.
+_STDIN_BODY_FILE = "-"
 
 
 def _is_gh_body_command(command: str) -> bool:
@@ -210,11 +348,41 @@ def _extract_body_inline(
 
 
 def _extract_body_file(command: str) -> str | None:
-    """Extract the file path from a ``--body-file``/``-F`` flag, or None."""
+    """Extract the file path from a ``--body-file``/``-F`` flag, or None.
+
+    Returns None when the flag is absent, when no value could be parsed, or
+    when the value is ``-`` (stdin) — see ``_STDIN_BODY_FILE``.
+    """
     m = _BODY_FILE_FLAG_RE.search(command)
     if not m:
         return None
-    return m.group(1) or m.group(2) or m.group(3) or None
+    value = m.group(1) or m.group(2) or m.group(3) or None
+    if value is None:
+        return None
+    if value == _STDIN_BODY_FILE:
+        # "read the body from stdin" — not a path.  Bail out BEFORE any
+        # filesystem access so a stray file literally named "-" in the working
+        # directory can never be read or reported on.
+        logger.debug("gh_footer_hook: --body-file - (stdin) — skipping")
+        return None
+    return value
+
+
+# Characters that are safe to leave completely unquoted in a POSIX shell word.
+# Mirrors the conservative set used by shlex.quote.
+_BARE_SAFE_RE = re.compile(r"^[\w@%+=:,./-]+$", re.ASCII)
+
+
+def _single_quote(value: str) -> str:
+    r"""Wrap *value* in single quotes using the POSIX ``'\''`` splice idiom.
+
+    Inside single quotes the shell performs NO expansion at all, so ``$``,
+    backticks, ``\``, ``"`` and newlines are all inert.  A literal single quote
+    cannot appear inside single quotes, so it is spliced out and back in as
+    ``'\''`` (close quote, escaped quote, reopen quote) — the standard,
+    universally portable idiom.
+    """
+    return "'" + value.replace("'", r"'\''") + "'"
 
 
 def _requote(value: str, quote_char: str) -> str:
@@ -228,37 +396,38 @@ def _requote(value: str, quote_char: str) -> str:
 
     Rules:
     - Double-quoted → keep double-quoted, escaping backslashes and embedded ``"``.
-    - Single-quoted → keep single-quoted (shell semantics: no escaping inside
-      single quotes, but we must ensure the value contains no literal ``'``; if
-      it does, fall back to double-quoting to avoid shell syntax breakage).
-    - Bare / unquoted → stay bare if safe (no spaces, newlines, or ``"``);
-      otherwise wrap in double quotes.
+      ``$`` and backticks are deliberately NOT escaped here: they were already
+      live in the caller's original double-quoted argument, so escaping them
+      would silently change the command's meaning.
+    - Single-quoted → STAY single-quoted, always, using the ``'\\''`` splice
+      idiom (fix 3C).  The previous implementation downgraded values containing
+      a literal ``'`` to double quotes, which turned inert ``$VAR`` and
+      ``` `cmd` ``` text inside the body into live shell expansion/command
+      substitution.  Single quotes never expand anything, so no shell
+      metacharacter can ever escape.
+    - Bare / unquoted → stay bare only when every character is in the
+      conservative shell-safe set; otherwise single-quote it (again, never
+      double quotes, so ``$``/backticks stay inert).
     """
     if quote_char == '"':
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     if quote_char == "'":
-        if "'" not in value:
-            return f"'{value}'"
-        # Value contains a single quote — cannot stay single-quoted safely;
-        # fall back to double quotes with proper escaping.
-        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
-    # Bare / no quote char — add double quotes only if value requires them.
-    if " " in value or "\n" in value or '"' in value or "'" in value:
-        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
-    return value
+        return _single_quote(value)
+    # Bare / no quote char — stay bare only when unambiguously safe.
+    if value and _BARE_SAFE_RE.match(value):
+        return value
+    return _single_quote(value)
 
 
 def rewrite_bash_command(command: str) -> str | None:
     """Rewrite a Bash command string so any old footer in the body is canonical.
 
-    WHAT: Parses ``--body``/``-b`` (inline) and ``--body-file``/``-F`` (file)
-          flags from a ``gh pr/issue create/edit`` command, rewrites any old
-          Claude Code footer in the body to the MPM canonical footer, and
-          returns the modified command string.  For file-based bodies, the file
-          is rewritten in place and the command string is returned unchanged.
+    WHAT: Parses the ``--body``/``-b`` (inline) flag from a ``gh pr/issue
+          create/edit`` command, rewrites any old Claude Code footer in the
+          body to the MPM canonical footer, and returns the modified command
+          string.  File-based bodies (``--body-file``/``-F``) are NOT handled
+          here — see ``build_body_file_advisory``.
     WHY:  This function is the single point where Bash-command bodies are
           normalised; it must be robust against edge cases (empty values,
           multi-line bodies, the old footer text appearing in other flags such
@@ -267,7 +436,8 @@ def rewrite_bash_command(command: str) -> str | None:
           search on the old value — to avoid false matches.
 
     Returns the rewritten command string, or None if no rewrite was needed
-    (already canonical, no footer found, or not a gh body command).
+    (already canonical, no footer found, not a gh body command, or the
+    quoting could not be parsed with confidence).
     Fail-safe: any unexpected exception is caught; None is returned so the
     original command is used unmodified.
     """
@@ -275,10 +445,41 @@ def rewrite_bash_command(command: str) -> str | None:
         if not _is_gh_body_command(command):
             return None
 
-        # Try inline --body / -b first.
+        # Try inline --body / -b.
         extracted = _extract_body_inline(command)
         if extracted is not None:
             body_value, match = extracted
+
+            # Parser-confidence guard (fix 3C, related gap).
+            #
+            # ``_BODY_FLAG_RE`` models a quoted value as a single balanced
+            # quote pair.  A shell word may instead be a CONCATENATION of
+            # adjacent quoted/bare chunks — most commonly the POSIX splice
+            # idiom ``'It'\''s'`` used to embed a literal apostrophe inside a
+            # single-quoted string.  In that case the regex stops at the first
+            # closing quote and captures only a PREFIX of the real body.
+            #
+            # Rewriting from a prefix would splice the canonical footer into
+            # the middle of a shell word and leave the tail (``\''s'``)
+            # dangling — a corrupted command.  We cannot parse the full word
+            # without replacing the whole regex approach with a shell
+            # tokeniser (see "Why not shlex.split" above), so instead we detect
+            # the situation and stand down: if the value token is not followed
+            # by whitespace or end-of-string, the parse is untrustworthy and we
+            # return None, leaving the command exactly as the agent wrote it.
+            #
+            # KNOWN LIMITATION: a body that uses the ``'\''`` idiom AND carries
+            # a stale Claude Code footer is therefore left un-normalised rather
+            # than corrupted.  This is a deliberate correctness-over-coverage
+            # tradeoff; see ``test_splice_quoted_body_is_left_alone``.
+            trailing = command[match.end() : match.end() + 1]
+            if trailing and not trailing.isspace():
+                logger.debug(
+                    "gh_footer_hook: body value token not followed by whitespace "
+                    "(concatenated shell word?) — standing down"
+                )
+                return None
+
             new_body = rewrite_footer(body_value)
             if new_body == body_value:
                 return None  # already canonical or no footer
@@ -305,58 +506,63 @@ def rewrite_bash_command(command: str) -> str | None:
             # text that may appear elsewhere in the command (e.g. in --title).
             return _BODY_FLAG_RE.sub(replacement, command, count=1)
 
-        # Try --body-file / -F.
-        file_path_str = _extract_body_file(command)
-        if file_path_str is not None:
-            file_path = Path(file_path_str)
-            try:
-                original_body = file_path.read_text(encoding="utf-8")
-            except OSError as exc:
-                logger.debug(
-                    "gh_footer_hook: cannot read body file %s: %s", file_path, exc
-                )
-                return None
-            new_body = rewrite_footer(original_body)
-            if new_body == original_body:
-                return None
-            try:
-                # Write atomically: write to a temp file in the same directory
-                # (guarantees same filesystem so Path.replace is atomic), then
-                # rename over the target.  Path.write_text is not atomic —
-                # a crash mid-write would corrupt the body file.
-                #
-                # Leak-safety: tmp_path is tracked from the moment the file is
-                # created.  A try/finally ensures the temp file is unlinked on
-                # any failure path (write error or rename error), so orphaned
-                # temp files cannot accumulate.
-                dir_path = file_path.parent
-                tmp_path: str | None = None
-                try:
-                    with tempfile.NamedTemporaryFile(
-                        mode="w",
-                        encoding="utf-8",
-                        dir=dir_path,
-                        delete=False,
-                        suffix=".tmp",
-                    ) as tmp:
-                        tmp_path = tmp.name
-                        tmp.write(new_body)
-                    Path(tmp_path).replace(file_path)
-                    tmp_path = None  # rename succeeded; nothing to clean up
-                finally:
-                    if tmp_path is not None:
-                        Path(tmp_path).unlink(missing_ok=True)
-            except OSError as exc:
-                logger.debug(
-                    "gh_footer_hook: cannot write body file %s: %s", file_path, exc
-                )
-                return None
-            # Command string itself is unchanged (file path is the same).
-            return command
-
-        return None  # no --body or --body-file flag found
+        # --body-file / -F is intentionally NOT handled here: the hook must
+        # never mutate a caller-owned file.  See build_body_file_advisory.
+        return None  # no inline --body flag found
     except Exception as exc:
         logger.debug("gh_footer_hook: rewrite_bash_command error (degrading): %s", exc)
+        return None
+
+
+# Template for the advisory surfaced to the agent when a ``--body-file``
+# target still carries a stale Claude Code footer.
+_BODY_FILE_ADVISORY = (
+    "[claude-mpm] The body file '{path}' passed to this gh command still "
+    "contains a Claude Code attribution footer. claude-mpm does not edit "
+    "agent-owned files, so please update it yourself with Edit/Write before "
+    "(re-)running the command, replacing the footer line with exactly:\n"
+    "{footer}"
+)
+
+
+def build_body_file_advisory(command: str) -> str | None:
+    """Return an advisory message if a ``--body-file`` target has a stale footer.
+
+    WHAT: Reads (read-only!) the file named by ``--body-file``/``-F`` and, if
+          its contents would be changed by ``rewrite_footer``, returns a
+          human-readable advisory naming the file and the canonical footer.
+          Returns None in every other case.
+    WHY:  The previous implementation rewrote the body file IN PLACE from
+          inside a PreToolUse hook.  That silently mutated a file the calling
+          agent owns, outside all Edit/Write tool bookkeeping — the agent's
+          view of the file diverged from disk, and the change was invisible in
+          the transcript.  Surfacing an advisory instead keeps the hook
+          side-effect-free and lets the agent make the edit through its own
+          tools, so the mutation stays visible and attributable.
+
+    Fail-safe: any I/O error or unexpected exception yields None.
+    """
+    try:
+        if not _is_gh_body_command(command):
+            return None
+        file_path_str = _extract_body_file(command)
+        if file_path_str is None:
+            return None
+        file_path = Path(file_path_str)
+        try:
+            original_body = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug("gh_footer_hook: cannot read body file %s: %s", file_path, exc)
+            return None
+        if rewrite_footer(original_body) == original_body:
+            return None
+        return _BODY_FILE_ADVISORY.format(
+            path=file_path_str, footer=MPM_FOOTER_CANONICAL
+        )
+    except Exception as exc:
+        logger.debug(
+            "gh_footer_hook: build_body_file_advisory error (degrading): %s", exc
+        )
         return None
 
 
@@ -409,18 +615,27 @@ def rewrite_mcp_body(
 def build_gh_footer_response(event: dict[str, Any]) -> dict[str, Any]:
     """Build a PreToolUse hook response that normalises PR/issue body footers.
 
-    WHAT: Wraps rewrite_bash_command / rewrite_mcp_body and formats the result
-          as a Claude Code PreToolUse wire-format response dict.
+    WHAT: Wraps rewrite_bash_command / build_body_file_advisory /
+          rewrite_mcp_body and formats the result as a Claude Code PreToolUse
+          wire-format response dict.
     WHY:  Single callable that the pretooluse_dispatcher and tool_handler can
-          both call without duplicating the response-envelope logic.
+          both call without duplicating the response-envelope logic.  It is
+          also the single choke point for the opt-out switch, so disabling the
+          hook is guaranteed to short-circuit EVERY tool path.
 
     Returns:
         ``{"hookSpecificOutput": {"hookEventName": "PreToolUse",
             "updatedInput": <modified tool_input>}}``  when a rewrite occurs.
+        ``{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+            "additionalContext": <advisory>}}``  when a ``--body-file`` target
+            carries a stale footer (advisory only — nothing is written).
         ``{"continue": True}``  when no rewrite is needed.
         ``{"continue": True}``  on any error (fail-safe).
     """
     try:
+        if _is_disabled(event.get("cwd", "") or ""):
+            return {"continue": True}
+
         tool_name: str = event.get("tool_name", "")
         tool_input: dict[str, Any] = event.get("tool_input", {}) or {}
 
@@ -429,17 +644,32 @@ def build_gh_footer_response(event: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(command, str) or not command.strip():
                 return {"continue": True}
             new_command = rewrite_bash_command(command)
-            if new_command is None:
-                return {"continue": True}
-            updated_input = dict(tool_input)
-            updated_input["command"] = new_command
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                    "updatedInput": updated_input,
+            # Only emit updatedInput when the command text ACTUALLY changed —
+            # a byte-identical "update" is pure bookkeeping noise for the
+            # harness and misrepresents the hook as having rewritten something.
+            if new_command is not None and new_command != command:
+                updated_input = dict(tool_input)
+                updated_input["command"] = new_command
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "allow",
+                        "updatedInput": updated_input,
+                    }
                 }
-            }
+            # No inline rewrite — check for a stale footer in a --body-file
+            # target and surface it as advice.  Read-only: the hook never
+            # touches a file the calling agent owns.
+            advisory = build_body_file_advisory(command)
+            if advisory is not None:
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "allow",
+                        "additionalContext": advisory,
+                    }
+                }
+            return {"continue": True}
 
         # MCP GitHub tool path
         updated_input = rewrite_mcp_body(tool_name, tool_input)

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -171,6 +171,10 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
                     # without mutating the caller's event dict in-place.
                     ztk_event = {**event, "tool_input": _updated}
                     _footer_rewrite = _footer_resp
+                elif _footer_resp["hookSpecificOutput"].get("additionalContext"):
+                    # --body-file advisory: no command rewrite, but the advice
+                    # must still reach the agent if ztk does not fire.
+                    _footer_rewrite = _footer_resp
             response = ztk_hook.build_ztk_response(ztk_event)
             if response.get("hookSpecificOutput"):
                 return _merge_warning_into_response(response, warning_reason)

--- a/src/claude_mpm/hooks/pretooluse_dispatcher.py
+++ b/src/claude_mpm/hooks/pretooluse_dispatcher.py
@@ -162,21 +162,39 @@ def dispatch(event: dict[str, Any]) -> dict[str, Any]:
             # wraps the command.  If ztk does not fire (absent binary or
             # compound command), the footer-fixed response is returned directly.
             _footer_rewrite: dict | None = None
+            _footer_advisory = ""
             _footer_resp = gh_footer_hook.build_gh_footer_response(event)
             ztk_event = event  # default: ztk sees the original event
-            if _footer_resp.get("hookSpecificOutput"):
-                _updated = _footer_resp["hookSpecificOutput"].get("updatedInput")
-                if isinstance(_updated, dict):
-                    # Use a shallow copy so ztk sees the footer-fixed command
-                    # without mutating the caller's event dict in-place.
-                    ztk_event = {**event, "tool_input": _updated}
-                    _footer_rewrite = _footer_resp
-                elif _footer_resp["hookSpecificOutput"].get("additionalContext"):
-                    # --body-file advisory: no command rewrite, but the advice
-                    # must still reach the agent if ztk does not fire.
+            # ``or {}`` keeps every downstream read total: the fail-safe
+            # response is ``{"continue": True}`` with no hookSpecificOutput key.
+            _footer_hso = _footer_resp.get("hookSpecificOutput") or {}
+            _updated = _footer_hso.get("updatedInput")
+            if isinstance(_updated, dict):
+                # Use a shallow copy so ztk sees the footer-fixed command
+                # without mutating the caller's event dict in-place.
+                ztk_event = {**event, "tool_input": _updated}
+                _footer_rewrite = _footer_resp
+            _advisory = _footer_hso.get("additionalContext")
+            if isinstance(_advisory, str) and _advisory:
+                # --body-file advisory: no command rewrite, but the advice
+                # must still reach the agent whether or not ztk fires.
+                _footer_advisory = _advisory
+                if _footer_rewrite is None:
                     _footer_rewrite = _footer_resp
             response = ztk_hook.build_ztk_response(ztk_event)
-            if response.get("hookSpecificOutput"):
+            _ztk_hso = response.get("hookSpecificOutput")
+            if _ztk_hso:
+                # ztk's response replaces the footer hook's, so carry the
+                # body-file advisory across or it would be dropped.  Append
+                # rather than overwrite so ztk's own context survives too.
+                # Mirrors ToolHandler.handle_pre_tool_fast, the live path.
+                if _footer_advisory and isinstance(_ztk_hso, dict):
+                    _existing = _ztk_hso.get("additionalContext")
+                    _ztk_hso["additionalContext"] = (
+                        f"{_existing}\n\n{_footer_advisory}"
+                        if _existing
+                        else _footer_advisory
+                    )
                 return _merge_warning_into_response(response, warning_reason)
             if _footer_rewrite is not None:
                 return _merge_warning_into_response(_footer_rewrite, warning_reason)

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -1244,3 +1244,240 @@ class TestBodyFileAdvisoryThroughToolHandler:
         hso = response.get("hookSpecificOutput")
         assert hso is not None
         assert MPM_FOOTER_CANONICAL in hso["updatedInput"]["command"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 review follow-up — the advisory must MERGE with ztk's own
+# additionalContext, never be silently yielded to it.
+# ---------------------------------------------------------------------------
+
+_ZTK_CONTEXT = "[ztk] command was compressed"
+
+
+def _make_tool_handler():
+    """Build a minimal ToolHandler with mocked observability dependencies."""
+    from unittest.mock import MagicMock
+
+    from claude_mpm.hooks.claude_hooks.handlers.base import BaseEventHandler
+    from claude_mpm.hooks.claude_hooks.handlers.tool_handler import ToolHandler
+
+    mock_hh = MagicMock()
+    mock_hh._emit_socketio_event = MagicMock(return_value=None)
+    mock_hh._get_delegation_agent_type = MagicMock(return_value="unknown")
+
+    base = MagicMock(spec=BaseEventHandler)
+    base.hook_handler = mock_hh
+    base._get_git_branch = MagicMock(return_value="main")
+    base.log_manager = None
+
+    return ToolHandler(base)
+
+
+def _ztk_response_factory(*, additional_context: str | None):
+    """Return a fake ``build_ztk_response`` that always rewrites the command."""
+
+    def _fake(event):
+        hso = {
+            "hookEventName": "PreToolUse",
+            "updatedInput": {"command": "ztk-wrapped-command"},
+        }
+        if additional_context is not None:
+            hso["additionalContext"] = additional_context
+        return {"hookSpecificOutput": hso}
+
+    return _fake
+
+
+class TestAdvisorySurvivesZtkAdditionalContext:
+    """``ztk_hook`` may populate ``additionalContext`` itself.
+
+    Both dispatch sites used to write the gh_footer body-file advisory only
+    when that field was still empty, so a ztk response that claimed the field
+    silently DROPPED the advisory — the exact failure the merge exists to
+    prevent.  Both messages must now survive.
+    """
+
+    @staticmethod
+    def _body_file_event(tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"Body\n\n{CLAUDE_CODE_FOOTER_OLD}")
+        return body_file, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": f"gh pr create --body-file {body_file}"},
+            "session_id": "test-session",
+            "cwd": str(tmp_path),
+        }
+
+    # --- live path: ToolHandler.handle_pre_tool_fast -------------------------
+
+    def test_tool_handler_appends_advisory_to_ztk_context(self, tmp_path, monkeypatch):
+        from claude_mpm.hooks import context_circuit_breaker, ztk_hook
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _e: {})
+        monkeypatch.setattr(
+            ztk_hook,
+            "build_ztk_response",
+            _ztk_response_factory(additional_context=_ZTK_CONTEXT),
+        )
+
+        body_file, event = self._body_file_event(tmp_path)
+        response = _make_tool_handler().handle_pre_tool_fast(event)
+
+        hso = (response or {}).get("hookSpecificOutput")
+        assert hso is not None, f"Expected hookSpecificOutput, got {response!r}"
+        context = hso.get("additionalContext", "")
+        assert _ZTK_CONTEXT in context, "ztk's own additionalContext was clobbered"
+        assert str(body_file) in context, "footer advisory was dropped by ztk"
+        assert MPM_FOOTER_CANONICAL in context
+        # ztk's rewrite still wins for the command itself.
+        assert hso["updatedInput"]["command"] == "ztk-wrapped-command"
+
+    def test_tool_handler_sets_advisory_when_ztk_context_absent(
+        self, tmp_path, monkeypatch
+    ):
+        from claude_mpm.hooks import context_circuit_breaker, ztk_hook
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _e: {})
+        monkeypatch.setattr(
+            ztk_hook,
+            "build_ztk_response",
+            _ztk_response_factory(additional_context=None),
+        )
+
+        body_file, event = self._body_file_event(tmp_path)
+        response = _make_tool_handler().handle_pre_tool_fast(event)
+
+        hso = (response or {}).get("hookSpecificOutput")
+        assert hso is not None
+        context = hso.get("additionalContext", "")
+        assert str(body_file) in context
+        assert MPM_FOOTER_CANONICAL in context
+        # No stray separator when there was nothing to append to.
+        assert not context.startswith("\n")
+
+    # --- legacy path: pretooluse_dispatcher.dispatch -------------------------
+
+    def test_dispatcher_appends_advisory_to_ztk_context(self, tmp_path, monkeypatch):
+        from claude_mpm.hooks import (
+            context_circuit_breaker,
+            pretooluse_dispatcher,
+            ztk_hook,
+        )
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _e: {})
+        monkeypatch.setattr(
+            ztk_hook,
+            "build_ztk_response",
+            _ztk_response_factory(additional_context=_ZTK_CONTEXT),
+        )
+
+        body_file, event = self._body_file_event(tmp_path)
+        response = pretooluse_dispatcher.dispatch(event)
+
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, f"Expected hookSpecificOutput, got {response!r}"
+        context = hso.get("additionalContext", "")
+        assert _ZTK_CONTEXT in context, "ztk's own additionalContext was clobbered"
+        assert str(body_file) in context, "footer advisory was dropped by ztk"
+        assert MPM_FOOTER_CANONICAL in context
+
+    def test_dispatcher_failsafe_footer_response_does_not_break_bash_branch(
+        self, monkeypatch
+    ):
+        """A footer response with NO ``hookSpecificOutput`` key must be inert.
+
+        ``build_gh_footer_response`` fails open to ``{"continue": True}``.  The
+        Bash branch reads ``hookSpecificOutput`` several times; every read must
+        be total.  ``dispatch`` swallows exceptions, so the discriminator is
+        that ztk's response still comes back: had the footer block raised,
+        the fail-open handler would have returned a bare pass-through.
+        """
+        from claude_mpm.hooks import (
+            context_circuit_breaker,
+            gh_footer_hook as _gh,
+            pretooluse_dispatcher,
+            ztk_hook,
+        )
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _e: {})
+        monkeypatch.setattr(
+            _gh, "build_gh_footer_response", lambda _e: {"continue": True}
+        )
+        monkeypatch.setattr(
+            ztk_hook,
+            "build_ztk_response",
+            _ztk_response_factory(additional_context=None),
+        )
+
+        response = pretooluse_dispatcher.dispatch(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh pr create --body-file body.md"},
+            }
+        )
+
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, (
+            "Bash branch aborted before ztk ran — the footer response with no "
+            f"hookSpecificOutput was not handled totally: {response!r}"
+        )
+        assert hso["updatedInput"]["command"] == "ztk-wrapped-command"
+        assert "additionalContext" not in hso
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 review follow-up — _BODY_FILE_FLAG_RE anchor semantics
+# ---------------------------------------------------------------------------
+
+
+class TestBodyFileFlagAnchor:
+    """``_BODY_FILE_FLAG_RE`` uses ``(?:^|\\s)`` WITHOUT ``re.MULTILINE``.
+
+    That is deliberate and sufficient: ``\\s`` already matches ``\\n``, so a
+    flag on a backslash-continued line is reached through the ``\\s`` branch
+    and never needs ``^`` to match at a line start.  Adding ``re.MULTILINE``
+    would change nothing, so it is not added.
+    """
+
+    def test_flag_at_string_start_matches(self):
+        assert _extract_body_file("--body-file=body.md") == "body.md"
+        assert _extract_body_file("-F body.md") == "body.md"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr create \\\n  -F body.md",
+            'gh pr create --title "x" \\\n  --body-file body.md',
+            "gh pr create\n-F body.md",
+        ],
+    )
+    def test_flag_after_newline_matches_without_multiline(self, command):
+        """The ``\\s`` branch consumes the newline — no ``re.MULTILINE`` needed."""
+        assert _extract_body_file(command) == "body.md"
+
+    def test_flag_inside_a_longer_token_is_not_matched_as_dash_f(self):
+        """``(?:^|\\s)`` keeps ``-F`` from matching inside ``--body-file``."""
+        assert _extract_body_file("gh pr create --body-file report.md") == "report.md"
+
+    def test_dash_f_inside_a_quoted_value_is_a_harmless_false_positive(
+        self, tmp_path, monkeypatch
+    ):
+        """KNOWN LIMITATION, pinned deliberately.
+
+        The regex is not shell-aware, so ``-F`` preceded by a space *inside* a
+        quoted argument is matched.  ``re.MULTILINE`` is irrelevant to this —
+        the match comes from the ``\\s`` branch either way.  It is harmless
+        because the extracted token is not a real path: the hook is read-only
+        and ``build_body_file_advisory`` degrades to None on the failed read,
+        so nothing is emitted and no file is ever touched.
+        """
+        monkeypatch.chdir(tmp_path)
+        command = "gh pr create --title \"use -F for files\" --body 'hello'"
+
+        # The raw extractor does match the phantom token...
+        assert _extract_body_file(command) == "for"
+        # ...but the advisory builder emits nothing, because there is no such file.
+        assert build_body_file_advisory(command) is None
+        assert not (tmp_path / "for").exists()

--- a/tests/hooks/test_gh_footer_hook.py
+++ b/tests/hooks/test_gh_footer_hook.py
@@ -19,12 +19,23 @@ from claude_mpm.hooks.footer_constants import (
     MPM_FOOTER_CANONICAL,
 )
 from claude_mpm.hooks.gh_footer_hook import (
+    _DISABLE_ENV_VAR,
+    _extract_body_file,
     _is_gh_body_command,
+    _requote,
+    build_body_file_advisory,
     build_gh_footer_response,
     rewrite_bash_command,
     rewrite_footer,
     rewrite_mcp_body,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_disable_env(monkeypatch):
+    """Ensure a developer's exported opt-out cannot silently pass the suite."""
+    monkeypatch.delenv(_DISABLE_ENV_VAR, raising=False)
+
 
 # ---------------------------------------------------------------------------
 # rewrite_footer — pure string transformation
@@ -196,25 +207,24 @@ class TestRewriteBashCommand:
     def test_pr_view_returns_none(self):
         assert rewrite_bash_command("gh pr view 42") is None
 
-    def test_body_file_flag(self, tmp_path):
+    def test_body_file_flag_never_rewrites_command_or_file(self, tmp_path):
+        """Regression (defect 1): --body-file is advisory-only, never mutating."""
         body_file = tmp_path / "body.md"
-        body_file.write_text(f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}")
+        original = f"Content\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        body_file.write_text(original)
         cmd = f"gh pr create --body-file {body_file}"
-        result = rewrite_bash_command(cmd)
-        # Command string is unchanged (same file path)
-        assert result == cmd
-        # But file content was rewritten
-        new_content = body_file.read_text()
-        assert MPM_FOOTER_CANONICAL in new_content
-        assert CLAUDE_CODE_FOOTER_OLD not in new_content
+        # No command rewrite is possible for a file body.
+        assert rewrite_bash_command(cmd) is None
+        # And the file on disk must be byte-identical.
+        assert body_file.read_text() == original
 
-    def test_body_file_short_flag(self, tmp_path):
+    def test_body_file_short_flag_never_mutates(self, tmp_path):
         body_file = tmp_path / "body.md"
-        body_file.write_text(f"{CLAUDE_CODE_FOOTER_OLD_ALT}")
+        original = f"{CLAUDE_CODE_FOOTER_OLD_ALT}"
+        body_file.write_text(original)
         cmd = f"gh issue create -F {body_file}"
-        result = rewrite_bash_command(cmd)
-        assert result == cmd
-        assert MPM_FOOTER_CANONICAL in body_file.read_text()
+        assert rewrite_bash_command(cmd) is None
+        assert body_file.read_text() == original
 
     def test_body_file_already_canonical_returns_none(self, tmp_path):
         body_file = tmp_path / "body.md"
@@ -681,3 +691,556 @@ class TestCbWarningReasonToolHandlerMcpBranch:
         assert not hso.get("permissionDecisionReason"), (
             "Expected no permissionDecisionReason when circuit breaker was silent"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — Defect 2: first-pass footer duplication on dirty input
+# ---------------------------------------------------------------------------
+
+ROBOT = "\U0001f916"  # 🤖
+PEOPLE = "\U0001f465"  # 👥
+
+
+class TestFooterEmojiDuplication:
+    """Regression (#937 defect 2): stale attribution emoji must be consumed.
+
+    Before the fix ``_FOOTER_LINE_RE`` only swallowed a bare adjacent ``🤖``,
+    so every shape below gained a duplicated ``🤖👥`` prefix on the FIRST
+    rewrite pass (and only stabilised on the second).
+    """
+
+    @pytest.mark.parametrize(
+        "dirty",
+        [
+            pytest.param(
+                f"{ROBOT}{PEOPLE} {CLAUDE_CODE_FOOTER_OLD}", id="robot+people-same-line"
+            ),
+            pytest.param(f"{ROBOT}\n{CLAUDE_CODE_FOOTER_OLD}", id="robot-own-line"),
+            pytest.param(
+                f"{ROBOT}{PEOPLE}\n{CLAUDE_CODE_FOOTER_OLD}", id="robot+people-own-line"
+            ),
+            pytest.param(
+                f"{PEOPLE} {CLAUDE_CODE_FOOTER_OLD}", id="people-only-same-line"
+            ),
+        ],
+    )
+    def test_no_duplicate_emoji_prefix(self, dirty):
+        result = rewrite_footer(dirty)
+        assert result == MPM_FOOTER_CANONICAL, (
+            f"Expected exactly the canonical footer, got {result!r}"
+        )
+        # Belt and braces: the emoji run must appear exactly once.
+        assert result.count(ROBOT) == 1
+        assert result.count(PEOPLE) == 1
+        assert f"{ROBOT}{PEOPLE}{ROBOT}{PEOPLE}" not in result
+
+    @pytest.mark.parametrize(
+        "dirty",
+        [
+            f"{ROBOT}{PEOPLE} {CLAUDE_CODE_FOOTER_OLD}",
+            f"{ROBOT}\n{CLAUDE_CODE_FOOTER_OLD}",
+            f"{ROBOT}{PEOPLE}\n{CLAUDE_CODE_FOOTER_OLD}",
+            f"{PEOPLE} {CLAUDE_CODE_FOOTER_OLD}",
+            f"{ROBOT} {CLAUDE_CODE_FOOTER_OLD_ALT}",
+        ],
+    )
+    def test_first_pass_equals_second_pass(self, dirty):
+        """The very first pass must already be a fixed point."""
+        once = rewrite_footer(dirty)
+        twice = rewrite_footer(once)
+        assert once == twice
+
+    def test_dirty_footer_in_larger_body(self):
+        body = f"## Summary\n\nSome text.\n\n{ROBOT}{PEOPLE} {CLAUDE_CODE_FOOTER_OLD}\n"
+        result = rewrite_footer(body)
+        assert result.count(MPM_FOOTER_CANONICAL) == 1
+        assert f"{ROBOT}{PEOPLE}{ROBOT}{PEOPLE}" not in result
+        assert "## Summary" in result
+        assert "Some text." in result
+
+    # --- the over-strip guard ------------------------------------------------
+
+    def test_emoji_prose_on_preceding_line_is_not_eaten(self):
+        """CRITICAL negative case: a naive 'strip across the newline' fix
+        destroys legitimate prose.  The sentence must survive intact."""
+        prose = f"{ROBOT} indicates an automated build step"
+        body = f"{prose}\n{CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert prose in result, f"Prose was destroyed: {result!r}"
+        assert result == f"{prose}\n{MPM_FOOTER_CANONICAL}"
+
+    def test_emoji_prose_with_trailing_words_same_line_not_eaten(self):
+        body = f"Use {ROBOT} for bots and {PEOPLE} for teams.\n{CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert f"Use {ROBOT} for bots and {PEOPLE} for teams." in result
+        assert MPM_FOOTER_CANONICAL in result
+
+    def test_emoji_only_line_two_lines_above_is_not_eaten(self):
+        """Only the IMMEDIATELY preceding emoji-only line is consumed."""
+        body = f"{ROBOT}\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        result = rewrite_footer(body)
+        assert result.startswith(f"{ROBOT}\n")
+        assert MPM_FOOTER_CANONICAL in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — Defect 1: --body-file is advisory-only, never mutating
+# ---------------------------------------------------------------------------
+
+
+class TestBodyFileAdvisory:
+    """The hook must never write to a file the calling agent owns."""
+
+    def test_advisory_returned_and_file_untouched(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        original = f"## Summary\n\nStuff\n\n{CLAUDE_CODE_FOOTER_OLD}\n"
+        body_file.write_text(original)
+        before_mtime = body_file.stat().st_mtime_ns
+
+        advisory = build_body_file_advisory(f"gh pr create --body-file {body_file}")
+
+        assert advisory is not None
+        assert str(body_file) in advisory
+        assert MPM_FOOTER_CANONICAL in advisory
+        assert body_file.read_text() == original
+        assert body_file.stat().st_mtime_ns == before_mtime
+
+    def test_no_advisory_when_already_canonical(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"Content\n\n{MPM_FOOTER_CANONICAL}")
+        assert build_body_file_advisory(f"gh pr create -F {body_file}") is None
+
+    def test_no_advisory_for_missing_file(self):
+        cmd = "gh pr create --body-file /nonexistent/path/body.md"
+        assert build_body_file_advisory(cmd) is None
+
+    def test_no_advisory_for_unrelated_command(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(CLAUDE_CODE_FOOTER_OLD)
+        assert build_body_file_advisory(f"cat {body_file}") is None
+
+    def test_no_temp_files_left_behind(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"x\n\n{CLAUDE_CODE_FOOTER_OLD}")
+        build_body_file_advisory(f"gh pr create --body-file {body_file}")
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["body.md"]
+
+    def test_response_has_additional_context_and_no_updated_input(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        original = f"Body\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        body_file.write_text(original)
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"gh pr create --body-file {body_file}"},
+        }
+        response = build_gh_footer_response(event)
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, f"Expected an advisory response, got {response!r}"
+        assert "updatedInput" not in hso, (
+            "No command text changed — updatedInput must be omitted"
+        )
+        assert MPM_FOOTER_CANONICAL in hso["additionalContext"]
+        assert str(body_file) in hso["additionalContext"]
+        # Still no mutation.
+        assert body_file.read_text() == original
+
+    def test_no_response_when_body_file_already_canonical(self, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"Body\n\n{MPM_FOOTER_CANONICAL}")
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"gh pr create --body-file {body_file}"},
+        }
+        assert build_gh_footer_response(event) == {"continue": True}
+
+
+class TestBodyFileStdin:
+    """``--body-file -`` means stdin, NOT a file named ``-``."""
+
+    def test_extract_returns_none_for_stdin(self):
+        assert _extract_body_file("gh pr create --body-file -") is None
+        assert _extract_body_file("gh issue create -F -") is None
+
+    def test_real_file_named_dash_is_never_touched(self, tmp_path, monkeypatch):
+        """Proven-dangerous case: a real file literally named ``-`` in cwd."""
+        monkeypatch.chdir(tmp_path)
+        dash = tmp_path / "-"
+        original = f"Body\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        dash.write_text(original)
+        before_mtime = dash.stat().st_mtime_ns
+
+        cmd = "gh pr create --title T --body-file -"
+        assert rewrite_bash_command(cmd) is None
+        assert build_body_file_advisory(cmd) is None
+        assert build_gh_footer_response(
+            {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        ) == {"continue": True}
+
+        # The file must be untouched: same bytes, same mtime, no temp siblings.
+        assert dash.read_text() == original
+        assert dash.stat().st_mtime_ns == before_mtime
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["-"]
+
+    def test_short_flag_dash_stdin_file_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dash = tmp_path / "-"
+        original = f"{CLAUDE_CODE_FOOTER_OLD_ALT}"
+        dash.write_text(original)
+        assert build_body_file_advisory("gh issue create -F -") is None
+        assert dash.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — Defect 3B: flag-form coverage matrix
+# ---------------------------------------------------------------------------
+
+
+class TestBodyFileFlagForms:
+    """``--body-file=p``, ``-F=p`` and ``-Fp`` used to bypass the hook."""
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("gh pr create --body-file {p}", id="long-space"),
+            pytest.param("gh pr create --body-file={p}", id="long-equals"),
+            pytest.param("gh pr create -F {p}", id="short-space"),
+            pytest.param("gh pr create -F={p}", id="short-equals"),
+            pytest.param("gh pr create -F{p}", id="short-glued"),
+            pytest.param('gh pr create --body-file "{p}"', id="long-space-dquoted"),
+            pytest.param("gh pr create --body-file='{p}'", id="long-equals-squoted"),
+        ],
+    )
+    def test_every_flag_form_is_detected(self, tmp_path, template):
+        body_file = tmp_path / "body.md"
+        original = f"Body\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        body_file.write_text(original)
+        cmd = template.format(p=body_file)
+
+        assert _extract_body_file(cmd) == str(body_file), (
+            f"Flag form not parsed: {cmd!r}"
+        )
+        advisory = build_body_file_advisory(cmd)
+        assert advisory is not None, f"Flag form bypassed the hook: {cmd!r}"
+        assert str(body_file) in advisory
+        # Advisory-only: still no mutation for any flag form.
+        assert body_file.read_text() == original
+
+    def test_body_file_not_matched_inside_longer_token(self):
+        # -F must not match mid-token.
+        assert _extract_body_file("gh pr create --draft") is None
+        assert _extract_body_file("gh pr create --title xxx-Fyyy") is None
+
+
+class TestInlineBodyFlagForms:
+    """Inline ``--body``/``-b`` separator matrix.
+
+    The equals form already worked before #937; recorded here so a
+    regression is caught.
+    """
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param('gh pr create --body "{b}"', id="long-space"),
+            pytest.param('gh pr create --body="{b}"', id="long-equals"),
+            pytest.param('gh pr create -b "{b}"', id="short-space"),
+            pytest.param('gh pr create -b="{b}"', id="short-equals"),
+        ],
+    )
+    def test_every_inline_form_rewrites(self, template):
+        cmd = template.format(b=CLAUDE_CODE_FOOTER_OLD)
+        result = rewrite_bash_command(cmd)
+        assert result is not None, f"Inline form bypassed the hook: {cmd!r}"
+        assert MPM_FOOTER_CANONICAL in result
+        assert CLAUDE_CODE_FOOTER_OLD not in result
+
+    def test_glued_short_b_is_deliberately_unsupported(self):
+        """``-bVALUE`` is NOT supported on purpose.
+
+        Supporting it would make ``-base main`` parse as ``-b`` + ``ase``,
+        corrupting a legitimate command.  The false-positive risk outweighs
+        the coverage gain, so the glued short form is left alone.
+        """
+        cmd = f'gh pr create -b"{CLAUDE_CODE_FOOTER_OLD}"'
+        assert rewrite_bash_command(cmd) is None
+        # And the reason it stays that way:
+        cmd2 = f'gh pr create -base main --body "{CLAUDE_CODE_FOOTER_OLD}"'
+        result = rewrite_bash_command(cmd2)
+        assert result is not None
+        assert "-base main" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — Defect 3C: _requote must never expose shell metacharacters
+# ---------------------------------------------------------------------------
+
+
+class TestRequoteShellSafety:
+    def test_single_quoted_body_with_apostrophe_stays_single_quoted(self):
+        value = "Fixes it's the bug. $USER ran `whoami` here."
+        quoted = _requote(value, "'")
+        assert quoted.startswith("'") and quoted.endswith("'")
+        # $ and ` must remain inside single quotes (inert), never bare in a
+        # double-quoted string.
+        assert not quoted.startswith('"')
+        assert quoted == "'Fixes it'\\''s the bug. $USER ran `whoami` here.'"
+
+    def test_single_quoted_roundtrips_through_a_real_shell(self):
+        """The re-quoted token must survive an actual POSIX shell verbatim."""
+        import subprocess
+
+        value = "Fixes it's the bug. $USER ran `whoami` here. 50% \\ done"
+        quoted = _requote(value, "'")
+        out = subprocess.run(  # noqa: S603
+            ["/bin/sh", "-c", f"printf %s {quoted}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert out.stdout == value, f"Shell mangled the value: {out.stdout!r}"
+
+    def test_bare_value_with_metacharacters_is_single_quoted(self):
+        quoted = _requote("has space $x and `y`", "")
+        assert quoted.startswith("'") and quoted.endswith("'")
+        assert "$x" in quoted and "`y`" in quoted
+
+    def test_bare_safe_value_stays_bare(self):
+        assert _requote("simple-value_1.txt", "") == "simple-value_1.txt"
+
+    def test_end_to_end_single_quoted_body_with_dollar_and_backtick(self):
+        """Full command rewrite: $ and ` must stay inert after the rewrite."""
+        body = f"Fixes $USER bug; ran `whoami`.\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        cmd = f"gh pr create --title T --body '{body}'"
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+        # Must still be single-quoted — never downgraded to double quotes.
+        assert "--body '" in result
+        assert '--body "' not in result
+        assert "$USER" in result
+        assert "`whoami`" in result
+
+
+class TestSpliceQuotedBodyLimitation:
+    r"""Documented limitation: bodies using the POSIX ``'\''`` splice idiom.
+
+    ``_BODY_FLAG_RE`` models a quoted value as ONE balanced quote pair, but a
+    shell word may be a concatenation of adjacent chunks.  We cannot parse the
+    full word without replacing the regex with a shell tokeniser, so the hook
+    detects the situation and stands down.  Correctness over coverage: the
+    footer is left stale rather than the command being corrupted.
+    """
+
+    def test_splice_quoted_body_is_left_alone(self):
+        # Body: "Generated with [Claude Code](...) it's here"
+        cmd = "gh pr create --body '" + CLAUDE_CODE_FOOTER_OLD + " it'\\''s here'"
+        # No rewrite — and crucially, no corrupted half-rewrite either.
+        assert rewrite_bash_command(cmd) is None
+
+    def test_splice_quoted_body_response_is_passthrough(self):
+        cmd = "gh pr create --body 'It'\\''s " + CLAUDE_CODE_FOOTER_OLD + "'"
+        event = {"tool_name": "Bash", "tool_input": {"command": cmd}}
+        assert build_gh_footer_response(event) == {"continue": True}
+
+    @pytest.mark.xfail(
+        reason=(
+            "Known limitation (#937 defect 3C): a body built with the POSIX "
+            "'\\'' splice idiom cannot be parsed by the regex-based flag "
+            "parser, so its stale footer is left un-normalised. Fixing this "
+            "requires a real shell tokeniser; the hook deliberately stands "
+            "down instead of corrupting the command."
+        ),
+        strict=True,
+    )
+    def test_splice_quoted_body_would_ideally_be_normalised(self):
+        cmd = "gh pr create --body 'It'\\''s " + CLAUDE_CODE_FOOTER_OLD + "'"
+        result = rewrite_bash_command(cmd)
+        assert result is not None
+        assert MPM_FOOTER_CANONICAL in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — Defect 3A: opt-out switch
+# ---------------------------------------------------------------------------
+
+
+class TestOptOut:
+    def _bash_event(self, cwd: str = "") -> dict:
+        return {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": f'gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+            },
+            "cwd": cwd,
+        }
+
+    def _mcp_event(self, cwd: str = "") -> dict:
+        return {
+            "tool_name": "mcp__github__create_pull_request",
+            "tool_input": {"title": "T", "body": f"x\n\n{CLAUDE_CODE_FOOTER_OLD}"},
+            "cwd": cwd,
+        }
+
+    def _write_settings(self, tmp_path, filename: str, payload: dict) -> None:
+        import json
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(exist_ok=True)
+        (claude_dir / filename).write_text(json.dumps(payload))
+
+    # --- baseline: hook is ON by default -------------------------------------
+
+    def test_enabled_by_default_bash(self, tmp_path):
+        response = build_gh_footer_response(self._bash_event(str(tmp_path)))
+        assert "hookSpecificOutput" in response
+
+    # --- env var -------------------------------------------------------------
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+    def test_env_var_disables_bash_path(self, monkeypatch, value):
+        monkeypatch.setenv(_DISABLE_ENV_VAR, value)
+        assert build_gh_footer_response(self._bash_event()) == {"continue": True}
+
+    def test_env_var_disables_mcp_path(self, monkeypatch):
+        monkeypatch.setenv(_DISABLE_ENV_VAR, "true")
+        assert build_gh_footer_response(self._mcp_event()) == {"continue": True}
+
+    def test_env_var_disables_body_file_advisory(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(_DISABLE_ENV_VAR, "1")
+        body_file = tmp_path / "body.md"
+        body_file.write_text(f"x\n\n{CLAUDE_CODE_FOOTER_OLD}")
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"gh pr create --body-file {body_file}"},
+        }
+        assert build_gh_footer_response(event) == {"continue": True}
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_env_values_do_not_disable(self, monkeypatch, value):
+        monkeypatch.setenv(_DISABLE_ENV_VAR, value)
+        response = build_gh_footer_response(self._bash_event())
+        assert "hookSpecificOutput" in response
+
+    # --- settings key --------------------------------------------------------
+
+    @pytest.mark.parametrize("filename", ["settings.local.json", "settings.json"])
+    def test_settings_key_disables_bash_path(self, tmp_path, filename):
+        self._write_settings(tmp_path, filename, {"gh_footer_hook": {"disabled": True}})
+        assert build_gh_footer_response(self._bash_event(str(tmp_path))) == {
+            "continue": True
+        }
+
+    def test_settings_key_disables_mcp_path(self, tmp_path):
+        self._write_settings(
+            tmp_path, "settings.json", {"gh_footer_hook": {"disabled": True}}
+        )
+        assert build_gh_footer_response(self._mcp_event(str(tmp_path))) == {
+            "continue": True
+        }
+
+    def test_settings_key_false_leaves_hook_enabled(self, tmp_path):
+        self._write_settings(
+            tmp_path, "settings.json", {"gh_footer_hook": {"disabled": False}}
+        )
+        response = build_gh_footer_response(self._bash_event(str(tmp_path)))
+        assert "hookSpecificOutput" in response
+
+    def test_unrelated_settings_leave_hook_enabled(self, tmp_path):
+        self._write_settings(tmp_path, "settings.json", {"other_hook": {"x": 1}})
+        response = build_gh_footer_response(self._bash_event(str(tmp_path)))
+        assert "hookSpecificOutput" in response
+
+    def test_malformed_settings_file_leaves_hook_enabled(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{not json")
+        response = build_gh_footer_response(self._bash_event(str(tmp_path)))
+        assert "hookSpecificOutput" in response
+
+
+# ---------------------------------------------------------------------------
+# Issue #937 — the advisory must survive the LIVE dispatch path
+# ---------------------------------------------------------------------------
+
+
+class TestBodyFileAdvisoryThroughToolHandler:
+    """The live PreToolUse dispatch site is ToolHandler.handle_pre_tool_fast.
+
+    Its Bash branch used to look only at ``updatedInput``, so an
+    advisory-only response (no command rewrite) would have been dropped.
+    """
+
+    def _make_tool_handler(self):
+        from unittest.mock import MagicMock
+
+        from claude_mpm.hooks.claude_hooks.handlers.base import BaseEventHandler
+        from claude_mpm.hooks.claude_hooks.handlers.tool_handler import ToolHandler
+
+        mock_hh = MagicMock()
+        mock_hh._emit_socketio_event = MagicMock(return_value=None)
+        mock_hh._get_delegation_agent_type = MagicMock(return_value="unknown")
+
+        base = MagicMock(spec=BaseEventHandler)
+        base.hook_handler = mock_hh
+        base._get_git_branch = MagicMock(return_value="main")
+        base.log_manager = None
+
+        return ToolHandler(base)
+
+    def test_advisory_reaches_the_harness_and_file_is_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        from claude_mpm.hooks import context_circuit_breaker
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _event: {})
+
+        body_file = tmp_path / "body.md"
+        original = f"Body\n\n{CLAUDE_CODE_FOOTER_OLD}"
+        body_file.write_text(original)
+
+        handler = self._make_tool_handler()
+        response = handler.handle_pre_tool_fast(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": f"gh pr create --body-file {body_file}"},
+                "session_id": "test-session",
+                "cwd": str(tmp_path),
+            }
+        )
+
+        assert response is not None, "Advisory response was dropped by ToolHandler"
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None, f"Expected hookSpecificOutput, got {response!r}"
+        assert str(body_file) in hso.get("additionalContext", "")
+        assert MPM_FOOTER_CANONICAL in hso.get("additionalContext", "")
+        # NOTE: ztk_hook also runs on the Bash branch and may return its own
+        # response carrying an updatedInput.  What matters here is that the
+        # footer advisory is merged into whichever response wins, rather than
+        # being dropped — which is exactly what used to happen.
+        #
+        # The hook must not have written to the agent-owned file.
+        assert body_file.read_text() == original
+
+    def test_inline_rewrite_still_reaches_the_harness(self, monkeypatch):
+        from claude_mpm.hooks import context_circuit_breaker
+
+        monkeypatch.setattr(context_circuit_breaker, "evaluate", lambda _event: {})
+
+        handler = self._make_tool_handler()
+        response = handler.handle_pre_tool_fast(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": f'gh pr create --body "{CLAUDE_CODE_FOOTER_OLD}"'
+                },
+                "session_id": "test-session",
+                "cwd": "/tmp",
+            }
+        )
+
+        assert response is not None
+        hso = response.get("hookSpecificOutput")
+        assert hso is not None
+        assert MPM_FOOTER_CANONICAL in hso["updatedInput"]["command"]

--- a/tests/services/mutation/test_runner.py
+++ b/tests/services/mutation/test_runner.py
@@ -559,11 +559,50 @@ def test_restore_target_skips_checkout_when_clean(tmp_path, monkeypatch):
 # Integration test: real mutmut against the pilot module (on demand only).
 # ---------------------------------------------------------------------------
 
+# OPT-IN GATE (issue #937 CI flake). This test drives REAL mutmut, which mutates
+# src/claude_mpm/services/trusty_search_allowlist.py IN PLACE in the working
+# tree for the several minutes it runs. The default suite runs under
+# `pytest -n auto`, so while this test holds a mutant on disk every other xdist
+# worker sees the mutated source. Any concurrently-starting test that imports
+# that module — notably tests/test_e2e.py, which subprocesses
+# `scripts/claude-mpm --version` and reaches it via
+# cli/parsers/base_parser.create_parser -> cli/commands/search_index — crashes
+# with a spurious TypeError (e.g. "can't multiply sequence by non-int of type
+# 'PosixPath'" from a `/` -> `*` mutant). That failure is a pure race: it points
+# at innocent code, reproduces only under parallelism, and is invisible in the
+# committed source, so it costs a full CI cycle to even locate.
+#
+# The runner's finally-block restore cannot fix this — the mutant is *supposed*
+# to be on disk while mutmut evaluates it. In-place mutation testing is simply
+# incompatible with a parallel suite sharing the same working tree, so the only
+# correct fix is to keep mutmut out of the default run.
+#
+# This matches the already-documented intent everywhere else: the section header
+# above says "on demand only", the Makefile `mutation-test` target is described
+# as "advisory, on-demand only", and .github/workflows/test.yml states "CI does
+# NOT currently run mutmut in any workflow". Nothing actually enforced that, so
+# the test ran on every PR. This env gate enforces it.
+#
+# Run it deliberately with:
+#     MPM_RUN_MUTATION_INTEGRATION=1 uv run pytest \
+#         tests/services/mutation/test_runner.py -p no:xdist -k real_mutmut
+_MUTATION_INTEGRATION_ENABLED = (
+    os.environ.get("MPM_RUN_MUTATION_INTEGRATION", "") == "1"
+)
+
 
 @pytest.mark.integration
 @pytest.mark.timeout(0)  # real mutmut over the full module takes minutes; the
 # default 120s pytest-timeout would SIGALRM-kill the process mid-run, bypassing
 # the runner's finally-block restore and leaving a mutant on disk.
+@pytest.mark.skipif(
+    not _MUTATION_INTEGRATION_ENABLED,
+    reason=(
+        "real-mutmut integration test is opt-in: it mutates the pilot module "
+        "in place and corrupts concurrent xdist workers. "
+        "Set MPM_RUN_MUTATION_INTEGRATION=1 (and use -p no:xdist) to run it."
+    ),
+)
 @pytest.mark.skipif(
     not Path("src/claude_mpm/services/trusty_search_allowlist.py").exists(),
     reason="pilot module not present (run from repo root)",
@@ -575,6 +614,9 @@ def test_integration_real_mutmut_against_pilot():
           healthy kill rate, non-empty parsed survivors, and a clean error.
     WHY:  This is the go/no-go evidence that the runner works end to end with
           real mutmut 2.5.1 on Python 3.13 before we build the CLI/agent slices.
+
+    Opt-in via MPM_RUN_MUTATION_INTEGRATION=1 — see the gate comment above for
+    why this must never run inside the default parallel suite.
     """
     target = Path("src/claude_mpm/services/trusty_search_allowlist.py").resolve()
     tests_file = Path("tests/services/test_trusty_search_allowlist.py").resolve()


### PR DESCRIPTION
Fixes the three defects reported and independently verified in #937. All three were confirmed present at HEAD (`gh_footer_hook.py` blob `e207be396780237c67c348d09b5107864f33eed5`, byte-identical v6.5.72 → v6.5.81 → HEAD).

## Defect 1 — silent in-place mutation of agent-owned files

`rewrite_bash_command()` read the file referenced by `--body-file` / `-F`, rewrote the footer, and wrote it back **in place** via `NamedTemporaryFile` + `Path.replace()` while returning the command string unchanged — mutating a file the calling agent owns, entirely outside Edit/Write tool bookkeeping. Agents observed their own scratch files changing between their own tool calls and began treating the environment as tampered.

**Fix: advisory-only.** The hook no longer performs any filesystem mutation of caller-owned files. When a body file contains a stale footer, it surfaces an `additionalContext` advisory naming the file path and the canonical footer, so the agent corrects it with its own tools. The inline `--body` / `-b` and `mcp__github__*` paths are unchanged — they already rewrote content via the return value with no on-disk side effect.

This deliberately avoids the "hook-owned temp file" alternative, which has no cleanup owner (the hook process exits before `gh` runs) and would have traded the correctness bug for an unbounded temp-file leak.

Also fixed: `build_gh_footer_response` no longer emits an `updatedInput` when the command text is byte-identical to its input.

**Latent bug closed:** `--body-file -` means "read from stdin", but the regex matched it and `_extract_body_file` returned the literal `'-'`; it only failed to act because `Path('-').read_text()` raised. With a file literally named `-` in cwd, the hook **was proven to read and rewrite it in place** — corrupting a file `gh` never touches. `-` is now recognised as stdin and skipped before any read.

## Defect 2 — first-pass footer duplication on dirty input

The optional emoji group in `_FOOTER_LINE_RE` consumed only a bare adjacent `🤖`, never `👥`, and could not cross a newline. Verified duplicating shapes (each doubled once, then stabilised):

| Input | Old output |
|---|---|
| `🤖👥 Generated with [Claude Code](…)` | `🤖👥🤖👥 Generated with [Claude MPM](…)` |
| `🤖\nGenerated with [Claude Code](…)` | `🤖\n🤖👥 Generated with [Claude MPM](…)` |
| `🤖👥\nGenerated with …` | duplicated |
| `👥 Generated with …` | `👥🤖👥 Generated with …` |

The last two were **not** in the original report — the real rule is *any* prefix on the footer line or the line before it that isn't a bare adjacent `🤖`.

**Fix:** consume either an emoji run immediately adjacent to the footer text on the same line, or a preceding line whose entire content is such a run — and nothing broader. A naive "strip across the line break" fix was verified to destroy legitimate prose (`🤖 indicates an automated build step\n…`); that input is now covered by an explicit negative regression test.

## Defect 3 — no opt-out, flag coverage, quoting

**3A — opt-out added.** `gh_footer_hook` was the only hook in the live PreToolUse chain with no off-switch (`context_circuit_breaker` has both an env var and a settings key; `ztk_hook` has `CLAUDE_MPM_DISABLE_ZTK`). Now mirrors the `context_circuit_breaker` precedent exactly: settings key `{"gh_footer_hook": {"disabled": true}}` (primary, resolved `.claude/settings.local.json` → `.claude/settings.json` → `~/.claude/settings.json`) plus `CLAUDE_MPM_DISABLE_GH_FOOTER` (secondary), checked at the top of `build_gh_footer_response()`.

**3B — flag coverage closed.** `_BODY_FILE_FLAG_RE` required `\s+`, so `--body-file=path`, `-F=path`, and `-Fpath` bypassed the hook entirely. All five forms are now recognised.

**3C — `_requote` hardened.** Both branches escaped only `\` and `"`, so a single-quoted body containing an apostrophe was downgraded to double quotes with `$` and backticks left shell-expandable. Now uses the POSIX `'\''` splice idiom so single-quoted values are never downgraded and no metacharacter is ever exposed.

## Verification

Independently verified by a QA pass driving the real code, separate from the unit tests:

- Body file sha256 **identical** before/after; response carries the advisory, no `updatedInput`
- File literally named `-` **untouched**
- All four Defect-2 shapes collapse to exactly one canonical footer, stable across 3 applications
- Over-strip guard: prose line survives verbatim
- All five flag forms emit an advisory
- `$USER` / backticks confirmed never to land in a double-quoted context (`shlex` round-trip clean)
- Both opt-out mechanisms independently produce a clean no-op

```
tests/hooks/test_gh_footer_hook.py:  137 passed, 1 xfailed
tests/hooks/:                        390 passed, 23 skipped, 1 xfailed
ruff format --check .:               2202 files already formatted
ruff check .:                        All checks passed!
```

The single xfail documents a known parser limitation: a body already using the correct `'\''` shell idiom is not matched by the quote regex, so its stale footer is left alone (a silent no-op rather than a corruption).

## Notes for reviewers

- The report described the hook as hardwired at two dispatch sites. Verified: `pretooluse_dispatcher.py` is **legacy/dead** — nothing in `.claude/settings.json`, `pyproject.toml` console_scripts, or `installer.py` invokes it. The single live site is `ToolHandler.handle_pre_tool_fast`. The dispatcher is kept consistent for safety but is not the active path.
- Trade-off accepted: advisory-only weakens the original "footer never leaks" guarantee for the `--body-file` path, since it depends on the agent acting on the advisory. This was chosen deliberately over silently writing to files the agent owns.
- Follow-up worth a separate issue (pre-existing, out of scope): when a footer directly follows prose on the *same* line with no newline, the rewrite eats the separating space (`…here.🤖👥 Generated…`).

Closes #937
