### PR TITLE
fix: skip pre-commit hook install inside linked worktrees (#948)

### DIFF
--- a/src/claude_mpm/init.py
+++ b/src/claude_mpm/init.py
@@ -392,6 +392,61 @@ class ProjectInitializer:
                 if not dst_file.exists():
                     shutil.copy2(template_file, dst_file)
 
+    def _is_git_worktree(self, project_root: Path) -> bool:
+        """Detect whether ``project_root`` is a linked git worktree.
+
+        WHAT: Compares ``git rev-parse --git-dir`` against
+        ``--git-common-dir``. In the primary checkout (or any non-worktree
+        repo) they resolve to the same path; in a linked worktree
+        (e.g. ``.claude/worktrees/agent-XXXX``) ``--git-dir`` points at the
+        worktree-private ``.git/worktrees/<name>`` directory while
+        ``--git-common-dir`` still points at the shared ``.git`` of the
+        primary checkout.
+
+        WHY: Tools like ``pre-commit install`` write hooks to
+        ``$(git rev-parse --git-common-dir)/hooks``, which is shared across
+        all worktrees. Running hook installation from inside a subagent's
+        worktree would overwrite the primary checkout's hooks — see #948.
+        Callers use this to skip hook installation when not in the primary
+        checkout.
+
+        Args:
+            project_root: Directory to check.
+
+        Returns:
+            True if project_root is inside a linked git worktree, False if
+            it is the primary checkout or worktree status can't be
+            determined (fail open so normal repos are unaffected).
+        """
+        try:
+            import subprocess  # nosec B404 - required for git operations
+
+            git_dir = subprocess.run(  # nosec B603 B607 - trusted git command
+                ["git", "-C", str(project_root), "rev-parse", "--git-dir"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True,
+            ).stdout.strip()
+            git_common_dir = subprocess.run(  # nosec B603 B607 - trusted git command
+                ["git", "-C", str(project_root), "rev-parse", "--git-common-dir"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True,
+            ).stdout.strip()
+        except Exception as e:
+            self.logger.debug(f"Could not determine git worktree status: {e}")
+            return False
+
+        def _resolve(path_str: str) -> Path:
+            path = Path(path_str)
+            if not path.is_absolute():
+                path = project_root / path
+            return path.resolve()
+
+        return _resolve(git_dir) != _resolve(git_common_dir)
+
     def _setup_security_hooks(
         self, project_root: Path, is_mcp_mode: bool = False
     ) -> None:
@@ -413,6 +468,23 @@ class ProjectInitializer:
             # Only set up hooks if this is a git repository
             if not (project_root / ".git").exists():
                 self.logger.debug("Not a git repository, skipping security hooks setup")
+                return
+
+            # Skip entirely inside a linked git worktree (e.g. a subagent's
+            # isolated .claude/worktrees/agent-XXXX checkout). `pre-commit
+            # install` writes to the *shared* hooks directory
+            # ($(git rev-parse --git-common-dir)/hooks), which for a linked
+            # worktree resolves back to the primary checkout's .git/hooks.
+            # Running this from inside a worktree would silently overwrite
+            # the primary checkout's hooks with a shim pointing at the
+            # worktree's (often ephemeral/pruned) venv interpreter. See #948.
+            if self._is_git_worktree(project_root):
+                self.logger.debug(
+                    "%s is a linked git worktree; skipping pre-commit/security "
+                    "hook installation to avoid clobbering the primary "
+                    "checkout's shared .git/hooks",
+                    project_root,
+                )
                 return
 
             # Check/install pre-commit

--- a/tests/unit/test_init_security_hooks.py
+++ b/tests/unit/test_init_security_hooks.py
@@ -1,0 +1,110 @@
+"""Tests for ProjectInitializer worktree-aware security hook setup.
+
+Verifies that ``_is_git_worktree()`` correctly distinguishes a linked git
+worktree from the primary checkout, and that ``_setup_security_hooks()``
+skips ``pre-commit install`` (and all other hook-installation side effects)
+when running inside a linked worktree. Without this guard, ``pre-commit
+install`` writes to the shared ``$(git rev-parse --git-common-dir)/hooks``
+directory, silently clobbering the primary checkout's ``.git/hooks/pre-commit``
+with a shim referencing the worktree's (often ephemeral) venv interpreter.
+
+See: GitHub issue #948
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from claude_mpm.init import ProjectInitializer
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+class TestIsGitWorktree:
+    """Covers _is_git_worktree() for main checkout vs. linked worktree."""
+
+    def test_main_checkout_returns_false(self, tmp_path: Path):
+        """git-dir == git-common-dir => not a linked worktree."""
+        initializer = ProjectInitializer()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[-1] == "--git-dir":
+                return _completed(".git")
+            if cmd[-1] == "--git-common-dir":
+                return _completed(".git")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert initializer._is_git_worktree(tmp_path) is False
+
+    def test_linked_worktree_returns_true(self, tmp_path: Path):
+        """git-dir under .git/worktrees/<name> differs from shared git-common-dir."""
+        initializer = ProjectInitializer()
+        main_repo = tmp_path / "main-repo"
+        worktree = tmp_path / "main-repo" / ".claude" / "worktrees" / "agent-xyz"
+        main_repo.mkdir(parents=True)
+        worktree.mkdir(parents=True)
+
+        git_dir = str(main_repo / ".git" / "worktrees" / "agent-xyz")
+        git_common_dir = str(main_repo / ".git")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[-1] == "--git-dir":
+                return _completed(git_dir)
+            if cmd[-1] == "--git-common-dir":
+                return _completed(git_common_dir)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert initializer._is_git_worktree(worktree) is True
+
+    def test_relative_paths_are_resolved_against_project_root(self, tmp_path: Path):
+        """git rev-parse can return relative paths; both must resolve consistently."""
+        initializer = ProjectInitializer()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[-1] == "--git-dir":
+                return _completed(".git")
+            if cmd[-1] == "--git-common-dir":
+                # Same absolute location, expressed relative to project_root.
+                return _completed(str((tmp_path / ".git").resolve()))
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert initializer._is_git_worktree(tmp_path) is False
+
+    def test_git_command_failure_fails_open(self, tmp_path: Path):
+        """If git can't be queried, treat as not-a-worktree (don't block normal repos)."""
+        initializer = ProjectInitializer()
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("git not found")):
+            assert initializer._is_git_worktree(tmp_path) is False
+
+
+class TestSetupSecurityHooksWorktreeGuard:
+    """Covers the worktree short-circuit in _setup_security_hooks()."""
+
+    def test_skips_pre_commit_install_in_linked_worktree(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        initializer = ProjectInitializer()
+
+        with patch.object(initializer, "_is_git_worktree", return_value=True):
+            with patch("subprocess.run") as mock_run:
+                initializer._setup_security_hooks(tmp_path, is_mcp_mode=True)
+
+        mock_run.assert_not_called()
+
+    def test_proceeds_in_primary_checkout(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        initializer = ProjectInitializer()
+
+        with patch.object(initializer, "_is_git_worktree", return_value=False):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                initializer._setup_security_hooks(tmp_path, is_mcp_mode=True)
+
+        # In the primary checkout, hook setup should attempt at least the
+        # `pre-commit --version` check (first subprocess call).
+        assert mock_run.called


### PR DESCRIPTION
## Summary
- Subagent worktrees were clobbering the primary checkout's `.git/hooks/pre-commit` because `pre-commit install` writes to the shared `git-common-dir`
- Added a worktree-detection guard to skip hook install when running inside a linked worktree
- Prevents hook conflicts and ensures each checkout maintains its own hook state

Closes #948