### PR TITLE
fix: correct stale settings path in output-style trailing-newline test

### DIFF
--- a/tests/test_output_style_user_preference_preservation.py
+++ b/tests/test_output_style_user_preference_preservation.py
@@ -212,7 +212,7 @@ def test_deploy_output_style_with_activate_true_preserves_user_choice(temp_home)
 def test_settings_file_ends_with_single_trailing_newline(temp_home):
     """Test 8: Regression test for issue #944.
 
-    Every write to ``.claude/settings.json`` via ``_activate_output_style``
+    Every write to ``.claude/settings.local.json`` via ``_activate_output_style``
     must end with exactly one trailing newline. Writing JSON without a
     trailing newline deterministically diverges from the POSIX-text-file
     convention used elsewhere in the repo, which caused ``cz bump`` to see a
@@ -222,10 +222,12 @@ def test_settings_file_ends_with_single_trailing_newline(temp_home):
     manager.claude_version = "1.0.83"
     manager.deploy_all_styles(activate_default=True)
 
-    settings_path = temp_home / ".claude" / "settings.json"
+    settings_path = temp_home / ".claude" / "settings.local.json"
     raw = settings_path.read_text()
-    assert raw.endswith("\n"), "settings.json must end with a trailing newline"
-    assert not raw.endswith("\n\n"), "settings.json must not end with a blank line"
+    assert raw.endswith("\n"), "settings.local.json must end with a trailing newline"
+    assert not raw.endswith("\n\n"), (
+        "settings.local.json must not end with a blank line"
+    )
 
 
 def test_cleanup_global_output_style_writes_trailing_newline(temp_home):


### PR DESCRIPTION
## Summary

`test_settings_file_ends_with_single_trailing_newline` (added by #953 for issue #944) asserted against `.claude/settings.json`, but `_activate_output_style` has written to `.claude/settings.local.json` since issue #943's fix (commit c08e32b06), which merged just before #944's PR was authored. The test has been silently broken since #944 merged — it never asserted anything meaningful, it just crashed with `FileNotFoundError`.

- Change the asserted path from `.claude/settings.json` to `.claude/settings.local.json`
- Update the docstring/assertion messages to match

The sibling test `test_cleanup_global_output_style_writes_trailing_newline` is untouched — it correctly exercises `_cleanup_global_output_style()` against the HOME-based global `settings.json`, a different code path unaffected by #943.

## Test plan

- [x] `uv run pytest tests/test_output_style_user_preference_preservation.py -p no:xdist -v` — all 9 tests pass
- [x] `uv run ruff format` / `ruff check --fix` on the changed file — no changes needed

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)