### PR TITLE
fix: make outputStyle guard read/write settings from the same scope (#943)

### DIFF
--- a/src/claude_mpm/cli/startup.py
+++ b/src/claude_mpm/cli/startup.py
@@ -1214,10 +1214,18 @@ def deploy_output_style_on_startup():
             # Styles are ready, but ensure activation is set
             # Check if we need to activate default style
             # Only activate if no style is currently set (preserve user choices)
+            #
+            # Read manager.project_settings_file (the project-scoped, git-ignored
+            # .claude/settings.local.json) here -- it is the same file
+            # manager._activate_output_style() writes to. Previously this read
+            # manager.settings_file (the global ~/.claude/settings.json) while the
+            # write landed in the project-local file, so this guard could never
+            # be satisfied by its own write and re-fired on every startup,
+            # producing permanent tracked-file drift (issue #943).
             settings = {}
-            if manager.settings_file.exists():
+            if manager.project_settings_file.exists():
                 try:
-                    settings = json.loads(manager.settings_file.read_text())
+                    settings = json.loads(manager.project_settings_file.read_text())
                 except json.JSONDecodeError:
                     pass
 

--- a/src/claude_mpm/core/output_style_manager.py
+++ b/src/claude_mpm/core/output_style_manager.py
@@ -105,13 +105,32 @@ class OutputStyleManager:
     """
 
     def __init__(self) -> None:
-        """Initialize the output style manager."""
+        """Initialize the output style manager.
+
+        WHAT: Sets up logging, detects the running Claude Code version,
+        resolves the on-disk paths used for output-style deployment and
+        activation (global settings, project-scoped git-ignored settings,
+        and the output-style source/target pairs), and builds the
+        ``styles`` registry consumed by the rest of this class.
+
+        WHY: Centralizing path resolution here keeps the global-vs-project
+        settings distinction (see :pyattr:`project_settings_file`) in one
+        place, which is what issue #943 (global-read/project-write
+        mismatch causing tracked-file drift) depends on being correct.
+        """
         self.logger = get_logger("output_style_manager")  # type: ignore[misc]
         self.claude_version = self._detect_claude_version()
 
         # Deploy to ~/.claude/output-styles/ directory (official Claude Code location)
         self.output_style_dir = Path.home() / ".claude" / "output-styles"
         self.settings_file = Path.home() / ".claude" / "settings.json"
+
+        # Project-scoped, git-ignored file for the user's personal outputStyle
+        # preference. Activation writes here -- never to the tracked,
+        # team-shared .claude/settings.json -- so the choice stays scoped to
+        # this project (issue #924) without producing permanent uncommitted
+        # drift in a file every contributor has checked out (issue #943).
+        self.project_settings_file = Path.cwd() / ".claude" / "settings.local.json"
 
         # Style definitions
         self.styles: dict[str, StyleConfig] = {
@@ -423,6 +442,87 @@ class OutputStyleManager:
         except Exception as e:  # pragma: no cover - defensive
             self.logger.debug("Global outputStyle cleanup skipped: %s", e)
 
+    def _migrate_tracked_project_output_style(self) -> None:
+        """Self-heal any MPM-owned ``outputStyle`` written to the tracked,
+        git-shared ``.claude/settings.json`` by the issue #943 regression.
+
+        Between PR #934 (2026-07-17) and this fix, activation wrote
+        ``outputStyle`` into the project's tracked ``.claude/settings.json``
+        instead of a git-ignored file, producing permanent uncommitted drift
+        for every contributor. This helper strips any ``claude_mpm*`` value
+        left behind by that bug and, if the user hadn't already set a
+        preference in the new location, carries it forward into
+        :pyattr:`project_settings_file` so their choice isn't lost.
+
+        WHAT: Reads the tracked ``.claude/settings.json``; if it contains an
+        ``outputStyle`` value starting with ``claude_mpm``, removes it from
+        that tracked file and, unless the project-scoped git-ignored file
+        already has its own ``outputStyle``, writes the value there instead.
+        No-ops entirely when the tracked file is absent, unparsable, or has
+        no MPM-owned value.
+
+        WHY: This is the one-time remediation half of the issue #943 fix --
+        without it, contributors who already hit the bug would keep a
+        stray ``outputStyle`` permanently drifted into the tracked,
+        team-shared settings file even after upgrading past the regression.
+        """
+        tracked_path = Path.cwd() / ".claude" / "settings.json"
+        try:
+            if not tracked_path.exists():
+                return
+
+            try:
+                tracked_settings = json.loads(tracked_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                # Don't touch a file we can't parse.
+                return
+
+            if not isinstance(tracked_settings, dict):
+                return
+
+            value = tracked_settings.get("outputStyle")
+            if not (isinstance(value, str) and value.startswith("claude_mpm")):
+                return
+
+            # Never leave a personal preference in the tracked, team-shared
+            # file (issue #943).
+            del tracked_settings["outputStyle"]
+            tracked_path.write_text(
+                json.dumps(tracked_settings, indent=2), encoding="utf-8"
+            )
+            self.logger.info(
+                "Removed MPM-owned outputStyle '%s' from tracked %s (issue #943)",
+                value,
+                tracked_path,
+            )
+
+            # Carry the value forward to the git-ignored, project-scoped
+            # file -- unless the user already has a preference recorded
+            # there, in which case we must not clobber it.
+            local_settings: dict[str, Any] = {}
+            if self.project_settings_file.exists():
+                try:
+                    local_settings = json.loads(self.project_settings_file.read_text())
+                except (json.JSONDecodeError, OSError):
+                    local_settings = {}
+
+            if not isinstance(local_settings, dict):
+                local_settings = {}
+
+            if "outputStyle" not in local_settings:
+                local_settings["outputStyle"] = value
+                self.project_settings_file.parent.mkdir(parents=True, exist_ok=True)
+                self.project_settings_file.write_text(
+                    json.dumps(local_settings, indent=2), encoding="utf-8"
+                )
+                self.logger.info(
+                    "Migrated outputStyle '%s' to %s (issue #943)",
+                    value,
+                    self.project_settings_file,
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.debug("Tracked project outputStyle migration skipped: %s", e)
+
     def _activate_output_style(
         self, style_name: str = "Claude MPM", is_fresh_install: bool = False
     ) -> bool:
@@ -458,9 +558,16 @@ class OutputStyleManager:
             # Claude Code session on the machine (issue #924).
             self._cleanup_global_output_style()
 
-            # Write the activation to the PROJECT-LOCAL .claude/settings.json so
-            # the outputStyle only applies to this project, not globally.
-            settings_path = Path.cwd() / ".claude" / "settings.json"
+            # Self-heal: strip any MPM-owned outputStyle previously written to
+            # the tracked, git-shared project settings.json by the issue #943
+            # regression, carrying the value forward if not already migrated.
+            self._migrate_tracked_project_output_style()
+
+            # Write the activation to the project-scoped, git-ignored
+            # .claude/settings.local.json so the outputStyle only applies to
+            # this project (not globally, issue #924) and never pollutes the
+            # tracked, team-shared .claude/settings.json (issue #943).
+            settings_path = self.project_settings_file
 
             # Load existing settings or create new
             settings = {}
@@ -591,10 +698,17 @@ class OutputStyleManager:
             else:
                 status["file_status"] = "Pending deployment"
 
-            # Check active style
-            if self.settings_file.exists():
+            # Check active style. Prefer the project-scoped file activation
+            # actually writes to; fall back to the global file only if the
+            # project-scoped one hasn't been created yet (issue #943).
+            status_settings_file = (
+                self.project_settings_file
+                if self.project_settings_file.exists()
+                else self.settings_file
+            )
+            if status_settings_file.exists():
                 try:
-                    settings = json.loads(self.settings_file.read_text())
+                    settings = json.loads(status_settings_file.read_text())
                     status["active_style"] = settings.get("outputStyle", "none")
                 except Exception:
                     status["active_style"] = "Error reading settings"
@@ -668,13 +782,16 @@ class OutputStyleManager:
         if activate_default and results.get("professional", False):
             file_fresh_install = not professional_style_existed
 
-            # Check for existing preferences (both native and legacy)
+            # Check for existing preferences (both native and legacy). Read
+            # the same project-scoped file _activate_output_style() writes
+            # to -- reading manager.settings_file (global) here would check
+            # a different file than the one being updated (issue #943).
             existing_preference = None
             has_settings_file = False
-            if self.settings_file.exists():
+            if self.project_settings_file.exists():
                 has_settings_file = True
                 try:
-                    settings = json.loads(self.settings_file.read_text())
+                    settings = json.loads(self.project_settings_file.read_text())
                     existing_preference = settings.get("outputStyle") or settings.get(
                         "activeOutputStyle"
                     )

--- a/tests/test_output_style_deployment.py
+++ b/tests/test_output_style_deployment.py
@@ -71,11 +71,12 @@ def test_deployment_function():
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_home = Path(temp_dir)
         output_styles_dir = temp_home / ".claude" / "output-styles"
-        settings_file = temp_home / ".claude" / "settings.json"
+        settings_file = temp_home / ".claude" / "settings.local.json"
+        tracked_settings_file = temp_home / ".claude" / "settings.json"
 
         # Mock Path.home() and Path.cwd() to the temp directory so both the
-        # HOME-based output-styles dir and the project-local (cwd) settings.json
-        # (issue #924) resolve under the temp tree.
+        # HOME-based output-styles dir and the project-local (cwd)
+        # settings.local.json (issues #924, #943) resolve under the temp tree.
         with (
             patch("pathlib.Path.home", return_value=temp_home),
             patch("pathlib.Path.cwd", return_value=temp_home),
@@ -100,16 +101,20 @@ def test_deployment_function():
                 deployed_content = output_style_file.read_text()
                 assert deployed_content == source_content, "Content mismatch"
 
-                # Check settings.json was created
-                assert settings_file.exists(), "settings.json not created"
+                # Check settings.local.json was created (git-ignored, project-
+                # scoped file -- never the tracked settings.json, issue #943)
+                assert settings_file.exists(), "settings.local.json not created"
                 settings = json.loads(settings_file.read_text())
                 assert settings.get("outputStyle") == "claude_mpm", (
                     "outputStyle not set"
                 )
+                assert not tracked_settings_file.exists(), (
+                    "tracked .claude/settings.json should never be written (issue #943)"
+                )
 
                 print(f"✓ Output style file created at: {output_style_file}")
                 print(f"✓ Content matches source ({len(deployed_content)} characters)")
-                print("✓ settings.json created with outputStyle: claude_mpm")
+                print("✓ settings.local.json created with outputStyle: claude_mpm")
                 print()
 
 

--- a/tests/test_output_style_migration.py
+++ b/tests/test_output_style_migration.py
@@ -17,9 +17,9 @@ from claude_mpm.core.output_style_manager import OutputStyleManager
 def temp_home(monkeypatch):
     """Create temporary home directory for testing.
 
