### PR TITLE
refactor: unify statusLine ownership detection across removal paths (stacked on #936)

### DIFF
--- a/src/claude_mpm/cli/commands/uninstall_global.py
+++ b/src/claude_mpm/cli/commands/uninstall_global.py
@@ -28,6 +28,14 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# #939: reuse the canonical statusLine ownership/removability classifier rather
+# than re-deriving ownership from a substring here.
+from ...migrations.migrate_statusline_autoconfig import (
+    StatuslineDisposition,
+    classify_statusline_entry,
+    strip_statusline_marker,
+)
+
 # Spinner keys mirror src/claude_mpm/cli/startup_migrations.py::_SPINNER_GLOBAL_KEYS.
 _SPINNER_KEYS: tuple[str, ...] = (
     "spinnerVerbs",
@@ -38,7 +46,8 @@ _SPINNER_VERSION_KEY = "_mpm_spinner_version"
 
 # Marker comment written into MPM-managed statusline.sh scripts.
 _STATUSLINE_MARKER = "# claude-mpm-managed:"
-# Substring that identifies an MPM-owned statusLine command / Stop hook.
+# Substring that identifies an MPM-owned Stop hook command.  The ``statusLine``
+# entry itself is classified by ``classify_statusline_entry`` instead (#939).
 _STATUSLINE_MATCH = "statusline.sh"
 
 # Frontmatter markers identifying an MPM-owned agent .md file. Matched against the
@@ -127,13 +136,19 @@ def _remove_statusline_script(claude_dir: Path, summary: CleanupSummary) -> None
 def _clean_settings(claude_dir: Path, summary: CleanupSummary) -> None:
     """Strip MPM-owned keys from ``~/.claude/settings.json``.
 
-    WHAT: Removes the ``outputStyle`` (when ``claude_mpm*``), ``statusLine``
-    (when it points at ``statusline.sh``), the spinner keys and version stamp,
-    and any ``hooks.Stop`` entry invoking ``statusline.sh`` — pruning emptied
-    hook groups — then rewrites the file (unless ``dry_run``).
+    WHAT: Removes the ``outputStyle`` (when ``claude_mpm*``), the spinner keys and
+    version stamp, and any ``hooks.Stop`` entry invoking ``statusline.sh`` —
+    pruning emptied hook groups.  ``statusLine`` is handled by disposition
+    (``classify_statusline_entry``): deleted when it points at the bundled
+    ``statusline.sh``, otherwise reduced to just dropping the ``_mpm`` marker when
+    MPM owns an entry holding the user's own command.  The file is then rewritten
+    (unless ``dry_run``).
 
     WHY: Ownership must be established per-key so user-authored settings survive;
     a blanket delete would destroy unrelated configuration in the shared file.
+    For ``statusLine`` that is not enough on its own — under the CUSTOM policy MPM
+    stamps its marker onto an entry whose ``command`` is the user's, so deleting
+    every entry MPM owns would discard user configuration (issue #939).
     """
     settings_path = claude_dir / "settings.json"
     if not settings_path.is_file():
@@ -155,15 +170,21 @@ def _clean_settings(claude_dir: Path, summary: CleanupSummary) -> None:
         if not summary.dry_run:
             del data["outputStyle"]
 
-    # statusLine: remove only when it points at statusline.sh.
+    # statusLine: #939 — ownership is not removability.  Delete the entry only
+    # when it points at our bundled script; a marker-bearing entry holding the
+    # user's own command keeps that command and loses only the marker.
     status_line = data.get("statusLine")
-    if isinstance(status_line, dict) and _STATUSLINE_MATCH in str(
-        status_line.get("command", "")
-    ):
+    disposition = classify_statusline_entry(status_line)
+    if disposition is StatuslineDisposition.REMOVE:
         summary.settings_keys.append("statusLine")
         changed = True
         if not summary.dry_run:
             del data["statusLine"]
+    elif disposition is StatuslineDisposition.DISOWN:
+        summary.settings_keys.append("statusLine._mpm")
+        changed = True
+        if not summary.dry_run:
+            strip_statusline_marker(status_line)
 
     # Spinner keys + version stamp.
     for key in (*_SPINNER_KEYS, _SPINNER_VERSION_KEY):

--- a/src/claude_mpm/migrations/migrate_statusline_autoconfig.py
+++ b/src/claude_mpm/migrations/migrate_statusline_autoconfig.py
@@ -232,6 +232,82 @@ _STATUSLINE_COMMAND_MATCH = "statusline.sh"
 _MPM_OWNED_KEY = "_mpm"
 
 
+class StatuslineDisposition(Enum):
+    """What a removal path may safely do with an existing ``statusLine`` entry.
+
+    WHY: Every claude-mpm removal path (legacy project cleanup, global uninstall,
+    the issue #924 global self-heal) needs to know more than *who owns* an entry —
+    it needs to know whether the entry is MPM's to delete.  Those diverge under
+    the CUSTOM policy, where MPM stamps its ownership marker onto an entry whose
+    ``command`` is the *user's*, so a single boolean "is it ours?" is not enough
+    to decide safely (issue #939).
+    WHAT: Three mutually exclusive dispositions returned by
+    ``classify_statusline_entry`` and consumed by every removal path.
+    """
+
+    #: Not MPM-owned at all — leave the entry strictly untouched.
+    LEAVE = "leave"
+    #: MPM's own artifact (``command`` points at the bundled ``statusline.sh``)
+    #: — remove the whole entry.
+    REMOVE = "remove"
+    #: MPM-owned via the marker, but ``command`` is the user's (CUSTOM policy)
+    #: — strip only the marker and keep the command.
+    DISOWN = "disown"
+
+
+def classify_statusline_entry(entry: object) -> StatuslineDisposition:
+    """Decide what a removal path may do with a ``statusLine`` settings entry.
+
+    Why: "claude-mpm owns this entry" and "this entry is claude-mpm's to delete"
+    are different facts, and removal paths need the second one.  Under the CUSTOM
+    policy MPM writes the *user's* command into the entry and stamps
+    ``_MPM_OWNED_KEY`` on it, so treating ownership as licence to delete would
+    destroy the user's own statusline configuration on uninstall (issue #939).
+    What: Returns ``REMOVE`` when ``command`` points at the bundled
+    ``statusline.sh`` — MPM's own artifact, true for marker-bearing MANAGED
+    entries and for legacy pre-marker ones alike, which is what preserves the
+    substring fallback.  Returns ``DISOWN`` when the entry carries the marker but
+    its command is not ours.  Returns ``LEAVE`` for everything else, including
+    non-dict values and genuinely user-authored entries.
+    Test: Assert ``REMOVE`` for a bundled-script command with and without the
+    marker, ``DISOWN`` for a marker-bearing custom command, and ``LEAVE`` for a
+    marker-less non-bundled command and for a non-dict value.
+    """
+    if not isinstance(entry, dict):
+        return StatuslineDisposition.LEAVE
+
+    # Checked before the marker: a command pointing at our bundled script is
+    # MPM's own artifact whether or not the entry was ever stamped, which is
+    # also the backward-compatibility fallback for pre-marker entries.
+    cmd = entry.get("command", "")
+    if isinstance(cmd, str) and _STATUSLINE_COMMAND_MATCH in cmd:
+        return StatuslineDisposition.REMOVE
+
+    # Marker present but the command is not ours → a CUSTOM-policy entry.
+    if entry.get(_MPM_OWNED_KEY) is True:
+        return StatuslineDisposition.DISOWN
+
+    return StatuslineDisposition.LEAVE
+
+
+def strip_statusline_marker(entry: dict) -> bool:
+    """Remove claude-mpm's ownership marker from ``entry``, leaving the rest.
+
+    Why: The ``DISOWN`` disposition needs MPM to relinquish ownership of an entry
+    whose ``command`` belongs to the user (issue #939), and every removal path
+    must do that identically without reaching for the private marker constant.
+    What: Deletes ``_MPM_OWNED_KEY`` from ``entry`` in place and returns True if
+    it was present; returns False without mutating anything otherwise.  No other
+    key — ``command`` above all — is touched.
+    Test: Assert True and a marker-free dict with an intact ``command`` for a
+    marker-bearing entry, and False plus an unchanged dict for one without.
+    """
+    if _MPM_OWNED_KEY not in entry:
+        return False
+    del entry[_MPM_OWNED_KEY]
+    return True
+
+
 def _is_mpm_owned_statusline(entry: object) -> bool:
     """Return True if a ``statusLine`` settings entry was written by claude-mpm.
 
@@ -243,22 +319,16 @@ def _is_mpm_owned_statusline(entry: object) -> bool:
     What: Returns True when the entry carries the explicit ``_MPM_OWNED_KEY``
     marker, or — as a backward-compatibility fallback for entries written
     before the marker existed — when its ``command`` contains
-    ``_STATUSLINE_COMMAND_MATCH``.  A genuinely user-authored entry (no marker,
-    non-bundled command) returns False and must be left untouched.
+    ``_STATUSLINE_COMMAND_MATCH``.  Delegates to
+    ``classify_statusline_entry`` so the ownership question and the removability
+    question can never drift apart: "owned" is exactly "not ``LEAVE``".  A
+    genuinely user-authored entry (no marker, non-bundled command) returns False
+    and must be left untouched.
     Test: Assert True for a marker-bearing entry with an arbitrary command,
     True for a marker-less entry pointing at ``statusline.sh`` (legacy), and
     False for a marker-less entry pointing anywhere else.
     """
-    if not isinstance(entry, dict):
-        return False
-
-    # Primary: the explicit marker is the certain signal.
-    if entry.get(_MPM_OWNED_KEY) is True:
-        return True
-
-    # Legacy fallback: entries written before the marker was introduced.
-    cmd = entry.get("command", "")
-    return isinstance(cmd, str) and _STATUSLINE_COMMAND_MATCH in cmd
+    return classify_statusline_entry(entry) is not StatuslineDisposition.LEAVE
 
 
 # Statusline script content (byte-identical to .claude/hooks/scripts/statusline.sh
@@ -884,9 +954,12 @@ def _cleanup_global_statusline_settings(settings_path: Path) -> bool:
     in the project-local ``.claude/settings.json``; this helper removes the
     stale global copies so existing installs self-heal.
 
-    Only MPM-owned entries are touched:
-    - ``statusLine`` is removed only when ``_is_mpm_owned_statusline`` says we
-      wrote it (explicit marker, or the legacy ``statusline.sh`` command).
+    Only MPM-owned entries are touched, and ownership alone does not authorise
+    deletion (issue #939 — see ``classify_statusline_entry``):
+    - ``statusLine`` is removed outright only when its ``command`` points at the
+      bundled ``statusline.sh`` (explicitly marked or legacy pre-marker alike).
+    - A marker-bearing entry holding the user's own command loses only the
+      marker; its ``command`` is preserved.
     - Stop-hook entries are removed only when their ``command`` contains
       ``statusline.sh --clear``; empty hook groups left behind are pruned.
 
@@ -906,10 +979,16 @@ def _cleanup_global_statusline_settings(settings_path: Path) -> bool:
 
     changed = False
 
-    # Remove MPM-owned statusLine entry.
+    # #939: ownership is not removability — a marker-bearing CUSTOM entry holds
+    # the user's own command, so relinquish ownership instead of deleting it.
     existing = settings.get("statusLine")
-    if _is_mpm_owned_statusline(existing):
+    disposition = classify_statusline_entry(existing)
+    if disposition is StatuslineDisposition.REMOVE:
         del settings["statusLine"]
+        changed = True
+    elif disposition is StatuslineDisposition.DISOWN and strip_statusline_marker(
+        existing
+    ):
         changed = True
 
     # Remove MPM-owned Stop hooks (and prune emptied groups).

--- a/src/claude_mpm/migrations/migrate_statusline_user_level.py
+++ b/src/claude_mpm/migrations/migrate_statusline_user_level.py
@@ -18,9 +18,12 @@ the *current* project so they don't shadow the user-level copy:
    existing user-level script here; that's the autoconfig migration's
    job).  Then remove the project-level file.
 
-2. If ``<cwd>/.claude/settings.json`` has a ``statusLine`` entry whose
-   ``command`` references the MPM-managed script (substring match on
-   ``statusline.sh``), remove the ``statusLine`` key.
+2. The ``statusLine`` entry in ``<cwd>/.claude/settings.json`` is handled
+   according to ``classify_statusline_entry`` (see
+   ``migrate_statusline_autoconfig``, issue #939): an entry whose ``command``
+   references the MPM-managed script is removed outright, while an entry MPM
+   owns via its ``_mpm`` marker but whose ``command`` is the user's own
+   (CUSTOM policy) keeps that command and loses only the marker.
 
 3. Same for the Stop hook: any hook command containing
    ``statusline.sh --clear`` is removed from
@@ -28,8 +31,8 @@ the *current* project so they don't shadow the user-level copy:
    ``Stop`` list are pruned to keep settings tidy.
 
 User-customised scripts (no MPM marker) and user-owned settings entries
-(``statusLine.command`` pointing somewhere else, Stop hooks unrelated to
-statusline) are always left untouched.
+(no ``_mpm`` marker and a ``statusLine.command`` pointing somewhere else,
+Stop hooks unrelated to statusline) are always left untouched.
 
 Idempotent: re-running the migration on an already-cleaned project is a
 no-op.
@@ -41,14 +44,22 @@ import shutil
 import stat
 from pathlib import Path
 
+# #939: the ``statusLine`` ownership/removability vocabulary lives beside the
+# code that stamps the marker, so reader and writer can never drift apart.
+from .migrate_statusline_autoconfig import (
+    StatuslineDisposition,
+    classify_statusline_entry,
+    strip_statusline_marker,
+)
+
 logger = logging.getLogger(__name__)
 
 # Marker line that identifies an MPM-managed statusline.sh.
 _MPM_MARKER = "# claude-mpm-managed:"
 
-# Substring used to identify an MPM-managed statusLine.command or Stop hook
-# command, regardless of whether the path is project-relative or absolute.
-_STATUSLINE_COMMAND_MATCH = "statusline.sh"
+# Substring used to identify an MPM-managed Stop hook command, regardless of
+# whether the path is project-relative or absolute.  The ``statusLine`` entry
+# itself is classified by ``classify_statusline_entry`` instead.
 _STOP_HOOK_MATCH = "statusline.sh --clear"
 
 
@@ -131,15 +142,17 @@ def _clean_settings(project_claude: Path) -> bool:
     """Strip MPM-owned statusLine and Stop hook entries from project settings.
 
     Mutations:
-    - Remove ``settings["statusLine"]`` if its ``command`` substring-matches
-      ``statusline.sh``.
+    - Apply ``classify_statusline_entry`` to ``settings["statusLine"]``:
+      ``REMOVE`` (``command`` points at the bundled ``statusline.sh``) deletes
+      the key, ``DISOWN`` (MPM-owned marker over the user's own command) strips
+      only the marker, and ``LEAVE`` touches nothing.
     - Remove every Stop hook whose ``command`` substring-matches
       ``statusline.sh --clear``.  Empty ``hooks`` lists / empty Stop groups
       are pruned, as is an empty top-level ``Stop`` list and an empty
       ``hooks`` dict.
 
-    User-owned entries (those whose command does not contain the substring)
-    are left in place.
+    User-owned entries (no MPM marker and a command that does not contain the
+    substring) are left in place.
 
     Args:
         project_claude: Path to ``<cwd>/.claude``.
@@ -169,13 +182,23 @@ def _clean_settings(project_claude: Path) -> bool:
     changed = False
 
     # --- statusLine ----------------------------------------------------------
+    # #939: ownership is not removability — a marker-bearing CUSTOM entry holds
+    # the user's own command, so relinquish ownership instead of deleting it.
     existing = settings.get("statusLine")
-    if isinstance(existing, dict):
-        cmd = existing.get("command", "")
-        if isinstance(cmd, str) and _STATUSLINE_COMMAND_MATCH in cmd:
-            del settings["statusLine"]
-            changed = True
-            logger.info("Removed MPM-managed statusLine entry from %s", settings_path)
+    disposition = classify_statusline_entry(existing)
+    if disposition is StatuslineDisposition.REMOVE:
+        del settings["statusLine"]
+        changed = True
+        logger.info("Removed MPM-managed statusLine entry from %s", settings_path)
+    elif disposition is StatuslineDisposition.DISOWN and strip_statusline_marker(
+        existing
+    ):
+        changed = True
+        logger.info(
+            "Relinquished MPM ownership of the user's statusLine command in %s "
+            "(command preserved)",
+            settings_path,
+        )
 
     # --- Stop hooks ----------------------------------------------------------
     hooks = settings.get("hooks")

--- a/tests/cli/commands/test_uninstall_global.py
+++ b/tests/cli/commands/test_uninstall_global.py
@@ -8,6 +8,9 @@ Coverage:
    hooks preserved.
 5. ``dry_run=True`` reports without touching the filesystem.
 6. Empty ``~/.claude/`` is a clean no-op.
+7. ``statusLine`` is handled by disposition (issue #939): a bundled-script entry
+   is deleted, a marker-bearing CUSTOM entry keeps its command and loses only the
+   ``_mpm`` marker, and a user-authored entry is left strictly alone.
 """
 
 from __future__ import annotations
@@ -166,3 +169,83 @@ def test_empty_claude_dir_is_noop(tmp_path: Path) -> None:
 
     summary = run_global_cleanup(claude_dir=claude_dir, dry_run=False)
     assert summary.total == 0
+
+
+# ---------------------------------------------------------------------------
+# statusLine disposition (issue #939)
+# ---------------------------------------------------------------------------
+
+
+def _seed_status_line(claude_dir: Path, status_line: dict) -> Path:
+    """Write a ~/.claude/settings.json containing only ``status_line``."""
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    path = claude_dir / "settings.json"
+    path.write_text(json.dumps({"statusLine": status_line, "keepme": True}))
+    return path
+
+
+def test_marked_bundled_status_line_is_removed(tmp_path: Path) -> None:
+    """Regression guard: a marked bundled-script entry is still deleted.
+
+    Why: This is claude-mpm's own MANAGED artifact. The #939 disposition refactor
+    must not weaken the removal that the uninstall command exists to perform.
+    """
+    claude_dir = tmp_path / ".claude"
+    path = _seed_status_line(
+        claude_dir,
+        {"type": "command", "command": "/x/statusline.sh", "_mpm": True},
+    )
+
+    summary = run_global_cleanup(claude_dir=claude_dir, dry_run=False)
+
+    settings = json.loads(path.read_text())
+    assert "statusLine" not in settings
+    assert settings["keepme"] is True
+    assert "statusLine" in summary.settings_keys
+
+
+def test_custom_status_line_keeps_command_and_loses_marker(tmp_path: Path) -> None:
+    """A marker-bearing CUSTOM entry keeps ``command``, drops only ``_mpm``.
+
+    Why: Under the CUSTOM policy claude-mpm stamps its ownership marker onto an
+    entry whose ``command`` is the *user's*. Uninstall must relinquish ownership
+    without discarding the user's statusline configuration (issue #939).
+    """
+    claude_dir = tmp_path / ".claude"
+    path = _seed_status_line(
+        claude_dir,
+        {"type": "command", "command": "/opt/mybar --fancy", "_mpm": True},
+    )
+
+    summary = run_global_cleanup(claude_dir=claude_dir, dry_run=False)
+
+    settings = json.loads(path.read_text())
+    assert settings["statusLine"] == {
+        "type": "command",
+        "command": "/opt/mybar --fancy",
+    }
+    assert summary.settings_keys == ["statusLine._mpm"]
+
+
+def test_custom_status_line_dry_run_reports_without_mutating(tmp_path: Path) -> None:
+    """The disown branch honours ``dry_run``: reported, but nothing written."""
+    claude_dir = tmp_path / ".claude"
+    original = {"type": "command", "command": "/opt/mybar", "_mpm": True}
+    path = _seed_status_line(claude_dir, original)
+
+    summary = run_global_cleanup(claude_dir=claude_dir, dry_run=True)
+
+    assert summary.settings_keys == ["statusLine._mpm"]
+    assert json.loads(path.read_text())["statusLine"] == original
+
+
+def test_user_authored_status_line_is_untouched(tmp_path: Path) -> None:
+    """No marker and a non-bundled command → the entry is not reported or changed."""
+    claude_dir = tmp_path / ".claude"
+    original = {"type": "command", "command": "/opt/mybar"}
+    path = _seed_status_line(claude_dir, original)
+
+    summary = run_global_cleanup(claude_dir=claude_dir, dry_run=False)
+
+    assert json.loads(path.read_text())["statusLine"] == original
+    assert summary.settings_keys == []

--- a/tests/migrations/test_statusline_ownership_disposition.py
+++ b/tests/migrations/test_statusline_ownership_disposition.py
@@ -1,0 +1,183 @@
+"""Tests for statusLine ownership-vs-removability classification (issue #939).
+
+WHAT: Exercises ``classify_statusline_entry``, ``strip_statusline_marker`` and the
+``_cleanup_global_statusline_settings`` removal path in
+:mod:`claude_mpm.migrations.migrate_statusline_autoconfig`.
+
+WHY: PR #936 made statusLine ownership an explicit recorded fact (``_mpm: True``).
+Ownership alone is not licence to delete: under the CUSTOM policy claude-mpm
+stamps that marker onto an entry whose ``command`` is the *user's*, so a removal
+path that deletes every entry it owns destroys user configuration. These tests
+pin the three-way disposition — REMOVE the bundled-script entry, DISOWN (marker
+only) a custom one, LEAVE a user-authored one — that every removal path shares.
+
+References: https://github.com/bobmatnyc/claude-mpm/issues/939
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from claude_mpm.migrations.migrate_statusline_autoconfig import (
+    StatuslineDisposition,
+    _cleanup_global_statusline_settings,
+    _is_mpm_owned_statusline,
+    classify_statusline_entry,
+    strip_statusline_marker,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# 1. classify_statusline_entry
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_script_entry_is_removable() -> None:
+    """A marked entry pointing at the bundled script is MPM's own artifact.
+
+    Why: This is the MANAGED-policy entry claude-mpm writes for itself, so an
+    uninstall must delete it outright — that is today's behaviour and the
+    disposition must preserve it.
+    """
+    entry = {
+        "type": "command",
+        "command": "/home/u/.claude/hooks/scripts/statusline.sh",
+        "_mpm": True,
+    }
+    assert classify_statusline_entry(entry) is StatuslineDisposition.REMOVE
+
+
+def test_legacy_marker_less_bundled_entry_is_removable() -> None:
+    """A pre-marker entry is still recognised via the command substring.
+
+    Why: Entries written by MPM versions predating the ``_mpm`` marker carry no
+    marker at all; the substring fallback is the only signal available for them
+    and dropping it would strand MPM's own footprint on every older install.
+    """
+    entry = {"type": "command", "command": ".claude/hooks/scripts/statusline.sh"}
+    assert classify_statusline_entry(entry) is StatuslineDisposition.REMOVE
+
+
+def test_custom_marked_entry_is_disowned_not_removed() -> None:
+    """A marker-bearing entry whose command is the user's must only be disowned.
+
+    Why: This is the whole point of #939. Under the CUSTOM policy MPM writes the
+    user's command and stamps the marker, so treating "MPM-owned" as "safe to
+    delete" would erase the user's own statusline configuration.
+    """
+    entry = {"type": "command", "command": "/opt/mybar --fancy", "_mpm": True}
+    assert classify_statusline_entry(entry) is StatuslineDisposition.DISOWN
+
+
+def test_user_authored_entry_is_left_alone() -> None:
+    """No marker plus a non-bundled command means claude-mpm never wrote it."""
+    entry = {"type": "command", "command": "/opt/mybar --fancy"}
+    assert classify_statusline_entry(entry) is StatuslineDisposition.LEAVE
+
+
+def test_non_dict_entries_are_left_alone() -> None:
+    """Malformed settings must never be classified as removable."""
+    for value in (None, "not-a-dict", 42, [], {"command": 5}):
+        assert classify_statusline_entry(value) is StatuslineDisposition.LEAVE
+
+
+def test_ownership_predicate_agrees_with_disposition() -> None:
+    """``_is_mpm_owned_statusline`` is exactly "disposition is not LEAVE".
+
+    Why: The ownership question and the removability question must be derived
+    from one classification so they can never drift apart again.
+    """
+    for entry in (
+        {"command": "/x/statusline.sh"},
+        {"command": "/x/statusline.sh", "_mpm": True},
+        {"command": "/opt/mybar", "_mpm": True},
+        {"command": "/opt/mybar"},
+        None,
+    ):
+        expected = classify_statusline_entry(entry) is not StatuslineDisposition.LEAVE
+        assert _is_mpm_owned_statusline(entry) is expected
+
+
+# ---------------------------------------------------------------------------
+# 2. strip_statusline_marker
+# ---------------------------------------------------------------------------
+
+
+def test_strip_marker_preserves_every_other_key() -> None:
+    """Disowning removes only ``_mpm`` — ``command`` above all must survive."""
+    entry = {"type": "command", "command": "/opt/mybar", "_mpm": True, "padding": 3}
+
+    assert strip_statusline_marker(entry) is True
+    assert entry == {"type": "command", "command": "/opt/mybar", "padding": 3}
+
+
+def test_strip_marker_on_unmarked_entry_is_a_no_op() -> None:
+    """A marker-less entry is reported unchanged and is not mutated."""
+    entry = {"type": "command", "command": "/opt/mybar"}
+
+    assert strip_statusline_marker(entry) is False
+    assert entry == {"type": "command", "command": "/opt/mybar"}
+
+
+# ---------------------------------------------------------------------------
+# 3. _cleanup_global_statusline_settings (the issue #924 global self-heal)
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_global_self_heal_removes_bundled_entry(tmp_path: Path) -> None:
+    """Regression guard: the bundled-script entry is still deleted outright."""
+    settings = tmp_path / "settings.json"
+    _write(
+        settings,
+        {
+            "statusLine": {"command": "/legacy/statusline.sh", "_mpm": True},
+            "keepme": True,
+        },
+    )
+
+    assert _cleanup_global_statusline_settings(settings) is True
+
+    data = _read(settings)
+    assert "statusLine" not in data
+    assert data["keepme"] is True
+
+
+def test_global_self_heal_disowns_custom_entry(tmp_path: Path) -> None:
+    """A marker-bearing custom entry keeps its command and loses the marker.
+
+    Why: The self-heal used to delete anything ``_is_mpm_owned_statusline``
+    matched, which would have taken the user's own command with it.
+    """
+    settings = tmp_path / "settings.json"
+    _write(
+        settings,
+        {"statusLine": {"type": "command", "command": "/opt/mybar", "_mpm": True}},
+    )
+
+    assert _cleanup_global_statusline_settings(settings) is True
+
+    data = _read(settings)
+    assert data["statusLine"] == {"type": "command", "command": "/opt/mybar"}
+
+
+def test_global_self_heal_leaves_user_authored_entry(tmp_path: Path) -> None:
+    """An entry with no marker and a non-bundled command is untouched."""
+    settings = tmp_path / "settings.json"
+    original = {"statusLine": {"type": "command", "command": "/opt/mybar"}}
+    _write(settings, original)
+
+    assert _cleanup_global_statusline_settings(settings) is True
+    assert _read(settings) == original

--- a/tests/migrations/test_statusline_user_level.py
+++ b/tests/migrations/test_statusline_user_level.py
@@ -1,0 +1,149 @@
+"""Tests for the legacy project-level statusline cleanup (issue #939).
+
+WHAT: Exercises ``_clean_settings`` in
+:mod:`claude_mpm.migrations.migrate_statusline_user_level`, the migration that
+strips legacy project-scoped ``statusLine`` / Stop-hook entries from
+``<project>/.claude/settings.json``.
+
+WHY: This removal path identified MPM-owned entries by substring-matching the
+bundled ``statusline.sh`` path, so it could not recognise a CUSTOM-policy entry
+as MPM's and left the ``_mpm`` marker behind. Simply asking "is it MPM-owned?"
+instead would have deleted the user's own command, so the path now acts on the
+shared three-way disposition. These tests pin all four entry shapes plus the
+Stop-hook behaviour that deliberately did not change.
+
+References: https://github.com/bobmatnyc/claude-mpm/issues/939
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from claude_mpm.migrations.migrate_statusline_user_level import _clean_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed(project_claude: Path, settings: dict) -> Path:
+    project_claude.mkdir(parents=True, exist_ok=True)
+    path = project_claude / "settings.json"
+    path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    return path
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_bundled_entry_is_removed(tmp_path: Path) -> None:
+    """Regression guard: a bundled-script entry is still deleted outright.
+
+    Why: This is MPM's own MANAGED artifact; the disposition refactor must not
+    weaken the cleanup that motivated this migration in the first place.
+    """
+    project_claude = tmp_path / ".claude"
+    path = _seed(
+        project_claude,
+        {
+            "statusLine": {
+                "type": "command",
+                "command": ".claude/hooks/scripts/statusline.sh",
+                "_mpm": True,
+            },
+            "keepme": True,
+        },
+    )
+
+    assert _clean_settings(project_claude) is True
+
+    data = _read(path)
+    assert "statusLine" not in data
+    assert data["keepme"] is True
+
+
+def test_legacy_marker_less_bundled_entry_is_removed(tmp_path: Path) -> None:
+    """A pre-marker legacy entry is still recognised by the command substring."""
+    project_claude = tmp_path / ".claude"
+    path = _seed(
+        project_claude,
+        {
+            "statusLine": {
+                "type": "command",
+                "command": ".claude/hooks/scripts/statusline.sh",
+            }
+        },
+    )
+
+    assert _clean_settings(project_claude) is True
+    assert "statusLine" not in _read(path)
+
+
+def test_custom_entry_keeps_command_and_loses_marker(tmp_path: Path) -> None:
+    """A marker-bearing CUSTOM entry keeps ``command`` and drops ``_mpm``.
+
+    Why: The command in a CUSTOM entry belongs to the user. claude-mpm
+    relinquishes ownership on cleanup without discarding that configuration —
+    the core requirement of issue #939.
+    """
+    project_claude = tmp_path / ".claude"
+    path = _seed(
+        project_claude,
+        {"statusLine": {"type": "command", "command": "/opt/mybar --x", "_mpm": True}},
+    )
+
+    assert _clean_settings(project_claude) is True
+
+    data = _read(path)
+    assert data["statusLine"] == {"type": "command", "command": "/opt/mybar --x"}
+
+
+def test_user_authored_entry_is_untouched(tmp_path: Path) -> None:
+    """No marker and a non-bundled command means the file is not rewritten."""
+    project_claude = tmp_path / ".claude"
+    original = {"statusLine": {"type": "command", "command": "/opt/mybar"}}
+    path = _seed(project_claude, original)
+
+    assert _clean_settings(project_claude) is True
+    assert _read(path) == original
+
+
+def test_stop_hooks_still_pruned_and_user_hooks_kept(tmp_path: Path) -> None:
+    """Stop-hook handling is unchanged: only ``--clear`` hooks are removed.
+
+    Why: claude-mpm never installs a ``--clear`` hook for a custom command, so
+    the command substring remains the correct ownership signal for Stop hooks and
+    the disposition refactor deliberately leaves that logic alone.
+    """
+    project_claude = tmp_path / ".claude"
+    path = _seed(
+        project_claude,
+        {
+            "hooks": {
+                "Stop": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {"command": ".claude/hooks/scripts/statusline.sh --clear"},
+                            {"command": "/my/own/on-stop.sh"},
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+
+    assert _clean_settings(project_claude) is True
+
+    data = _read(path)
+    assert data["hooks"]["Stop"][0]["hooks"] == [{"command": "/my/own/on-stop.sh"}]
+
+
+def test_missing_settings_file_is_a_no_op(tmp_path: Path) -> None:
+    """A project with no settings.json is a clean success."""
+    project_claude = tmp_path / ".claude"
+    project_claude.mkdir(parents=True)
+
+    assert _clean_settings(project_claude) is True
+    assert not (project_claude / "settings.json").exists()


### PR DESCRIPTION
> ## ⚠️ Stacked on #936 — DO NOT MERGE BEFORE #936
>
> This branch is cut from **#936's head (`e871ae5c8`)**, not from `main`.
> `_is_mpm_owned_statusline` — the helper this PR builds on — does not exist on
> `main` until #936 lands. Merging this first would break the build.
>
> **Merge order: #936 → then this PR.** The diff against `main` will contain
> #936's commits until it merges.

Closes #939

## Problem

#936 made statusLine ownership an explicit recorded fact: every entry claude-mpm
writes carries `"_mpm": True`, and `_is_mpm_owned_statusline` reads that marker
with the legacy `statusline.sh` command substring as a pre-marker fallback.

Two removal paths were left on the old substring check, so they could not
recognise a CUSTOM-policy entry as MPM's and left MPM's own marker behind on
uninstall:

- `src/claude_mpm/migrations/migrate_statusline_user_level.py`
- `src/claude_mpm/cli/commands/uninstall_global.py`

Pointing them at `_is_mpm_owned_statusline` would have been a **regression that
destroys user configuration**: under the CUSTOM policy MPM writes the *user's*
command into the entry and stamps the marker, so "MPM-owned" is true for an entry
whose `command` belongs to the user. A removal path reading ownership as licence
to delete would erase the user's own statusline.

## Resolution — separate ownership from removability

`classify_statusline_entry` (in `migrate_statusline_autoconfig.py`, beside the
code that stamps the marker) returns one of three dispositions:

| Disposition | Condition | Action |
|---|---|---|
| `REMOVE` | `command` points at the bundled `statusline.sh` | delete the entry outright — **today's behaviour, preserved** |
| `DISOWN` | marker present, `command` is the user's (CUSTOM) | strip **only** `_mpm`; `command` untouched |
| `LEAVE`  | no marker, non-bundled command | strictly untouched — **today's behaviour, preserved** |

The bundled-script check runs *before* the marker check, which is what keeps the
legacy pre-marker substring fallback intact: an unmarked legacy entry still
classifies `REMOVE`.

`_is_mpm_owned_statusline` now delegates to the classifier — "owned" is exactly
"not `LEAVE`" — so the ownership and removability answers cannot drift apart
again. Its behaviour is unchanged for every input.

### Helper placement

Kept in `migrations/migrate_statusline_autoconfig.py`; both other paths import it
from there. Rationale:

1. **The established import direction in this repo is `cli/` → `migrations`.**
   `cli/commands/run.py:1008` and `cli/commands/update_statusline.py:86` already
   import from this exact module; `cli/startup_migrations.py:1045` imports from
   `migrations` too. Nothing needed relocating.
2. **`migrations/` already hosts shared support modules consumed by siblings** —
   e.g. `migrate_check_migration_skills.py` imports `migrations/user_choices.py`.
3. **Reader belongs next to writer.** `_MPM_OWNED_KEY` and
   `_STATUSLINE_COMMAND_MATCH` live in this module because this module is what
   stamps the marker. Moving the classifier to `core/` or `utils/` would split
   the ownership vocabulary across packages, which is exactly the drift #939 is
   about.

## Third call site found

The issue names two files. A **third** removal path had the same latent bug:
`_cleanup_global_statusline_settings` (the issue #924 global self-heal, in
`migrate_statusline_autoconfig.py` itself) already used
`_is_mpm_owned_statusline` and then `del settings["statusLine"]` unconditionally —
ownership read as licence to delete. It is now disposition-driven too.

No reachable state changes today: since #936 the CUSTOM entry is written to the
project-local `.claude/settings.json`, which this path never reads, so a
marker-bearing entry cannot currently appear in `~/.claude/settings.json`. But
with the old code the bug was real once one did — the new test fails with
`KeyError: 'statusLine'` against the pre-change branch. Fixing it here keeps all
three removal paths consistent.

### Deliberately not changed

- **Stop-hook removal** (`_strip_mpm_stop_hooks`, and the `_STOP_HOOK_MATCH` /
  `_STATUSLINE_MATCH` checks in the other two files). claude-mpm only ever
  installs a `--clear` hook for the *bundled* script and never for a custom
  command, so the command substring **is** the correct ownership signal there and
  no ownership/removability divergence exists. Forcing the pattern in would add
  a distinction with no possible second case.
- **`hooks/claude_hooks/installer.py::_fix_status_line`** and
  **`v6_3_1_deploy_claude_assets.py`** both touch `statusLine`, but they are
  write/rewrite paths, not removal paths, and neither derives ownership from a
  `statusline.sh` substring. Untouched.
- **`CHANGELOG.md`.** This repo generates it from conventional commits via
  `commitizen` (`make release-*`); there is no `## [Unreleased]` section and #936
  likewise added no entry. Hand-editing would fight the tooling.

## Tests

Every acceptance-criteria bullet is covered. New behavioural tests were verified
to **fail on `pr-936-base` and pass after** (full raw evidence in the task
report):

| Test | Before | After |
|---|---|---|
| `test_custom_entry_keeps_command_and_loses_marker` (user_level) | FAIL — marker survived (`left contains 1 more item: {'_mpm': True}`) | PASS |
| `test_custom_status_line_keeps_command_and_loses_marker` (uninstall) | FAIL — same | PASS |
| `test_custom_status_line_dry_run_reports_without_mutating` | FAIL — `assert [] == ['statusLine._mpm']` (entry not recognised at all) | PASS |
| `test_global_self_heal_disowns_custom_entry` | FAIL — `KeyError: 'statusLine'` (user's command deleted) | PASS |
| whole `test_statusline_ownership_disposition.py` module | ERROR — `ImportError: cannot import name 'StatuslineDisposition'` | PASS |

Regression guards (correctly green before *and* after — these pin the behaviour
the change must **not** alter): bundled-script entry removed, legacy unmarked
entry still removed via the substring fallback, user-authored entry untouched,
`--clear` Stop hooks still pruned while user Stop hooks survive.

`migrate_statusline_user_level.py` previously had **no test file at all**; its
removal path is now covered.

No existing test needed editing — all 31 pre-existing statusline/uninstall tests
pass unmodified.

## Gates

- `uv run ruff format .` → `2205 files left unchanged`
- `uv run ruff check --fix .` → `All checks passed!`
- `uv run pytest tests/migrations/ -v` → `283 passed`
- `uv run pytest -n auto` → `7 failed, 11329 passed, 293 skipped` — all 7 are
  known-environmental (bundled-skills frontmatter, mutmut wall-clock bound,
  e2e-without-API-access) plus `test_duplicate_detection_within_threshold`, a
  `sleep(30ms)`-inside-a-100ms-window timing assertion that passes in isolation
  under `-n auto` (3/3) and whose test file and entire import graph
  (`hooks/claude_hooks/services`) are byte-identical to `pr-936-base`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
