### PR TITLE
fix: always terminate written JSON settings with a trailing newline (#944)

### DIFF
--- a/src/claude_mpm/cli/startup_migrations.py
+++ b/src/claude_mpm/cli/startup_migrations.py
@@ -324,6 +324,7 @@ def _clean_user_level_hooks() -> bool:
         if removed_count > 0:
             with open(settings_file, "w") as f:
                 json.dump(data, f, indent=4)
+                f.write("\n")
             print(f"   Cleaning user-level hooks... ({removed_count} removed)")
             logger.info(f"Cleaned {removed_count} duplicate hook entries")
         else:
@@ -432,6 +433,7 @@ def _remove_hook_handler_sh() -> bool:
             if file_removed > 0:
                 with open(settings_file, "w") as f:
                     json.dump(data, f, indent=2)
+                    f.write("\n")
                 total_removed += file_removed
                 logger.info(
                     f"Removed {file_removed} hook-handler.sh entries from {settings_file}"
@@ -597,6 +599,7 @@ def _upgrade_to_fast_hook() -> bool:
             if file_upgraded > 0:
                 with open(settings_file, "w") as f:
                     json.dump(data, f, indent=2)
+                    f.write("\n")
                 total_upgraded += file_upgraded
                 logger.info(
                     f"Upgraded {file_upgraded} hooks to PATH-based claude-hook "
@@ -889,6 +892,7 @@ def _clean_stale_hook_paths() -> bool:
             if file_changed:
                 with open(settings_file, "w") as f:
                     json.dump(data, f, indent=2)
+                    f.write("\n")
                 total_removed_paths += removed_paths
                 total_removed_events += removed_events
                 total_upgraded_commands += upgraded_commands
@@ -1009,6 +1013,7 @@ def _remove_unsupported_hook_events() -> bool:
             if removed:
                 with open(settings_file, "w") as f:
                     json.dump(data, f, indent=2)
+                    f.write("\n")
                 total_removed += len(removed)
                 logger.info(
                     f"Removed unsupported hook events {removed} from {settings_file}"
@@ -1754,6 +1759,7 @@ def migrate_plugin_scope_v1() -> bool:
         try:
             with open(global_plugins_file, "w") as f:
                 json.dump(global_data, f, indent=2)
+                f.write("\n")
             logger.debug(f"Updated global plugins registry: {global_plugins_file}")
         except Exception as e:
             logger.warning(f"Failed to write global plugins registry: {e}")
@@ -1764,6 +1770,7 @@ def migrate_plugin_scope_v1() -> bool:
             project_plugins_file.parent.mkdir(parents=True, exist_ok=True)
             with open(project_plugins_file, "w") as f:
                 json.dump(project_data, f, indent=2)
+                f.write("\n")
             logger.debug(f"Updated project plugins registry: {project_plugins_file}")
         except Exception as e:
             logger.warning(f"Failed to write project plugins registry: {e}")

--- a/src/claude_mpm/core/output_style_manager.py
+++ b/src/claude_mpm/core/output_style_manager.py
@@ -413,7 +413,7 @@ class OutputStyleManager:
             if isinstance(value, str) and value.startswith("claude_mpm"):
                 del settings["outputStyle"]
                 self.settings_file.write_text(
-                    json.dumps(settings, indent=2), encoding="utf-8"
+                    json.dumps(settings, indent=2) + "\n", encoding="utf-8"
                 )
                 self.logger.info(
                     "Removed MPM-owned outputStyle '%s' from global %s (issue #924)",
@@ -518,7 +518,7 @@ class OutputStyleManager:
 
                 # Write updated settings
                 settings_path.write_text(
-                    json.dumps(settings, indent=2), encoding="utf-8"
+                    json.dumps(settings, indent=2) + "\n", encoding="utf-8"
                 )
 
                 self.logger.info(
@@ -540,7 +540,7 @@ class OutputStyleManager:
 
                 # Write updated settings
                 settings_path.write_text(
-                    json.dumps(settings, indent=2), encoding="utf-8"
+                    json.dumps(settings, indent=2) + "\n", encoding="utf-8"
                 )
 
                 self.logger.info(
@@ -552,7 +552,7 @@ class OutputStyleManager:
                     del settings["activeOutputStyle"]
                     settings_path.parent.mkdir(parents=True, exist_ok=True)
                     settings_path.write_text(
-                        json.dumps(settings, indent=2), encoding="utf-8"
+                        json.dumps(settings, indent=2) + "\n", encoding="utf-8"
                     )
                     self.logger.debug("Cleaned up legacy activeOutputStyle key")
 

--- a/tests/cli/test_startup_migrations.py
+++ b/tests/cli/test_startup_migrations.py
@@ -833,3 +833,199 @@ class TestMcpSecurityReviewRename:
             f"Bundled skill(s) with 'mcp' prefix found — these shadow the native "
             f"/mcp command: {mcp_prefixed}. Rename them (see issue #736)."
         )
+
+
+def _assert_single_trailing_newline(path: Path) -> None:
+    """Shared assertion for issue #944: files must end with exactly one ``\\n``."""
+    raw = path.read_text()
+    assert raw.endswith("\n"), f"{path} must end with a trailing newline (issue #944)"
+    assert not raw.endswith("\n\n"), (
+        f"{path} must not end with a blank line (issue #944)"
+    )
+
+
+class TestTrailingNewlineIssue944:
+    """Regression tests for issue #944.
+
+    ``claude-mpm`` writes several tracked settings files (``settings.json``,
+    ``settings.local.json``, plugin registries) via ``json.dump``/``json.dumps``.
+    Without a trailing newline these writes deterministically differ from the
+    POSIX-text-file convention used elsewhere in the repo, which made ``cz
+    bump`` see a spurious diff on every release. Each of these tests exercises
+    a distinct ``json.dump`` call site and asserts the written file ends with
+    exactly one trailing newline.
+    """
+
+    @pytest.fixture
+    def home_dir(self, tmp_path):
+        """Temp $HOME with a ``.claude`` directory already created."""
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        return home
+
+    def test_clean_user_level_hooks_writes_trailing_newline(self, home_dir):
+        """``_clean_user_level_hooks`` (settings.local.json dedup) call site."""
+        from claude_mpm.cli.startup_migrations import _clean_user_level_hooks
+
+        settings_file = home_dir / ".claude" / "settings.local.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "Stop": [
+                            {"hooks": [{"command": "claude-hook"}]},
+                            {"hooks": [{"command": "claude-hook"}]},  # duplicate
+                        ]
+                    }
+                },
+                indent=2,
+            )
+        )
+
+        with patch.object(Path, "home", return_value=home_dir):
+            result = _clean_user_level_hooks()
+
+        assert result is True
+        _assert_single_trailing_newline(settings_file)
+
+    def test_remove_hook_handler_sh_writes_trailing_newline(self, home_dir):
+        """``_remove_hook_handler_sh`` call site."""
+        from claude_mpm.cli.startup_migrations import _remove_hook_handler_sh
+
+        settings_file = home_dir / ".claude" / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "Stop": [
+                            {"hooks": [{"command": "claude-hook-handler.sh"}]},
+                        ]
+                    }
+                },
+                indent=2,
+            )
+        )
+
+        with (
+            patch.object(Path, "home", return_value=home_dir),
+            patch.object(Path, "cwd", return_value=home_dir),
+        ):
+            result = _remove_hook_handler_sh()
+
+        assert result is True
+        _assert_single_trailing_newline(settings_file)
+
+    def test_upgrade_to_fast_hook_writes_trailing_newline(self, home_dir):
+        """``_upgrade_to_fast_hook`` call site."""
+        from claude_mpm.cli.startup_migrations import _upgrade_to_fast_hook
+
+        settings_file = home_dir / ".claude" / "settings.local.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "Stop": [
+                            {"hooks": [{"command": "claude-hook-fast.sh"}]},
+                        ]
+                    }
+                },
+                indent=2,
+            )
+        )
+
+        with (
+            patch.object(Path, "home", return_value=home_dir),
+            patch.object(Path, "cwd", return_value=home_dir),
+        ):
+            result = _upgrade_to_fast_hook()
+
+        assert result is True
+        _assert_single_trailing_newline(settings_file)
+
+    def test_clean_stale_hook_paths_writes_trailing_newline(self, home_dir):
+        """``_clean_stale_hook_paths`` call site."""
+        from claude_mpm.cli.startup_migrations import _clean_stale_hook_paths
+
+        settings_file = home_dir / ".claude" / "settings.local.json"
+        settings_file.write_text(
+            json.dumps(
+                {"hooks": {"SubagentStart": [{"hooks": [{"command": "claude-hook"}]}]}},
+                indent=2,
+            )
+        )
+
+        with (
+            patch.object(Path, "home", return_value=home_dir),
+            patch.object(Path, "cwd", return_value=home_dir),
+        ):
+            result = _clean_stale_hook_paths()
+
+        assert result is True
+        _assert_single_trailing_newline(settings_file)
+
+    def test_remove_unsupported_hook_events_writes_trailing_newline(self, home_dir):
+        """``_remove_unsupported_hook_events`` call site."""
+        from claude_mpm.cli.startup_migrations import _remove_unsupported_hook_events
+
+        settings_file = home_dir / ".claude" / "settings.local.json"
+        settings_file.write_text(
+            json.dumps({"hooks": {"WorktreeCreate": []}}, indent=2)
+        )
+
+        with patch.object(Path, "home", return_value=home_dir):
+            result = _remove_unsupported_hook_events()
+
+        assert result is True
+        _assert_single_trailing_newline(settings_file)
+
+    def test_migrate_plugin_scope_v1_writes_trailing_newline(
+        self, home_dir, monkeypatch
+    ):
+        """``migrate_plugin_scope_v1`` writes both the global and project
+        plugin registries — both call sites must end with a single newline."""
+        from claude_mpm.cli import startup_migrations
+        from claude_mpm.cli.startup_migrations import (
+            check_plugin_scope_v1,
+            migrate_plugin_scope_v1,
+        )
+
+        project = home_dir.parent / "project"
+        project.mkdir()
+
+        global_plugins_file = (
+            home_dir / ".claude" / "plugins" / "installed_plugins.json"
+        )
+        global_plugins_file.parent.mkdir(parents=True)
+        global_plugins_file.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "some-plugin@1.0.0": [
+                            {"scope": "user", "installPath": "/tmp/some-plugin"}
+                        ]
+                    },
+                },
+                indent=2,
+            )
+        )
+
+        monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+        with (
+            patch.object(Path, "home", return_value=home_dir),
+            patch.object(Path, "cwd", return_value=project),
+        ):
+            assert check_plugin_scope_v1() is True
+            result = migrate_plugin_scope_v1()
+
+        assert result is True
+        _assert_single_trailing_newline(global_plugins_file)
+        project_plugins_file = (
+            project / ".claude" / "plugins" / "installed_plugins.json"
+        )
+        _assert_single_trailing_newline(project_plugins_file)
+
+        # Reset module-level cache populated by check_plugin_scope_v1 so this
+        # test doesn't leak state into other tests running in the same worker.
+        startup_migrations._plugin_scope_check_result = {}

