### PR TITLE
fix: correlate release CI watch to the pushed commit SHA (#946)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1060,10 +1060,11 @@ update-homebrew-tap: ## Update Homebrew tap formula after PyPI publish (non-bloc
 	@echo "$(YELLOW)⏳ Waiting for release-wheels.yml CI to finish before polling PyPI...$(NC)"
 	@VERSION=$$(cat VERSION); \
 	TAG="v$$VERSION"; \
-	SHA=$$(git rev-parse "$$TAG^{}" 2>/dev/null || git rev-parse "$$TAG" 2>/dev/null) || { \
+	SHA=$$(git rev-parse --verify "$$TAG^{}" 2>/dev/null || git rev-parse --verify "$$TAG" 2>/dev/null); \
+	if [ -z "$$SHA" ]; then \
 		echo "$(RED)✗ Could not resolve tag $$TAG to a commit SHA — aborting Homebrew update$(NC)"; \
 		exit 1; \
-	}; \
+	fi; \
 	echo "$(BLUE)ℹ  Locating release-wheels.yml run for $$TAG (commit $$SHA)...$(NC)"; \
 	RUN_ID=$$(./scripts/lib/find_release_ci_run.sh --repo bobmatnyc/claude-mpm --workflow release-wheels.yml --sha "$$SHA" --timeout 180 --interval 5) || { \
 		echo "$(RED)✗ Could not find a release-wheels.yml run for $$TAG (commit $$SHA) — aborting Homebrew update$(NC)"; \

--- a/Makefile
+++ b/Makefile
@@ -1058,15 +1058,20 @@ publish-pypi: ## Publish package to PyPI using credentials from .env.local
 update-homebrew-tap: ## Update Homebrew tap formula after PyPI publish (non-blocking)
 	@echo "$(YELLOW)🍺 Updating Homebrew tap...$(NC)"
 	@echo "$(YELLOW)⏳ Waiting for release-wheels.yml CI to finish before polling PyPI...$(NC)"
-	@RUN_ID=$$(gh run list --workflow=release-wheels.yml --repo bobmatnyc/claude-mpm --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null); \
-	if [ -n "$$RUN_ID" ]; then \
-		echo "$(BLUE)ℹ  Watching CI run $$RUN_ID (release-wheels.yml)...$(NC)"; \
-		gh run watch "$$RUN_ID" --repo bobmatnyc/claude-mpm --exit-status 2>/dev/null && \
-			echo "$(GREEN)✓ CI wheels build completed$(NC)" || \
-			echo "$(YELLOW)⚠️  CI run did not finish cleanly — attempting Homebrew update anyway$(NC)"; \
-	else \
-		echo "$(YELLOW)⚠️  Could not find release-wheels.yml run ID — attempting Homebrew update anyway$(NC)"; \
-	fi
+	@VERSION=$$(cat VERSION); \
+	TAG="v$$VERSION"; \
+	SHA=$$(git rev-parse "$$TAG" 2>/dev/null || git rev-parse HEAD); \
+	echo "$(BLUE)ℹ  Locating release-wheels.yml run for $$TAG (commit $$SHA)...$(NC)"; \
+	RUN_ID=$$(./scripts/lib/find_release_ci_run.sh --repo bobmatnyc/claude-mpm --workflow release-wheels.yml --sha "$$SHA" --timeout 180 --interval 5) || { \
+		echo "$(RED)✗ Could not find a release-wheels.yml run for $$TAG (commit $$SHA) — aborting Homebrew update$(NC)"; \
+		exit 1; \
+	}; \
+	echo "$(BLUE)ℹ  Watching CI run $$RUN_ID (release-wheels.yml, commit $$SHA)...$(NC)"; \
+	gh run watch "$$RUN_ID" --repo bobmatnyc/claude-mpm --exit-status && \
+		echo "$(GREEN)✓ CI wheels build completed$(NC)" || { \
+			echo "$(RED)✗ CI run $$RUN_ID (release-wheels.yml) did not finish successfully — aborting Homebrew update$(NC)"; \
+			exit 1; \
+		}
 	@export GH_REQUIRED_ACCOUNT="$$(cat .gh-account 2>/dev/null | tr -d '[:space:]')"; \
 	VERSION=$$(cat VERSION); \
 	if [ -f "scripts/update_homebrew_tap.sh" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1060,7 +1060,10 @@ update-homebrew-tap: ## Update Homebrew tap formula after PyPI publish (non-bloc
 	@echo "$(YELLOW)⏳ Waiting for release-wheels.yml CI to finish before polling PyPI...$(NC)"
 	@VERSION=$$(cat VERSION); \
 	TAG="v$$VERSION"; \
-	SHA=$$(git rev-parse "$$TAG" 2>/dev/null || git rev-parse HEAD); \
+	SHA=$$(git rev-parse "$$TAG^{}" 2>/dev/null || git rev-parse "$$TAG" 2>/dev/null) || { \
+		echo "$(RED)✗ Could not resolve tag $$TAG to a commit SHA — aborting Homebrew update$(NC)"; \
+		exit 1; \
+	}; \
 	echo "$(BLUE)ℹ  Locating release-wheels.yml run for $$TAG (commit $$SHA)...$(NC)"; \
 	RUN_ID=$$(./scripts/lib/find_release_ci_run.sh --repo bobmatnyc/claude-mpm --workflow release-wheels.yml --sha "$$SHA" --timeout 180 --interval 5) || { \
 		echo "$(RED)✗ Could not find a release-wheels.yml run for $$TAG (commit $$SHA) — aborting Homebrew update$(NC)"; \

--- a/scripts/lib/find_release_ci_run.sh
+++ b/scripts/lib/find_release_ci_run.sh
@@ -19,7 +19,12 @@
 #   head_sha matches the given commit appears, then prints its databaseId to
 #   stdout and exits 0. If no matching run appears within the timeout, it
 #   prints a clear error to stderr and exits 1. It never guesses at a run ID
-#   and never silently reports success for the wrong run.
+#   and never silently reports success for the wrong run. A `gh api` call
+#   that itself fails (auth error, 404, rate limit, transient network issue)
+#   is logged as a warning to stderr as soon as it happens, distinct from
+#   the ordinary "no matching run yet" case — so a persistent `gh` failure
+#   is visible immediately instead of only surfacing as an opaque timeout
+#   180 seconds later.
 #
 # Usage:
 #   find_release_ci_run.sh --repo <owner/repo> --workflow <file.yml> --sha <commit-sha> \
@@ -30,9 +35,10 @@
 # Test: tests/test_find_release_ci_run.py exercises this script against a
 #   fake `gh` binary on PATH that returns canned JSON, verifying that (a) a
 #   run matching the requested head_sha is selected even when a newer,
-#   unrelated run exists, (b) polling retries until the run appears, and
-#   (c) the script fails loudly (non-zero exit, stderr message) when no
-#   matching run ever appears before the timeout.
+#   unrelated run exists, (b) polling retries until the run appears, (c) the
+#   script fails loudly (non-zero exit, stderr message) when no matching run
+#   ever appears before the timeout, and (d) a `gh api` failure is logged to
+#   stderr immediately rather than being silently swallowed.
 
 set -euo pipefail
 
@@ -84,6 +90,8 @@ done
 [ -n "$SHA" ] || usage
 
 ELAPSED=0
+GH_STDERR_FILE=$(mktemp)
+trap 'rm -f "$GH_STDERR_FILE"' EXIT
 
 while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
     # Server-side filter by head_sha: only runs actually triggered by this
@@ -91,7 +99,19 @@ while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
     # client-side. Sort defensively in case the API ever returns more than
     # one match (e.g. a manual workflow_dispatch re-run against the same SHA)
     # and pick the most recently created one.
-    RESPONSE=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}" 2>/dev/null || true)
+    #
+    # A `gh api` failure (auth error, 404, rate limit, network blip) is
+    # distinguished from "no matching run yet": the former is surfaced as
+    # a warning on stderr immediately (so it isn't silently swallowed for
+    # the full timeout), while the latter is expected during the first few
+    # polls right after a push and just keeps the loop going.
+    if RESPONSE=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}" 2>"$GH_STDERR_FILE"); then
+        :
+    else
+        GH_EXIT=$?
+        echo "WARNING: gh api call failed (exit ${GH_EXIT}): $(cat "$GH_STDERR_FILE")" >&2
+        RESPONSE=""
+    fi
 
     if [ -n "$RESPONSE" ]; then
         RUN_ID=$(printf '%s' "$RESPONSE" | jq -r '[.workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')

--- a/scripts/lib/find_release_ci_run.sh
+++ b/scripts/lib/find_release_ci_run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# find_release_ci_run.sh — Correlate a GitHub Actions workflow run with the
+# exact commit/tag that should have triggered it.
+#
+# Why: `gh run list --workflow=<file> --limit=1` returns the most recently
+#   *created* run for that workflow, not the run triggered by a specific
+#   push. Immediately after `git push origin vX.Y.Z`, GitHub Actions has not
+#   necessarily materialised the new run record yet (it can take several
+#   seconds), so `--limit=1` silently returns a stale run from a PREVIOUS
+#   release that happens to already be complete and green. Watching that run
+#   with `gh run watch --exit-status` then reports success immediately even
+#   though the real release CI is still running (or has failed), masking
+#   publish failures. See GitHub issue #946 for the incident this fixes
+#   (v6.5.82: watched the v6.5.81 run instead of v6.5.82's).
+#
+# What: Polls `gh api repos/<repo>/actions/workflows/<workflow>/runs?head_sha=<sha>`
+#   — a server-side filter, not a client-side guess — until a run whose
+#   head_sha matches the given commit appears, then prints its databaseId to
+#   stdout and exits 0. If no matching run appears within the timeout, it
+#   prints a clear error to stderr and exits 1. It never guesses at a run ID
+#   and never silently reports success for the wrong run.
+#
+# Usage:
+#   find_release_ci_run.sh --repo <owner/repo> --workflow <file.yml> --sha <commit-sha> \
+#       [--timeout <seconds>] [--interval <seconds>]
+#
+#   Prints the matching run's databaseId to stdout on success.
+#
+# Test: tests/test_find_release_ci_run.py exercises this script against a
+#   fake `gh` binary on PATH that returns canned JSON, verifying that (a) a
+#   run matching the requested head_sha is selected even when a newer,
+#   unrelated run exists, (b) polling retries until the run appears, and
+#   (c) the script fails loudly (non-zero exit, stderr message) when no
+#   matching run ever appears before the timeout.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --repo <owner/repo> --workflow <file.yml> --sha <commit-sha> [--timeout <seconds>] [--interval <seconds>]" >&2
+    exit 2
+}
+
+REPO=""
+WORKFLOW=""
+SHA=""
+TIMEOUT=180
+INTERVAL=5
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --workflow)
+            WORKFLOW="$2"
+            shift 2
+            ;;
+        --sha)
+            SHA="$2"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --interval)
+            INTERVAL="$2"
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+[ -n "$REPO" ] || usage
+[ -n "$WORKFLOW" ] || usage
+[ -n "$SHA" ] || usage
+
+ELAPSED=0
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+    # Server-side filter by head_sha: only runs actually triggered by this
+    # commit are ever returned, so we never have to guess or correlate
+    # client-side. Sort defensively in case the API ever returns more than
+    # one match (e.g. a manual workflow_dispatch re-run against the same SHA)
+    # and pick the most recently created one.
+    RESPONSE=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}" 2>/dev/null || true)
+
+    if [ -n "$RESPONSE" ]; then
+        RUN_ID=$(printf '%s' "$RESPONSE" | jq -r '[.workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
+
+        if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+            echo "$RUN_ID"
+            exit 0
+        fi
+    fi
+
+    sleep "$INTERVAL"
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "ERROR: no run of workflow '${WORKFLOW}' in ${REPO} matched commit ${SHA} within ${TIMEOUT}s" >&2
+echo "  This usually means GitHub Actions has not started the run yet, or the tag/commit was never pushed." >&2
+exit 1

--- a/tests/test_find_release_ci_run.py
+++ b/tests/test_find_release_ci_run.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/lib/find_release_ci_run.sh.
+
+The script correlates a GitHub Actions workflow run with the exact commit
+that should have triggered it, instead of blindly taking `gh run list
+--limit=1` (which returns the most recently *created* run, not the one for
+a specific push — see GitHub issue #946: v6.5.82's Homebrew update watched
+the stale, already-green v6.5.81 run instead).
+
+These tests exercise the real script against a fake `gh` binary placed
+first on PATH. The fake `gh` implements just enough of `gh api
+repos/<repo>/actions/workflows/<workflow>/runs?head_sha=<sha>` to be a
+faithful stand-in: it honors the `head_sha` query parameter server-side
+(returning only runs for that SHA, exactly like the real endpoint) and can
+simulate GitHub Actions not having created the run yet via
+FAKE_GH_READY_AFTER.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent / "scripts" / "lib" / "find_release_ci_run.sh"
+)
+
+# Fake `gh` CLI. Reads its canned dataset from FAKE_GH_DATA_FILE (a JSON
+# object mapping head_sha -> list of run objects), filters by the head_sha
+# query parameter (mimicking the real API's server-side filter), and can
+# withhold matches for the first FAKE_GH_READY_AFTER calls to simulate
+# GitHub Actions not having materialised the run yet.
+FAKE_GH_SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "api" ]; then
+    echo "fake gh: unsupported subcommand '${1:-}'" >&2
+    exit 1
+fi
+URL="${2:-}"
+SHA="$(printf '%s' "$URL" | sed -n 's/.*head_sha=\\([^&]*\\).*/\\1/p')"
+
+COUNT=0
+if [ -f "$FAKE_GH_CALL_COUNTER" ]; then
+    COUNT="$(cat "$FAKE_GH_CALL_COUNTER")"
+fi
+echo $((COUNT + 1)) > "$FAKE_GH_CALL_COUNTER"
+
+READY_AFTER="${FAKE_GH_READY_AFTER:-0}"
+if [ "$COUNT" -lt "$READY_AFTER" ]; then
+    echo '{"workflow_runs": []}'
+    exit 0
+fi
+
+python3 - "$FAKE_GH_DATA_FILE" "$SHA" <<'PYEOF'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+runs = data.get(sys.argv[2], [])
+print(json.dumps({"workflow_runs": runs}))
+PYEOF
+"""
+
+
+class TestFindReleaseCIRun(unittest.TestCase):
+    """Exercise find_release_ci_run.sh against a fake `gh` on PATH."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+
+        self.bin_dir = self.tmp_path / "bin"
+        self.bin_dir.mkdir()
+        fake_gh = self.bin_dir / "gh"
+        fake_gh.write_text(FAKE_GH_SCRIPT)
+        fake_gh.chmod(0o755)
+
+        self.data_file = self.tmp_path / "gh_data.json"
+        self.counter_file = self.tmp_path / "gh_call_count"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, sha, data, timeout=5, interval=1, ready_after=0):
+        """Run the real script against the fake gh with the given dataset."""
+        self.data_file.write_text(json.dumps(data))
+        if self.counter_file.exists():
+            self.counter_file.unlink()
+
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin_dir}{os.pathsep}{env.get('PATH', '')}"
+        env["FAKE_GH_DATA_FILE"] = str(self.data_file)
+        env["FAKE_GH_CALL_COUNTER"] = str(self.counter_file)
+        env["FAKE_GH_READY_AFTER"] = str(ready_after)
+
+        return subprocess.run(
+            [
+                "bash",
+                str(SCRIPT_PATH),
+                "--repo",
+                "bobmatnyc/claude-mpm",
+                "--workflow",
+                "release-wheels.yml",
+                "--sha",
+                sha,
+                "--timeout",
+                str(timeout),
+                "--interval",
+                str(interval),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,
+        )
+
+    def _call_count(self):
+        return int(self.counter_file.read_text().strip())
+
+    def test_selects_run_matching_head_sha_ignoring_unrelated_newer_run(self):
+        """A run for the requested SHA is chosen even though a newer,
+        unrelated run (a different commit's CI run) also exists.
+        """
+        data = {
+            "matching-sha": [
+                {
+                    "id": 111,
+                    "head_sha": "matching-sha",
+                    "created_at": "2026-07-26T10:00:00Z",
+                }
+            ],
+            "unrelated-sha": [
+                {
+                    "id": 999,
+                    "head_sha": "unrelated-sha",
+                    "created_at": "2026-07-26T12:00:00Z",
+                }
+            ],
+        }
+
+        result = self._run("matching-sha", data)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "111")
+
+    def test_picks_most_recently_created_when_multiple_runs_match_same_sha(self):
+        """When more than one run matches the SHA (e.g. a manual re-run),
+        the most recently created one is selected, per the script's
+        defensive sort_by(.created_at) | reverse | .[0].
+        """
+        data = {
+            "matching-sha": [
+                {
+                    "id": 100,
+                    "head_sha": "matching-sha",
+                    "created_at": "2026-07-26T09:00:00Z",
+                },
+                {
+                    "id": 200,
+                    "head_sha": "matching-sha",
+                    "created_at": "2026-07-26T11:00:00Z",
+                },
+            ]
+        }
+
+        result = self._run("matching-sha", data)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "200")
+
+    def test_polls_until_run_appears(self):
+        """GitHub Actions may not have created the run yet right after the
+        push; the script must keep polling (not give up on the first empty
+        response) until a matching run shows up.
+        """
+        data = {
+            "matching-sha": [
+                {
+                    "id": 42,
+                    "head_sha": "matching-sha",
+                    "created_at": "2026-07-26T10:00:00Z",
+                }
+            ]
+        }
+
+        result = self._run("matching-sha", data, timeout=5, interval=1, ready_after=2)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "42")
+        # Confirm it actually retried rather than matching by luck on the
+        # first call.
+        self.assertGreaterEqual(self._call_count(), 3)
+
+    def test_fails_loudly_when_no_matching_run_within_timeout(self):
+        """If no run ever matches the requested SHA before the timeout, the
+        script must abort with a non-zero exit and an explanatory stderr
+        message — never silently report success for the wrong run.
+        """
+        data = {
+            "other-sha": [
+                {
+                    "id": 1,
+                    "head_sha": "other-sha",
+                    "created_at": "2026-07-26T10:00:00Z",
+                }
+            ]
+        }
+
+        result = self._run("never-appears-sha", data, timeout=2, interval=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertIn("no run of workflow", result.stderr)
+        self.assertIn("release-wheels.yml", result.stderr)
+        self.assertIn("never-appears-sha", result.stderr)
+
+    def test_missing_required_argument_exits_with_usage(self):
+        """Missing --sha (or any required arg) should fail fast with usage,
+        not attempt to poll the GitHub API at all.
+        """
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(SCRIPT_PATH),
+                "--repo",
+                "bobmatnyc/claude-mpm",
+                "--workflow",
+                "release-wheels.yml",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_find_release_ci_run.py
+++ b/tests/test_find_release_ci_run.py
@@ -49,6 +49,12 @@ if [ -f "$FAKE_GH_CALL_COUNTER" ]; then
 fi
 echo $((COUNT + 1)) > "$FAKE_GH_CALL_COUNTER"
 
+FAIL_UNTIL="${FAKE_GH_FAIL_UNTIL:-0}"
+if [ "$COUNT" -lt "$FAIL_UNTIL" ]; then
+    echo "fake gh: simulated auth failure (HTTP 401)" >&2
+    exit 1
+fi
+
 READY_AFTER="${FAKE_GH_READY_AFTER:-0}"
 if [ "$COUNT" -lt "$READY_AFTER" ]; then
     echo '{"workflow_runs": []}'

--- a/tests/test_release_sha_resolution.py
+++ b/tests/test_release_sha_resolution.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Tests for the release-tag -> commit-SHA resolution used by the
+`update-homebrew-tap` Makefile target.
+
+Background (security/correctness followup to #946 / PR #951):
+`git rev-parse "$TAG"` on an *annotated* tag (created via `git tag -a` or
+`git tag -s` — the norm for release workflows) returns the tag OBJECT's
+SHA, not the SHA of the commit it points to. The GitHub Actions API filters
+workflow runs by `head_sha` (a commit SHA), so passing the tag-object SHA
+to scripts/lib/find_release_ci_run.sh would never match any run, and every
+annotated-tag release would poll until it timed out.
+
+The fix dereferences the tag with `TAG^{}` first (which peels an annotated
+tag down to its commit and is a harmless no-op for lightweight tags, whose
+`rev-parse` output already equals `rev-parse TAG^{}`), and only falls back
+to a bare `git rev-parse "$TAG"` if that somehow fails — never silently
+substituting HEAD, which could refer to an unrelated commit.
+
+These tests exercise the same resolution logic against real temporary git
+repositories (asserting the underlying git behaviour that the fix depends
+on) and statically check that the Makefile still contains the corrected
+pattern, so a future edit can't silently reintroduce the bug.
+"""
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MAKEFILE_PATH = REPO_ROOT / "Makefile"
+
+
+def _git(repo, *args):
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+class TestAnnotatedTagShaResolution(unittest.TestCase):
+    """Verify the git behaviour the update-homebrew-tap fix relies on."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        _git(self.repo, "init", "-q")
+        _git(self.repo, "config", "user.email", "test@example.com")
+        _git(self.repo, "config", "user.name", "Test")
+        (self.repo / "a.txt").write_text("a\n")
+        _git(self.repo, "add", "a.txt")
+        _git(self.repo, "commit", "-q", "-m", "initial")
+        self.commit_sha = _git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_annotated_tag_rev_parse_differs_from_commit_sha(self):
+        """`git rev-parse TAG` on an annotated tag returns the tag OBJECT
+        SHA, not the commit SHA — this is the root cause of the bug.
+        """
+        _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
+        tag_object_sha = _git(self.repo, "rev-parse", "release-tag")
+
+        self.assertNotEqual(
+            tag_object_sha,
+            self.commit_sha,
+            "annotated tag's rev-parse unexpectedly matched the commit SHA "
+            "directly — test fixture no longer exercises the bug",
+        )
+
+    def test_dereferenced_annotated_tag_matches_commit_sha(self):
+        """`git rev-parse TAG^{}` peels the annotated tag to the commit it
+        points to — this is what the Makefile fix now does first.
+        """
+        _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
+        dereferenced_sha = _git(self.repo, "rev-parse", "release-tag^{}")
+
+        self.assertEqual(dereferenced_sha, self.commit_sha)
+
+    def test_dereferenced_lightweight_tag_matches_commit_sha(self):
+        """`TAG^{}` is a safe no-op for lightweight tags: it resolves
+        identically to a bare `rev-parse TAG`.
+        """
+        _git(self.repo, "tag", "lightweight-tag")
+
+        bare_sha = _git(self.repo, "rev-parse", "lightweight-tag")
+        dereferenced_sha = _git(self.repo, "rev-parse", "lightweight-tag^{}")
+
+        self.assertEqual(bare_sha, self.commit_sha)
+        self.assertEqual(dereferenced_sha, self.commit_sha)
+
+    def test_makefile_shell_snippet_resolves_annotated_tag_correctly(self):
+        """Run the actual shell resolution line used by update-homebrew-tap
+        (TAG^{} first, then bare TAG, no silent HEAD fallback) against a
+        repo with an annotated tag, and confirm it yields the commit SHA.
+        """
+        _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
+
+        snippet = (
+            'TAG="release-tag"; '
+            'SHA=$(git rev-parse "$TAG^{}" 2>/dev/null '
+            '|| git rev-parse "$TAG" 2>/dev/null) || exit 1; '
+            'echo "$SHA"'
+        )
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), self.commit_sha)
+
+    def test_makefile_shell_snippet_fails_loudly_when_tag_is_missing(self):
+        """If the tag cannot be resolved at all, the snippet must exit
+        non-zero instead of silently substituting HEAD.
+        """
+        snippet = (
+            'TAG="nonexistent-tag"; '
+            'SHA=$(git rev-parse "$TAG^{}" 2>/dev/null '
+            '|| git rev-parse "$TAG" 2>/dev/null) || exit 1; '
+            'echo "$SHA"'
+        )
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+
+
+class TestMakefileUsesCorrectedShaResolutionPattern(unittest.TestCase):
+    """Guard against silently regressing the fix in the Makefile itself."""
+
+    def setUp(self):
+        self.makefile_text = MAKEFILE_PATH.read_text()
+
+    def test_update_homebrew_tap_dereferences_tag_before_rev_parse(self):
+        match = re.search(
+            r"update-homebrew-tap:.*?(?=\n[a-zA-Z0-9_.-]+:\s*(?:##|\n|$))",
+            self.makefile_text,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            match, "could not locate update-homebrew-tap target in Makefile"
+        )
+        target_body = match.group(0)
+
+        self.assertIn(
+            'git rev-parse "$$TAG^{}"',
+            target_body,
+            "update-homebrew-tap must dereference annotated tags with "
+            "TAG^{} before resolving the commit SHA (see #946 / PR #951)",
+        )
+
+    def test_update_homebrew_tap_does_not_silently_fall_back_to_head(self):
+        match = re.search(
+            r"update-homebrew-tap:.*?(?=\n[a-zA-Z0-9_.-]+:\s*(?:##|\n|$))",
+            self.makefile_text,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            match, "could not locate update-homebrew-tap target in Makefile"
+        )
+        target_body = match.group(0)
+
+        self.assertNotIn(
+            'git rev-parse "$$TAG" 2>/dev/null || git rev-parse HEAD',
+            target_body,
+            "SHA resolution must not silently fall back to HEAD when the "
+            "tag cannot be resolved — it should fail loudly instead",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_sha_resolution.py
+++ b/tests/test_release_sha_resolution.py
@@ -3,24 +3,50 @@
 Tests for the release-tag -> commit-SHA resolution used by the
 `update-homebrew-tap` Makefile target.
 
-Background (security/correctness followup to #946 / PR #951):
-`git rev-parse "$TAG"` on an *annotated* tag (created via `git tag -a` or
-`git tag -s` — the norm for release workflows) returns the tag OBJECT's
-SHA, not the SHA of the commit it points to. The GitHub Actions API filters
-workflow runs by `head_sha` (a commit SHA), so passing the tag-object SHA
-to scripts/lib/find_release_ci_run.sh would never match any run, and every
-annotated-tag release would poll until it timed out.
+Background (security/correctness followups to #946 / PR #951):
 
-The fix dereferences the tag with `TAG^{}` first (which peels an annotated
-tag down to its commit and is a harmless no-op for lightweight tags, whose
-`rev-parse` output already equals `rev-parse TAG^{}`), and only falls back
-to a bare `git rev-parse "$TAG"` if that somehow fails — never silently
-substituting HEAD, which could refer to an unrelated commit.
+1. `git rev-parse "$TAG"` on an *annotated* tag (created via `git tag -a` or
+   `git tag -s` — the norm for release workflows) returns the tag OBJECT's
+   SHA, not the SHA of the commit it points to. The GitHub Actions API
+   filters workflow runs by `head_sha` (a commit SHA), so passing the
+   tag-object SHA to scripts/lib/find_release_ci_run.sh would never match
+   any run, and every annotated-tag release would poll until it timed out.
+   Fixed by dereferencing with `TAG^{}` before falling back to a bare
+   `git rev-parse "$TAG"`.
 
-These tests exercise the same resolution logic against real temporary git
-repositories (asserting the underlying git behaviour that the fix depends
-on) and statically check that the Makefile still contains the corrected
-pattern, so a future edit can't silently reintroduce the bug.
+2. A later adversarial review of PR #951 flagged that `SHA=$(...) || { ...
+   exit 1; }` relies on the exit status of a bare shell assignment
+   propagating the command substitution's failure — a pattern considered
+   fragile/non-obvious across shells, so the target was changed to resolve
+   SHA first and then explicitly check `if [ -z "$SHA" ]; then ... exit 1;
+   fi`.
+
+3. Investigating (2) surfaced a THIRD, more consequential bug that a naive
+   application of fix (2) would have introduced: `git rev-parse` (without
+   `--verify`) does not just fail on an unresolvable ref — it also echoes
+   the literal ref text back on STDOUT as part of its "ambiguous argument:
+   could be a revision or a path" disambiguation hint, even though it
+   exits non-zero. That means `SHA=$(git rev-parse "$TAG^{}" 2>/dev/null
+   || git rev-parse "$TAG" 2>/dev/null)` for a missing tag does NOT
+   produce an empty string — it produces garbage like `"my-tag^{}\nmy-tag"`.
+   An `if [ -z "$SHA" ]` check alone would never trigger, and the target
+   would silently proceed to poll find_release_ci_run.sh with a bogus
+   `--sha` value for the full 180s timeout instead of failing fast with a
+   clear message — i.e. fix (2), applied literally without also switching
+   to `git rev-parse --verify`, would have been WORSE than the
+   exit-status check it replaced (which, empirically, already propagated
+   the failure correctly in bash). `git rev-parse --verify` suppresses
+   that stdout disambiguation dance (it only ever prints the resolved SHA
+   on success), so the Makefile now uses `--verify` on both the
+   dereferencing attempt and the fallback, which makes the explicit `-z`
+   check actually correct.
+
+These tests exercise the *actual* SHA-resolution recipe text extracted
+verbatim from the Makefile (not a hand-retyped analog) against real
+temporary git repositories, so a future edit that silently drops
+`--verify` or the `-z` check is caught by running the real snippet, not by
+a static string match that could drift from what the Makefile actually
+does.
 """
 
 import re
@@ -40,6 +66,69 @@ def _git(repo, *args):
         check=True,
     )
     return result.stdout.strip()
+
+
+def _extract_sha_resolution_snippet():
+    r"""Pull the real `SHA=... ; if [ -z "$SHA" ]; then ... fi` block out of
+    the `update-homebrew-tap` target, verbatim, and convert it from
+    Makefile syntax (`$$`, trailing `\` line continuations, `$(RED)` etc.
+    Make variable references) into a plain, directly-runnable bash
+    snippet.
+
+    Returns the snippet text; callers are expected to prepend a `TAG=...`
+    assignment and run the whole thing with `bash -c`.
+    """
+    lines = MAKEFILE_PATH.read_text().splitlines()
+
+    start = None
+    end = None
+    for i, line in enumerate(lines):
+        if start is None and "SHA=$$(git rev-parse" in line:
+            start = i
+            continue
+        if start is not None and line.strip() == "fi; \\":
+            end = i
+            break
+
+    assert start is not None and end is not None, (
+        'could not locate the SHA=...; if [ -z "$$SHA" ]; then ... fi '
+        "block in update-homebrew-tap — the Makefile recipe shape changed; "
+        "update this extractor to match"
+    )
+
+    block_lines = lines[start : end + 1]
+    processed = []
+    for line in block_lines:
+        text = line.strip()
+        if text.endswith("\\"):
+            text = text[:-1].rstrip()
+        text = text.replace("$$", "$")
+        # Make variable references like $(RED)/$(NC) are substituted by
+        # `make` itself before the shell ever sees this line; outside of
+        # `make` they'd be parsed as (nonexistent) command substitutions,
+        # so strip them for standalone execution. The behavior under test
+        # (exit status / whether SHA resolves) does not depend on color
+        # codes.
+        text = re.sub(r"\$\([A-Z_]+\)", "", text)
+        processed.append(text)
+
+    return "\n".join(processed)
+
+
+def _run_sha_resolution(repo, tag):
+    """Run the real, verbatim-extracted SHA-resolution snippet from the
+    Makefile against `repo` with the given TAG, returning the completed
+    process (stdout carries `SHA_RESULT=<value>` on the success path).
+    """
+    snippet = _extract_sha_resolution_snippet()
+    script = f'TAG="{tag}"\n{snippet}\necho "SHA_RESULT=$SHA"\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 class TestAnnotatedTagShaResolution(unittest.TestCase):
@@ -63,7 +152,7 @@ class TestAnnotatedTagShaResolution(unittest.TestCase):
 
     def test_annotated_tag_rev_parse_differs_from_commit_sha(self):
         """`git rev-parse TAG` on an annotated tag returns the tag OBJECT
-        SHA, not the commit SHA — this is the root cause of the bug.
+        SHA, not the commit SHA — this is the root cause of bug #1.
         """
         _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
         tag_object_sha = _git(self.repo, "rev-parse", "release-tag")
@@ -77,7 +166,7 @@ class TestAnnotatedTagShaResolution(unittest.TestCase):
 
     def test_dereferenced_annotated_tag_matches_commit_sha(self):
         """`git rev-parse TAG^{}` peels the annotated tag to the commit it
-        points to — this is what the Makefile fix now does first.
+        points to — this is what the Makefile fix does first.
         """
         _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
         dereferenced_sha = _git(self.repo, "rev-parse", "release-tag^{}")
@@ -96,42 +185,17 @@ class TestAnnotatedTagShaResolution(unittest.TestCase):
         self.assertEqual(bare_sha, self.commit_sha)
         self.assertEqual(dereferenced_sha, self.commit_sha)
 
-    def test_makefile_shell_snippet_resolves_annotated_tag_correctly(self):
-        """Run the actual shell resolution line used by update-homebrew-tap
-        (TAG^{} first, then bare TAG, no silent HEAD fallback) against a
-        repo with an annotated tag, and confirm it yields the commit SHA.
+    def test_missing_ref_rev_parse_leaks_ref_text_onto_stdout(self):
+        """Document the git quirk that motivates `--verify`: a bare
+        `git rev-parse` on an unresolvable ref does not just fail with a
+        non-zero exit — it also prints the literal ref argument back on
+        STDOUT (its "ambiguous argument: could be a revision or a path"
+        disambiguation hint), even with stderr redirected away. Any code
+        that captures this into a variable and only checks `[ -z "$VAR" ]`
+        will treat that leaked text as a resolved value.
         """
-        _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
-
-        snippet = (
-            'TAG="release-tag"; '
-            'SHA=$(git rev-parse "$TAG^{}" 2>/dev/null '
-            '|| git rev-parse "$TAG" 2>/dev/null) || exit 1; '
-            'echo "$SHA"'
-        )
         result = subprocess.run(
-            ["bash", "-c", snippet],
-            cwd=self.repo,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertEqual(result.stdout.strip(), self.commit_sha)
-
-    def test_makefile_shell_snippet_fails_loudly_when_tag_is_missing(self):
-        """If the tag cannot be resolved at all, the snippet must exit
-        non-zero instead of silently substituting HEAD.
-        """
-        snippet = (
-            'TAG="nonexistent-tag"; '
-            'SHA=$(git rev-parse "$TAG^{}" 2>/dev/null '
-            '|| git rev-parse "$TAG" 2>/dev/null) || exit 1; '
-            'echo "$SHA"'
-        )
-        result = subprocess.run(
-            ["bash", "-c", snippet],
+            ["git", "rev-parse", "totally-bogus-ref^{}"],
             cwd=self.repo,
             capture_output=True,
             text=True,
@@ -139,16 +203,100 @@ class TestAnnotatedTagShaResolution(unittest.TestCase):
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertEqual(result.stdout.strip(), "")
+        self.assertIn("totally-bogus-ref", result.stdout)
+
+    def test_missing_ref_rev_parse_verify_produces_empty_stdout(self):
+        """`git rev-parse --verify` on the same unresolvable ref exits
+        non-zero WITHOUT leaking anything onto stdout — this is why the
+        Makefile fix uses `--verify` rather than bare `rev-parse`.
+        """
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "totally-bogus-ref^{}"],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_makefile_snippet_resolves_annotated_tag_correctly(self):
+        """Run the real, verbatim-extracted Makefile SHA-resolution block
+        against a repo with an annotated tag and confirm it yields the
+        commit SHA and reaches the success path (no abort).
+        """
+        _git(self.repo, "tag", "-a", "release-tag", "-m", "release")
+
+        result = _run_sha_resolution(self.repo, "release-tag")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(f"SHA_RESULT={self.commit_sha}", result.stdout)
+
+    def test_makefile_snippet_resolves_lightweight_tag_correctly(self):
+        """Same as above, for a lightweight tag (no dereferencing needed,
+        but `TAG^{}` must remain a harmless no-op).
+        """
+        _git(self.repo, "tag", "lightweight-tag")
+
+        result = _run_sha_resolution(self.repo, "lightweight-tag")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(f"SHA_RESULT={self.commit_sha}", result.stdout)
+
+    def test_makefile_snippet_fails_loudly_when_tag_is_missing(self):
+        """If the tag cannot be resolved at all, the real Makefile
+        SHA-resolution block must abort (non-zero exit) before ever
+        reaching the success-path echo — never silently proceed with a
+        bogus SHA value.
+        """
+        result = _run_sha_resolution(self.repo, "nonexistent-tag")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("SHA_RESULT=", result.stdout)
+
+    def test_bare_rev_parse_without_verify_would_defeat_the_z_check(self):
+        """Regression guard for the bug this fix surfaced: if a future
+        edit "simplifies" the Makefile by dropping `--verify` (keeping
+        only the `if [ -z "$SHA" ]` check), the target would silently
+        proceed with a garbage SHA instead of aborting. This runs that
+        exact (deliberately broken) variant to prove it is broken, so the
+        Makefile must keep `--verify` — see
+        test_makefile_snippet_fails_loudly_when_tag_is_missing above for
+        the correct, currently-shipped behaviour.
+        """
+        broken_snippet = (
+            'SHA=$(git rev-parse "$TAG^{}" 2>/dev/null '
+            '|| git rev-parse "$TAG" 2>/dev/null)\n'
+            'if [ -z "$SHA" ]; then\n'
+            "    exit 1\n"
+            "fi\n"
+            'echo "SHA_RESULT=$SHA"\n'
+        )
+        script = f'TAG="nonexistent-tag"\n{broken_snippet}'
+
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        # This documents the broken behaviour: it does NOT abort, and it
+        # DOES reach the success-path echo with a garbage, non-SHA value.
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("SHA_RESULT=", result.stdout)
+        self.assertNotIn(f"SHA_RESULT={self.commit_sha}", result.stdout)
 
 
 class TestMakefileUsesCorrectedShaResolutionPattern(unittest.TestCase):
-    """Guard against silently regressing the fix in the Makefile itself."""
+    """Guard against silently regressing either fix in the Makefile itself."""
 
     def setUp(self):
         self.makefile_text = MAKEFILE_PATH.read_text()
 
-    def test_update_homebrew_tap_dereferences_tag_before_rev_parse(self):
+    def _target_body(self):
         match = re.search(
             r"update-homebrew-tap:.*?(?=\n[a-zA-Z0-9_.-]+:\s*(?:##|\n|$))",
             self.makefile_text,
@@ -157,25 +305,45 @@ class TestMakefileUsesCorrectedShaResolutionPattern(unittest.TestCase):
         self.assertIsNotNone(
             match, "could not locate update-homebrew-tap target in Makefile"
         )
-        target_body = match.group(0)
+        return match.group(0)
+
+    def test_update_homebrew_tap_dereferences_tag_before_rev_parse(self):
+        target_body = self._target_body()
 
         self.assertIn(
-            'git rev-parse "$$TAG^{}"',
+            'git rev-parse --verify "$$TAG^{}"',
             target_body,
             "update-homebrew-tap must dereference annotated tags with "
             "TAG^{} before resolving the commit SHA (see #946 / PR #951)",
         )
 
+    def test_update_homebrew_tap_uses_verify_on_both_resolution_attempts(self):
+        target_body = self._target_body()
+
+        self.assertEqual(
+            target_body.count("git rev-parse --verify"),
+            2,
+            "both the dereferencing attempt and the bare-tag fallback must "
+            "use `git rev-parse --verify` — without it, an unresolvable "
+            "ref leaks its literal text onto stdout instead of producing "
+            'an empty string, which defeats the `-z "$$SHA"` check '
+            "below (see test_bare_rev_parse_without_verify_would_defeat_"
+            "the_z_check)",
+        )
+
+    def test_update_homebrew_tap_checks_sha_emptiness_explicitly(self):
+        target_body = self._target_body()
+
+        self.assertIn(
+            'if [ -z "$$SHA" ]; then',
+            target_body,
+            "SHA resolution must explicitly check for an empty result "
+            "after the assignment rather than relying solely on the "
+            "assignment statement's own exit status",
+        )
+
     def test_update_homebrew_tap_does_not_silently_fall_back_to_head(self):
-        match = re.search(
-            r"update-homebrew-tap:.*?(?=\n[a-zA-Z0-9_.-]+:\s*(?:##|\n|$))",
-            self.makefile_text,
-            re.DOTALL,
-        )
-        self.assertIsNotNone(
-            match, "could not locate update-homebrew-tap target in Makefile"
-        )
-        target_body = match.group(0)
+        target_body = self._target_body()
 
         self.assertNotIn(
             'git rev-parse "$$TAG" 2>/dev/null || git rev-parse HEAD',


### PR DESCRIPTION
## Summary
- `gh run list --limit=1` raced against GitHub Actions run creation right after a push
- Sometimes picked the prior release's already-green run and reported false success
- Now polls `gh api .../runs?head_sha=<sha>` until the run matching the pushed tag's exact commit appears
- Fails loudly on timeout instead of silently succeeding with wrong run

Closes #946