### PR TITLE
fix: stop test suite from corrupting real .claude-mpm/configuration.yaml (#945)

### DIFF
--- a/tests/cli/test_skills_startup_sync.py
+++ b/tests/cli/test_skills_startup_sync.py
@@ -18,10 +18,19 @@ class TestSyncRemoteSkillsOnStartup:
         with patch("claude_mpm.cli.startup._is_sync_fresh", return_value=False):
             yield
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager")
     @patch("claude_mpm.config.skill_sources.SkillSourceConfiguration")
-    def test_successful_skills_sync(self, mock_config_class, mock_manager_class):
-        """Test successful synchronization of skills."""
+    def test_successful_skills_sync(
+        self, mock_config_class, mock_manager_class, mock_save_config
+    ):
+        """Test successful synchronization of skills.
+
+        ``save_agent_skills_to_config`` is mocked so this test never writes to
+        the real ``.claude-mpm/configuration.yaml`` (see #945).
+        """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 
         # Mock configuration
@@ -174,13 +183,24 @@ class TestTwoPhaseProgressBars:
         with patch("claude_mpm.cli.startup._is_sync_fresh", return_value=False):
             yield
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.utils.progress.ProgressBar")
     @patch("claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager")
     @patch("claude_mpm.config.skill_sources.SkillSourceConfiguration")
     def test_two_progress_bars_created(
-        self, mock_config_class, mock_manager_class, mock_progress_class
+        self,
+        mock_config_class,
+        mock_manager_class,
+        mock_progress_class,
+        mock_save_config,
     ):
-        """Test that two separate progress bars are created for sync and deploy."""
+        """Test that two separate progress bars are created for sync and deploy.
+
+        ``save_agent_skills_to_config`` is mocked so this test never writes to
+        the real ``.claude-mpm/configuration.yaml`` (see #945).
+        """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 
         # Mock configuration
@@ -242,13 +262,24 @@ class TestTwoPhaseProgressBars:
         sync_progress.finish.assert_called_once()
         deploy_progress.finish.assert_called_once()
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.utils.progress.ProgressBar")
     @patch("claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager")
     @patch("claude_mpm.config.skill_sources.SkillSourceConfiguration")
     def test_progress_callback_invoked_during_sync(
-        self, mock_config_class, mock_manager_class, mock_progress_class
+        self,
+        mock_config_class,
+        mock_manager_class,
+        mock_progress_class,
+        mock_save_config,
     ):
-        """Test that progress callback is passed to sync_all_sources."""
+        """Test that progress callback is passed to sync_all_sources.
+
+        ``save_agent_skills_to_config`` is mocked so this test never writes to
+        the real ``.claude-mpm/configuration.yaml`` (see #945).
+        """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 
         # Mock configuration
@@ -284,16 +315,26 @@ class TestTwoPhaseProgressBars:
         assert "progress_callback" in call_args[1]
         assert callable(call_args[1]["progress_callback"])
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.utils.progress.ProgressBar")
     @patch("claude_mpm.services.skills.git_skill_source_manager.GitSkillSourceManager")
     @patch("claude_mpm.config.skill_sources.SkillSourceConfiguration")
     def test_progress_callback_invoked_during_deploy(
-        self, mock_config_class, mock_manager_class, mock_progress_class
+        self,
+        mock_config_class,
+        mock_manager_class,
+        mock_progress_class,
+        mock_save_config,
     ):
         """Test that deploy_skills is called with target_dir and skill_filter args.
 
         NOTE: The implementation no longer passes progress_callback to deploy_skills.
         deploy_skills is called with target_dir, force, and skill_filter parameters.
+
+        ``save_agent_skills_to_config`` is mocked so this test never writes to
+        the real ``.claude-mpm/configuration.yaml`` (see #945).
         """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 
@@ -342,6 +383,9 @@ class TestTwoPhaseProgressBars:
         # skill_filter is passed (may be a set or None)
         assert "skill_filter" in call_args[1]
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.services.skills.selective_skill_deployer.get_skills_to_deploy")
     @patch(
         "claude_mpm.services.skills.selective_skill_deployer.get_required_skills_from_agents"
@@ -356,6 +400,7 @@ class TestTwoPhaseProgressBars:
         mock_progress_class,
         mock_required_skills,
         mock_skills_to_deploy,
+        mock_save_config,
     ):
         """Test that deploy_skills is skipped when there are no skills to deploy.
 
@@ -367,10 +412,11 @@ class TestTwoPhaseProgressBars:
         is NOT called.
 
         This test fully mocks the skill-resolution inputs
-        (``get_required_skills_from_agents``, ``get_skills_to_deploy``, and
-        ``manager.get_all_skills``) so the no-skills scenario is deterministic and
-        does not depend on the real filesystem ``.claude/agents/`` directory or a
-        project ``configuration.yaml``.
+        (``get_required_skills_from_agents``, ``get_skills_to_deploy``,
+        ``save_agent_skills_to_config``, and ``manager.get_all_skills``) so the
+        no-skills scenario is deterministic and does not depend on the real
+        filesystem ``.claude/agents/`` directory or write to the real project
+        ``configuration.yaml`` (see #945).
         """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 
@@ -416,6 +462,9 @@ class TestTwoPhaseProgressBars:
         # Verify sync was performed
         mock_manager.sync_all_sources.assert_called_once()
 
+    @patch(
+        "claude_mpm.services.skills.selective_skill_deployer.save_agent_skills_to_config"
+    )
     @patch("claude_mpm.services.skills.selective_skill_deployer.get_skills_to_deploy")
     @patch(
         "claude_mpm.services.skills.selective_skill_deployer.get_required_skills_from_agents"
@@ -430,6 +479,7 @@ class TestTwoPhaseProgressBars:
         mock_progress_class,
         mock_required_skills,
         mock_skills_to_deploy,
+        mock_save_config,
     ):
         """Test that deploy_skills IS called when there are skills to deploy.
 
@@ -437,6 +487,9 @@ class TestTwoPhaseProgressBars:
         skill resolution yields a non-empty list, ``skill_count > 0`` and the
         gate opens, so ``deploy_skills`` is invoked exactly once. Skill resolution
         is fully mocked to keep the test independent of real filesystem state.
+
+        ``save_agent_skills_to_config`` is also mocked so this test never writes
+        to the real ``.claude-mpm/configuration.yaml`` (see #945).
         """
         from claude_mpm.cli.startup import sync_remote_skills_on_startup
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,75 @@ def verify_source_agents_untouched():
     )
 
 