--- a/tests/test_output_style_user_preference_preservation.py
+++ b/tests/test_output_style_user_preference_preservation.py
@@ -203,5 +203,47 @@ def test_deploy_output_style_with_activate_true_preserves_user_choice(temp_home)
     )
 
 
+def test_settings_file_ends_with_single_trailing_newline(temp_home):
+    """Test 8: Regression test for issue #944.
+
+    Every write to ``.claude/settings.json`` via ``_activate_output_style``
+    must end with exactly one trailing newline. Writing JSON without a
+    trailing newline deterministically diverges from the POSIX-text-file
+    convention used elsewhere in the repo, which caused ``cz bump`` to see a
+    spurious diff on every release.
+    """
+    manager = OutputStyleManager()
+    manager.claude_version = "1.0.83"
+    manager.deploy_all_styles(activate_default=True)
+
+    settings_path = temp_home / ".claude" / "settings.json"
+    raw = settings_path.read_text()
+    assert raw.endswith("\n"), "settings.json must end with a trailing newline"
+    assert not raw.endswith("\n\n"), "settings.json must not end with a blank line"
+
+
+def test_cleanup_global_output_style_writes_trailing_newline(temp_home):
+    """Test 9: Regression test for issue #944.
+
+    ``_cleanup_global_output_style`` (issue #924 self-heal path) writes the
+    shared global settings file directly and must also end with exactly one
+    trailing newline.
+    """
+    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps({"outputStyle": "claude_mpm"}, indent=2))
+
+    manager = OutputStyleManager()
+    manager._cleanup_global_output_style()
+
+    raw = settings_path.read_text()
+    assert raw.endswith("\n"), "settings.json must end with a trailing newline"
+    assert not raw.endswith("\n\n"), "settings.json must not end with a blank line"
+    settings = json.loads(raw)
+    assert "outputStyle" not in settings, (
+        "MPM-owned outputStyle should be stripped from the global settings file"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-xvs"])


### PR DESCRIPTION
## Summary
- Several `json.dump`/`json.dumps` call sites across `startup_migrations.py` and `output_style_manager.py` wrote files without a trailing newline
- `cz bump` detected spurious diffs on every release because of missing final newline
- Fixed all call sites to append `\n` after JSON serialization
- Added regression tests to verify trailing newline behavior

Closes #944