-    Also chdir into it so the project-local ``.claude/settings.json`` that the
-    output-style activation now writes (issue #924) resolves under the same
-    temp tree as the HOME-based output-styles directory.
+    Also chdir into it so the project-local ``.claude/settings.local.json``
+    that the output-style activation writes (issues #924, #943) resolves
+    under the same temp tree as the HOME-based output-styles directory.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_path = Path(tmpdir)
@@ -30,7 +30,7 @@ def temp_home(monkeypatch):
 
 def test_migration_from_legacy_key(temp_home):
     """Test migration from legacy activeOutputStyle to native outputStyle."""
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Create settings with only legacy key
@@ -65,7 +65,7 @@ def test_migration_preserves_user_custom_style(temp_home):
     Note: When users have custom styles, the system will reset to default
     on fresh installs for safety, but preserve known MPM styles.
     """
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Create settings with legacy key containing user's custom choice
@@ -90,7 +90,7 @@ def test_migration_preserves_user_custom_style(temp_home):
 
 def test_no_migration_when_native_key_exists(temp_home):
     """Test that existing native keys are preserved and legacy keys are cleaned up."""
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Pre-create style file to simulate normal operation (not fresh install)
@@ -131,7 +131,7 @@ def test_style_name_to_id_conversion(temp_home):
         ("Some Custom Style", "some_custom_style"),
     ]
 
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
     for display_name, expected_id in test_cases:

--- a/tests/test_output_style_system.py
+++ b/tests/test_output_style_system.py
@@ -169,9 +169,9 @@ class TestOutputStyleManager:
     def test_deploy_output_style_success(self, tmp_path):
         """Test successful deployment to Claude Code."""
         tmpdir = tmp_path
-        # outputStyle activation now writes to the PROJECT-LOCAL
-        # .claude/settings.json (cwd) rather than manager.settings_file
-        # (issue #924), so redirect cwd to the temp dir.
+        # outputStyle activation writes to the project-scoped, git-ignored
+        # .claude/settings.local.json (cwd) rather than manager.settings_file
+        # (issues #924, #943), so redirect cwd to the temp dir.
         with (
             patch("subprocess.run") as mock_run,
             patch("pathlib.Path.cwd", return_value=tmp_path),
@@ -200,12 +200,19 @@ class TestOutputStyleManager:
             assert target_path.exists()
             assert target_path.read_text() == content
 
-            # Check settings were updated in the project-local .claude/settings.json
-            project_settings = tmp_path / ".claude" / "settings.json"
+            # Check settings were updated in the project-local, git-ignored
+            # .claude/settings.local.json -- never the tracked settings.json
+            # (issue #943).
+            project_settings = tmp_path / ".claude" / "settings.local.json"
             assert project_settings.exists()
             settings = json.loads(project_settings.read_text())
             # _activate_output_style now uses the style ID "claude_mpm" (native outputStyle key)
             assert settings["outputStyle"] == "claude_mpm"
+
+            tracked_settings = tmp_path / ".claude" / "settings.json"
+            assert not tracked_settings.exists(), (
+                "the tracked .claude/settings.json should never be written (issue #943)"
+            )
 
     def test_deploy_output_style_unsupported_version(self):
         """Test deployment fails for older Claude versions."""

--- a/tests/test_output_style_user_preference_preservation.py
+++ b/tests/test_output_style_user_preference_preservation.py
@@ -21,9 +21,9 @@ from claude_mpm.core.output_style_manager import OutputStyleManager
 def temp_home(monkeypatch):
     """Create temporary home directory for testing.
 
-    Also chdir into it so the project-local ``.claude/settings.json`` that the
-    output-style activation now writes (issue #924) resolves under the same
-    temp tree as the HOME-based output-styles directory.
+    Also chdir into it so the project-local ``.claude/settings.local.json``
+    that the output-style activation writes (issues #924, #943) resolves
+    under the same temp tree as the HOME-based output-styles directory.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_path = Path(tmpdir)
@@ -46,13 +46,19 @@ def test_first_deployment_sets_active_style(temp_home):
     # Verify deployment succeeded
     assert results.get("professional"), "Professional style should deploy successfully"
 
-    # Verify outputStyle was set
-    settings_path = temp_home / ".claude" / "settings.json"
-    assert settings_path.exists(), "settings.json should be created"
+    # Verify outputStyle was set in the git-ignored, project-scoped file --
+    # never in the tracked .claude/settings.json (issue #943).
+    settings_path = temp_home / ".claude" / "settings.local.json"
+    assert settings_path.exists(), "settings.local.json should be created"
 
     settings = json.loads(settings_path.read_text())
     assert settings.get("outputStyle") == "claude_mpm", (
         "outputStyle should be set to 'claude_mpm' on first deployment"
+    )
+
+    tracked_path = temp_home / ".claude" / "settings.json"
+    assert not tracked_path.exists(), (
+        "the tracked .claude/settings.json should never be written (issue #943)"
     )
 
 
@@ -64,7 +70,7 @@ def test_second_deployment_preserves_user_choice(temp_home):
     manager.deploy_all_styles(activate_default=True)
 
     # User changes their preference to a different style
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings = json.loads(settings_path.read_text())
     settings["outputStyle"] = "my_custom_style"
     settings_path.write_text(json.dumps(settings, indent=2))
@@ -97,7 +103,7 @@ def test_redeployment_after_file_deletion_sets_active_style(temp_home):
     style_file.unlink()
 
     # User had changed their preference
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings = json.loads(settings_path.read_text())
     settings["outputStyle"] = "my_custom_style"
     settings_path.write_text(json.dumps(settings, indent=2))
@@ -117,7 +123,7 @@ def test_redeployment_after_file_deletion_sets_active_style(temp_home):
 def test_no_active_style_set_activates_default(temp_home):
     """Test 4: If no outputStyle is set, deployment should set it."""
     # Create settings without outputStyle
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps({"someOtherSetting": "value"}, indent=2))
 
@@ -146,7 +152,7 @@ def test_deploy_output_style_with_activate_false(temp_home):
     assert result, "Deployment should succeed"
 
     # Verify outputStyle was NOT set
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     if settings_path.exists():
         settings = json.loads(settings_path.read_text())
         assert "outputStyle" not in settings or settings.get("outputStyle") is None, (
@@ -164,8 +170,8 @@ def test_deploy_output_style_with_activate_true_on_fresh_install(temp_home):
     assert result, "Deployment should succeed"
 
     # Verify outputStyle was set
-    settings_path = temp_home / ".claude" / "settings.json"
-    assert settings_path.exists(), "settings.json should be created"
+    settings_path = temp_home / ".claude" / "settings.local.json"
+    assert settings_path.exists(), "settings.local.json should be created"
 
     settings = json.loads(settings_path.read_text())
     assert settings.get("outputStyle") == "claude_mpm", (
@@ -182,7 +188,7 @@ def test_deploy_output_style_with_activate_true_preserves_user_choice(temp_home)
     manager.deploy_output_style(style="professional", activate=True)
 
     # User changes preference
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     settings = json.loads(settings_path.read_text())
     settings["outputStyle"] = "users_preference"
     settings_path.write_text(json.dumps(settings, indent=2))


### PR DESCRIPTION
## Summary
- The guard read the effective/global outputStyle setting but wrote its result into the project-local tracked settings.json
- This caused spurious drift on every run and inconsistent scoping behavior
- Fixed so read and write target the same scope consistently
- Updated test coverage across 4 test files to verify scope consistency

Closes #943