+@pytest.fixture(autouse=True)
+def verify_configuration_yaml_untouched():
+    """Detect any test that modifies the real .claude-mpm/configuration.yaml.
+
+    Regression guard for #945: production code in
+    ``sync_remote_skills_on_startup()`` (src/claude_mpm/cli/startup.py) resolves
+    both the agent scan directory and the config write target from bare
+    ``Path.cwd()``. When a test mocks ``get_required_skills_from_agents`` or
+    ``get_skills_to_deploy`` but not the downstream ``save_agent_skills_to_config``
+    writer, the real writer still executes against the developer's actual repo
+    and clobbers the checked-in ``configuration.yaml`` with placeholder skill
+    data (e.g. ``agent_referenced: [skill1]``).
+
+    If a test does corrupt the file, its original content is restored here so
+    the damage doesn't leak into subsequent tests or a developer's working
+    tree, but the test run still fails loudly via the assertion below so the
+    offending test gets fixed.
+
+    Uses Path(__file__) rather than Path.cwd() so the guard is stable in CI
+    environments where the working directory may differ from the repo root.
+    """
+    import hashlib
+
+    repo_root = Path(__file__).resolve().parent.parent
+    config_path = repo_root / ".claude-mpm" / "configuration.yaml"
+
+    def _snapshot() -> dict | None:
+        if not config_path.exists():
+            return None
+        content = config_path.read_bytes()
+        return {
+            "content": content,
+            "hash": hashlib.md5(
+                content
+            ).hexdigest(),  # MD5 is sufficient for detecting accidental overwrites; not used for security
+        }
+
+    before = _snapshot()
+
+    yield
+
+    after = _snapshot()
+
+    if before is None:
+        # File didn't exist before the test; nothing to protect or restore.
+        return
+
+    problem = None
+    if after is None:
+        problem = f"configuration.yaml was DELETED: {config_path}"
+    elif after["hash"] != before["hash"]:
+        problem = (
+            f"configuration.yaml CONTENT MODIFIED: {config_path} "
+            f"(size {len(before['content'])} -> {len(after['content'])})"
+        )
+
+    if problem is not None:
+        # Restore the real file immediately so the corruption doesn't
+        # persist into later tests or a developer's working tree.
+        config_path.write_bytes(before["content"])
+
+    assert problem is None, (
+        "TEST BUG: The real .claude-mpm/configuration.yaml was modified during "
+        "a test (restored automatically). Mock the downstream writer "
+        "(e.g. save_agent_skills_to_config) instead of letting the real "
+        f"function resolve Path.cwd() and write to the repo.\n  - {problem}"
+    )
+
+
 # ===== Mock Objects Fixtures =====
 
 

--- a/tests/dashboard/test_analyze_subprocess.py
+++ b/tests/dashboard/test_analyze_subprocess.py
@@ -14,6 +14,7 @@ is called via subprocess to analyze codebases.
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,10 +39,18 @@ def test_analyze_code_subprocess():
 
     print(f"Running command: {' '.join(cmd)}")
 
-    # Run subprocess
-    result = subprocess.run(
-        cmd, check=False, capture_output=True, text=True, timeout=30
-    )
+    # Run subprocess in an isolated cwd so this test never resolves paths
+    # (e.g. .claude/agents, .claude-mpm/configuration.yaml) against the real
+    # repo root (see #945).
+    with tempfile.TemporaryDirectory() as isolated_cwd:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=isolated_cwd,
+        )
 
     print(f"Return code: {result.returncode}")
 


### PR DESCRIPTION
## Summary
- Tests mocked the skills scan but not the downstream config writer
- Both resolved paths via bare `Path.cwd()`, so running the suite from repo root clobbered the real tracked config file
- Fixed test mocking to prevent config writer from activating
- Added autouse conftest guard that fails loudly if any test modifies the real `.claude-mpm/configuration.yaml`

Closes #945