### PR TITLE
chore: make required pytest CI check name version-agnostic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   test:
-    name: pytest (Python 3.13)
+    name: pytest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Branch protection on `main` requires the status check `pytest (Python 3.13)` by exact context string. That string is produced by `.github/workflows/test.yml`'s job `name:` field (no matrix — Python 3.13 is hardcoded), so:

- Bumping the Python version, or adding a matrix leg later, silently changes the rendered context string.
- The old required context then simply stops reporting (GitHub doesn't rename a required check when a workflow's job name changes — it just never sees that context again).
- Every subsequent merge blocks on a required check that will never turn green, until someone manually edits branch protection to point at the new string.

This PR renames the job so the reported context no longer embeds the version:

- Old rendered context: `pytest (Python 3.13)`
- New rendered context: `pytest`

Only the job's `name:` field changes (`.github/workflows/test.yml`, one line). Same Python 3.13, same steps (`check_clean_workspace.sh` guard → `uv sync --all-extras` → WWL granularity ratchet → full suite via `pytest -n auto`), same triggers (push/PR to `main`).

Related to #941 — that issue restored a working CI gate after a PR merged with zero check activity; this hardens the gate so a future version bump can't silently disable it the same way.

## Why this PR can't merge normally (please read before reviewing)

This PR's own CI run will report the **new** context `pytest`. The currently-required context is the **old** string, `pytest (Python 3.13)`, which this run will never produce. That means this PR will show a permanently-pending required check and will appear unmergeable — that is expected, not a bug in the PR.

Fixing that needs a branch-protection edit (drop the old required context, merge this PR, then add the new `pytest` context as required) — a repo-admin action that is intentionally **not** part of this PR and is being handled separately. This PR only contains the workflow rename; please do not force-merge or admin-bypass it as part of this review — the branch-protection swap is tracked and executed out of band.

## Test plan

- [x] Workflow diff is a single-line rename (`name: pytest (Python 3.13)` → `name: pytest`); no behavioral change to steps/triggers.
- [ ] CI runs on this PR and reports context `pytest` (confirmed via `gh pr checks`).
- [ ] Branch protection swap (drop old required context, merge, add new context) — handled separately, not in this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools